### PR TITLE
  Make `updateReleasedVersions` idempotent for final releases

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/ReleasedVersionsHelper.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/ReleasedVersionsHelper.kt
@@ -55,11 +55,25 @@ fun updateReleasedVersions(currentReleasedVersion: ReleasedVersion, releasedVers
             releasedVersions.latestRc
         },
         if (currentReleasedVersion.gradleVersion().finalRelease()) {
-            (releasedVersions.finalReleases + currentReleasedVersion).sortedBy { it.gradleVersion() }.reversed()
+            normalizedFinalReleases(releasedVersions.finalReleases + currentReleasedVersion)
         } else {
-            releasedVersions.finalReleases
+            normalizedFinalReleases(releasedVersions.finalReleases)
         }
     )
+
+
+/**
+ * One entry per released version string, newest buildTime first when duplicates exist.
+ * Applying this after updates makes [updateReleasedVersions] idempotent for final releases.
+ */
+private
+fun normalizedFinalReleases(finalReleases: List<ReleasedVersion>): List<ReleasedVersion> =
+    finalReleases
+        .sortedWith(
+            compareByDescending<ReleasedVersion> { it.gradleVersion() }
+                .thenByDescending { it.buildTime }
+        )
+        .distinctBy { it.version }
 
 
 private

--- a/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateReleasedVersionsTest.groovy
+++ b/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateReleasedVersionsTest.groovy
@@ -42,7 +42,7 @@ class UpdateReleasedVersionsTest extends Specification {
         ReleasedVersionsHelperKt.updateReleasedVersions(version, versions) == releasedVersions(snapshot, rc, [version])
     }
 
-    def "final releases are sorted by version"() {
+    def "final releases are deduplicated and ordered by Gradle version (desc)"() {
         def snapshot = snapshot('4.3')
         def rc = releasedVersion('4.3-rc-1')
         def referenceBuildTime = System.currentTimeMillis() - DAYS.toMillis(10)
@@ -56,8 +56,34 @@ class UpdateReleasedVersionsTest extends Specification {
         def versions = releasedVersions(snapshot, rc, finalVersionsBefore)
         def version = new ReleasedVersion('4.2', '20170913122310+0000')
         expect:
-        def expectedVersions = (finalVersionsBefore + version).sort { it.version }.reverse()
+        def expectedVersions = [
+            releasedVersion('4.4', referenceBuildTime + 5),
+            releasedVersion('4.3.1', referenceBuildTime + 7),
+            releasedVersion('4.3', referenceBuildTime + 2),
+            releasedVersion('4.2.1', referenceBuildTime + 3),
+            releasedVersion('4.2', referenceBuildTime),
+        ]
         ReleasedVersionsHelperKt.updateReleasedVersions(version, versions) == releasedVersions(snapshot, rc, expectedVersions)
+    }
+
+    def "final release update is idempotent"() {
+        def snapshot = snapshot('4.3')
+        def rc = releasedVersion('4.3-rc-1')
+        def finalRow = releasedVersion('4.2')
+        def versions = releasedVersions(snapshot, rc, [])
+        expect:
+        def once = ReleasedVersionsHelperKt.updateReleasedVersions(finalRow, versions)
+        ReleasedVersionsHelperKt.updateReleasedVersions(finalRow, once) == once
+    }
+
+    def "duplicate identical final releases in file are collapsed"() {
+        def snapshot = snapshot('4.3')
+        def rc = releasedVersion('4.3-rc-1')
+        def duplicate = releasedVersion('4.2')
+        def versions = releasedVersions(snapshot, rc, [duplicate, duplicate])
+        expect:
+        ReleasedVersionsHelperKt.updateReleasedVersions(duplicate, versions) ==
+            releasedVersions(snapshot, rc, [duplicate])
     }
 
     def "newer snapshots are stored"() {


### PR DESCRIPTION
In https://github.com/gradle/bt-marketplace/issues/14 we found that running `updateReleasedVersions` multiple times with same final release will result in duplicate entries in `released-versions.json`.

This PR makes it idempotent by deduplicating the versions.