### PR TITLE
Add archive task file timestamp property

### DIFF
--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -35,6 +35,7 @@ import org.gradle.internal.IoActions;
 import java.io.File;
 import java.io.OutputStream;
 import java.util.OptionalLong;
+import java.util.function.LongUnaryOperator;
 
 public class TarCopyAction implements CopyAction {
     /**
@@ -49,12 +50,18 @@ public class TarCopyAction implements CopyAction {
 
     private final File tarFile;
     private final ArchiveOutputStreamFactory compressor;
-    private final OptionalLong fileTimestampMillis;
+    private final OptionalLong reproducibleFileTimestampMs;
 
     public TarCopyAction(File tarFile, ArchiveOutputStreamFactory compressor, boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp) {
         this.tarFile = tarFile;
         this.compressor = compressor;
-        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(preserveFileTimestamps, reproducibleFileTimestamp, CONSTANT_TIME_FOR_TAR_ENTRIES);
+        this.reproducibleFileTimestampMs = CopyActionUtil.computeReproducibleTimestamp(
+            preserveFileTimestamps,
+            reproducibleFileTimestamp,
+            LongUnaryOperator.identity(),
+            CONSTANT_TIME_FOR_TAR_ENTRIES,
+            Long.MAX_VALUE
+        );
     }
 
     @Override
@@ -136,6 +143,6 @@ public class TarCopyAction implements CopyAction {
     }
 
     private long getArchiveTimeFor(FileCopyDetails details) {
-        return fileTimestampMillis.orElseGet(details::getLastModified);
+        return reproducibleFileTimestampMs.orElseGet(details::getLastModified);
     }
 }

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/TarCopyAction.java
@@ -24,7 +24,9 @@ import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.archive.compression.ArchiveOutputStreamFactory;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
+import org.gradle.api.internal.file.copy.CopyActionUtil;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.ErroringAction;
@@ -32,6 +34,7 @@ import org.gradle.internal.IoActions;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.util.OptionalLong;
 
 public class TarCopyAction implements CopyAction {
     /**
@@ -46,12 +49,12 @@ public class TarCopyAction implements CopyAction {
 
     private final File tarFile;
     private final ArchiveOutputStreamFactory compressor;
-    private final boolean preserveFileTimestamps;
+    private final OptionalLong fileTimestampMillis;
 
-    public TarCopyAction(File tarFile, ArchiveOutputStreamFactory compressor, boolean preserveFileTimestamps) {
+    public TarCopyAction(File tarFile, ArchiveOutputStreamFactory compressor, boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp) {
         this.tarFile = tarFile;
         this.compressor = compressor;
-        this.preserveFileTimestamps = preserveFileTimestamps;
+        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(preserveFileTimestamps, reproducibleFileTimestamp, CONSTANT_TIME_FOR_TAR_ENTRIES);
     }
 
     @Override
@@ -133,6 +136,6 @@ public class TarCopyAction implements CopyAction {
     }
 
     private long getArchiveTimeFor(FileCopyDetails details) {
-        return preserveFileTimestamps ? details.getLastModified() : CONSTANT_TIME_FOR_TAR_ENTRIES;
+        return fileTimestampMillis.orElseGet(details::getLastModified);
     }
 }

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -25,13 +25,18 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream;
+import org.gradle.api.internal.file.copy.CopyActionUtil;
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal;
 import org.gradle.api.internal.file.copy.ZipCompressor;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.IoActions;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.OptionalLong;
 
 public class ZipCopyAction implements CopyAction {
 
@@ -39,14 +44,17 @@ public class ZipCopyAction implements CopyAction {
     private final ZipCompressor compressor;
     private final DocumentationRegistry documentationRegistry;
     private final String encoding;
-    private final boolean preserveFileTimestamps;
+    private final OptionalLong fileTimestampMillis;
 
-    public ZipCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry, String encoding, boolean preserveFileTimestamps) {
+    public ZipCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry, String encoding, boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp) {
         this.zipFile = zipFile;
         this.compressor = compressor;
         this.documentationRegistry = documentationRegistry;
         this.encoding = encoding;
-        this.preserveFileTimestamps = preserveFileTimestamps;
+        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(preserveFileTimestamps, reproducibleFileTimestamp.map(ms -> {
+            final Instant utcTime = Instant.ofEpochMilli(ms);
+            return utcTime.minusSeconds(ZoneId.systemDefault().getRules().getOffset(utcTime).getTotalSeconds()).toEpochMilli();
+        }), ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES);
     }
 
     @Override
@@ -124,6 +132,6 @@ public class ZipCopyAction implements CopyAction {
     }
 
     private long getArchiveTimeFor(FileCopyDetails details) {
-        return preserveFileTimestamps ? details.getLastModified() : ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES;
+        return fileTimestampMillis.orElseGet(details::getLastModified);
     }
 }

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -35,7 +35,9 @@ import org.gradle.internal.IoActions;
 
 import java.io.File;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.OptionalLong;
 
 public class ZipCopyAction implements CopyAction {
@@ -51,10 +53,23 @@ public class ZipCopyAction implements CopyAction {
         this.compressor = compressor;
         this.documentationRegistry = documentationRegistry;
         this.encoding = encoding;
-        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(preserveFileTimestamps, reproducibleFileTimestamp.map(ms -> {
-            final Instant utcTime = Instant.ofEpochMilli(ms);
-            return utcTime.minusSeconds(ZoneId.systemDefault().getRules().getOffset(utcTime).getTotalSeconds()).toEpochMilli();
-        }), ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES);
+        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(
+            preserveFileTimestamps,
+            reproducibleFileTimestamp.map(ZipCopyAction::normalizeTimestamp),
+            ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
+        );
+    }
+
+    /**
+     * Zip stores entry times as MS-DOS date/time rendered in the default time zone (see ZipUtil.toDosTime),
+     * so shift the timestamp to make the stored fields equal its UTC wall clock, independent of the zone.
+     */
+    private static long normalizeTimestamp(long timestampMillis) {
+        Instant utcTime = Instant.ofEpochMilli(timestampMillis);
+        return LocalDateTime.ofInstant(utcTime, ZoneOffset.UTC)
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli();
     }
 
     @Override

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -20,6 +20,7 @@ import org.apache.commons.compress.archivers.zip.Zip64RequiredException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
@@ -55,7 +56,14 @@ public class ZipCopyAction implements CopyAction {
         this.encoding = encoding;
         this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(
             preserveFileTimestamps,
-            reproducibleFileTimestamp.map(ZipCopyAction::normalizeTimestamp),
+            reproducibleFileTimestamp.map(ms -> {
+                if (ms > ZipEntryConstants.MAXIMUM_TIME_FOR_ZIP_ENTRIES) {
+                    throw new InvalidUserDataException(String.format(
+                        "The reproducible file timestamp %s is greater than the maximum timestamp %s supported for ZIP archives.",
+                        Instant.ofEpochMilli(ms), Instant.ofEpochMilli(ZipEntryConstants.MAXIMUM_TIME_FOR_ZIP_ENTRIES)));
+                }
+                return normalizeTimestamp(ms);
+            }),
             ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
         );
     }

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -20,7 +20,6 @@ import org.apache.commons.compress.archivers.zip.Zip64RequiredException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.gradle.api.GradleException;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
@@ -47,24 +46,19 @@ public class ZipCopyAction implements CopyAction {
     private final ZipCompressor compressor;
     private final DocumentationRegistry documentationRegistry;
     private final String encoding;
-    private final OptionalLong fileTimestampMillis;
+    private final OptionalLong reproducibleFileTimestampMs;
 
     public ZipCopyAction(File zipFile, ZipCompressor compressor, DocumentationRegistry documentationRegistry, String encoding, boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp) {
         this.zipFile = zipFile;
         this.compressor = compressor;
         this.documentationRegistry = documentationRegistry;
         this.encoding = encoding;
-        this.fileTimestampMillis = CopyActionUtil.computeReproducibleTimestamp(
+        this.reproducibleFileTimestampMs = CopyActionUtil.computeReproducibleTimestamp(
             preserveFileTimestamps,
-            reproducibleFileTimestamp.map(ms -> {
-                if (ms > ZipEntryConstants.MAXIMUM_TIME_FOR_ZIP_ENTRIES) {
-                    throw new InvalidUserDataException(String.format(
-                        "The reproducible file timestamp %s is greater than the maximum timestamp %s supported for ZIP archives.",
-                        Instant.ofEpochMilli(ms), Instant.ofEpochMilli(ZipEntryConstants.MAXIMUM_TIME_FOR_ZIP_ENTRIES)));
-                }
-                return normalizeTimestamp(ms);
-            }),
-            ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
+            reproducibleFileTimestamp,
+            ZipCopyAction::normalizeTimezone,
+            ZipEntryConstants.MINIMUM_TIME_FOR_ZIP_ENTRIES_UTC,
+            ZipEntryConstants.MAXIMUM_TIME_FOR_ZIP_ENTRIES_UTC
         );
     }
 
@@ -72,7 +66,7 @@ public class ZipCopyAction implements CopyAction {
      * Zip stores entry times as MS-DOS date/time rendered in the default time zone (see ZipUtil.toDosTime),
      * so shift the timestamp to make the stored fields equal its UTC wall clock, independent of the zone.
      */
-    private static long normalizeTimestamp(long timestampMillis) {
+    private static long normalizeTimezone(long timestampMillis) {
         Instant utcTime = Instant.ofEpochMilli(timestampMillis);
         return LocalDateTime.ofInstant(utcTime, ZoneOffset.UTC)
             .atZone(ZoneId.systemDefault())
@@ -155,6 +149,6 @@ public class ZipCopyAction implements CopyAction {
     }
 
     private long getArchiveTimeFor(FileCopyDetails details) {
-        return fileTimestampMillis.orElseGet(details::getLastModified);
+        return reproducibleFileTimestampMs.orElseGet(details::getLastModified);
     }
 }

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/CopyActionUtil.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/CopyActionUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.file.copy;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.provider.Provider;
+
+import java.util.OptionalLong;
+
+public class CopyActionUtil {
+
+    /**
+     * Computes the optional reproducible timestamp from the archive task properties.
+     * <p>
+     * An exception is thrown if the preserve file timestamps property is true and a reproducible file timestamp is specified.
+     *
+     * @param preserveFileTimestamps true to preserve file timestamps
+     * @param reproducibleFileTimestamp the reproducible file timestamp property
+     * @param minimumValue the minimum timestamp that can be specified
+     * @return the optional reproducible timestamp computed based on the properties
+     */
+    public static OptionalLong computeReproducibleTimestamp(boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp, long minimumValue) {
+        if (!reproducibleFileTimestamp.isPresent()) {
+            return preserveFileTimestamps ? OptionalLong.empty() : OptionalLong.of(minimumValue);
+        } else if (preserveFileTimestamps) {
+            throw new InvalidUserDataException("The reproducible file timestamp property cannot be used when the preserve file timestamps property is set to true");
+        } else {
+            return OptionalLong.of(Math.max(reproducibleFileTimestamp.get(), minimumValue));
+        }
+    }
+
+}

--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/CopyActionUtil.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/CopyActionUtil.java
@@ -18,28 +18,41 @@ package org.gradle.api.internal.file.copy;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.provider.Provider;
 
+import java.time.Instant;
 import java.util.OptionalLong;
+import java.util.function.LongUnaryOperator;
 
 public class CopyActionUtil {
 
     /**
-     * Computes the optional reproducible timestamp from the archive task properties.
+     * Computes the fixed timestamp for every archive entry, or empty to preserve each file's own timestamp.
      * <p>
-     * An exception is thrown if the preserve file timestamps property is true and a reproducible file timestamp is specified.
+     * When a timestamp is set it is clamped to the {@code [minimumValue, maximumValue]} range — values above the
+     * maximum fail, values below the minimum are raised to it — and then adjusted by {@code timezoneNormalizer} for
+     * how the format stores it. Clamping the literal value before normalizing keeps the result independent of the
+     * build time zone.
      *
      * @param preserveFileTimestamps true to preserve file timestamps
      * @param reproducibleFileTimestamp the reproducible file timestamp property
-     * @param minimumValue the minimum timestamp that can be specified
-     * @return the optional reproducible timestamp computed based on the properties
+     * @param timezoneNormalizer adjusts the timestamp for the time zone in which the format stores it (identity if none is needed)
+     * @param minimumValue the minimum storable timestamp; smaller values are raised to it
+     * @param maximumValue the maximum storable timestamp; larger values fail, use {@link Long#MAX_VALUE} for no maximum
+     * @throws InvalidUserDataException if a timestamp is set together with preserveFileTimestamps, or if it exceeds maximumValue
+     * @return the timestamp for every entry, or empty to preserve each file's timestamp
      */
-    public static OptionalLong computeReproducibleTimestamp(boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp, long minimumValue) {
+    public static OptionalLong computeReproducibleTimestamp(boolean preserveFileTimestamps, Provider<Long> reproducibleFileTimestamp, LongUnaryOperator timezoneNormalizer, long minimumValue, long maximumValue) {
         if (!reproducibleFileTimestamp.isPresent()) {
-            return preserveFileTimestamps ? OptionalLong.empty() : OptionalLong.of(minimumValue);
+            return preserveFileTimestamps ? OptionalLong.empty() : OptionalLong.of(timezoneNormalizer.applyAsLong(minimumValue));
         } else if (preserveFileTimestamps) {
             throw new InvalidUserDataException("The reproducible file timestamp property cannot be used when the preserve file timestamps property is set to true");
         } else {
-            return OptionalLong.of(Math.max(reproducibleFileTimestamp.get(), minimumValue));
+            long timestamp = reproducibleFileTimestamp.get();
+            if (timestamp > maximumValue) {
+                throw new InvalidUserDataException(String.format(
+                    "The reproducible file timestamp %s is greater than the maximum supported timestamp %s.",
+                    Instant.ofEpochMilli(timestamp), Instant.ofEpochMilli(maximumValue)));
+            }
+            return OptionalLong.of(timezoneNormalizer.applyAsLong(Math.max(timestamp, minimumValue)));
         }
     }
-
 }

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file.archive;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
@@ -37,6 +38,17 @@ public class ZipEntryConstants {
      * The date is 1980 February 1st CET.
      */
     public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis();
+
+    /**
+     * The maximum timestamp that can be stored in a zip entry.
+     * <p>
+     * Commons-compress can store timestamps only up to 128 * 365 days from the Unix epoch (2097-11-30T00:00:00Z)
+     * as MS-DOS date/time, and silently adds an NTFS extra field for anything larger. The NTFS field stores an
+     * absolute instant, so the archive bytes would depend on the time zone of the machine that built the archive.
+     * The maximum is chosen with enough margin so that the timestamp stays storable as MS-DOS date/time after
+     * being adjusted to the default time zone.
+     */
+    public static final long MAXIMUM_TIME_FOR_ZIP_ENTRIES = Instant.parse("2097-11-01T00:00:00Z").toEpochMilli();
 
     private ZipEntryConstants() {}
 

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
@@ -35,20 +35,30 @@ public class ZipEntryConstants {
      * Moreover, parsing happens via `new Date(millis)` in {@code java.util.zip.ZipUtils#javaToDosTime()} so we
      * must use default timezone and locale.
      *
-     * The date is 1980 February 1st CET.
+     * The value is 1980 February 1st in the JVM's default (local) time zone, because zip stores entry times in the
+     * local time zone (as MS-DOS date/time). Use {@link #MINIMUM_TIME_FOR_ZIP_ENTRIES_UTC} when comparing against a raw (UTC) timestamp instead.
      */
     public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis();
 
     /**
-     * The maximum timestamp that can be stored in a zip entry.
+     * The minimum timestamp that can be stored in a zip entry, as a UTC instant.
+     * <p>
+     * MS-DOS date/time cannot represent dates before 1980, so smaller values are raised to this minimum.
+     * This is the UTC-instant form of {@link #CONSTANT_TIME_FOR_ZIP_ENTRIES}: once adjusted to the default
+     * time zone for storage it produces the same 1980-02-01 entry date, independent of the build time zone.
+     */
+    public static final long MINIMUM_TIME_FOR_ZIP_ENTRIES_UTC = Instant.parse("1980-02-01T00:00:00Z").toEpochMilli();
+
+    /**
+     * The maximum timestamp that can be stored in a zip entry, as a UTC instant.
      * <p>
      * Commons-compress can store timestamps only up to 128 * 365 days from the Unix epoch (2097-11-30T00:00:00Z)
      * as MS-DOS date/time, and silently adds an NTFS extra field for anything larger. The NTFS field stores an
-     * absolute instant, so the archive bytes would depend on the time zone of the machine that built the archive.
-     * The maximum is chosen with enough margin so that the timestamp stays storable as MS-DOS date/time after
-     * being adjusted to the default time zone.
+     * absolute instant, so the archive bytes would then depend on the build time zone; larger values fail instead.
+     * The margin to that limit ensures the timestamp stays storable as MS-DOS date/time once adjusted to the
+     * default time zone for storage.
      */
-    public static final long MAXIMUM_TIME_FOR_ZIP_ENTRIES = Instant.parse("2097-11-01T00:00:00Z").toEpochMilli();
+    public static final long MAXIMUM_TIME_FOR_ZIP_ENTRIES_UTC = Instant.parse("2097-11-01T00:00:00Z").toEpochMilli();
 
     private ZipEntryConstants() {}
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,6 +79,25 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
+#### Custom timestamps for reproducible archives
+
+Gradle produces [reproducible archives](userguide/working_with_files.html#sec:reproducible_archives) by default, using fixed timestamps for all entries.
+However, some environments, such as those following the [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) specification, require a meaningful, verifiable timestamp rather than a fixed default.
+
+Archive tasks now support a [`reproducibleFileTimestamp`](userguide/working_with_files.html#sec:reproducible_timestamp) property that lets you set a custom timestamp for every entry in the archive:
+
+```kotlin
+import java.time.Instant
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    reproducibleFileTimestamp = providers.environmentVariable("SOURCE_DATE_EPOCH").map {
+        Instant.ofEpochSecond(it.toLong()).toEpochMilli()
+    }
+}
+```
+
+See the [Timestamp for files inside archives](userguide/working_with_files.html#sec:reproducible_timestamp) section in the Gradle User Manual for more details.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -1052,8 +1052,9 @@ Starting with Gradle 9.0.0, all link:{groovyDslPath}/org.gradle.api.tasks.bundli
 - Directories have fixed permissions set to `0755`
 - Files have fixed permissions set to `0644`
 
-You can <<sec:setting_file_permissions,further customize>> the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:dirPermissions-org.gradle.api.Action-[directory permissions]
-or link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:filePermissions-org.gradle.api.Action-[file permissions]
+You can <<sec:setting_file_permissions,further customize>> the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:dirPermissions-org.gradle.api.Action-[directory permissions],
+link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:filePermissions-org.gradle.api.Action-[file permissions],
+or link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[file timestamps]
 while keeping the archives reproducible.
 
 [[sec:revert_reproducible_archives]]
@@ -1089,6 +1090,28 @@ We recognize two main cases, where users may want to change the permissions of f
 For such configuration see <<#sec:revert_reproducible_archives,Preserve file system-defined aspects>> section.
 2. Case where the permissions of files and directories in the archive should be set to specific values, for example to set the executable bit on a script file.
 For such configuration see <<#sec:setting_file_permissions,Setting file permissions>> section.
+
+[[sec:reproducible_timestamp]]
+== Timestamp for files inside archives incubating-label:[]
+
+The link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[`reproducibleFileTimestamp`] property allows you to set a custom timestamp for every entry in the archive.
+Note that the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:preserveFileTimestamps[`isPreserveFileTimestamps`] property must be `false` (which is the default value) to use a custom timestamp.
+
+The timestamp is specified in milliseconds since the Unix epoch.
+It can be used to complement reproducibility by using a meaningful, verifiable timestamp rather than the default.
+
+For example, the `SOURCE_DATE_EPOCH` environment variable can be set to the Unix timestamp from the most recent git commit using `git log -1 --format=%ct`, and then used in the Gradle build:
+
+====
+include::sample[dir="snippets/reference/gradle-types/archives/kotlin",files="build.gradle.kts[tags=reproducible-timestamp]"]
+include::sample[dir="snippets/reference/gradle-types/archives/groovy",files="build.gradle[tags=reproducible-timestamp]"]
+====
+
+[NOTE]
+====
+Timestamp resolution varies by archive format.
+The exact value stored in the archive file may have lower resolution than the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[`reproducibleFileTimestamp`] property.
+====
 
 [[sec:unpacking_archives_example]]
 == Unpacking archives

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -1113,6 +1113,7 @@ Timestamp resolution and range vary by archive format.
 The exact value stored in the archive file may have lower resolution than the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[`reproducibleFileTimestamp`] property.
 Each format also has a minimum supported timestamp: 1980-02-01 00:00 for ZIP archives and 1970-01-02T00:00:00Z for TAR archives.
 Smaller values are raised to the minimum.
+ZIP archives also have a maximum supported timestamp of 2097-11-01T00:00:00Z; the build fails for larger values.
 ====
 
 [[sec:unpacking_archives_example]]

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -1095,7 +1095,7 @@ For such configuration see <<#sec:setting_file_permissions,Setting file permissi
 == Timestamp for files inside archives incubating-label:[]
 
 The link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[`reproducibleFileTimestamp`] property allows you to set a custom timestamp for every entry in the archive.
-Note that the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:preserveFileTimestamps[`isPreserveFileTimestamps`] property must be `false` (which is the default value) to use a custom timestamp.
+Note that the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:preserveFileTimestamps[`isPreserveFileTimestamps`] property must be `false` (which is the default value) to use a custom timestamp, otherwise the build fails.
 
 The timestamp is specified in milliseconds since the Unix epoch.
 It can be used to complement reproducibility by using a meaningful, verifiable timestamp rather than the default.
@@ -1109,8 +1109,10 @@ include::sample[dir="snippets/reference/gradle-types/archives/groovy",files="bui
 
 [NOTE]
 ====
-Timestamp resolution varies by archive format.
+Timestamp resolution and range vary by archive format.
 The exact value stored in the archive file may have lower resolution than the link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:reproducibleFileTimestamp[`reproducibleFileTimestamp`] property.
+Each format also has a minimum supported timestamp: 1980-02-01 00:00 for ZIP archives and 1970-01-02T00:00:00Z for TAR archives.
+Smaller values are raised to the minimum.
 ====
 
 [[sec:unpacking_archives_example]]

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/archives/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/archives/groovy/build.gradle
@@ -56,3 +56,14 @@ tasks.withType(AbstractArchiveTask).configureEach {
 }
 // end::revert-reproducible[]
 
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false // Reset to the default value
+}
+
+// tag::reproducible-timestamp[]
+tasks.withType(AbstractArchiveTask).configureEach {
+    reproducibleFileTimestamp = providers.environmentVariable('SOURCE_DATE_EPOCH').map {
+        java.time.Instant.ofEpochSecond(it.toLong()).toEpochMilli()
+    }
+}
+// end::reproducible-timestamp[]

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/archives/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/archives/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Instant
+
 // tag::zip[]
 // tag::tar[]
 plugins {
@@ -58,3 +60,16 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 }
 // end::revert-reproducible[]
 
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false // Reset to the default value
+}
+
+// tag::reproducible-timestamp[]
+// import java.time.Instant
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    reproducibleFileTimestamp = providers.environmentVariable("SOURCE_DATE_EPOCH").map {
+        Instant.ofEpochSecond(it.toLong()).toEpochMilli()
+    }
+}
+// end::reproducible-timestamp[]

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/archives/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/archives/groovy/build.gradle
@@ -56,3 +56,14 @@ tasks.withType(AbstractArchiveTask).configureEach {
 }
 // end::revert-reproducible[]
 
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false // Reset to the default value
+}
+
+// tag::reproducible-timestamp[]
+tasks.withType(AbstractArchiveTask).configureEach {
+    reproducibleFileTimestamp = providers.environmentVariable('SOURCE_DATE_EPOCH').map {
+        java.time.Instant.ofEpochSecond(it.toLong()).toEpochMilli()
+    }
+}
+// end::reproducible-timestamp[]

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/archives/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/archives/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Instant
+
 // tag::zip[]
 // tag::tar[]
 plugins {
@@ -58,3 +60,16 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 }
 // end::revert-reproducible[]
 
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false // Reset to the default value
+}
+
+// tag::reproducible-timestamp[]
+// import java.time.Instant
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    reproducibleFileTimestamp = providers.environmentVariable("SOURCE_DATE_EPOCH").map {
+        Instant.ofEpochSecond(it.toLong()).toEpochMilli()
+    }
+}
+// end::reproducible-timestamp[]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -99,6 +99,113 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         fileExtension = taskName
     }
 
+    def "reproducible #taskName for directory with timestamps - #files"() {
+        given:
+        files.each {
+            file("src/${it}").text = it
+        }
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                reproducibleFileOrder = true
+                reproducibleFileTimestamp = java.time.Instant.ofEpochSecond(1248072216).toEpochMilli()
+                from 'src'
+                destinationDirectory = buildDir
+                archiveFileName = 'test.${fileExtension}'
+                filePermissions {}
+                dirPermissions {}
+            }
+            """
+
+        when:
+        succeeds taskName
+
+        then:
+        file("build/test.${fileExtension}").md5Hash == expectedHash
+
+        where:
+        input << [
+            ['DIR1/FILE11.txt', 'dir2/file22.txt', 'DIR3/file33.txt'].permutations(),
+            ['zip', 'tar']
+        ].combinations()
+        files = input[0]
+        taskName = input[1]
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+        expectedHash = taskName == 'tar' ? 'df5074300ec3fe8403071e64cfe3cb1a' : '477313f3ced595c7c75dffde90c54aba'
+    }
+
+    def "reproducible #taskName with reproducibleFileTimestamp is independent of the build timezone"() {
+        given:
+        files.each {
+            file("src/${it}").text = it
+        }
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                reproducibleFileTimestamp = java.time.Instant.ofEpochSecond(1248072216).toEpochMilli()
+                from 'src'
+                destinationDirectory = buildDir
+                archiveFileName = 'test.${fileExtension}'
+                def layout = project.layout
+                doFirst {
+                    java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(System.getProperty("archiveBuildTimeZone")))
+                }
+                doLast {
+                    layout.buildDirectory.file("effective-tz.txt").get().asFile.text = java.util.TimeZone.getDefault().getID()
+                }
+            }
+            """
+
+        when: "the archive is built on machines in different timezones"
+        def utc = runArchiveInTimeZone(taskName, fileExtension, "UTC")
+        def kolkata = runArchiveInTimeZone(taskName, fileExtension, "Asia/Kolkata")
+
+        then: "the timezone actually changed in the build JVM and the produced archives are identical"
+        kolkata.tz == "Asia/Kolkata"
+        utc.tz == "UTC"
+        utc.hash == kolkata.hash
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize() as String
+        fileExtension = taskName as String
+        files = ['DIR1/FILE11.txt', 'dir2/file22.txt', 'DIR3/file33.txt']
+    }
+
+    private Map<String, String> runArchiveInTimeZone(String taskName, String fileExtension, String timeZoneId) {
+        executer.requireDaemon().requireIsolatedDaemons()
+        executer.withArgument("-DarchiveBuildTimeZone=${timeZoneId}")
+        succeeds(taskName, "--rerun")
+        return [hash: file("build/test.${fileExtension}").md5Hash, tz: file("build/effective-tz.txt").text.trim()]
+    }
+
+    def "reproducible #taskName fails when preserveFileTimestamps = true and reproducibleFileTimestamp is specified"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task ${taskName}(type: ${taskType}) {
+                reproducibleFileOrder = true
+                reproducibleFileTimestamp = java.time.Instant.ofEpochSecond(1208789700).toEpochMilli()
+                preserveFileTimestamps = true
+                from 'dir1'
+                destinationDirectory = buildDir
+                archiveFileName = 'test.${fileExtension}'
+                filePermissions {}
+                dirPermissions {}
+            }
+            """
+
+        when:
+        fails taskName
+
+        then:
+        failure.assertHasCause("The reproducible file timestamp property cannot be used when the preserve file timestamps property is set to true")
+
+        where:
+        taskName << ['zip', 'tar']
+        taskType = taskName.capitalize()
+        fileExtension = taskName
+    }
+
     def "#compression compressed tar files are reproducible"() {
         given:
         createTestFiles()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -134,7 +134,7 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         expectedHash = taskName == 'tar' ? 'df5074300ec3fe8403071e64cfe3cb1a' : '477313f3ced595c7c75dffde90c54aba'
     }
 
-    def "reproducible #taskName with reproducibleFileTimestamp is independent of the build timezone - #otherTimeZone"() {
+    def "reproducible #taskName with reproducibleFileTimestamp #timestampEpochSeconds is independent of the build timezone - #otherTimeZone"() {
         given:
         files.each {
             file("src/${it}").text = it
@@ -182,6 +182,25 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         executer.withArgument("-DarchiveBuildTimeZone=${timeZoneId}")
         succeeds(taskName, "--rerun")
         return [hash: file("build/test.${fileExtension}").md5Hash, tz: file("build/effective-tz.txt").text.trim()]
+    }
+
+    def "reproducible zip fails when reproducibleFileTimestamp is greater than the maximum supported timestamp"() {
+        given:
+        createTestFiles()
+        buildFile << """
+            task zip(type: Zip) {
+                reproducibleFileTimestamp = java.time.Instant.parse("2100-01-01T00:00:00Z").toEpochMilli()
+                from 'dir1'
+                destinationDirectory = buildDir
+                archiveFileName = 'test.zip'
+            }
+            """
+
+        when:
+        fails 'zip'
+
+        then:
+        failure.assertHasCause("The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum timestamp 2097-11-01T00:00:00Z supported for ZIP archives.")
     }
 
     def "reproducible #taskName fails when preserveFileTimestamps = true and reproducibleFileTimestamp is specified"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -134,14 +134,14 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         expectedHash = taskName == 'tar' ? 'df5074300ec3fe8403071e64cfe3cb1a' : '477313f3ced595c7c75dffde90c54aba'
     }
 
-    def "reproducible #taskName with reproducibleFileTimestamp is independent of the build timezone"() {
+    def "reproducible #taskName with reproducibleFileTimestamp is independent of the build timezone - #otherTimeZone"() {
         given:
         files.each {
             file("src/${it}").text = it
         }
         buildFile << """
             task ${taskName}(type: ${taskType}) {
-                reproducibleFileTimestamp = java.time.Instant.ofEpochSecond(1248072216).toEpochMilli()
+                reproducibleFileTimestamp = java.time.Instant.ofEpochSecond(${timestampEpochSeconds}).toEpochMilli()
                 from 'src'
                 destinationDirectory = buildDir
                 archiveFileName = 'test.${fileExtension}'
@@ -157,15 +157,21 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
 
         when: "the archive is built on machines in different timezones"
         def utc = runArchiveInTimeZone(taskName, fileExtension, "UTC")
-        def kolkata = runArchiveInTimeZone(taskName, fileExtension, "Asia/Kolkata")
+        def other = runArchiveInTimeZone(taskName, fileExtension, otherTimeZone)
 
         then: "the timezone actually changed in the build JVM and the produced archives are identical"
-        kolkata.tz == "Asia/Kolkata"
+        other.tz == otherTimeZone
         utc.tz == "UTC"
-        utc.hash == kolkata.hash
+        utc.hash == other.hash
 
         where:
-        taskName << ['zip', 'tar']
+        taskName | timestampEpochSeconds | otherTimeZone
+        'zip'    | 1248072216            | 'Asia/Kolkata'
+        'tar'    | 1248072216            | 'Asia/Kolkata'
+        // 2009-03-29T01:30:00Z is 30 minutes after the Europe/Paris DST transition at 2009-03-29T01:00:00Z,
+        // so the zone offset at the timestamp (+02:00) differs from the offset at the instant stored in the zip
+        'zip'    | 1238290200            | 'Europe/Paris'
+
         taskType = taskName.capitalize() as String
         fileExtension = taskName as String
         files = ['DIR1/FILE11.txt', 'dir2/file22.txt', 'DIR3/file33.txt']

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -200,7 +200,7 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         fails 'zip'
 
         then:
-        failure.assertHasCause("The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum timestamp 2097-11-01T00:00:00Z supported for ZIP archives.")
+        failure.assertHasCause("The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum supported timestamp 2097-11-01T00:00:00Z.")
     }
 
     def "reproducible #taskName fails when preserveFileTimestamps = true and reproducibleFileTimestamp is specified"() {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.bundling;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DirectoryProperty;
@@ -30,6 +31,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -238,6 +240,20 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
         super.into(destPath, copySpec);
         return this;
     }
+
+    /**
+     * Specifies the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z.
+     * <p>
+     * If not set, then each archive entry will use the value as determined by the <code>preserveFileTimestamps</code> property.
+     * If set, then each archive entry will use the reproducible file timestamp.
+     *
+     * @return the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    @Optional
+    public abstract Property<Long> getReproducibleFileTimestamp();
 
     /**
      * Specifies whether file timestamps should be preserved in the archive.

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -245,7 +245,11 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Specifies the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z.
      * <p>
      * If not set, then each archive entry will use the value as determined by the <code>preserveFileTimestamps</code> property.
-     * If set, then each archive entry will use the reproducible file timestamp.
+     * If set, then each archive entry will use the reproducible file timestamp, and the <code>preserveFileTimestamps</code> property
+     * must be <code>false</code> (the default value), otherwise the task fails.
+     * <p>
+     * Each archive format has a minimum supported timestamp, and smaller values are raised to that minimum:
+     * 1980-02-01 00:00 for ZIP archives and 1970-01-02T00:00:00Z for TAR archives.
      *
      * @return the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z
      * @since 9.7.0

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -245,14 +245,13 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Specifies the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z.
      * <p>
      * If not set, then each archive entry will use the value as determined by the <code>preserveFileTimestamps</code> property.
-     * If set, then each archive entry will use the reproducible file timestamp, and the <code>preserveFileTimestamps</code> property
-     * must be <code>false</code> (the default value), otherwise the task fails.
+     * If set, then each archive entry will use the reproducible file timestamp.
+     * If set, the <code>preserveFileTimestamps</code> property must be <code>false</code> (the default value), otherwise the task fails.
      * <p>
      * Each archive format has a minimum supported timestamp, and smaller values are raised to that minimum:
      * 1980-02-01 00:00 for ZIP archives and 1970-01-02T00:00:00Z for TAR archives.
-     * ZIP archives also have a maximum supported timestamp of 2097-11-01T00:00:00Z, and the task fails for larger values.
      *
-     * @return the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z
+     * @return the reproducible file timestamp used for each entry in the archive
      * @since 9.7.0
      */
     @Incubating

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -250,6 +250,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * <p>
      * Each archive format has a minimum supported timestamp, and smaller values are raised to that minimum:
      * 1980-02-01 00:00 for ZIP archives and 1970-01-02T00:00:00Z for TAR archives.
+     * ZIP archives also have a maximum supported timestamp of 2097-11-01T00:00:00Z, and the task fails for larger values.
      *
      * @return the reproducible file timestamp used for each entry in the archive in milliseconds from the epoch of 1970-01-01T00:00:00Z
      * @since 9.7.0

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Tar.java
@@ -39,7 +39,7 @@ public abstract class Tar extends AbstractArchiveTask {
 
     @Override
     protected CopyAction createCopyAction() {
-        return new TarCopyAction(getArchiveFile().get().getAsFile(), getCompressor(), isPreserveFileTimestamps());
+        return new TarCopyAction(getArchiveFile().get().getAsFile(), getCompressor(), isPreserveFileTimestamps(), getReproducibleFileTimestamp());
     }
 
     private ArchiveOutputStreamFactory getCompressor() {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -63,7 +63,7 @@ public abstract class Zip extends AbstractArchiveTask {
     @Override
     protected CopyAction createCopyAction() {
         DocumentationRegistry documentationRegistry = getServices().get(DocumentationRegistry.class);
-        return new ZipCopyAction(getArchiveFile().get().getAsFile(), getCompressor(), documentationRegistry, metadataCharset, isPreserveFileTimestamps());
+        return new ZipCopyAction(getArchiveFile().get().getAsFile(), getCompressor(), documentationRegistry, metadataCharset, isPreserveFileTimestamps(), getReproducibleFileTimestamp());
     }
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.archive.compression.GzipArchiver
 import org.gradle.api.internal.file.archive.compression.SimpleCompressor
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
+import org.gradle.api.internal.provider.Providers
 import org.gradle.test.fixtures.archive.TarTestFixture
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
@@ -111,7 +112,7 @@ class TarCopyActionSpec extends Specification {
     }
 
     private TestFile initializeTarFile(final TestFile tarFile, final ArchiveOutputStreamFactory compressor) {
-        action = new TarCopyAction(tarFile, compressor, false)
+        action = new TarCopyAction(tarFile, compressor, false, Providers.notDefined())
         return tarFile
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.copy.CopyActionExecuterUtil.visit
@@ -142,6 +143,56 @@ class ZipCopyActionTest extends Specification {
         def e = thrown(Exception)
         e.message == String.format("Could not add $brokenFile to ZIP '%s'.", zipFile)
         e.cause.is(failure)
+    }
+
+    @Issue("https://github.com/gradle/gradle/pull/37790")
+    def "zip with reproducibleFileTimestamp just after a DST transition is independent of the default time zone"() {
+        given:
+        // 2009-03-29T01:30:00Z is 30 minutes after the Europe/Paris DST transition at 2009-03-29T01:00:00Z,
+        // so the zone offset at the timestamp (+02:00) differs from the offset at the instant stored in the zip
+        def timestamp = java.time.Instant.ofEpochSecond(1238290200).toEpochMilli()
+        def utcZip = tmpDir.testDirectory.file("utc.zip")
+        def parisZip = tmpDir.testDirectory.file("paris.zip")
+
+        when:
+        zipInTimeZone(utcZip, timestamp, "UTC")
+        zipInTimeZone(parisZip, timestamp, "Europe/Paris")
+
+        then:
+        entryLastModified(utcZip) == entryLastModified(parisZip)
+        utcZip.md5Hash == parisZip.md5Hash
+    }
+
+    private FileCopyDetailsInternal plainFile(final String path) {
+        // a Spock mock would also work here, but a plain coercion keeps the test runnable
+        // in environments where the Mockito mock maker cannot self-attach its Java agent
+        return [
+            getRelativePath: { RelativePath.parse(false, path) },
+            getLastModified: { 1000L },
+            isDirectory: { false },
+            getPermissions: { new DefaultFilePermissions(1) },
+            copyTo: { OutputStream out -> out << "contents of $path" }
+        ] as FileCopyDetailsInternal
+    }
+
+    private static long entryLastModified(TestFile zipFile) {
+        def zip = new java.util.zip.ZipFile(zipFile)
+        try {
+            return zip.entries().nextElement().time
+        } finally {
+            zip.close()
+        }
+    }
+
+    private void zipInTimeZone(TestFile zipFile, long timestamp, String timeZoneId) {
+        def originalTimeZone = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId))
+            visitor = new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false, Providers.of(timestamp))
+            zip(plainFile("file"))
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
     }
 
     private void zip(final FileCopyDetailsInternal... files) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -165,6 +165,24 @@ class ZipCopyActionTest extends Specification {
     }
 
     @Issue("https://github.com/gradle/gradle/pull/37790")
+    def "zip with reproducibleFileTimestamp below the zip minimum is raised to it and independent of the default time zone"() {
+        given:
+        // before 1980-02-01, the earliest date storable as MS-DOS date/time
+        def timestamp = java.time.Instant.parse("1979-06-01T00:00:00Z").toEpochMilli()
+        def utcZip = tmpDir.testDirectory.file("utc.zip")
+        def parisZip = tmpDir.testDirectory.file("paris.zip")
+
+        when:
+        zipInTimeZone(utcZip, timestamp, "UTC")
+        zipInTimeZone(parisZip, timestamp, "Europe/Paris")
+
+        then:
+        entryLastModified(utcZip) == new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).timeInMillis
+        entryLastModified(utcZip) == entryLastModified(parisZip)
+        utcZip.md5Hash == parisZip.md5Hash
+    }
+
+    @Issue("https://github.com/gradle/gradle/pull/37790")
     def "zip with reproducibleFileTimestamp above the zip maximum fails"() {
         given:
         // above MAXIMUM_TIME_FOR_ZIP_ENTRIES; commons-compress would add an NTFS extra field with
@@ -176,7 +194,7 @@ class ZipCopyActionTest extends Specification {
 
         then:
         def e = thrown(InvalidUserDataException)
-        e.message == "The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum timestamp 2097-11-01T00:00:00Z supported for ZIP archives."
+        e.message == "The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum supported timestamp 2097-11-01T00:00:00Z."
     }
 
     private FileCopyDetailsInternal plainFile(final String path) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file.archive
 
 import org.apache.commons.compress.archivers.zip.Zip64RequiredException
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
@@ -161,6 +162,21 @@ class ZipCopyActionTest extends Specification {
         then:
         entryLastModified(utcZip) == entryLastModified(parisZip)
         utcZip.md5Hash == parisZip.md5Hash
+    }
+
+    @Issue("https://github.com/gradle/gradle/pull/37790")
+    def "zip with reproducibleFileTimestamp above the zip maximum fails"() {
+        given:
+        // above MAXIMUM_TIME_FOR_ZIP_ENTRIES; commons-compress would add an NTFS extra field with
+        // a timezone-dependent value instead of storing the timestamp as MS-DOS date/time
+        def timestamp = java.time.Instant.parse("2100-01-01T00:00:00Z").toEpochMilli()
+
+        when:
+        new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false, Providers.of(timestamp))
+
+        then:
+        def e = thrown(InvalidUserDataException)
+        e.message == "The reproducible file timestamp 2100-01-01T00:00:00Z is greater than the maximum timestamp 2097-11-01T00:00:00Z supported for ZIP archives."
     }
 
     private FileCopyDetailsInternal plainFile(final String path) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.DefaultFilePermissions
 import org.gradle.api.internal.file.copy.CopyActionProcessingStream
 import org.gradle.api.internal.file.copy.DefaultZipCompressor
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.file.TestFile
@@ -45,7 +46,7 @@ class ZipCopyActionTest extends Specification {
 
     def setup() {
         zipFile = tmpDir.getTestDirectory().file("test.zip")
-        visitor = new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false)
+        visitor = new ZipCopyAction(zipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false, Providers.notDefined())
     }
 
     void createsZipFile() {
@@ -87,7 +88,7 @@ class ZipCopyActionTest extends Specification {
     void wrapsFailureToOpenOutputFile() {
         given:
         def invalidZipFile = tmpDir.createDir("test.zip")
-        visitor = new ZipCopyAction(invalidZipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false)
+        visitor = new ZipCopyAction(invalidZipFile, new DefaultZipCompressor(false, ZipArchiveOutputStream.STORED), new DocumentationRegistry(), encoding, false, Providers.notDefined())
 
         when:
         visitor.execute(new CopyActionProcessingStream() {
@@ -119,7 +120,7 @@ class ZipCopyActionTest extends Specification {
         1 * docRegistry.getDslRefForProperty(Zip.name, "zip64") >> "doc url"
         0 * docRegistry._
 
-        visitor = new ZipCopyAction(zipFile, compressor, docRegistry, encoding, false)
+        visitor = new ZipCopyAction(zipFile, compressor, docRegistry, encoding, false, Providers.notDefined())
 
         when:
         zip(file("file2"))


### PR DESCRIPTION
Fixes #14819. (See issue for related issues and discussions.)

This change adds a new `fileTimestamp` property to archive tasks. If specified, this property will set all timestamps in the archive to the specified value. If not specified, existing functionality is retained, and timestamps are determined by the `preserveFileTimestamps` property. Integration tests have been added to [ReproducibleArchivesIntegrationTest.groovy](https://github.com/gradle/gradle/compare/master...nicklauslittle-gov:gradle:add-archive-timestamp) to check new functionality, and the documentation has been updated.