### PR TITLE
Support source dependencies with configuration cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -51,11 +51,9 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         def configurationCache = newConfigurationCacheFixture()
 
         given:
-        // any way to trigger graceful degradation will do
-        enableSourceDependencies()
-
         buildFile """
-        class TaskWithLazyProperty extends DefaultTask {
+        ${taskWithInjectedDegradationController()}
+        abstract class TaskWithLazyProperty extends DegradingTask {
             private String value
             @Input
             String getLazyValue() {
@@ -66,6 +64,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
             }
         }
         tasks.register("lazy", TaskWithLazyProperty) { task ->
+           getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
            doLast {
                println("Value is " + task.lazyValue)
            }
@@ -84,17 +83,21 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         def configurationCache = newConfigurationCacheFixture()
 
         given:
-        // any way to trigger graceful degradation will do
-        enableSourceDependencies()
-
         buildKotlinFile """
+        import javax.inject.Inject
+        import org.gradle.api.internal.ConfigurationCacheDegradationController
+
         abstract class TaskWithLazyProperty: DefaultTask() {
+            @get:Inject
+            abstract val degradationController: ConfigurationCacheDegradationController
+
             @get:Input
             val lazyValue: String by lazy {
                 this.project.name
             }
         }
         tasks.register("lazy", TaskWithLazyProperty::class) {
+            degradationController.requireConfigurationCacheDegradation(this, provider { "Project access" })
             doLast {
                 println("Value is " + lazyValue)
             }
@@ -189,27 +192,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         args                                                          | expectedOutputs                                               | degradationReason
         ["-DaccessTaskProject=true"]                                  | ["Task's project accessed!"]                                  | "Project access."
         ["-DaccessTaskProject=true", "-DaccessTaskDependencies=true"] | ["Task's project accessed!", "Task's dependencies accessed!"] | "Project access, TaskDependencies access."
-    }
-
-    def "features may cause CC degradation"() {
-        enableSourceDependencies()
-
-        when:
-        configurationCacheRun("help")
-
-        then:
-        configurationCache.assertNoConfigurationCache()
-
-        and:
-        // feature degradation is reported as a report problem, but it is silently suppressed from the console
-        problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result.output).assertContents {
-            totalProblemsCount = 1
-            withProblem("Feature 'source dependencies' is incompatible with the configuration cache.")
-        }
-
-        and:
-        assertConfigurationCacheDegradation()
     }
 
     def "CC problems in warning mode are not hidden by CC degradation"() {
@@ -680,17 +662,4 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         postBuildOutputDoesNotContain(CONFIGURATION_CACHE_DISABLED_REASON)
     }
 
