### PR TITLE
Make Attribute and EmptyImmutableAttributes hash codes stable across JVMs

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
@@ -160,4 +160,34 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
         JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME | LibraryElements.CLASSES
         JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME | LibraryElements.RESOURCES
     }
+
+    def "attribute container hash codes are stable across invocations (#description)"() {
+        buildFile << """
+            def color = Attribute.of("color", String)
+            def shape = Attribute.of("shape", String)
+
+            def attrs = configurations.create("foo").attributes
+            ${attributeSetup}
+            println("Hash: \${attrs.asImmutable().hashCode()}")
+            println(System.getProperty("foo")) // To invalidate CC
+        """
+
+        when:
+        succeeds("help", '--no-daemon', '-Dfoo=1')
+        def hash1 = (output =~ /Hash: (-?\d+)/)[0][1]
+
+        and:
+        succeeds("help", '--no-daemon', "-Dfoo=2")
+        def hash2 = (output =~ /Hash: (-?\d+)/)[0][1]
+
+        then:
+        hash1 == hash2
+
+        where:
+        description         | attributeSetup
+        "no attributes"     | ""
+        "single attribute"  | 'attrs.attribute(color, "green")'
+        "two attributes"    | 'attrs.attribute(color, "green"); attrs.attribute(shape, "square")'
+    }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
@@ -68,7 +68,7 @@ public class Attribute<T> implements Named {
         this.name = name;
         this.type = type;
         int hashCode = name.hashCode();
-        hashCode = 31 * hashCode + type.hashCode();
+        hashCode = 31 * hashCode + type.getName().hashCode();
         this.hashCode = hashCode;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/EmptyImmutableAttributes.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/EmptyImmutableAttributes.java
@@ -89,7 +89,7 @@ public final class EmptyImmutableAttributes extends AbstractAttributeContainer i
 
     @Override
     public int hashCode() {
-        return EmptyImmutableAttributes.class.hashCode();
+        return EmptyImmutableAttributes.class.getName().hashCode();
     }
 
 }


### PR DESCRIPTION
Attribute.hashCode() included Class.hashCode(), which is identity-based and not stable across JVM instances. This caused flaky up-to-date checks when configuration cache restored a DefaultResolvedVariantResult with a pre-computed hashCode from a previous JVM. On the next build, freshly created variants had different hash codes, causing HashSet.contains() to fail in ResolvedComponentResultSerializer when includeAllSelectableVariantResults was enabled.

Replace Class.hashCode() with Class.getName().hashCode() in both Attribute and EmptyImmutableAttributes to ensure hash codes are deterministic across JVM instances.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
