### PR TITLE
Allow referencing buildSrc tasks via gradle.includedBuild('buildSrc')

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/structuring-builds/composite_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/structuring-builds/composite_builds.adoc
@@ -328,6 +328,38 @@ include::sample[dir="snippets/structuring-builds/composite-builds-hierarchical-m
 include::sample[dir="snippets/structuring-builds/composite-builds-hierarchical-multirepo/groovy",files="build.gradle"]
 ====
 
+[[depending_on_buildsrc_tasks]]
+==== Depending on `buildSrc` tasks
+
+A `buildSrc` build can also be referenced by name through `Gradle.includedBuild("buildSrc")`, which lets the consuming build depend on tasks declared in `buildSrc`. For example, to make the root build's `check` task also run `buildSrc`'s `check`:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.named("check") {
+    dependsOn(gradle.includedBuild("buildSrc").task(":check"))
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.named("check") {
+    dependsOn gradle.includedBuild("buildSrc").task(":check")
+}
+----
+=====
+====
+
+The task path must be qualified (start with `:`). For a multi-project `buildSrc`, depend on each subproject's task explicitly (e.g. `gradle.includedBuild("buildSrc").task(":sub:check")`); there is no implicit aggregation across `buildSrc` subprojects from the consuming build.
+
+NOTE: `buildSrc` is only resolvable through `includedBuild("buildSrc")` from the build that directly contains the `buildSrc/` directory. It does not appear in `Gradle.getIncludedBuilds()`, and `buildSrc` cannot reference itself this way.
+
 [[referencing_included_build_projects]]
 === Referencing Projects
 

--- a/platforms/documentation/docs/src/docs/userguide/structuring-builds/composite_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/structuring-builds/composite_builds.adoc
@@ -334,26 +334,8 @@ include::sample[dir="snippets/structuring-builds/composite-builds-hierarchical-m
 A `buildSrc` build can also be referenced by name through `Gradle.includedBuild("buildSrc")`, which lets the consuming build depend on tasks declared in `buildSrc`. For example, to make the root build's `check` task also run `buildSrc`'s `check`:
 
 ====
-[.multi-language-sample]
-=====
-.build.gradle.kts
-[source,kotlin]
-----
-tasks.named("check") {
-    dependsOn(gradle.includedBuild("buildSrc").task(":check"))
-}
-----
-=====
-[.multi-language-sample]
-=====
-.build.gradle
-[source,groovy]
-----
-tasks.named("check") {
-    dependsOn gradle.includedBuild("buildSrc").task(":check")
-}
-----
-=====
+include::sample[dir="snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin",files="build.gradle.kts[tags=check-buildsrc]"]
+include::sample[dir="snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy",files="build.gradle[tags=check-buildsrc]"]
 ====
 
 The task path must be qualified (start with `:`). For a multi-project `buildSrc`, depend on each subproject's task explicitly (e.g. `gradle.includedBuild("buildSrc").task(":sub:check")`); there is no implicit aggregation across `buildSrc` subprojects from the consuming build.

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'base'
+}
+
+// tag::check-buildsrc[]
+tasks.named("check") {
+    dependsOn gradle.includedBuild("buildSrc").task(":check")
+}
+// end::check-buildsrc[]

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/buildSrc/build.gradle
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/buildSrc/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "composite-builds-buildsrc-tasks"

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    base
+}
+
+// tag::check-buildsrc[]
+tasks.named("check") {
+    dependsOn(gradle.includedBuild("buildSrc").task(":check"))
+}
+// end::check-buildsrc[]

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/buildSrc/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "composite-builds-buildsrc-tasks"

--- a/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/structuring-builds/composite-builds-buildsrc-tasks/tests/sanityCheck.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: check -q

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcTaskDependencyIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcTaskDependencyIntegrationTest.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+/**
+ * Tests for referencing tasks in {@code buildSrc} via {@code gradle.includedBuild('buildSrc').task(...)},
+ * the same way tasks of any other included build can be referenced.
+ */
+class CompositeBuildBuildSrcTaskDependencyIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    def setup() {
+        buildA.file("buildSrc/build.gradle") << """
+            allprojects {
+                task logProject {
+                    def rootProjectName = project.rootProject.name
+                    def projectPath = project.path
+                    doLast {
+                        println "Executing build '" + rootProjectName + "' project '" + projectPath + "' task '" + path + "'"
+                    }
+                }
+            }
+        """
+    }
+
+    def "can depend on task in root project of buildSrc"() {
+        when:
+        buildA.buildFile << """
+            task delegate {
+                dependsOn gradle.includedBuild('buildSrc').task(':logProject')
+            }
+        """
+
+        execute(buildA, ":delegate")
+
+        then:
+        executed ":buildSrc:logProject"
+        output.contains("Executing build 'buildSrc' project ':' task ':logProject'")
+    }
+
+    def "can depend on task in subproject of buildSrc"() {
+        given:
+        createDirs("buildA/buildSrc", "buildA/buildSrc/sub")
+        buildA.file("buildSrc/settings.gradle") << """
+            include 'sub'
+        """
+
+        when:
+        buildA.buildFile << """
+            task delegate {
+                dependsOn gradle.includedBuild('buildSrc').task(':sub:logProject')
+            }
+        """
+
+        execute(buildA, ":delegate")
+
+        then:
+        executed ":buildSrc:sub:logProject"
+        output.contains("Executing build 'buildSrc' project ':sub' task ':sub:logProject'")
+    }
+
+    def "can depend on multiple tasks of buildSrc"() {
+        given:
+        createDirs("buildA/buildSrc", "buildA/buildSrc/sub")
+        buildA.file("buildSrc/settings.gradle") << """
+            include 'sub'
+        """
+
+        when:
+        buildA.buildFile << """
+            def buildSrc = gradle.includedBuild('buildSrc')
+            task delegate {
+                dependsOn 'delegate1', 'delegate2'
+            }
+            task delegate1 {
+                dependsOn buildSrc.task(':logProject')
+                dependsOn buildSrc.task(':sub:logProject')
+            }
+            task delegate2 {
+                dependsOn buildSrc.task(':logProject')
+            }
+        """
+
+        execute(buildA, ":delegate")
+
+        then:
+        executed ":buildSrc:logProject", ":buildSrc:sub:logProject"
+        output.contains("Executing build 'buildSrc' project ':' task ':logProject'")
+        output.contains("Executing build 'buildSrc' project ':sub' task ':sub:logProject'")
+    }
+
+    def "can depend on task in buildSrc from subproject of composing build"() {
+        given:
+        createDirs("buildA", "buildA/a1")
+        buildA.settingsFile << """
+            include 'a1'
+        """
+        buildA.buildFile << """
+            task("top-level") {
+                dependsOn ':a1:delegate'
+            }
+
+            project(':a1') {
+                task delegate {
+                    dependsOn gradle.includedBuild('buildSrc').task(':logProject')
+                }
+            }
+        """
+
+        when:
+        execute(buildA, ":top-level")
+
+        then:
+        executed ":buildSrc:logProject"
+        output.contains("Executing build 'buildSrc' project ':' task ':logProject'")
+    }
+
+    def "reports failure when task does not exist for buildSrc"() {
+        when:
+        buildA.buildFile << """
+            task delegate {
+                dependsOn gradle.includedBuild('buildSrc').task(':does-not-exist')
+            }
+        """
+
+        and:
+        fails(buildA, ":delegate")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':delegate'.")
+        failure.assertHasCause("Task with name 'does-not-exist' not found in project ':buildSrc'.")
+    }
+
+    def "reports failure when task path is not qualified for buildSrc"() {
+        when:
+        buildA.buildFile << """
+            task delegate {
+                dependsOn gradle.includedBuild('buildSrc').task('logProject')
+            }
+        """
+
+        and:
+        fails(buildA, "delegate")
+
+        then:
+        failure.assertHasDescription("A problem occurred evaluating root project 'buildA'.")
+        failure.assertHasCause("Task path 'logProject' is not a qualified task path (e.g. ':task' or ':project:task')")
+    }
+
+    def "buildSrc cannot reference tasks in itself via includedBuild"() {
+        when:
+        buildA.file("buildSrc/build.gradle") << """
+            task illegal {
+                dependsOn gradle.includedBuild('buildSrc').task(':logProject')
+            }
+        """
+
+        and:
+        fails(buildA, ":buildSrc:illegal")
+
+        then:
+        failure.assertHasDescription("A problem occurred evaluating project ':buildSrc'.")
+        failure.assertHasCause("Included build 'buildSrc' not found in build 'buildSrc'.")
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -392,12 +392,20 @@ public interface Gradle extends PluginAware, ExtensionAware {
     /**
      * Returns the included builds for this build.
      *
+     * <p>The {@code buildSrc} build, if present, is not included in the returned collection,
+     * even though it can be looked up by name via {@link #includedBuild(String)}.</p>
+     *
      * @since 3.1
      */
     Collection<IncludedBuild> getIncludedBuilds();
 
     /**
      * Returns the included build with the specified name for this build.
+     *
+     * <p>If this build has a {@code buildSrc} build, it can be looked up by passing
+     * {@code "buildSrc"} as the name, even though it does not appear in
+     * {@link #getIncludedBuilds()}. This allows referencing tasks in {@code buildSrc} via
+     * {@link IncludedBuild#task(String)} the same way as for any other included build.</p>
      *
      * @throws UnknownDomainObjectException when there is no build with the given name
      * @since 3.1

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedBuildSrcBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedBuildSrcBuild.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.File;
 
@@ -33,6 +34,7 @@ import java.io.File;
  * <p>Reachable only from the {@code Gradle} instance whose owner directly contains the
  * {@code buildSrc} directory.</p>
  */
+@NullMarked
 public class IncludedBuildSrcBuild implements IncludedBuildInternal {
 
     private final StandAloneNestedBuild buildSrcBuild;

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedBuildSrcBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/IncludedBuildSrcBuild.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.composite;
+
+import org.gradle.api.internal.tasks.DefaultTaskReference;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.tasks.TaskReference;
+import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
+
+import java.io.File;
+
+/**
+ * Public reference to a {@code buildSrc} build, exposing it through the same
+ * {@link org.gradle.api.initialization.IncludedBuild} API used for regular included builds
+ * so that consumers can address tasks via
+ * {@code gradle.includedBuild("buildSrc").task(":someTask")}.
+ *
+ * <p>Reachable only from the {@code Gradle} instance whose owner directly contains the
+ * {@code buildSrc} directory.</p>
+ */
+public class IncludedBuildSrcBuild implements IncludedBuildInternal {
+
+    private final StandAloneNestedBuild buildSrcBuild;
+    private final TaskDependencyFactory taskDependencyFactory;
+
+    public IncludedBuildSrcBuild(StandAloneNestedBuild buildSrcBuild, TaskDependencyFactory taskDependencyFactory) {
+        this.buildSrcBuild = buildSrcBuild;
+        this.taskDependencyFactory = taskDependencyFactory;
+    }
+
+    @Override
+    public String getName() {
+        return buildSrcBuild.getProjects().getRootProject().getName();
+    }
+
+    @Override
+    public File getProjectDir() {
+        return buildSrcBuild.getBuildRootDir();
+    }
+
+    @Override
+    public TaskReference task(String pathStr) {
+        return DefaultTaskReference.create(pathStr, taskDependencyFactory);
+    }
+
+    @Override
+    public BuildState getTarget() {
+        return buildSrcBuild;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IncludedBuildSrcBuild that = (IncludedBuildSrcBuild) o;
+        return buildSrcBuild.equals(that.buildSrcBuild);
+    }
+
+    @Override
+    public int hashCode() {
+        return buildSrcBuild.hashCode();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -43,6 +43,7 @@ import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.invocation.GradleLifecycle;
 import org.gradle.api.model.ObjectFactory;
@@ -58,8 +59,11 @@ import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.InternalListener;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.PublicBuildPath;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.composite.IncludedBuildInternal;
+import org.gradle.internal.composite.IncludedBuildSrcBuild;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -543,7 +547,24 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
                 return includedBuild;
             }
         }
+        if (SettingsInternal.BUILD_SRC.equals(name)) {
+            IncludedBuild buildSrc = findBuildSrcAsIncludedBuild();
+            if (buildSrc != null) {
+                return buildSrc;
+            }
+        }
         throw new UnknownDomainObjectException("Included build '" + name + "' not found in " + this + ".");
+    }
+
+    @Nullable
+    private IncludedBuild findBuildSrcAsIncludedBuild() {
+        BuildStateRegistry buildStateRegistry = buildScopeServices.get(BuildStateRegistry.class);
+        StandAloneNestedBuild buildSrcBuild = buildStateRegistry.getBuildSrcNestedBuild(buildState);
+        if (buildSrcBuild == null) {
+            return null;
+        }
+        TaskDependencyFactory taskDependencyFactory = buildSrcBuild.getMutableModel().getServices().get(TaskDependencyFactory.class);
+        return new IncludedBuildSrcBuild(buildSrcBuild, taskDependencyFactory);
     }
 
     @Override


### PR DESCRIPTION
Fixes #37803

## Summary

- Make the buildSrc build of the requesting `Gradle` reachable through the standard included-build `TaskReference` API. Consumers can now write
  ```
  dependsOn gradle.includedBuild('buildSrc').task(':someTask')
  ```
  the same way they reference tasks of regular included builds.
- Reachability is owner-scoped: only the build that directly contains the `buildSrc` directory can resolve it. Sibling, parent, and ancestor builds still get the standard *Included build 'buildSrc' not found* error.
- Adds `CompositeBuildBuildSrcTaskDependencyIntegrationTest` covering the new behavior, mirroring the patterns in `CompositeBuildTaskDependencyIntegrationTest`.

## How it works

The cross-build wiring (project resolution against nested builds, `TaskInAnotherBuild` wrapping, build-tree work graph scheduling) already exists today — it's exercised by `gradle :buildSrc:foo` from the CLI. This change is a small adapter on top of that:

- New `IncludedBuildSrcBuild` (in `org.gradle.internal.composite`) wraps the `StandAloneNestedBuild` for buildSrc and exposes `task(...)` using the buildSrc build's own `TaskDependencyFactory`, just like `IncludedRootBuild` does for the root build.
- `DefaultGradle.includedBuild(String)` falls back to `BuildStateRegistry.getBuildSrcNestedBuild(buildState)` when the requested name is `"buildSrc"`. Owner-scoped lookup gives the constraint for free.
- `getIncludedBuilds()` is intentionally left unchanged — buildSrc remains absent from the collection, so iterators (dependency substitution, project reports, IDE model builders) keep their current semantics.

The existing `validateNameIsNotBuildSrc` guard remains, so a regular included build still cannot be named `buildSrc`.

## Test plan

- [x] `:composite-builds:embeddedIntegTest --tests CompositeBuildBuildSrcTaskDependencyIntegrationTest` (7/7 passing)
- [ ] CI build
- [ ] Verify configuration cache compatibility
- [ ] Verify Tooling API / IDE model builders are unaffected (they iterate `getIncludedBuilds()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)