### PR TITLE
Ensure constraints attach to replaced node

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -993,6 +993,47 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
         }
     }
 
+    def "can have constraint on node failing conflict"() {
+        def foo = mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "bar", "1.0")
+            .dependencyConstraint(foo)
+            .withModuleMetadata()
+            .publish()
+
+        given:
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:foo:1.0")
+                implementation("org:bar:1.0")
+            }
+        """
+
+        capability("org", "cap") {
+            forModule("org:foo")
+            forModule("org:bar")
+            selectModule("org", "bar")
+        }
+
+        when:
+        succeeds(':checkDeps')
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:bar:1.0") {
+                    constraint("org:foo:1.0", "org:bar:1.0") {
+                        byConstraint()
+                    }
+                }
+                edge("org:foo:1.0", "org:bar:1.0") {
+                    byConflictResolution("Explicit selection of org:bar:1.0 variant runtime")
+                }
+            }
+        }
+    }
+
     // region test fixtures
 
     class CapabilityClosure {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -257,6 +257,9 @@ class EdgeState implements DependencyGraphEdge {
 
             // A constraint by definition attaches to any other nodes in the component it constrains.
             for (NodeState node : targetComponent.getNodes()) {
+                while (node.getReplacement() != null) {
+                    node = node.getReplacement();
+                }
                 if (node.isSelected() && !node.isRoot()) {
                     targetNodes.add(node);
                 }


### PR DESCRIPTION
A constraint by definition attaches to all nodes in the target component, as a constraint contains the version of a module and therfore does not involve itself with selecting individual variants.

However, when a constraint targets a module and a node of a component of that module loses a capability conflict, the node in that module is not selected. The node has a replacement that is selected.

Therefore, we ensure we look for replacements of nodes that we attach constraints to so they properly follow node replacements

Fixes failures found in: https://github.com/gradlex-org/jvm-dependency-conflict-resolution/pull/403


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
