### PR TITLE
Include regeneration command in lockfile header

### DIFF
--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/dependency-management/dependencyLocking-lockingSingleFilePerProject/common/gradle.lockfile
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/dependency-management/dependencyLocking-lockingSingleFilePerProject/common/gradle.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew :dependencies --write-locks
 org.springframework:spring-beans:5.0.5.RELEASE=compileClasspath, runtimeClasspath
 org.springframework:spring-core:5.0.5.RELEASE=compileClasspath, runtimeClasspath
 org.springframework:spring-jcl:5.0.5.RELEASE=compileClasspath, runtimeClasspath

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -224,11 +224,16 @@ public class LockFileReaderWriter {
             .forEach(GFileUtils::deleteQuietly);
     }
 
-    private static void writeUniqueLockfile(Path lockfilePath, Map<String, List<String>> dependencyToLockId, List<String> emptyLockIds) {
+    private String buildRegenerationComment() {
+        return "# To regenerate this file, run: ./gradlew " + context.projectPath("dependencies") + " --write-locks";
+    }
+
+    private void writeUniqueLockfile(Path lockfilePath, Map<String, List<String>> dependencyToLockId, List<String> emptyLockIds) {
         try {
             Files.createDirectories(lockfilePath.getParent());
             List<String> content = new ArrayList<>(50);
             content.addAll(LOCKFILE_HEADER_LIST);
+            content.add(buildRegenerationComment());
             for (Map.Entry<String, List<String>> entry : dependencyToLockId.entrySet()) {
                 String builder = entry.getKey() + "=" + entry.getValue().stream().sorted().collect(Collectors.joining(","));
                 content.add(builder);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -66,6 +66,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
     def setup() {
         context.identityPath(_) >> { String value -> Path.path(value) }
         context.getProjectPath() >> Path.path(':')
+        context.projectPath(_) >> { String value -> Path.path(":" + value) }
         resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
         resolver.resolve(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) >> uniqueLockFile
@@ -86,7 +87,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
         provider.buildFinished()
 
         then:
-        uniqueLockFile.text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        uniqueLockFile.text == """${expectedHeader()}
 org:bar:1.3=conf
 org:foo:1.0=conf
 empty=
@@ -268,10 +269,15 @@ empty=
         provider.buildFinished()
 
         then:
-        uniqueLockFile.text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        uniqueLockFile.text == """${expectedHeader()}
 org:foo:1.0=otherConf
 empty=
 """
+    }
+
+    private String expectedHeader() {
+        LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n') +
+            '\n# To regenerate this file, run: ./gradlew :dependencies --write-locks'
     }
 
     private DefaultDependencyLockingProvider newProvider() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets
 import org.gradle.util.GradleVersion
 import org.gradle.util.Path
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -44,6 +45,7 @@ class LockFileReaderWriterTest extends Specification {
     ProjectIdentity identity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":foo"))
     DomainObjectContext context = Mock() {
         identityPath(_) >> { String value -> Path.path(value) }
+        projectPath(_) >> { String value -> Path.path(":foo:" + value) }
         getProjectIdentity() >> identity
         getDisplayName() >> identity.displayName
     }
@@ -57,13 +59,18 @@ class LockFileReaderWriterTest extends Specification {
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context, lockFile, listener)
     }
 
+    private String expectedHeader() {
+        LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n') +
+            '\n# To regenerate this file, run: ./gradlew :foo:dependencies --write-locks'
+    }
+
     def 'writes a unique lock file'() {
         when:
         lockDir.deleteDir()
         lockFileReaderWriter.writeUniqueLockfile([a: ['foo', 'bar'], b: ['foo'], c: []])
 
         then:
-        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${expectedHeader()}
 bar=a
 foo=a,b
 empty=c
@@ -89,7 +96,7 @@ empty=c
         lockFileReaderWriter.writeUniqueLockfile([b: ['foo', 'bar'], d: ['bar', 'foobar'],a: ['foo'], e: [], f: [], c: []])
 
         then:
-        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${expectedHeader()}
 bar=b,d
 foo=a,b
 foobar=d
@@ -107,7 +114,7 @@ empty=c,e,f
         lockFileReaderWriter.writeUniqueLockfile([a: ['foo', 'bar'], b: ['foo'], c: []])
 
         then:
-        testLockFile.text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        testLockFile.text == """${expectedHeader()}
 bar=a
 foo=a,b
 empty=c
@@ -209,7 +216,7 @@ empty=d
         lockFileReaderWriter.writeUniqueLockfile([a: ['foo', 'bar'], b: ['foo'], c: []])
 
         then:
-        tmpDir.file("buildscript-$LockFileReaderWriter.UNIQUE_LOCKFILE_NAME").text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        tmpDir.file("buildscript-$LockFileReaderWriter.UNIQUE_LOCKFILE_NAME").text == """${expectedHeader()}
 bar=a
 foo=a,b
 empty=c
@@ -311,5 +318,31 @@ empty=d
         then:
         def ex = thrown(IllegalStateException)
         ex.getMessage().contains("Dependency locking cannot be used for project ':foo'")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37735")
+    def 'writes regeneration comment for root project'() {
+        given:
+        DomainObjectContext rootContext = Mock() {
+            identityPath(_) >> { String value -> Path.path(value) }
+            projectPath(_) >> { String value -> Path.path(":" + value) }
+            getDisplayName() >> "root project 'myProject'"
+        }
+        FileResolver rootResolver = Mock()
+        rootResolver.canResolveRelativePath() >> true
+        rootResolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
+        rootResolver.resolve(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) >> tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+        def writer = new LockFileReaderWriter(rootResolver, rootContext, lockFile, listener)
+
+        when:
+        writer.writeUniqueLockfile([a: ['foo']])
+
+        then:
+        def expectedRootHeader = LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n') +
+            '\n# To regenerate this file, run: ./gradlew :dependencies --write-locks'
+        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${expectedRootHeader}
+foo=a
+empty=
+"""
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #37735

### Context
Lockfiles have a 3-line header explaining the file's purpose but no hint about how to regenerate the file. The required command varies per module (`./gradlew :path:dependencies --write-locks`), so developers unfamiliar with Gradle have to dig through docs.

This PR adds a 4th header line with the exact regeneration command for the project that owns the lockfile:

`To regenerate this file, run: ./gradlew :app:dependencies --write-locks`

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