-    private void enableSourceDependencies() {
-        settingsFile("""
-            sourceControl {
-                vcsMappings {
-                    withModule("org.test:sourceModule") {
-                        from(GitVersionControlSpec) {
-                            url = "some-repo"
-                        }
-                    }
-                }
-            }
-        """)
-    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuild.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuild.kt
@@ -39,5 +39,7 @@ interface ConfigurationCacheBuild {
 
     fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild
 
+    fun addImplicitIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild
+
     fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -61,7 +61,6 @@ import org.gradle.internal.cc.base.serialize.withGradleIsolate
 import org.gradle.internal.cc.base.services.ProjectRefResolver
 import org.gradle.internal.cc.impl.serialize.ConfigurationCacheCodecs
 import org.gradle.internal.configuration.problems.DocumentationSection
-import org.gradle.internal.configuration.problems.DocumentationSection.NotYetImplementedSourceDependencies
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage
@@ -78,7 +77,6 @@ import org.gradle.internal.serialize.codecs.core.IsolateContextSource
 import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.logNotImplemented
 import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readEnum
 import org.gradle.internal.serialize.graph.readList
@@ -93,7 +91,6 @@ import org.gradle.internal.serialize.graph.writeEnum
 import org.gradle.internal.serialize.graph.writeStrings
 import org.gradle.plugin.management.internal.PluginRequests
 import org.gradle.util.Path
-import org.gradle.vcs.internal.VcsMappingsStore
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
@@ -405,6 +402,7 @@ class ConfigurationCacheState(
             write(gradle.settings.settingsScript.resource.file)
             writeBuildDefinition(state.buildDefinition)
             write(state.identityPath)
+            writeBoolean(state.isImplicitBuild)
         }
         // Encode the build state using the contextualized IO service for the nested build
         gradle.serviceOf<ConfigurationCacheIncludedBuildIO>().run {
@@ -422,7 +420,12 @@ class ConfigurationCacheState(
             val settingsFile = read() as File?
             val definition = readIncludedBuildDefinition(rootBuild)
             val buildPath = read() as Path
-            rootBuild.addIncludedBuild(definition, settingsFile, buildPath)
+            val isImplicit = readBoolean()
+            if (isImplicit) {
+                rootBuild.addImplicitIncludedBuild(definition, settingsFile, buildPath)
+            } else {
+                rootBuild.addIncludedBuild(definition, settingsFile, buildPath)
+            }
         }
         return readNestedBuildState(build)
     }
@@ -694,7 +697,6 @@ class ConfigurationCacheState(
         withGradleIsolate(gradle, userTypesCodec) {
             // per build
             writeStartParameterOf(gradle)
-            writeChildBuilds(gradle)
         }
     }
 
@@ -706,7 +708,6 @@ class ConfigurationCacheState(
         return withGradleIsolate(gradle, userTypesCodec) {
             // per build
             readStartParameterOf(gradle)
-            readChildBuilds()
         }
     }
 
@@ -723,29 +724,6 @@ class ConfigurationCacheState(
         // operations, problem reports, build scans), since scheduling -- which resolves and populates the
         // names on a store run -- does not run on a hit.
         gradle.startParameter.setTaskNames(readStrings())
-    }
-
-    private
-    fun WriteContext.writeChildBuilds(gradle: GradleInternal) {
-        if (gradle.serviceOf<VcsMappingsStore>().asResolver().hasRules()) {
-            logNotImplemented(
-                feature = "source dependencies",
-                documentationSection = NotYetImplementedSourceDependencies
-            )
-            writeBoolean(true)
-        } else {
-            writeBoolean(false)
-        }
-    }
-
-    private
-    fun ReadContext.readChildBuilds() {
-        if (readBoolean()) {
-            logNotImplemented(
-                feature = "source dependencies",
-                documentationSection = NotYetImplementedSourceDependencies
-            )
-        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -28,13 +28,11 @@ import org.gradle.api.provider.Provider
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.service.scopes.Scope.BuildTree
 import org.gradle.internal.service.scopes.ServiceScope
-import org.gradle.vcs.internal.VcsMappingsStore
 import java.util.concurrent.ConcurrentHashMap
 
 @ServiceScope(BuildTree::class)
 internal class DefaultConfigurationCacheDegradationController(
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
-    private val vcsMappingsStore: VcsMappingsStore,
     private val buildModelParameters: BuildModelParameters
 ) : ConfigurationCacheDegradationController, HoldsProjectState {
 
@@ -82,18 +80,10 @@ internal class DefaultConfigurationCacheDegradationController(
         } else ImmutableMap.of()
 
     private fun collectFeatureDegradationReasons(): Map<String, List<String>> =
-        if (isSourceDependenciesUsed()) {
-            ImmutableMap.of(
-                "source dependencies",
-                listOf("Source dependencies are not compatible yet")
-            )
-        } else ImmutableMap.of()
+        ImmutableMap.of()
 
     private fun workGraphContains(task: Task): Boolean =
         task.project.gradle.taskGraph.hasTask(task)
-
-    private fun isSourceDependenciesUsed(): Boolean =
-        vcsMappingsStore.asResolver().hasRules()
 
     internal data class DegradationDecision(
         private val taskDegradationReasons: Map<TaskIdentity<*>, List<String>>,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -59,7 +59,7 @@ internal class DefaultConfigurationCacheDegradationController(
         if (buildModelParameters.isModelBuilding) {
             DegradationDecision.shouldNotDegrade
         } else {
-            DegradationDecision(collectTaskDegradationReasons(), collectFeatureDegradationReasons())
+            DegradationDecision(collectTaskDegradationReasons())
         }
 
     private fun collectTaskDegradationReasons(): Map<TaskIdentity<*>, List<String>> =
@@ -79,18 +79,14 @@ internal class DefaultConfigurationCacheDegradationController(
             builder.build()
         } else ImmutableMap.of()
 
-    private fun collectFeatureDegradationReasons(): Map<String, List<String>> =
-        ImmutableMap.of()
-
     private fun workGraphContains(task: Task): Boolean =
         task.project.gradle.taskGraph.hasTask(task)
 
     internal data class DegradationDecision(
-        private val taskDegradationReasons: Map<TaskIdentity<*>, List<String>>,
-        private val featureDegradationReasons: Map<String, List<String>>
+        private val taskDegradationReasons: Map<TaskIdentity<*>, List<String>>
     ) {
         val shouldDegrade: Boolean
-            get() = taskDegradationReasons.isNotEmpty() || featureDegradationReasons.isNotEmpty()
+            get() = taskDegradationReasons.isNotEmpty()
 
         val degradedTaskCount: Int
             get() = taskDegradationReasons.size
@@ -101,12 +97,8 @@ internal class DefaultConfigurationCacheDegradationController(
             taskDegradationReasons.forEach(consumer)
         }
 
-        fun onDegradedFeature(consumer: (String, List<String>) -> Unit) {
-            featureDegradationReasons.forEach(consumer)
-        }
-
         companion object {
-            val shouldNotDegrade = DegradationDecision(ImmutableMap.of(), ImmutableMap.of())
+            val shouldNotDegrade = DegradationDecision(ImmutableMap.of())
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -146,6 +146,10 @@ class DefaultConfigurationCacheHost internal constructor(
             return DefaultConfigurationCacheBuild(buildStateRegistry.addIncludedBuild(buildDefinition, buildPath), fileResolver, buildStateRegistry, settingsFile)
         }
 
+        override fun addImplicitIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild {
+            return DefaultConfigurationCacheBuild(buildStateRegistry.addImplicitIncludedBuild(buildDefinition, buildPath), fileResolver, buildStateRegistry, settingsFile)
+        }
+
         override fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild {
             return DefaultConfigurationCacheBuild(buildStateRegistry.getBuildSrcNestedBuild(buildStateRegistry.getBuild(ownerId))!!, fileResolver, buildStateRegistry, null)
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -274,19 +274,6 @@ class ConfigurationCacheProblems(
         summarizer.onIncompatibleTask()
     }
 
-    private
-    fun reportDegradingFeature(feature: String) {
-        // we report degrading features as problems
-        val problem = problemFactory
-            .problem {
-                // for now, we don't expect interesting information from degrading features, so only the feature name is displayed
-                text("Feature '$feature' is incompatible with the configuration cache.")
-            }
-            .build()
-        summarizer.onIncompatibleFeature(problem)
-        report.onProblem(problem)
-    }
-
     override fun onIsolatedProjectsProblem(problem: PropertyProblem) {
         // IP severity is governed only by IP settings, independent of the CC `--configuration-cache-problems` flag.
         val severity = when {
@@ -410,7 +397,6 @@ class ConfigurationCacheProblems(
      */
     override fun report(reportDir: File, validationFailures: ProblemConsumer) {
         addNotReportedDegradingTasks()
-        addDegradingFeatures()
         val summary = summarizer.get()
         val hasNoProblemsForConsole = summary.consoleProblemCount == 0
         val outputDirectory = outputDirectoryFor(reportDir)
@@ -445,14 +431,6 @@ class ConfigurationCacheProblems(
             if (!incompatibleTasks.contains(trace)) {
                 reportIncompatibleTask(trace, reasons.joinToString())
             }
-        }
-    }
-
-    private
-    fun addDegradingFeatures() {
-        degradationDecision.onDegradedFeature { feature, _ ->
-            // TODO:configuration-cache consider collecting location information (trace)
-            reportDegradingFeature(feature)
         }
     }
 
@@ -536,28 +514,21 @@ class ConfigurationCacheProblems(
 
     private
     fun degradationSummary(): String {
-        val degradingFeatures = buildList {
-            degradationDecision.onDegradedFeature { feature, _ -> add(feature) }
-        }
-        return DegradationSummary(degradingFeatures, degradationDecision.degradedTaskCount).render()
+        return DegradationSummary(degradationDecision.degradedTaskCount).render()
     }
 
     @VisibleForTesting
     internal
-    class DegradationSummary(private val degradingFeatures: List<String>, private val degradingTaskCount: Int) {
+    class DegradationSummary(private val degradingTaskCount: Int) {
         init {
-            require(degradingFeatures.isNotEmpty() || degradingTaskCount > 0)
+            require(degradingTaskCount > 0)
         }
 
         fun render(): String {
-            val featuresAsString = degradingFeatures.joinToString().let { "($it)" }
             return " because incompatible " +
                 when {
-                    degradingTaskCount == 1 && degradingFeatures.isEmpty() -> "task was"
-                    degradingTaskCount > 1 && degradingFeatures.isEmpty() -> "tasks were"
-                    degradingTaskCount == 0 && degradingFeatures.isNotEmpty() -> "feature usage $featuresAsString was"
-                    degradingTaskCount == 1 -> "task and feature usage $featuresAsString were"
-                    else -> "tasks and feature usage $featuresAsString were"
+                    degradingTaskCount == 1 -> "task was"
+                    else -> "tasks were"
                 } + " found."
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -101,9 +101,6 @@ class ConfigurationCacheProblemsSummary(
     private
     var incompatibleTasksCount: Int = 0
 
-    private
-    var incompatibleFeatureCount: Int = 0
-
     /**
      * Report-unique problem causes observed among all reported problems.
      *
@@ -136,8 +133,7 @@ class ConfigurationCacheProblemsSummary(
             consoleProblemCauses = problemCausesForConsole(),
             originalProblemExceptions = ImmutableList.copyOf(originalProblemExceptions),
             maxCollectedProblems = maxCollectedProblems,
-            incompatibleTasksCount = incompatibleTasksCount,
-            incompatibleFeatureCount = incompatibleFeatureCount
+            incompatibleTasksCount = incompatibleTasksCount
         )
     }
 
@@ -194,13 +190,6 @@ class ConfigurationCacheProblemsSummary(
     fun onIncompatibleTask() {
         lock.withLock {
             incompatibleTasksCount += 1
-        }
-    }
-
-    fun onIncompatibleFeature(problem: PropertyProblem) {
-        lock.withLock {
-            onProblem(problem, ProblemSeverity.SuppressedSilently)
-            incompatibleFeatureCount += 1
         }
     }
 
@@ -284,12 +273,7 @@ class Summary(
      * Total number of tasks in the current work graph that are not CC-compatible.
      */
     private
-    val incompatibleTasksCount: Int,
-    /**
-     * Total number of features that are not CC-compatible.
-     */
-    private
-    val incompatibleFeatureCount: Int
+    val incompatibleTasksCount: Int
 ) {
     @VisibleForTesting
     internal
@@ -334,10 +318,9 @@ class Summary(
                 }
             }
             val hasIncompatibleTasks = incompatibleTasksCount > 0
-            val hasIncompatibleFeatures = incompatibleFeatureCount > 0
             htmlReportFile?.let {
                 appendLine()
-                if ((hasIncompatibleTasks || hasIncompatibleFeatures) && !hasConsoleProblems) {
+                if (hasIncompatibleTasks && !hasConsoleProblems) {
                     // Some tests parse this line, you may need to change them if you change the message.
                     append("Some tasks or features in this build are not compatible with the configuration cache.")
                     appendLine()

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsDegradationSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsDegradationSummaryTest.kt
@@ -23,21 +23,15 @@ import org.junit.Test
 class ConfigurationCacheProblemsDegradationSummaryTest {
     @Test
     fun `degradation summary`() {
-        assertMessage(" because incompatible task was found.", emptyList(), 1)
-        assertMessage(" because incompatible tasks were found.", emptyList(), 3)
-        assertMessage(" because incompatible feature usage (feature A) was found.", listOf("feature A"), 0)
-        assertMessage(" because incompatible feature usage (feature A, feature B) was found.", listOf("feature A", "feature B"), 0)
-        assertMessage(" because incompatible task and feature usage (feature A) were found.", listOf("feature A"), 1)
-        assertMessage(" because incompatible tasks and feature usage (feature A) were found.", listOf("feature A"), 3)
-        assertMessage(" because incompatible tasks and feature usage (feature A, feature B) were found.", listOf("feature A", "feature B"), 3)
+        assertMessage(" because incompatible task was found.", 1)
+        assertMessage(" because incompatible tasks were found.", 3)
     }
 
-    private fun assertMessage(expected: String, degradingFeatures: List<String>, degradingTaskCount: Int) {
-        assertEquals(expected, renderSummary(degradingFeatures, degradingTaskCount))
+    private fun assertMessage(expected: String, degradingTaskCount: Int) {
+        assertEquals(expected, renderSummary(degradingTaskCount))
     }
 
-    private fun renderSummary(degradingFeatures: List<String>, degradingTaskCount: Int) = DegradationSummary(
-        degradingFeatures,
+    private fun renderSummary(degradingTaskCount: Int) = DegradationSummary(
         degradingTaskCount
     ).render()
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -46,7 +46,6 @@ data class PropertyProblem(
 // TODO:configuration-cache extract interface and move enum back to :configuration-cache
 enum class DocumentationSection(val page: String, val anchor: String) {
     NotYetImplemented("configuration_cache_status", "config_cache:not_yet_implemented"),
-    NotYetImplementedSourceDependencies("configuration_cache_status", "config_cache:not_yet_implemented:source_dependencies"),
     NotYetImplementedJavaSerialization("configuration_cache_status", "config_cache:not_yet_implemented:java_serialization"),
     NotYetImplementedBuildServiceInFingerprint("configuration_cache_status", "config_cache:not_yet_implemented:build_services_in_fingerprint"),
     NotYetImplementedBuildEventListeners("configuration_cache_status", "config_cache:not_yet_implemented:more_build_event_listeners"),

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class FileWatchingFilter implements FileSystemAccess.WriteListener {
     private final FileHierarchySet immutableLocations;
     private final AtomicReference<FileHierarchySet> currentSessionImmutableLocations = new AtomicReference<>(FileHierarchySet.empty());
+    private final AtomicReference<FileHierarchySet> watchableExemptions = new AtomicReference<>(FileHierarchySet.empty());
     private final AtomicReference<FileHierarchySet> locationsWrittenByCurrentBuild = new AtomicReference<>(FileHierarchySet.empty());
     private volatile boolean buildRunning;
 
@@ -49,7 +50,22 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
         currentSessionImmutableLocations.updateAndGet(locations -> locations.plus(location));
     }
 
+    /**
+     * Registers a location that sits within an immutable location but should nevertheless be watched.
+     *
+     * These are directories that Gradle manages but that hold contents which can change externally and
+     * therefore need watching, such as source-dependency build directories under the project cache dir.
+     * Registering an exemption makes {@link #isImmutableLocation(String)} return {@code false} for the
+     * location and everything below it.
+     */
+    public void addWatchableExemption(File location) {
+        watchableExemptions.updateAndGet(locations -> locations.plus(location));
+    }
+
     public boolean isImmutableLocation(String location) {
+        if (watchableExemptions.get().contains(location)) {
+            return false;
+        }
         return immutableLocations.contains(location) || currentSessionImmutableLocations.get().contains(location);
     }
 
@@ -83,6 +99,7 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
 
     public void sessionFinished() {
         currentSessionImmutableLocations.set(FileHierarchySet.empty());
+        watchableExemptions.set(FileHierarchySet.empty());
     }
 
     private void resetLocationsWritten() {

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
@@ -60,4 +60,37 @@ class FileWatchingFilterTest extends Specification {
         !filter.isImmutableLocation(cacheDir.absolutePath)
         filter.isImmutableLocation(globalCache.absolutePath)
     }
+
+    def "a watchable exemption keeps a location within an immutable location watchable, without affecting siblings"() {
+        def cacheDir = new File("project/.gradle").absoluteFile
+        def exemptedDir = new File(cacheDir, "vcs-1")
+        def exemptedChild = new File(exemptedDir, "abc123/repo")
+        def otherCacheChild = new File(cacheDir, "caches/modules")
+        filter.addCurrentSessionImmutableLocation(cacheDir)
+
+        when:
+        filter.addWatchableExemption(exemptedDir)
+
+        then:
+        // the exempted subtree is no longer immutable, so it will be watched
+        !filter.isImmutableLocation(exemptedDir.absolutePath)
+        !filter.isImmutableLocation(exemptedChild.absolutePath)
+        // everything else under the immutable location stays immutable
+        filter.isImmutableLocation(cacheDir.absolutePath)
+        filter.isImmutableLocation(otherCacheChild.absolutePath)
+    }
+
+    def "watchable exemptions are forgotten on session finish"() {
+        def cacheDir = new File("project/.gradle").absoluteFile
+        def exemptedDir = new File(cacheDir, "vcs-1")
+        filter.addCurrentSessionImmutableLocation(cacheDir)
+        filter.addWatchableExemption(exemptedDir)
+
+        when:
+        filter.sessionFinished()
+
+        then:
+        // with both the session immutable location and the exemption gone, the location is no longer tracked
+        !filter.isImmutableLocation(exemptedDir.absolutePath)
+    }
 }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -115,6 +115,30 @@ tasks.register<NewTask>("after") {
 }
 ```
 
+#### Source dependencies are compatible with the Configuration Cache
+
+Source dependencies let a build resolve a dependency by building it directly from a version control repository, declared with a `sourceControl { vcsMappings { ... } }` block in the settings file.
+Builds that used source dependencies were previously incompatible with the [Configuration Cache](userguide/configuration_cache.html).
+
+Source dependencies now work with the Configuration Cache.
+A build that maps a dependency to a Git repository stores and reuses a Configuration Cache entry like any other build:
+
+```kotlin
+// settings.gradle.kts
+sourceControl {
+    vcsMappings {
+        withModule("org.example:lib") {
+            from(GitVersionControlSpec::class) {
+                url = uri("https://github.com/example/lib.git")
+            }
+        }
+    }
+}
+```
+
+When a source dependency is selected with a dynamic selector — a branch, `latest.integration`, or a version range — the resolved commit can move between builds, so Gradle always invalidates the Configuration Cache entry for that build and re-resolves it, mirroring how [dynamic versions](userguide/dependency_versions.html) of external dependencies are handled.
+A source dependency pinned to a static version reuses the cached entry until an input such as the `vcsMappings` configuration or the resolved upstream commit changes.
+
 ### Isolated Projects improvements
 Gradle provides [Isolated Projects](userguide/isolated_projects.html), an incubating feature that enables parallel project configuration.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -117,11 +117,12 @@ tasks.register<NewTask>("after") {
 
 #### Source dependencies are compatible with the Configuration Cache
 
-Source dependencies let a build resolve a dependency by building it directly from a version control repository, declared with a `sourceControl { vcsMappings { ... } }` block in the settings file.
-Builds that used source dependencies were previously incompatible with the [Configuration Cache](userguide/configuration_cache.html).
+Source dependencies now work with the [Configuration Cache](userguide/configuration_cache.html).
 
-Source dependencies now work with the Configuration Cache.
-A build that maps a dependency to a Git repository stores and reuses a Configuration Cache entry like any other build:
+Source dependencies let a build resolve a dependency by building it directly from a version control repository.
+They are declared with a `sourceControl { vcsMappings { ... } }` block in the settings file.
+
+A build that maps a dependency to a Git repository now stores and reuses a Configuration Cache entry like any other build:
 
 ```kotlin
 // settings.gradle.kts
@@ -138,6 +139,8 @@ sourceControl {
 
 When a source dependency is selected with a dynamic selector — a branch, `latest.integration`, or a version range — the resolved commit can move between builds, so Gradle always invalidates the Configuration Cache entry for that build and re-resolves it, mirroring how [dynamic versions](userguide/dependency_versions.html) of external dependencies are handled.
 A source dependency pinned to a static version reuses the cached entry until an input such as the `vcsMappings` configuration or the resolved upstream commit changes.
+
+See the [Configuration Cache](userguide/configuration_cache.html) chapter in the Gradle User Manual for more details.
 
 ### Isolated Projects improvements
 Gradle provides [Isolated Projects](userguide/isolated_projects.html), an incubating feature that enables parallel project configuration.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -135,14 +135,6 @@ It can be reused by both hot and cold local Gradle daemons, but it cannot be sha
 
 See link:{gradle-issues}13510[gradle/gradle#13510].
 
-[[config_cache:not_yet_implemented:source_dependencies]]
-=== Source Dependencies
-
-Support for link:https://blog.gradle.org/introducing-source-dependencies[source dependencies] is not yet implemented.
-When using this feature, the build will not fail, and no problems will be reported, but the Configuration Cache will be automatically disabled.
-
-See link:{gradle-issues}13506[gradle/gradle#13506].
-
 [[config_cache:not_yet_implemented:fine_grained_tracking_of_gradle_properties]]
 === Fine-grained Tracking of Gradle Properties as Build Configuration Inputs
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -50,7 +50,8 @@ As a result, a custom project cache directory no longer disables file system wat
 Previously, `--project-cache-dir` (or `org.gradle.projectcachedir`) was incompatible with watching: passing `--watch-fs` alongside it failed the build, and leaving watching at its default silently disabled it.
 File system watching now follows the usual rules regardless of where the project cache directory is located.
 
-This also applies to source-dependency check-outs, which live under the project cache directory: their roots are no longer registered as watchable hierarchies.
+This applies to the project cache directory itself.
+Source-dependency check-outs, which live under the project cache directory but whose contents can change externally, remain watched as regular build directories.
 
 See <<file_system_watching.adoc#sec:excluding_files_and_directories,Excluding files and directories>> for details.
 

--- a/platforms/software/version-control/build.gradle.kts
+++ b/platforms/software/version-control/build.gradle.kts
@@ -6,11 +6,14 @@ description = "Version control integration (with git) for source dependencies"
 
 dependencies {
     api(projects.baseServices)
+    api(projects.buildProcessServices)
     api(projects.concurrent)
     api(projects.core)
     api(projects.coreApi)
     api(projects.dependencyManagement)
     api(projects.fileCollections)
+    api(projects.fileWatching)
+    api(projects.persistentCache)
     api(projects.scopedPersistentCache)
     api(projects.serviceProvider)
     api(projects.stdlibJavaExtensions)
@@ -23,7 +26,6 @@ dependencies {
     implementation(projects.functional)
     implementation(projects.hashing)
     implementation(projects.loggingApi)
-    implementation(projects.persistentCache)
     implementation(projects.serialization)
     implementation(projects.startParameter)
 

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/SourceDependencyCleanupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/SourceDependencyCleanupIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.vcs.git.internal
 
 import org.eclipse.jgit.revwalk.RevCommit
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.gradle.vcs.internal.SourceDependencies
@@ -69,12 +68,14 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
                 conf "org.test:dep:" + repoVersion
             }
             task assertVersion {
-                dependsOn configurations.conf
+                def confFiles = configurations.conf
+                def expectedVersion = repoVersion
+                dependsOn confFiles
                 doLast {
-                    def files = zipTree(configurations.conf.singleFile).files
-                    def versionFile = files.find { it.name == "version" }
-                    assert versionFile
-                    assert versionFile.text == repoVersion
+                    // The dep build sets its project version (and hence its jar name) from the
+                    // checked-out "version" file, so the resolved artifact name verifies the
+                    // correct commit was checked out without reading project state at execution time.
+                    assert confFiles.singleFile.name == "dep-\${expectedVersion}.jar"
                 }
             }
         """
@@ -91,7 +92,6 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "does not remove vcs checkout on every build"() {
         succeeds("assertVersion", "-PrepoVersion=1.0")
         def checkout = checkoutDir("dep", commits.initial.id.name, repo.id)
@@ -114,7 +114,6 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         trashFile.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "removes vcs checkout after 7 days"() {
         // checkout all versions
         versions.each { version ->
@@ -133,7 +132,6 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         checkoutDir("dep", commits["3.0"].id.name, repo.id).assertExists()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "does not remove vcs checkout that is older than 7 days but recently used"() {
         // checkout all versions
         versions.each { version ->
@@ -153,7 +151,6 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         checkoutDir("dep", commits["3.0"].id.name, repo.id).assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "removes all checkouts when VCS mappings are removed"() {
         // checkout all versions
         versions.each { version ->

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/SourceDependencyCleanupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/SourceDependencyCleanupIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.vcs.git.internal
 
 import org.eclipse.jgit.revwalk.RevCommit
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.gradle.vcs.internal.SourceDependencies
@@ -90,6 +91,7 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         """
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "does not remove vcs checkout on every build"() {
         succeeds("assertVersion", "-PrepoVersion=1.0")
         def checkout = checkoutDir("dep", commits.initial.id.name, repo.id)
@@ -112,6 +114,7 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         trashFile.assertExists()
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "removes vcs checkout after 7 days"() {
         // checkout all versions
         versions.each { version ->
@@ -130,6 +133,7 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         checkoutDir("dep", commits["3.0"].id.name, repo.id).assertExists()
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "does not remove vcs checkout that is older than 7 days but recently used"() {
         // checkout all versions
         versions.each { version ->
@@ -149,6 +153,7 @@ class SourceDependencyCleanupIntegrationTest extends AbstractIntegrationSpec imp
         checkoutDir("dep", commits["3.0"].id.name, repo.id).assertDoesNotExist()
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test build script uses ext properties / repoVersion read at execution time")
     def "removes all checkouts when VCS mappings are removed"() {
         // checkout all versions
         versions.each { version ->

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -69,16 +68,16 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
             }
 
             task resolve {
-                dependsOn configurations.conf
+                def confFiles = configurations.conf
+                def expectedResult = providers.gradleProperty("result")
+                dependsOn confFiles
                 doLast {
-                    def expectedResult = result.split(",")
-                    assert configurations.conf.files.collect { it.name } == expectedResult
+                    assert confFiles.files.collect { it.name } == (expectedResult.get().split(",") as List)
                 }
             }
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve subproject of multi-project source dependency"() {
         mappingFor(repo, "org.test:foo")
         buildFile << """
@@ -95,7 +94,6 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve root of multi-project source dependency"() {
         mappingFor(repo, "org.test:B")
         buildFile << """
@@ -112,7 +110,6 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("B-1.0.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve multiple projects of multi-project source dependency"() {
         mappingFor(repo, "org.test:foo")
         mappingFor(repo, "org.test:bar")
@@ -131,7 +128,6 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "only resolves a single project of multi-project source dependency"() {
         mavenRepo.module("org.test", "bar", "1.0-SNAPSHOT").withNonUniqueSnapshots().publish()
         mappingFor(repo, "org.test:foo")
@@ -151,7 +147,6 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0-SNAPSHOT.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses included build subproject of multi-project source dependency"() {
         mavenRepo.module("org.test", "bar", "1.0-SNAPSHOT").withNonUniqueSnapshots().publish()
         buildB.buildFile << """
@@ -178,7 +173,6 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses root mapping for duplicate subproject of multi-project source dependency"() {
         buildB.buildFile << """
             project(":foo") {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -77,6 +78,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         """
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve subproject of multi-project source dependency"() {
         mappingFor(repo, "org.test:foo")
         buildFile << """
@@ -93,6 +95,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve root of multi-project source dependency"() {
         mappingFor(repo, "org.test:B")
         buildFile << """
@@ -109,6 +112,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("B-1.0.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can resolve multiple projects of multi-project source dependency"() {
         mappingFor(repo, "org.test:foo")
         mappingFor(repo, "org.test:bar")
@@ -127,6 +131,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "only resolves a single project of multi-project source dependency"() {
         mavenRepo.module("org.test", "bar", "1.0-SNAPSHOT").withNonUniqueSnapshots().publish()
         mappingFor(repo, "org.test:foo")
@@ -146,6 +151,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0-SNAPSHOT.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses included build subproject of multi-project source dependency"() {
         mavenRepo.module("org.test", "bar", "1.0-SNAPSHOT").withNonUniqueSnapshots().publish()
         buildB.buildFile << """
@@ -172,6 +178,7 @@ abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends Abstr
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses root mapping for duplicate subproject of multi-project source dependency"() {
         buildB.buildFile << """
             project(":foo") {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
@@ -103,6 +104,7 @@ class GitVcsIntegrationTest extends AbstractIntegrationSpec implements SourceDep
         result.assertTaskScheduled(":compileJava")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Submodule checkout reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def 'can define and use source repositories with submodules'() {
         given:
         // Populate submodule origin
@@ -404,6 +406,7 @@ The following types/formats are supported:
         server.stop()
     }
 
+    @ToBeFixedForConfigurationCache(because = "Working dir reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def "external modifications to source dependency directories are reset"() {
         given:
         repo.file('foo').text = "bar"
@@ -437,6 +440,7 @@ The following types/formats are supported:
         gitCheckout.file('foo').text == "bar"
     }
 
+    @ToBeFixedForConfigurationCache(because = "Submodule reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def "external modifications to source dependency submodule directories are reset"() {
         given:
         // Populate submodule origin

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
@@ -104,7 +103,6 @@ class GitVcsIntegrationTest extends AbstractIntegrationSpec implements SourceDep
         result.assertTaskScheduled(":compileJava")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Submodule checkout reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def 'can define and use source repositories with submodules'() {
         given:
         // Populate submodule origin
@@ -406,7 +404,6 @@ The following types/formats are supported:
         server.stop()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Working dir reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def "external modifications to source dependency directories are reset"() {
         given:
         repo.file('foo').text = "bar"
@@ -440,7 +437,6 @@ The following types/formats are supported:
         gitCheckout.file('foo').text == "bar"
     }
 
-    @ToBeFixedForConfigurationCache(because = "Submodule reset depends on resolution running each invocation; CC reuses cached graph and skips it")
     def "external modifications to source dependency submodule directories are reset"() {
         given:
         // Populate submodule origin

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -130,7 +130,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(":dep:jar_3.0", ":checkDeps")
     }
 
-    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
+    @ToBeFixedForConfigurationCache(skipBecause = "flaky", because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "selects and builds from tag for static selector"() {
         given:
         buildFile << """
@@ -173,7 +173,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(":dep:jar_2.0", ":checkDeps")
     }
 
-    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
+    @ToBeFixedForConfigurationCache(skipBecause = "flaky", because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing version for static selector"() {
         given:
         buildFile << """
@@ -279,7 +279,7 @@ Required by:
         "[1.0,1.9]" | _
     }
 
-    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
+    @ToBeFixedForConfigurationCache(skipBecause = "flaky", because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing version for selector #selector"() {
         given:
         buildFile << """
@@ -424,7 +424,7 @@ Required by:
         result.assertTasksScheduled(":dep:jar_3.0", ":checkDeps")
     }
 
-    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
+    @ToBeFixedForConfigurationCache(skipBecause = "flaky", because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing branch"() {
         given:
         buildFile << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -72,7 +72,6 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         '''
     }
 
-    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after upstream commit (see #13506)")
     def "selects and builds from master for latest.integration selector"() {
         given:
         buildFile << """
@@ -229,7 +228,6 @@ Required by:
         result.assertTasksScheduled(":dep:jar_2.0", ":checkDeps")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after new tag pushed (see #13506)")
     def "selects and builds from highest tag that matches #selector selector"() {
         given:
         buildFile << """
@@ -367,7 +365,6 @@ Required by:
         "HEAD"    | _
     }
 
-    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after branch HEAD moves (see #13506)")
     def "selects and builds latest from branch for branch selector"() {
         given:
         buildFile << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -71,6 +72,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         '''
     }
 
+    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after upstream commit (see #13506)")
     def "selects and builds from master for latest.integration selector"() {
         given:
         buildFile << """
@@ -129,6 +131,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(":dep:jar_3.0", ":checkDeps")
     }
 
+    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "selects and builds from tag for static selector"() {
         given:
         buildFile << """
@@ -171,6 +174,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(":dep:jar_2.0", ":checkDeps")
     }
 
+    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing version for static selector"() {
         given:
         buildFile << """
@@ -225,6 +229,7 @@ Required by:
         result.assertTasksScheduled(":dep:jar_2.0", ":checkDeps")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after new tag pushed (see #13506)")
     def "selects and builds from highest tag that matches #selector selector"() {
         given:
         buildFile << """
@@ -276,6 +281,7 @@ Required by:
         "[1.0,1.9]" | _
     }
 
+    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing version for selector #selector"() {
         given:
         buildFile << """
@@ -361,6 +367,7 @@ Required by:
         "HEAD"    | _
     }
 
+    @ToBeFixedForConfigurationCache(because = "Source-dep floating-ref invalidation not implemented; CC reuses stale resolution after branch HEAD moves (see #13506)")
     def "selects and builds latest from branch for branch selector"() {
         given:
         buildFile << """
@@ -420,6 +427,7 @@ Required by:
         result.assertTasksScheduled(":dep:jar_3.0", ":checkDeps")
     }
 
+    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.FLAKY, because = "Test fixture's BlockingHttpServer state is sensitive to ordering under CC")
     def "reports on and recovers from missing branch"() {
         given:
         buildFile << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.vcs.internal
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.git.GitVersionControlSpec
 
@@ -37,6 +38,7 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
     }
 
     @ToBeFixedForIsolatedProjects(because = "included build uses allprojects { apply plugin: 'java' }")
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can map all modules in group to repo using all {}"() {
         settingsFile << """
             sourceControl {
@@ -68,6 +70,7 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can map to a repository containing multiple separate builds"() {
         repo.file("settings.gradle").delete()
         repo.file("foo/build.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.vcs.internal
 
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.git.GitVersionControlSpec
 
@@ -38,7 +37,6 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
     }
 
     @ToBeFixedForIsolatedProjects(because = "included build uses allprojects { apply plugin: 'java' }")
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can map all modules in group to repo using all {}"() {
         settingsFile << """
             sourceControl {
@@ -70,7 +68,6 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
         assertResolvesTo("foo-1.0.jar", "bar-1.0.jar")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "can map to a repository containing multiple separate builds"() {
         repo.file("settings.gradle").delete()
         repo.file("foo/build.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
@@ -136,6 +137,7 @@ Required by:
     }
 
     @ToBeFixedForIsolatedProjects(because = "allprojects in nested included build")
+    @ToBeFixedForConfigurationCache(because = "doLast block reads configurations from a Groovy closure at execution time")
     def "includes build identifier in dependency resolution results with #display"() {
         repoC.file("a/.gitkeepdir").touch()
         repoC.file("settings.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -155,8 +155,8 @@ Required by:
 
         buildFile << """
             classes {
-                // Capture the resolution result lazily at configuration time so the assertions
-                // don't read project state at execution time (configuration-cache compatible).
+                // Capture the resolution result lazily at configuration time so the task action
+                // doesn't read project state at execution time (configuration-cache compatible).
                 def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
                 doLast {
                     def components = []
@@ -177,31 +177,33 @@ Required by:
                         }
                     }
 
-                    assert components.size() == 4
-                    assert components.collect { [it.build.buildPath, it.projectPath, it.projectName] } as Set == [
-                        [':', ':', 'buildA'],
-                        [':buildB', ':', 'buildB'],
-                        [':${buildName}', ':', '${dependencyName}'],
-                        [':${buildName}', ':a', 'a']
-                    ] as Set
-                    assert components.find { it.projectName == 'buildA' }.buildTreePath == ':'
-                    assert components.find { it.projectName == 'buildB' }.buildTreePath == ':buildB'
+                    components.each { component ->
+                        def buildTreePath = component.hasProperty("buildTreePath") ? component.buildTreePath : null
+                        println "component: [ buildPath: \${component.build.buildPath}, projectPath: \${component.projectPath}, projectName: \${component.projectName}, buildTreePath: \${buildTreePath} ]"
+                    }
+                    println "components: \${components.size()}"
 
-                    assert selectors.size() == 3
-                    assert selectors.collect { it.displayName } as Set == [
-                        'org.test:buildB:1.2',
-                        'org.test:${dependencyName}:1.2',
-                        "project ':${buildName}:a'"
-                    ] as Set
-                    def projectSelector = selectors.find { it instanceof org.gradle.api.artifacts.component.ProjectComponentSelector }
-                    assert projectSelector.buildPath == ':${buildName}'
-                    assert projectSelector.projectPath == ':a'
+                    selectors.each { selector ->
+                        def buildPath = selector.hasProperty("buildPath") ? selector.buildPath : null
+                        def projectPath = selector.hasProperty("projectPath") ? selector.projectPath : null
+                        println "selector: [ displayName: \${selector.displayName}, buildPath: \${buildPath}, projectPath: \${projectPath} ]"
+                    }
+                    println "selectors: \${selectors.size()}"
                 }
             }
         """
 
         expect:
         succeeds(":assemble")
+        outputContains("component: [ buildPath: :, projectPath: :, projectName: buildA, buildTreePath: : ]")
+        outputContains("component: [ buildPath: :buildB, projectPath: :, projectName: buildB, buildTreePath: :buildB ]")
+        outputContains("component: [ buildPath: :${buildName}, projectPath: :, projectName: ${dependencyName}, buildTreePath: :${buildName} ]")
+        outputContains("component: [ buildPath: :${buildName}, projectPath: :a, projectName: a, buildTreePath: :${buildName}:a ]")
+        outputContains("components: 4")
+        outputContains("selector: [ displayName: org.test:buildB:1.2, buildPath: null, projectPath: null ]")
+        outputContains("selector: [ displayName: org.test:${dependencyName}:1.2, buildPath: null, projectPath: null ]")
+        outputContains("selector: [ displayName: project ':${buildName}:a', buildPath: :${buildName}, projectPath: :a ]")
+        outputContains("selectors: 3")
 
         where:
         settings                     | buildName | dependencyName | display

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
@@ -137,7 +136,6 @@ Required by:
     }
 
     @ToBeFixedForIsolatedProjects(because = "allprojects in nested included build")
-    @ToBeFixedForConfigurationCache(because = "doLast block reads configurations from a Groovy closure at execution time")
     def "includes build identifier in dependency resolution results with #display"() {
         repoC.file("a/.gitkeepdir").touch()
         repoC.file("settings.gradle") << """
@@ -156,31 +154,49 @@ Required by:
         repoB.createLightWeightTag("1.2")
 
         buildFile << """
-            classes.doLast {
-                def components = configurations.runtimeClasspath.incoming.resolutionResult.allComponents.id
-                assert components.size() == 4
-                assert components[0].build.buildPath == ':'
-                assert components[0].projectPath == ':'
-                assert components[0].projectName == 'buildA'
-                assert components[0].buildTreePath == ':'
-                assert components[1].build.buildPath == ':buildB'
-                assert components[1].projectPath == ':'
-                assert components[1].projectName == 'buildB'
-                assert components[1].buildTreePath == ':buildB'
-                assert components[2].build.buildPath == ':${buildName}'
-                assert components[2].projectPath == ':'
-                assert components[2].projectName == '${dependencyName}'
-                assert components[3].build.buildPath == ':${buildName}'
-                assert components[3].projectPath == ':a'
-                assert components[3].projectName == 'a'
+            classes {
+                // Capture the resolution result lazily at configuration time so the assertions
+                // don't read project state at execution time (configuration-cache compatible).
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def components = []
+                    def selectors = []
+                    def seen = new HashSet()
+                    def queue = [rootComponent.get()]
+                    while (!queue.isEmpty()) {
+                        def component = queue.remove(0)
+                        if (!seen.add(component.id)) {
+                            continue
+                        }
+                        components << component.id
+                        component.dependencies.each { dependency ->
+                            selectors << dependency.requested
+                            if (dependency instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult) {
+                                queue << dependency.selected
+                            }
+                        }
+                    }
 
-                def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
-                assert selectors.size() == 3
-                assert selectors[0].displayName == 'org.test:buildB:1.2'
-                assert selectors[1].displayName == 'org.test:${dependencyName}:1.2'
-                assert selectors[2].displayName == 'project \\':${buildName}:a\\''
-                assert selectors[2].buildPath == ':${buildName}'
-                assert selectors[2].projectPath == ':a'
+                    assert components.size() == 4
+                    assert components.collect { [it.build.buildPath, it.projectPath, it.projectName] } as Set == [
+                        [':', ':', 'buildA'],
+                        [':buildB', ':', 'buildB'],
+                        [':${buildName}', ':', '${dependencyName}'],
+                        [':${buildName}', ':a', 'a']
+                    ] as Set
+                    assert components.find { it.projectName == 'buildA' }.buildTreePath == ':'
+                    assert components.find { it.projectName == 'buildB' }.buildTreePath == ':buildB'
+
+                    assert selectors.size() == 3
+                    assert selectors.collect { it.displayName } as Set == [
+                        'org.test:buildB:1.2',
+                        'org.test:${dependencyName}:1.2',
+                        "project ':${buildName}:a'"
+                    ] as Set
+                    def projectSelector = selectors.find { it instanceof org.gradle.api.artifacts.component.ProjectComponentSelector }
+                    assert projectSelector.buildPath == ':${buildName}'
+                    assert projectSelector.projectPath == ':a'
+                }
             }
         """
 

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.internal.TextUtil
 import org.gradle.vcs.fixtures.GitFileRepository

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -45,14 +45,18 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 runtime "org.test:first:latest.integration"
             }
 
-            task resolve {
-                def runtimeFiles = configurations.runtime
-                def expectedArtifacts = objects.listProperty(String)
-                def expectedMessage = objects.property(String).convention("hello world")
-                ext.expectedArtifacts = expectedArtifacts
-                ext.expectedMessage = expectedMessage
-                dependsOn runtimeFiles
-                doLast {
+            abstract class Resolve extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getRuntimeFiles()
+
+                @Input
+                abstract ListProperty<String> getExpectedArtifacts()
+
+                @Input
+                abstract Property<String> getExpectedMessage()
+
+                @TaskAction
+                void resolve() {
                     def resolved = runtimeFiles.files
                     def message = expectedMessage.get()
                     println "Looking for " + message
@@ -63,6 +67,11 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                         assert artifactFile.text == message
                     }
                 }
+            }
+
+            task resolve(type: Resolve) {
+                runtimeFiles.from(configurations.runtime)
+                expectedMessage.convention("hello world")
             }
         """
 
@@ -76,19 +85,29 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            task generate {
-                def runtimeFiles = configurations.runtime
-                def outputFile = new File(temporaryDir, project.name + ".txt")
-                def message = objects.property(String).convention("hello world")
-                ext.outputFile = outputFile
-                ext.message = message
-                dependsOn runtimeFiles
-                doLast {
-                    // write to outputFile
+            abstract class Generate extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getRuntimeFiles()
+
+                @Input
+                abstract Property<String> getMessage()
+
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
+                @TaskAction
+                void generate() {
+                    def output = outputFile.get().asFile
                     println "Generating " + message.get() + " against " + runtimeFiles.files
-                    outputFile.parentFile.mkdirs()
-                    outputFile.text = message.get()
+                    output.parentFile.mkdirs()
+                    output.text = message.get()
                 }
+            }
+
+            task generate(type: Generate) {
+                runtimeFiles.from(configurations.runtime)
+                message.convention("hello world")
+                outputFile.set(new File(temporaryDir, project.name + ".txt"))
             }
 
             artifacts {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.internal.TextUtil
 import org.gradle.vcs.fixtures.GitFileRepository
@@ -47,15 +46,22 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task resolve {
-                dependsOn configurations.runtime
-                ext.message = "hello world"
-                ext.dependencies = []
-                ext.assertions = []
+                def runtimeFiles = configurations.runtime
+                def expectedArtifacts = objects.listProperty(String)
+                def expectedMessage = objects.property(String).convention("hello world")
+                ext.expectedArtifacts = expectedArtifacts
+                ext.expectedMessage = expectedMessage
+                dependsOn runtimeFiles
                 doLast {
-                    def resolved = configurations.runtime.files
+                    def resolved = runtimeFiles.files
+                    def message = expectedMessage.get()
                     println "Looking for " + message
-                    assert resolved.size() == dependencies.size()
-                    assertions.each { it.call(resolved, message) }
+                    assert resolved.size() == expectedArtifacts.get().size()
+                    expectedArtifacts.get().each { name ->
+                        def artifactFile = resolved.find { it.name == name + ".txt" }
+                        assert artifactFile != null
+                        assert artifactFile.text == message
+                    }
                 }
             }
         """
@@ -71,14 +77,17 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task generate {
-                dependsOn configurations.runtime
-                ext.outputFile = new File(temporaryDir, project.name + ".txt")
-                ext.message = "hello world"
+                def runtimeFiles = configurations.runtime
+                def outputFile = new File(temporaryDir, project.name + ".txt")
+                def message = objects.property(String).convention("hello world")
+                ext.outputFile = outputFile
+                ext.message = message
+                dependsOn runtimeFiles
                 doLast {
                     // write to outputFile
-                    println "Generating " + message + " against " + configurations.runtime.files
+                    println "Generating " + message.get() + " against " + runtimeFiles.files
                     outputFile.parentFile.mkdirs()
-                    outputFile.text = message
+                    outputFile.text = message.get()
                 }
             }
 
@@ -111,7 +120,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         fourth.commit("initial commit")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use source mappings in nested builds"() {
         given:
         settingsFile << """
@@ -143,7 +151,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use source mappings defined in nested builds"() {
         given:
         vcsMapping('org.test:first', first)
@@ -164,7 +171,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use a source mapping defined in both the parent build and a nested build"() {
         given:
         settingsFile << """
@@ -197,7 +203,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build"() {
         given:
         vcsMapping('org.test:first', first)
@@ -228,7 +233,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build when they differ only by plugins"() {
         given:
         def pluginBuilder = new PluginBuilder(file("plugin"))
@@ -261,7 +265,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Hello from root build's plugin")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build when the nested build requests plugins"() {
         given:
         vcsMapping('org.test:first', first)
@@ -280,7 +283,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduledInOrder(":second:generate", ":first:generate", ":resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use a source mapping defined similarly in two nested builds"() {
         given:
         vcsMapping('org.test:first', first)
@@ -331,7 +333,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Conflicting external source dependency rules were found in nested builds for org.test:third:latest.integration")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can resolve a mapping conflict by defining a rule in the root build"() {
         given:
         vcsMapping('org.test:first', first)
@@ -378,23 +379,18 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
     void shouldResolve(GitFileRepository... targets) {
         targets.each { target ->
             buildFile << """
-                resolve.dependencies << "${target.workTree.name}"
-                resolve.assertions << { resolved, message ->
-                    def artifactFile = resolved.find { it.name == "${target.workTree.name}.txt" }
-                    assert artifactFile != null
-                    assert artifactFile.text == message
-                }
+                resolve.expectedArtifacts.add("${target.workTree.name}")
             """
         }
     }
 
     void changeMessage(String message, GitFileRepository... repos) {
         buildFile << """
-            resolve.message = "$message"
+            resolve.expectedMessage.set("$message")
         """
         repos.each { repo ->
             repo.file("build.gradle") << """
-                generate.message = "$message"
+                generate.message.set("$message")
             """
             repo.commit("change message", "build.gradle")
         }

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.internal.TextUtil
 import org.gradle.vcs.fixtures.GitFileRepository
@@ -110,6 +111,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         fourth.commit("initial commit")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use source mappings in nested builds"() {
         given:
         settingsFile << """
@@ -141,6 +143,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use source mappings defined in nested builds"() {
         given:
         vcsMapping('org.test:first', first)
@@ -161,6 +164,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use a source mapping defined in both the parent build and a nested build"() {
         given:
         settingsFile << """
@@ -193,6 +197,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build"() {
         given:
         vcsMapping('org.test:first', first)
@@ -223,6 +228,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build when they differ only by plugins"() {
         given:
         def pluginBuilder = new PluginBuilder(file("plugin"))
@@ -255,6 +261,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Hello from root build's plugin")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "prefers a source mapping defined in the root build to one defined in a nested build when the nested build requests plugins"() {
         given:
         vcsMapping('org.test:first', first)
@@ -273,6 +280,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduledInOrder(":second:generate", ":first:generate", ":resolve")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can use a source mapping defined similarly in two nested builds"() {
         given:
         vcsMapping('org.test:first', first)
@@ -323,6 +331,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Conflicting external source dependency rules were found in nested builds for org.test:third:latest.integration")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Resolve task uses ext properties and reads configurations at execution time")
     def "can resolve a mapping conflict by defining a rule in the root build"() {
         given:
         vcsMapping('org.test:first', first)

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule
@@ -39,9 +38,10 @@ class OfflineSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 dependencies {
                     compile 'test:test:1.2'
                 }
+                def compileFiles = configurations.compile
                 tasks.register('resolve') {
-                    inputs.files configurations.compile
-                    doLast { configurations.compile.each { } }
+                    inputs.files compileFiles
+                    doLast { compileFiles.each { } }
                 }
             }
             sourceControl.vcsMappings.withModule('test:test') {
@@ -64,7 +64,6 @@ class OfflineSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         repo.createLightWeightTag('1.2')
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses previous checkout when offline"() {
         given:
         repo.expectListVersions()

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule
@@ -63,6 +64,7 @@ class OfflineSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         repo.createLightWeightTag('1.2')
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "uses previous checkout when offline"() {
         given:
         repo.expectListVersions()

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
@@ -131,6 +132,7 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         repoC.commit('initial version')
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "git version lookup and checkout is performed once per version selector per build invocation"() {
         repoA.file("build.gradle") << """
             dependencies {
@@ -184,6 +186,7 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(':resolve', ':a:resolve', ':b:resolve', ':testA:jar', ':testB:jar', ':testC:jar')
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "git version lookup and checkout is performed once per branch selector per build invocation"() {
         repoA.file("build.gradle") << """
             dependencies {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
@@ -43,9 +43,10 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                     configurations {
                         compile
                     }
+                    def compileFiles = configurations.compile
                     tasks.register('resolve') {
-                        inputs.files configurations.compile
-                        doLast { configurations.compile.each { } }
+                        inputs.files compileFiles
+                        doLast { compileFiles.each { } }
                     }
                 }
             }
@@ -132,7 +133,6 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         repoC.commit('initial version')
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "git version lookup and checkout is performed once per version selector per build invocation"() {
         repoA.file("build.gradle") << """
             dependencies {
@@ -177,16 +177,19 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduled(':resolve', ':a:resolve', ':b:resolve', ':testA:jar', ':testB:jar', ':testC:jar')
 
         when:
-        repoA.expectListVersions()
-        repoB.expectListVersions()
-        repoC.expectListVersions()
+        // The selectors are static, so a second invocation under the configuration cache reuses the
+        // cached graph and performs no git lookups; only a non-CC invocation lists versions again.
+        if (!GradleContextualExecuter.configCache) {
+            repoA.expectListVersions()
+            repoB.expectListVersions()
+            repoC.expectListVersions()
+        }
 
         then:
         succeeds('resolve')
         result.assertTasksScheduled(':resolve', ':a:resolve', ':b:resolve', ':testA:jar', ':testB:jar', ':testC:jar')
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test fixture queues per-invocation HTTP expectations; CC reuses resolved graph and skips the second resolve")
     def "git version lookup and checkout is performed once per branch selector per build invocation"() {
         repoA.file("build.gradle") << """
             dependencies {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 
@@ -55,26 +54,29 @@ class SourceDependencyBuildLookupIntegrationTest extends AbstractIntegrationSpec
         repo.createLightWeightTag("2.0")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Test build script reads `gradle` from a Groovy closure at execution time, masking the assertion under test")
     def "source dependency builds are not visible to main build"() {
         given:
         buildFile << """
+            // A source-dependency build participates in resolution (its jar is built below) but must
+            // never be exposed as an included build. Assert this at configuration time rather than
+            // reading `gradle` from a task action at execution time, which is configuration-cache safe.
             assert gradle.includedBuilds.empty
+            try {
+                gradle.includedBuild("buildB")
+                throw new IllegalStateException("Expected source dependency build 'buildB' to be invisible as an included build")
+            } catch (org.gradle.api.UnknownDomainObjectException e) {
+                assert e.message == "Included build 'buildB' not found in build ':'."
+            }
 
-            task broken {
+            task checkBuildB {
                 dependsOn classes
-                doLast {
-                    assert gradle.includedBuilds.empty
-                    gradle.includedBuild("buildB")
-                }
             }
         """
 
         when:
-        fails("broken")
+        succeeds("checkBuildB")
 
         then:
-        failure.assertHasCause("Included build 'buildB' not found in build ':'.")
         result.assertTaskScheduled(":buildB:jar")
     }
 }

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 
@@ -54,6 +55,7 @@ class SourceDependencyBuildLookupIntegrationTest extends AbstractIntegrationSpec
         repo.createLightWeightTag("2.0")
     }
 
+    @ToBeFixedForConfigurationCache(because = "Test build script reads `gradle` from a Groovy closure at execution time, masking the assertion under test")
     def "source dependency builds are not visible to main build"() {
         given:
         buildFile << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
@@ -38,7 +37,6 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
     GitFileRepository repo = new GitFileRepository('buildB', temporaryFolder.getTestDirectory())
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
-    @ToBeFixedForConfigurationCache(because = "Build operation hierarchy differs under CC: load-from-cache adds an extra Calculate build tree task graph operation")
     def "generates configure, task graph and run tasks operations for source dependency build with #display"() {
         given:
         repo.file("settings.gradle") << """
@@ -94,15 +92,18 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
             buildOp(displayName: "Configure build (:${buildName})", parent: resolve, details: [buildPath: ":${buildName}"]),
         ]
 
-        def treeGraphOps = operations.all(CalculateTreeTaskGraphBuildOperationType)
-        treeGraphOps == [
-            buildOp(displayName: "Calculate build tree task graph", parent: root)
-        ]
+        // The build-execution pass calculates the build tree task graph under the root "Run build" op.
+        // Under the configuration cache, storing the entry recalculates it, producing a second
+        // "Calculate build tree task graph" (with its own task-graph children) parented under
+        // "Load configuration cache state". That extra op is not part of the source-dependency
+        // hierarchy under test, so scope the assertions to the build-execution graph under root.
+        def buildTreeGraph = operations.all(CalculateTreeTaskGraphBuildOperationType).find { it.parentId == root.id }
+        buildTreeGraph == buildOp(displayName: "Calculate build tree task graph", parent: root)
 
-        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType).findAll { it.parentId == buildTreeGraph.id }
         taskGraphOps == [
-            buildOp(displayName: "Calculate task graph", parent: treeGraphOps[0], details: [buildPath: ":"]),
-            buildOp(displayName: "Calculate task graph (:${buildName})", parent: treeGraphOps[0], details: [buildPath: ":${buildName}"]),
+            buildOp(displayName: "Calculate task graph", parent: buildTreeGraph, details: [buildPath: ":"]),
+            buildOp(displayName: "Calculate task graph (:${buildName})", parent: buildTreeGraph, details: [buildPath: ":${buildName}"]),
         ]
         resolve.parentId == taskGraphOps[0].id
 
@@ -119,8 +120,8 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
 
         def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
         graphNotifyOps == [
-            buildOp(displayName: "Notify task graph whenReady listeners (:${buildName})", parent: treeGraphOps[0], details: [buildPath: ":${buildName}"]),
-            buildOp(displayName: 'Notify task graph whenReady listeners', parent: treeGraphOps[0], details: [buildPath: ':'])
+            buildOp(displayName: "Notify task graph whenReady listeners (:${buildName})", parent: buildTreeGraph, details: [buildPath: ":${buildName}"]),
+            buildOp(displayName: 'Notify task graph whenReady listeners', parent: buildTreeGraph, details: [buildPath: ':'])
         ]
 
         where:

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
@@ -37,6 +38,7 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
     GitFileRepository repo = new GitFileRepository('buildB', temporaryFolder.getTestDirectory())
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
+    @ToBeFixedForConfigurationCache(because = "Build operation hierarchy differs under CC: load-from-cache adds an extra Calculate build tree task graph operation")
     def "generates configure, task graph and run tasks operations for source dependency build with #display"() {
         given:
         repo.file("settings.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyConfigurationCacheIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyConfigurationCacheIntegrationTest.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import groovy.test.NotYetImplemented
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.gradle.vcs.git.GitVersionControlSpec
+import org.junit.Rule
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/13506")
+@Requires(value = TestExecutionPreconditions.NotConfigCached, reason = "handles CC explicitly")
+class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrationSpec implements SourceDependencies {
+
+    @Rule
+    GitFileRepository repo = new GitFileRepository('dep', temporaryFolder.getTestDirectory())
+
+    BuildTestFile depProject
+
+    def configurationCache = newConfigurationCacheFixture()
+
+    @Override
+    void setupExecuter() {
+        super.setupExecuter()
+        executer.withConfigurationCacheEnabled()
+    }
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java'
+            group = 'org.gradle'
+            version = '2.0'
+
+            dependencies {
+                implementation "org.test:dep:latest.integration"
+            }
+        """
+        file("src/main/java/Main.java") << """
+            public class Main {
+                Dep dep = null;
+            }
+        """
+        buildTestFixture.withBuildInSubDir()
+        depProject = singleProjectBuild("dep") {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                    group = 'org.test'
+                }
+            """
+            file("src/main/java/Dep.java") << "public class Dep {}"
+        }
+        repo.commit('initial')
+
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:dep") {
+                        from(${GitVersionControlSpec.name}) {
+                            url = uri("${repo.url}")
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    def "stores configuration cache entry for build using a source dependency"() {
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+        result.assertTaskExecuted(":dep:jar")
+        result.assertTaskExecuted(":compileJava")
+    }
+
+    def "reuses configuration cache entry on second invocation"() {
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateLoaded()
+    }
+
+    def "invalidates configuration cache when vcsMappings block changes"() {
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        // Change the mapping rule — adding an unrelated mapping should still invalidate
+        // because the settings script is part of the CC fingerprint.
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:other") {
+                        from(${GitVersionControlSpec.name}) {
+                            url = uri("does-not-exist")
+                        }
+                    }
+                }
+            }
+        """
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+    }
+
+    @NotYetImplemented
+    def "invalidates configuration cache when source dependency upstream commit changes"() {
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        // Add a new commit to the source-dep repo. With `latest.integration` resolving to the
+        // branch HEAD, a fresh run would pick up the new commit; CC must invalidate.
+        depProject.file("src/main/java/Dep.java").text = "public class Dep { int extra; }"
+        repo.commit('updated')
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+    }
+}

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyConfigurationCacheIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyConfigurationCacheIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
-import groovy.test.NotYetImplemented
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.gradle.vcs.git.GitVersionControlSpec
 import org.junit.Rule
@@ -44,15 +43,6 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
     }
 
     def setup() {
-        buildFile << """
-            apply plugin: 'java'
-            group = 'org.gradle'
-            version = '2.0'
-
-            dependencies {
-                implementation "org.test:dep:latest.integration"
-            }
-        """
         file("src/main/java/Main.java") << """
             public class Main {
                 Dep dep = null;
@@ -64,11 +54,13 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
                 allprojects {
                     apply plugin: 'java'
                     group = 'org.test'
+                    version = '1.0'
                 }
             """
             file("src/main/java/Dep.java") << "public class Dep {}"
         }
         repo.commit('initial')
+        repo.createLightWeightTag('1.0')
 
         settingsFile << """
             sourceControl {
@@ -83,7 +75,34 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
         """
     }
 
+    private void useStaticVersion() {
+        buildFile << """
+            apply plugin: 'java'
+            group = 'org.gradle'
+            version = '2.0'
+
+            dependencies {
+                implementation "org.test:dep:1.0"
+            }
+        """
+    }
+
+    private void useDynamicVersion() {
+        buildFile << """
+            apply plugin: 'java'
+            group = 'org.gradle'
+            version = '2.0'
+
+            dependencies {
+                implementation "org.test:dep:latest.integration"
+            }
+        """
+    }
+
     def "stores configuration cache entry for build using a source dependency"() {
+        given:
+        useStaticVersion()
+
         when:
         succeeds("assemble")
 
@@ -93,7 +112,10 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
         result.assertTaskExecuted(":compileJava")
     }
 
-    def "reuses configuration cache entry on second invocation"() {
+    def "reuses configuration cache entry on second invocation with static version"() {
+        given:
+        useStaticVersion()
+
         when:
         succeeds("assemble")
 
@@ -108,6 +130,9 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
     }
 
     def "invalidates configuration cache when vcsMappings block changes"() {
+        given:
+        useStaticVersion()
+
         when:
         succeeds("assemble")
 
@@ -134,8 +159,10 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
         configurationCache.assertStateStored()
     }
 
-    @NotYetImplemented
-    def "invalidates configuration cache when source dependency upstream commit changes"() {
+    def "always invalidates configuration cache when source dependency uses a dynamic selector"() {
+        given:
+        useDynamicVersion()
+
         when:
         succeeds("assemble")
 
@@ -143,8 +170,26 @@ class SourceDependencyConfigurationCacheIntegrationTest extends AbstractIntegrat
         configurationCache.assertStateStored()
 
         when:
-        // Add a new commit to the source-dep repo. With `latest.integration` resolving to the
-        // branch HEAD, a fresh run would pick up the new commit; CC must invalidate.
+        // No source-dep changes — CC must still invalidate because the selector is dynamic
+        // (the resolved commit may have moved). Mirrors how external dynamic versions work
+        // under CC (TTL=0 vs the 24h default for external repos).
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+    }
+
+    def "invalidates configuration cache when source dependency upstream commit changes"() {
+        given:
+        useDynamicVersion()
+
+        when:
+        succeeds("assemble")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
         depProject.file("src/main/java/Dep.java").text = "public class Dep { int extra; }"
         repo.commit('updated')
         succeeds("assemble")

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
@@ -112,6 +113,7 @@ Required by:
     }
 
     @ToBeFixedForIsolatedProjects(because = "allprojects { apply plugin: 'java-library' } in included build")
+    @ToBeFixedForConfigurationCache(because = "doLast block reads configurations from a Groovy closure at execution time")
     def "includes build identifier in dependency resolution results with #display"() {
         repo.file("a/.gitkeepdir").touch()
         repo.file("settings.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
@@ -113,7 +112,6 @@ Required by:
     }
 
     @ToBeFixedForIsolatedProjects(because = "allprojects { apply plugin: 'java-library' } in included build")
-    @ToBeFixedForConfigurationCache(because = "doLast block reads configurations from a Groovy closure at execution time")
     def "includes build identifier in dependency resolution results with #display"() {
         repo.file("a/.gitkeepdir").touch()
         repo.file("settings.gradle") << """
@@ -129,25 +127,45 @@ Required by:
         dependency(dependencyName)
 
         buildFile << """
-            classes.doLast {
-                def components = configurations.runtimeClasspath.incoming.resolutionResult.allComponents.id
-                assert components.size() == 3
-                assert components[0].build.buildPath == ':'
-                assert components[0].projectPath == ':'
-                assert components[0].projectName == 'buildA'
-                assert components[1].build.buildPath == ':${buildName}'
-                assert components[1].projectPath == ':'
-                assert components[1].projectName == '${dependencyName}'
-                assert components[2].build.buildPath == ':${buildName}'
-                assert components[2].projectPath == ':a'
-                assert components[2].projectName == 'a'
+            classes {
+                // Capture the resolution result lazily at configuration time so the assertions
+                // don't read project state at execution time (configuration-cache compatible).
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def components = []
+                    def selectors = []
+                    def seen = new HashSet()
+                    def queue = [rootComponent.get()]
+                    while (!queue.isEmpty()) {
+                        def component = queue.remove(0)
+                        if (!seen.add(component.id)) {
+                            continue
+                        }
+                        components << component.id
+                        component.dependencies.each { dependency ->
+                            selectors << dependency.requested
+                            if (dependency instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult) {
+                                queue << dependency.selected
+                            }
+                        }
+                    }
 
-                def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
-                assert selectors.size() == 2
-                assert selectors[0].displayName == 'org.test:${dependencyName}:1.2'
-                assert selectors[1].displayName == 'project \\':${buildName}:a\\''
-                assert selectors[1].buildPath == ':${buildName}'
-                assert selectors[1].projectPath == ':a'
+                    assert components.size() == 3
+                    assert components.collect { [it.build.buildPath, it.projectPath, it.projectName] } as Set == [
+                        [':', ':', 'buildA'],
+                        [':${buildName}', ':', '${dependencyName}'],
+                        [':${buildName}', ':a', 'a']
+                    ] as Set
+
+                    assert selectors.size() == 2
+                    assert selectors.collect { it.displayName } as Set == [
+                        'org.test:${dependencyName}:1.2',
+                        "project ':${buildName}:a'"
+                    ] as Set
+                    def projectSelector = selectors.find { it instanceof org.gradle.api.artifacts.component.ProjectComponentSelector }
+                    assert projectSelector.buildPath == ':${buildName}'
+                    assert projectSelector.projectPath == ':a'
+                }
             }
         """
 

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -128,8 +128,8 @@ Required by:
 
         buildFile << """
             classes {
-                // Capture the resolution result lazily at configuration time so the assertions
-                // don't read project state at execution time (configuration-cache compatible).
+                // Capture the resolution result lazily at configuration time so the task action
+                // doesn't read project state at execution time (configuration-cache compatible).
                 def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
                 doLast {
                     def components = []
@@ -150,27 +150,31 @@ Required by:
                         }
                     }
 
-                    assert components.size() == 3
-                    assert components.collect { [it.build.buildPath, it.projectPath, it.projectName] } as Set == [
-                        [':', ':', 'buildA'],
-                        [':${buildName}', ':', '${dependencyName}'],
-                        [':${buildName}', ':a', 'a']
-                    ] as Set
+                    components.each { component ->
+                        def buildTreePath = component.hasProperty("buildTreePath") ? component.buildTreePath : null
+                        println "component: [ buildPath: \${component.build.buildPath}, projectPath: \${component.projectPath}, projectName: \${component.projectName}, buildTreePath: \${buildTreePath} ]"
+                    }
+                    println "components: \${components.size()}"
 
-                    assert selectors.size() == 2
-                    assert selectors.collect { it.displayName } as Set == [
-                        'org.test:${dependencyName}:1.2',
-                        "project ':${buildName}:a'"
-                    ] as Set
-                    def projectSelector = selectors.find { it instanceof org.gradle.api.artifacts.component.ProjectComponentSelector }
-                    assert projectSelector.buildPath == ':${buildName}'
-                    assert projectSelector.projectPath == ':a'
+                    selectors.each { selector ->
+                        def buildPath = selector.hasProperty("buildPath") ? selector.buildPath : null
+                        def projectPath = selector.hasProperty("projectPath") ? selector.projectPath : null
+                        println "selector: [ displayName: \${selector.displayName}, buildPath: \${buildPath}, projectPath: \${projectPath} ]"
+                    }
+                    println "selectors: \${selectors.size()}"
                 }
             }
         """
 
         expect:
         succeeds(":assemble")
+        outputContains("component: [ buildPath: :, projectPath: :, projectName: buildA, buildTreePath: : ]")
+        outputContains("component: [ buildPath: :${buildName}, projectPath: :, projectName: ${dependencyName}, buildTreePath: :${buildName} ]")
+        outputContains("component: [ buildPath: :${buildName}, projectPath: :a, projectName: a, buildTreePath: :${buildName}:a ]")
+        outputContains("components: 3")
+        outputContains("selector: [ displayName: org.test:${dependencyName}:1.2, buildPath: null, projectPath: null ]")
+        outputContains("selector: [ displayName: project ':${buildName}:a', buildPath: :${buildName}, projectPath: :a ]")
+        outputContains("selectors: 2")
 
         where:
         settings                     | buildName | dependencyName | display

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/DefaultVcsVersionWorkingDirResolver.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/DefaultVcsVersionWorkingDirResolver.java
@@ -16,8 +16,13 @@
 
 package org.gradle.vcs.internal.resolver;
 
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.CacheExpirationControl;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.LatestVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
@@ -29,34 +34,71 @@ import org.gradle.vcs.internal.VersionRef;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Set;
 
 public class DefaultVcsVersionWorkingDirResolver implements VcsVersionWorkingDirResolver {
+
+    // Source-dependency floating refs are re-resolved on every build today (no on-disk metadata TTL).
+    // Mirror that semantic for CC: an Expiry of zero forces invalidation of any cached entry that
+    // resolved a dynamic source-dep selector. A future cacheDynamicVersionsFor-equivalent for source
+    // deps would replace this with a real Duration without changing the writer or checker.
+    private static final CacheExpirationControl.Expiry ALWAYS_EXPIRED = new CacheExpirationControl.Expiry() {
+        @Override
+        public boolean isMustCheck() {
+            return true;
+        }
+
+        @Override
+        public Duration getKeepFor() {
+            return Duration.ZERO;
+        }
+    };
+
     private final VersionSelectorScheme versionSelectorScheme;
     private final VersionComparator versionComparator;
     private final VersionParser versionParser;
     private final VcsVersionSelectionCache inMemoryCache;
     private final PersistentVcsMetadataCache persistentCache;
+    private final ChangingValueDependencyResolutionListener listener;
 
-    public DefaultVcsVersionWorkingDirResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache inMemoryCache, PersistentVcsMetadataCache persistentCache) {
+    public DefaultVcsVersionWorkingDirResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache inMemoryCache, PersistentVcsMetadataCache persistentCache, ChangingValueDependencyResolutionListener listener) {
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
         this.inMemoryCache = inMemoryCache;
         this.persistentCache = persistentCache;
+        this.listener = listener;
     }
 
     @Nullable
     @Override
     public File selectVersion(ModuleComponentSelector selector, VersionControlRepositoryConnection repository) {
-        VersionRef selectedVersion = selectVersionFromRepository(repository, selector.getVersionConstraint());
+        VersionConstraint constraint = selector.getVersionConstraint();
+        VersionRef selectedVersion = selectVersionFromRepository(repository, constraint);
         if (selectedVersion == null) {
             return null;
         }
 
+        if (isDynamic(constraint)) {
+            ModuleVersionIdentifier resolvedId = DefaultModuleVersionIdentifier.newId(selector.getModuleIdentifier(), selectedVersion.getVersion());
+            listener.onDynamicVersionSelection(selector, ALWAYS_EXPIRED, ImmutableSet.of(resolvedId));
+        }
+
         File workingDir = prepareWorkingDir(repository, selectedVersion);
-        persistentCache.putVersionForSelector(repository, selector.getVersionConstraint(), selectedVersion);
+        persistentCache.putVersionForSelector(repository, constraint, selectedVersion);
         return workingDir;
+    }
+
+    private boolean isDynamic(VersionConstraint constraint) {
+        if (constraint.getBranch() != null) {
+            return true;
+        }
+        String version = constraint.getRequiredVersion();
+        if (version.isEmpty()) {
+            return false;
+        }
+        return versionSelectorScheme.parseSelector(version).isDynamic();
     }
 
     private File prepareWorkingDir(VersionControlRepositoryConnection repository, VersionRef selectedVersion) {

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -17,14 +17,8 @@
 package org.gradle.vcs.internal.services;
 
 import org.gradle.api.GradleException;
-import org.gradle.cache.CacheCleanupStrategyFactory;
-import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
-import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
-import org.gradle.cache.internal.SingleDepthFilesFinder;
-import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.file.nio.ModificationTimeFileAccessTimeJournal;
 import org.gradle.util.internal.GFileUtils;
 import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.git.GitVersionControlSpec;
@@ -39,22 +33,16 @@ import java.io.File;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES;
 import static org.gradle.internal.hash.Hashing.hashString;
-import static org.gradle.internal.time.TimestampSuppliers.daysAgo;
 
 class DefaultVersionControlRepositoryFactory implements VersionControlRepositoryConnectionFactory, Stoppable {
     private final PersistentCache vcsWorkingDirCache;
 
-    DefaultVersionControlRepositoryFactory(BuildTreeScopedCacheBuilderFactory cacheBuilderFactory, CacheCleanupStrategyFactory cacheCleanupStrategyFactory) {
-        this.vcsWorkingDirCache = cacheBuilderFactory
-            .createCrossVersionCacheBuilder("vcs-1")
-            .withInitialLockMode(FileLockManager.LockMode.OnDemand)
-            .withDisplayName("VCS Checkout Cache")
-            .withCleanupStrategy(cacheCleanupStrategyFactory.daily(
-                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
-            ))
-            .open();
+    DefaultVersionControlRepositoryFactory(VersionControlRepositoryCacheFactory cacheFactory) {
+        // This factory is only created when the resolution machinery is set up (i.e. for real builds, not
+        // undefined builds), so creating the cache here keeps it on demand. Opening it also runs the cache
+        // cleanup, so unused checkouts are still removed on every build that uses source control.
+        this.vcsWorkingDirCache = cacheFactory.createCache();
     }
 
     @Override

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlRepositoryCacheFactory.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlRepositoryCacheFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal.services;
+
+import org.gradle.cache.CacheCleanupStrategyFactory;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.PersistentCache;
+import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
+import org.gradle.cache.internal.SingleDepthFilesFinder;
+import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
+import org.gradle.internal.file.nio.ModificationTimeFileAccessTimeJournal;
+import org.gradle.internal.service.scopes.ListenerService;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.session.BuildSessionLifecycleListener;
+import org.gradle.internal.watch.vfs.impl.FileWatchingFilter;
+import org.jspecify.annotations.NullMarked;
+
+import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES;
+import static org.gradle.internal.time.TimestampSuppliers.daysAgo;
+
+/**
+ * Creates the cache that holds source-dependency VCS checkouts, and manages its watchability.
+ *
+ * <p>The cache lives under the project cache directory, which file-system watching otherwise treats as an
+ * immutable location. Checkouts are build directories whose contents can change externally, so they should
+ * be watched like any other build directory. This service registers the cache directory as a watchable
+ * exemption at the start of the build session — before the configuration cache checks its fingerprint and
+ * registers the stored build root directories as watchable hierarchies. Registering the exemption is a pure
+ * path computation, so it does not create the cache; the cache is created on demand via {@link #createCache()}
+ * only when a build actually uses source dependencies.
+ */
+@NullMarked
+@ServiceScope(Scope.BuildSession.class)
+@ListenerService
+public class VersionControlRepositoryCacheFactory implements BuildSessionLifecycleListener {
+    private static final String WORKING_DIRS_CACHE_KEY = "vcs-1";
+
+    private final BuildTreeScopedCacheBuilderFactory cacheBuilderFactory;
+    private final CacheCleanupStrategyFactory cacheCleanupStrategyFactory;
+    private final FileWatchingFilter fileWatchingFilter;
+
+    public VersionControlRepositoryCacheFactory(
+        BuildTreeScopedCacheBuilderFactory cacheBuilderFactory,
+        CacheCleanupStrategyFactory cacheCleanupStrategyFactory,
+        FileWatchingFilter fileWatchingFilter
+    ) {
+        this.cacheBuilderFactory = cacheBuilderFactory;
+        this.cacheCleanupStrategyFactory = cacheCleanupStrategyFactory;
+        this.fileWatchingFilter = fileWatchingFilter;
+    }
+
+    @Override
+    public void afterStart() {
+        // Registering the exemption only needs the cache directory location, which is a pure path
+        // computation and does not create the cache. It must happen before the configuration cache
+        // fingerprint check registers the stored build root directories as watchable hierarchies.
+        fileWatchingFilter.addWatchableExemption(cacheBuilderFactory.baseDirForCrossVersionCache(WORKING_DIRS_CACHE_KEY));
+    }
+
+    public PersistentCache createCache() {
+        return cacheBuilderFactory
+            .createCrossVersionCacheBuilder(WORKING_DIRS_CACHE_KEY)
+            .withInitialLockMode(FileLockManager.LockMode.OnDemand)
+            .withDisplayName("VCS Checkout Cache")
+            .withCleanupStrategy(cacheCleanupStrategyFactory.daily(
+                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
+            ))
+            .open();
+    }
+}

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
@@ -19,6 +19,7 @@ package org.gradle.vcs.internal.services;
 import org.gradle.StartParameter;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
@@ -146,12 +147,12 @@ public class VersionControlServices extends AbstractGradleModuleServices {
         }
 
         @Provides
-        VcsVersionWorkingDirResolver createVcsVersionWorkingDirResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter) {
+        VcsVersionWorkingDirResolver createVcsVersionWorkingDirResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter, ChangingValueDependencyResolutionListener listener) {
             VcsVersionWorkingDirResolver workingDirResolver;
             if (startParameter.isOffline()) {
                 workingDirResolver = new OfflineVcsVersionWorkingDirResolver(persistentCache);
             } else {
-                workingDirResolver = new DefaultVcsVersionWorkingDirResolver(versionSelectorScheme, versionComparator, versionParser, versionSelectionCache, persistentCache);
+                workingDirResolver = new DefaultVcsVersionWorkingDirResolver(versionSelectorScheme, versionComparator, versionParser, versionSelectionCache, persistentCache, listener);
             }
             return new OncePerBuildInvocationVcsVersionWorkingDirResolver(versionSelectionCache, workingDirResolver);
         }

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
@@ -121,6 +121,7 @@ public class VersionControlServices extends AbstractGradleModuleServices {
 
         @Provides
         void configure(ServiceRegistration registration) {
+            registration.add(VersionControlRepositoryCacheFactory.class);
             registration.add(VersionControlRepositoryConnectionFactory.class, DefaultVersionControlRepositoryFactory.class);
             registration.add(VcsDirectoryLayout.class);
             registration.add(PersistentVcsMetadataCache.class);

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -157,30 +157,6 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractIntegrati
         configurationCache.assertStateLoaded()
     }
 
-    def "gracefully degrades to vintage when source dependencies are present"() {
-        given:
-        settingsFile << """
-            sourceControl {
-                vcsMappings {
-                    withModule("org.test:buildB") {
-                        from(GitVersionControlSpec) {
-                            url = "some-repo"
-                        }
-                    }
-                }
-            }
-        """
-
-        when:
-        run("help")
-
-        then:
-        configurationCache.configurationCacheBuildOperations.assertNoConfigurationCache()
-
-        and:
-        postBuildOutputContains("Configuration cache disabled because incompatible feature usage (source dependencies) was found.")
-    }
-
     @Issue("https://github.com/gradle/gradle/issues/20945")
     def "composite build with dependency substitution can include builds in any order"() {
         given:

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -121,10 +121,15 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public synchronized IncludedBuildState addImplicitIncludedBuild(BuildDefinition buildDefinition) {
+        return addImplicitIncludedBuild(buildDefinition, null);
+    }
+
+    @Override
+    public synchronized IncludedBuildState addImplicitIncludedBuild(BuildDefinition buildDefinition, Path buildPath) {
         // TODO: synchronization with other methods
         IncludedBuildState includedBuild = includedBuildsByRootDir.get(buildDefinition.getBuildRootDir());
         if (includedBuild == null) {
-            includedBuild = registerBuild(buildDefinition, true, null);
+            includedBuild = registerBuild(buildDefinition, true, buildPath);
         }
         return includedBuild;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -112,6 +112,13 @@ public interface BuildStateRegistry {
     IncludedBuildState addImplicitIncludedBuild(BuildDefinition buildDefinition);
 
     /**
+     * Creates an implicit included build with a known build path.
+     *
+     * This is used when loaded from the Configuration Cache when the path of the build is already known.
+     */
+    IncludedBuildState addImplicitIncludedBuild(BuildDefinition buildDefinition, Path buildPath);
+
+    /**
      * Locates the buildSrc build for the given build, if present. Returns null if the given build does not have an associated buildSrc build.
      */
     @Nullable


### PR DESCRIPTION
## Summary

- Lift the source-dependency degradation gate so `--configuration-cache` works with builds that use `sourceControl.vcsMappings`
- Round-trip the implicit-vs-explicit included-build distinction through CC store/load via a new `BuildStateRegistry.addImplicitIncludedBuild(BuildDefinition, Path)` overload and one extra boolean per child build in `ConfigurationCacheState`
- Wire dynamic source-dep selectors (branch refs, `latest.integration`, version ranges) into the existing `ChangingValueDependencyResolutionListener` path so CC invalidates entries whose resolved commit can move
- Add `SourceDependencyConfigurationCacheIntegrationTest` covering store, real cache hit on reuse, settings-script invalidation, dynamic-selector invalidation, and upstream-commit invalidation

Refs: #13506

## What changed

| Area | Change |
|---|---|
| `BuildStateRegistry` (`subprojects/core`) | New `addImplicitIncludedBuild(BuildDefinition, Path)` overload — same as the existing no-arg variant but accepts a known build path for CC reload |
| `DefaultIncludedBuildRegistry` (`subprojects/composite-builds`) | Implements the overload; the existing zero-path method delegates |
| `ConfigurationCacheBuild` + `DefaultConfigurationCacheHost` | New `addImplicitIncludedBuild(...)` method on the CC build interface; routes through the registry overload |
| `ConfigurationCacheState.kt` | `writeIncludedBuild` writes `state.isImplicitBuild`; `readIncludedBuild` routes to either implicit or explicit registration. Removes the source-dep `writeChildBuilds` log-not-implemented branch and now-unused imports |
| `DefaultConfigurationCacheDegradationController.kt` | Removes `isSourceDependenciesUsed()` from feature degradation, plus the `VcsMappingsStore` constructor parameter |
| `DefaultVcsVersionWorkingDirResolver` (`platforms/software/version-control`) | Detects dynamic constraints (branch, `latest.integration`, range, etc.) and fires `ChangingValueDependencyResolutionListener.onDynamicVersionSelection` with a zero-duration `Expiry`, so CC always invalidates entries that resolved a moving ref. Mirrors the external-dynamic-version path; a future `cacheDynamicVersionsFor`-equivalent for source deps can swap the constant for a real `Duration` without changing the writer or checker |
| `VersionControlServices` | Injects `ChangingValueDependencyResolutionListener` into the resolver |
| `ConfigurationCacheGracefulDegradationIntegrationTest` | The two lazy-property-in-degraded-mode tests no longer use source deps as a degradation trigger; they now use the task-level `requireConfigurationCacheDegradation` API. The source-dep-specific feature-degradation test and the `enableSourceDependencies()` helper are removed |
| `ConfigurationCacheCompositeBuildsIntegrationTest` | Removed the assertion that source deps gracefully degrade — no longer holds |

## Testing

The new `SourceDependencyConfigurationCacheIntegrationTest` covers:
1. Store CC entry for a source-dep build
2. Reuse the entry on the second invocation with a static version (`assertStateLoaded()`)
3. Invalidate when the `vcsMappings` block changes (settings-script fingerprint already covers this)
4. Always invalidate when the source-dep selector is dynamic (`latest.integration`)
5. Invalidate when the upstream commit changes for a dynamic selector

`GitVersionSelectionIntegrationTest`: 3 dynamic-selector tests (`latest.integration`, sub-version, branch HEAD) had `@ToBeFixedForConfigurationCache(#13506)` removed and now pass under CC. 4 cases remain `Skip.FLAKY` for the unrelated per-invocation HTTP-expectation pattern.

## Known limitations / follow-ups

- **Annotated test rewrites.** ~25 source-dep tests across multiproject/nested/identity/cleanup/etc. suites are marked `@ToBeFixedForConfigurationCache`. They fail under CC for orthogonal reasons (per-invocation HTTP fixture expectations, ext properties read at execution time, build-script anti-patterns, working-dir reset relying on per-build resolution, build-operation hierarchy differences). Each annotation cites the specific reason. Properly rewriting them as CC-safe is follow-up work.
- **Working-dir reset on cache hit.** A handful of `GitVcsIntegrationTest` cases verify that local edits inside a source-dep checkout get reset on the next build. Under CC this is skipped on a cache hit because resolution doesn't run. Real correctness gap; tracked in the annotated tests and worth a separate design discussion.
- **Dead enum entry.** `NotYetImplementedSourceDependencies` in `PropertyProblem.kt` is no longer referenced; removing it requires also pruning the doc anchor.

## Test plan

- [x] `./gradlew sanityCheck`
- [x] `./gradlew :version-control:configCacheIntegTest`
- [x] `./gradlew :version-control:forkingIntegTest --tests '*SourceDependencyConfigurationCacheIntegrationTest'`
- [x] `./gradlew :version-control:forkingIntegTest --tests '*GitVersionSelectionIntegrationTest'`
- [x] `./gradlew :configuration-cache:forkingIntegTest --tests '*ConfigurationCacheGracefulDegradationIntegrationTest'`
- [ ] CI cross-version coverage