### PR TITLE
Clean up some usages of ProjectInternal in CrossProjectModelAccess

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -158,6 +158,14 @@
         <constraint name="receiver" nameOfExprType="InternalOptions" exprTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="opt" nameOfExprType="InternalOption&lt;.*Nullable String&gt;" exprTypeWithinHierarchy="true" within="" contains="" />
       </replaceConfiguration>
+      <replaceConfiguration name="Use Path.asString() instead of toString()" suppressId="use_path_asString" problemDescriptor="Use `asString()` instead of `toString()` on `org.gradle.util.Path`" text="$receiver$.toString()" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="$receiver$.asString()">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="receiver" nameOfExprType="org\.gradle\.util\.Path" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Use Path.asString() instead of toString() (Kotlin)" suppressId="use_path_asString" problemDescriptor="Use `asString()` instead of `toString()` on `org.gradle.util.Path`" text="$receiver$.toString()" recursive="false" caseInsensitive="false" type="Kotlin" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="$receiver$.asString()">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="receiver" nameOfExprType="org\.gradle\.util\.Path" exprTypeWithinHierarchy="true" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="Use @ToBeImplemented annotation" suppressId="not_yet_implemented" problemDescriptor="Prefer '@ToBeImplemented' annotation" text="@NotYetImplemented" recursive="false" caseInsensitive="false" type="Groovy" pattern_context="File" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="@org.gradle.util.internal.ToBeImplemented">
         <constraint name="__context__" within="" contains="" />
       </replaceConfiguration>

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CoupledProjectsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CoupledProjectsListener.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.internal.project.ProjectState
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
 
@@ -32,5 +32,5 @@ interface CoupledProjectsListener {
      * The [referrer] and [target] might represent the same project, and the listener implementation
      * should handle this specifically, probably ignoring such calls, as a project is naturally coupled with itself.
      */
-    fun onProjectReference(referrer: ProjectState, target: ProjectState)
+    fun onProjectReference(referrer: ProjectIdentity, target: ProjectIdentity)
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -32,6 +32,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.CrossProjectConfigurator
 import org.gradle.api.internal.project.CrossProjectModelAccess
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.api.internal.project.ProjectState as InternalProjectState
@@ -58,7 +59,7 @@ import java.util.function.Supplier
 
 class CrossProjectConfigurationReportingGradle(
     gradle: GradleInternal,
-    private val referrerProject: ProjectInternal,
+    private val referrerProject: ProjectIdentity,
 ) : GradleInternal {
 
     private
@@ -98,7 +99,7 @@ class CrossProjectConfigurationReportingGradle(
         delegate.rootProject {
             // Instead of the rootProject's `allProjects`, collect the projects while still tracking the current referrer project
             val root = this@CrossProjectConfigurationReportingGradle.getCrossProjectRootProject()
-            projectConfigurator.allprojects(crossProjectModelAccess.getAllprojects(referrerProject, root), action)
+            projectConfigurator.allprojects(crossProjectModelAccess.getAllprojects(referrerProject, root.projectIdentity), action)
         }
     }
 
@@ -201,7 +202,7 @@ class CrossProjectConfigurationReportingGradle(
     private
     class CrossProjectModelAccessProjectEvaluationListener(
         private val delegate: ProjectEvaluationListener,
-        private val referrerProject: ProjectInternal,
+        private val referrerProject: ProjectIdentity,
         private val crossProjectModelAccess: CrossProjectModelAccess
     ) : ProjectEvaluationListener {
         override fun beforeEvaluate(project: Project) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -18,12 +18,14 @@ package org.gradle.internal.cc.impl
 
 import groovy.lang.Closure
 import org.gradle.api.Action
-import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.execution.TaskExecutionGraphListener
+import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.CrossProjectModelAccess
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.execution.plan.FinalizedExecutionPlan
 import org.gradle.execution.plan.ScheduledWork
 import org.gradle.execution.taskgraph.TaskExecutionGraphExecutionListener
@@ -38,10 +40,11 @@ import java.util.Objects
 internal
 class CrossProjectConfigurationReportingTaskExecutionGraph(
     taskGraph: TaskExecutionGraphInternal,
-    private val referrerProject: ProjectInternal,
+    private val referrerProject: ProjectIdentity,
     private val ipProblems: IsolatedProjectsProblemsReporter,
     private val crossProjectModelAccess: CrossProjectModelAccess,
     private val coupledProjectsListener: CoupledProjectsListener,
+    private val projectStateLookup: ProjectStateLookup,
 ) : TaskExecutionGraphInternal {
 
     private
@@ -80,10 +83,12 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
             if (task == null) {
                 // check whether the path refers to a different project
                 val parentPath = Path.path(path).parent?.asString()
-                if (parentPath != referrerProject.path) {
+                if (parentPath != referrerProject.projectPath.asString()) {
                     // even though the task was not found, the current project is coupled with the other project:
                     // if the configuration of that project changes, the result of this call might be different
-                    val coupledProjects = listOfNotNull(parentPath?.let { referrerProject.findProject(it) })
+                    val coupledProjects = listOfNotNull(parentPath?.let { p ->
+                        projectStateLookup.findProject(referrerProject.resolveProjectPath(p))?.identity
+                    })
                     reportCrossProjectTaskAccess(coupledProjects, path)
                 }
             } else {
@@ -98,8 +103,8 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
 
     private
     fun checkCrossProjectTaskAccess(task: Task) {
-        val taskOwner = task.project as ProjectInternal
-        if (!taskOwner.isReferrerProject) {
+        val taskOwner = (task as TaskInternal).taskIdentity.projectIdentity
+        if (taskOwner != referrerProject) {
             val coupledProjects = listOf(taskOwner)
             reportCrossProjectTaskAccess(coupledProjects, task.path)
         }
@@ -133,23 +138,21 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     private
     fun observingTasksMaybeFromOtherProjects(tasks: Collection<Task>) {
         val otherProjects = tasks.mapNotNullTo(LinkedHashSet(tasks.size / 8)) { task ->
-            (task.project as? ProjectInternal)?.takeIf { project -> !project.isReferrerProject }
+            (task.project as ProjectInternal).owner.identity.takeIf {
+                it != referrerProject
+            }
         }
         reportCrossProjectTaskAccess(otherProjects)
     }
 
     private
-    val Project.isReferrerProject: Boolean
-        get() = this is ProjectInternal && identityPath == referrerProject.identityPath
-
-    private
-    fun reportCrossProjectTaskAccess(coupledProjects: Iterable<ProjectInternal>, requestPath: String? = null) {
+    fun reportCrossProjectTaskAccess(coupledProjects: Iterable<ProjectIdentity>, requestPath: String? = null) {
         reportCoupledProjects(coupledProjects)
 
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrerProject.identityPath.toString())
+                reference(referrerProject.buildTreePath.toString())
                 text(" cannot access the tasks in the task graph that were created by other projects")
             }.exception { message ->
                 // As the exception message is not used for grouping, we can safely add the exact task name to it:
@@ -159,9 +162,9 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     }
 
     private
-    fun reportCoupledProjects(coupledProjects: Iterable<ProjectInternal>) {
+    fun reportCoupledProjects(coupledProjects: Iterable<ProjectIdentity>) {
         coupledProjects.forEach { other ->
-            coupledProjectsListener.onProjectReference(referrerProject.owner, other.owner)
+            coupledProjectsListener.onProjectReference(referrerProject, other)
         }
     }
 
@@ -171,7 +174,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     private
     class CrossProjectAccessTrackingTaskExecutionGraphListener(
         private val delegate: TaskExecutionGraphListener,
-        private val referrerProject: ProjectInternal,
+        private val referrerProject: ProjectIdentity,
         private val crossProjectModelAccess: CrossProjectModelAccess
     ) : TaskExecutionGraphListener {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -152,7 +152,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrerProject.buildTreePath.toString())
+                reference(referrerProject.buildTreePath)
                 text(" cannot access the tasks in the task graph that were created by other projects")
             }.exception { message ->
                 // As the exception message is not used for grouping, we can safely add the exact task name to it:

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessPattern.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessPattern.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectIdentity
 
 
 internal
@@ -31,5 +31,5 @@ enum class CrossProjectModelAccessPattern {
 internal
 data class CrossProjectModelAccessInstance(
     val pattern: CrossProjectModelAccessPattern,
-    val relativeTo: ProjectInternal,
+    val relativeTo: ProjectIdentity,
 )

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingClosure.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingClosure.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import groovy.lang.Closure
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.CrossProjectModelAccess
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import java.util.Objects
@@ -26,7 +27,7 @@ import java.util.Objects
 
 class CrossProjectModelAccessTrackingClosure<T>(
     private val delegate: Closure<T>,
-    private val referrerProject: ProjectInternal,
+    private val referrerProject: ProjectIdentity,
     private val crossProjectModelAccess: CrossProjectModelAccess
 ) : Closure<T>(
     trackingProjectAccess(crossProjectModelAccess, referrerProject, delegate.owner),
@@ -53,7 +54,7 @@ class CrossProjectModelAccessTrackingClosure<T>(
 
     companion object {
         private
-        fun trackingProjectAccess(crossProjectModelAccess: CrossProjectModelAccess, referrerProject: ProjectInternal, modelObject: Any): Any =
+        fun trackingProjectAccess(crossProjectModelAccess: CrossProjectModelAccess, referrerProject: ProjectIdentity, modelObject: Any): Any =
             when (modelObject) {
                 is ProjectInternal -> crossProjectModelAccess.access(referrerProject, modelObject)
                 is GradleInternal -> crossProjectModelAccess.gradleInstanceForProject(referrerProject, modelObject)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -149,17 +149,17 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrerProject.buildTreePath.toString())
+                reference(referrerProject.buildTreePath)
                 text(" cannot dynamically look up a ")
                 text(memberKind.name.lowercase(ENGLISH))
                 text(" in the parent project ")
-                reference(ownerProject.buildTreePath.toString())
+                reference(ownerProject.buildTreePath)
             }
                 .mapLocation { location ->
                     when (memberKind) {
                         MemberKind.PROPERTY -> {
                             if (memberName != null)
-                                Property(PropertyKind.PropertyUsage, memberName, Project(referrerProject.projectPath.toString(), location))
+                                Property(PropertyKind.PropertyUsage, memberName, Project(referrerProject.projectPath.asString(), location))
                             else location
                         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -18,7 +18,7 @@ package org.gradle.internal.cc.impl
 
 import groovy.lang.MissingMethodException
 import groovy.lang.MissingPropertyException
-import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace.Project
@@ -30,9 +30,9 @@ import java.util.Locale.ENGLISH
 
 internal
 class CrossProjectModelAccessTrackingParentDynamicObject(
-    private val ownerProject: ProjectInternal,
+    private val ownerProject: ProjectIdentity,
     private val delegate: HierarchicalDynamicObject,
-    private val referrerProject: ProjectInternal,
+    private val referrerProject: ProjectIdentity,
     private val ipProblems: IsolatedProjectsProblemsReporter,
     private val coupledProjectsListener: CoupledProjectsListener,
 ) : HierarchicalDynamicObject {
@@ -144,22 +144,22 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
     @Suppress("ThrowingExceptionsWithoutMessageOrCause") // false-positive on the `.exception()` call
     private
     fun onAccess(memberKind: MemberKind, memberName: String?) {
-        coupledProjectsListener.onProjectReference(referrerProject.owner, ownerProject.owner)
+        coupledProjectsListener.onProjectReference(referrerProject, ownerProject)
 
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrerProject.identityPath.toString())
+                reference(referrerProject.buildTreePath.toString())
                 text(" cannot dynamically look up a ")
                 text(memberKind.name.lowercase(ENGLISH))
                 text(" in the parent project ")
-                reference(ownerProject.identityPath.toString())
+                reference(ownerProject.buildTreePath.toString())
             }
                 .mapLocation { location ->
                     when (memberKind) {
                         MemberKind.PROPERTY -> {
                             if (memberName != null)
-                                Property(PropertyKind.PropertyUsage, memberName, Project(referrerProject.path, location))
+                                Property(PropertyKind.PropertyUsage, memberName, Project(referrerProject.projectPath.toString(), location))
                             else location
                         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import groovy.lang.MissingMethodException
 import groovy.lang.MissingPropertyException
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace.Project
@@ -30,110 +31,111 @@ import java.util.Locale.ENGLISH
 
 internal
 class CrossProjectModelAccessTrackingParentDynamicObject(
-    private val ownerProject: ProjectIdentity,
-    private val delegate: HierarchicalDynamicObject,
+    private val parent: ProjectState,
     private val referrerProject: ProjectIdentity,
     private val ipProblems: IsolatedProjectsProblemsReporter,
     private val coupledProjectsListener: CoupledProjectsListener,
 ) : HierarchicalDynamicObject {
 
+    private fun getMutableDelegate(): HierarchicalDynamicObject = parent.mutableModel.inheritedScope
+
     override fun getParent(): HierarchicalDynamicObject? {
-        return delegate.getParent()
+        return getMutableDelegate().getParent()
     }
 
     override fun hasMethod(name: String, vararg arguments: Any?): Boolean {
         onAccess(MemberKind.METHOD, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.hasMethod(name, *arguments)
+            getMutableDelegate().hasMethod(name, *arguments)
         }
     }
 
     override fun tryInvokeMethod(name: String, vararg arguments: Any?): DynamicInvokeResult {
         onAccess(MemberKind.METHOD, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.tryInvokeMethod(name, *arguments)
+            getMutableDelegate().tryInvokeMethod(name, *arguments)
         }
     }
 
     override fun hasProperty(name: String): Boolean {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.hasProperty(name)
+            getMutableDelegate().hasProperty(name)
         }
     }
 
     override fun tryGetProperty(name: String): DynamicInvokeResult {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.tryGetProperty(name)
+            getMutableDelegate().tryGetProperty(name)
         }
     }
 
     override fun trySetProperty(name: String, value: Any?): DynamicInvokeResult {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.trySetProperty(name, value)
+            getMutableDelegate().trySetProperty(name, value)
         }
     }
 
     override fun trySetPropertyWithoutInstrumentation(name: String, value: Any?): DynamicInvokeResult {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.trySetPropertyWithoutInstrumentation(name, value)
+            getMutableDelegate().trySetPropertyWithoutInstrumentation(name, value)
         }
     }
 
     override fun getProperties(): MutableMap<String, *> {
         onAccess(MemberKind.PROPERTY, null)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.properties
+            getMutableDelegate().properties
         }
     }
 
     override fun getMissingProperty(name: String): MissingPropertyException {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.getMissingProperty(name)
+            getMutableDelegate().getMissingProperty(name)
         }
     }
 
     override fun setMissingProperty(name: String): MissingPropertyException {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.setMissingProperty(name)
+            getMutableDelegate().setMissingProperty(name)
         }
     }
 
     override fun methodMissingException(name: String, vararg params: Any?): MissingMethodException {
         onAccess(MemberKind.METHOD, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.methodMissingException(name, *params)
+            getMutableDelegate().methodMissingException(name, *params)
         }
     }
 
     override fun getProperty(name: String): Any? {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.getProperty(name)
+            getMutableDelegate().getProperty(name)
         }
     }
 
     override fun setProperty(name: String, value: Any?) {
         onAccess(MemberKind.PROPERTY, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.setProperty(name, value)
+            getMutableDelegate().setProperty(name, value)
         }
     }
 
     override fun invokeMethod(name: String, vararg arguments: Any?): Any? {
         onAccess(MemberKind.METHOD, name)
         return ipProblems.runIgnoringProblemsOnCurrentThread {
-            delegate.invokeMethod(name, *arguments)
+            getMutableDelegate().invokeMethod(name, *arguments)
         }
     }
 
     override fun getDisplayName(): String {
-        return delegate.displayName
+        return getMutableDelegate().displayName
     }
 
     private
@@ -144,7 +146,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
     @Suppress("ThrowingExceptionsWithoutMessageOrCause") // false-positive on the `.exception()` call
     private
     fun onAccess(memberKind: MemberKind, memberName: String?) {
-        coupledProjectsListener.onProjectReference(referrerProject, ownerProject)
+        coupledProjectsListener.onProjectReference(referrerProject, this.parent.identity)
 
         ipProblems.report {
             problem {
@@ -153,7 +155,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
                 text(" cannot dynamically look up a ")
                 text(memberKind.name.lowercase(ENGLISH))
                 text(" in the parent project ")
-                reference(ownerProject.buildTreePath)
+                reference(parent.identityPath)
             }
                 .mapLocation { location ->
                     when (memberKind) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -663,6 +663,6 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         private
-        fun StructuredMessage.Builder.reference(identity: ProjectIdentity) = reference(identity.buildTreePath.toString())
+        fun StructuredMessage.Builder.reference(identity: ProjectIdentity) = reference(identity.buildTreePath)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -40,9 +40,12 @@ import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.DefaultCrossProjectModelAccess
 import org.gradle.api.internal.project.MutableStateAccessAwareProject
 import org.gradle.api.internal.project.ProjectIdentifier
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectOrderingUtil
 import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.api.internal.project.ProjectState
+import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker
 import org.gradle.api.logging.Logger
@@ -86,72 +89,72 @@ class ProblemReportingCrossProjectModelAccess(
     private val coupledProjectsListener: CoupledProjectsListener,
     private val buildModelParameters: BuildModelParameters,
     private val instantiator: Instantiator,
+    private val projectStateLookup: ProjectStateLookup,
     projectRegistry: ProjectRegistry,
     gradleLifecycleActionExecutor: GradleLifecycleActionExecutor
 ) : CrossProjectModelAccess {
 
     private val delegate = DefaultCrossProjectModelAccess(projectRegistry, instantiator, gradleLifecycleActionExecutor)
 
-    override fun findProject(referrer: ProjectInternal, path: Path): ProjectInternal? {
+    override fun findProject(referrer: ProjectIdentity, path: Path): ProjectInternal? {
         return delegate.findProject(referrer, path)?.let {
-            it.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, it), instantiator)
+            it.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, it.projectIdentity))
         }
     }
 
-    override fun access(referrer: ProjectInternal, project: ProjectInternal): ProjectInternal {
+    override fun access(referrer: ProjectIdentity, project: ProjectInternal): ProjectInternal {
         // We purposefully leak mutable state here, as we wrap all mutable access with immediate failures in the case of cross-project access,
         // so there's no risk of race conditions.
-        return project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, project), instantiator)
+        return project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, project.projectIdentity))
     }
 
-    override fun accessFromState(referrer: ProjectInternal, projectState: ProjectState): ProjectInternal {
+    override fun accessFromState(referrer: ProjectIdentity, projectState: ProjectState): ProjectInternal {
         return projectState.fromMutableState { project ->
             access(referrer, project)
         }
     }
 
-    override fun getChildProjects(referrer: ProjectInternal, target: ProjectInternal): MutableMap<String, Project> {
+    override fun getChildProjects(referrer: ProjectIdentity, target: ProjectState): MutableMap<String, Project> {
         return delegate.getChildProjects(referrer, target).mapValuesTo(LinkedHashMap()) {
-            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, target), instantiator)
+            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, target.identity))
         }
     }
 
-    override fun getSubprojects(referrer: ProjectInternal, target: ProjectInternal): MutableSet<out ProjectInternal> {
+    override fun getSubprojects(referrer: ProjectIdentity, target: ProjectIdentity): MutableSet<out ProjectInternal> {
         return delegate.getSubprojects(referrer, target).mapTo(LinkedHashSet()) {
-            it.wrap(referrer, CrossProjectModelAccessInstance(SUBPROJECT, target), instantiator)
+            it.wrap(referrer, CrossProjectModelAccessInstance(SUBPROJECT, target))
         }
     }
 
-    override fun getAllprojects(referrer: ProjectInternal, target: ProjectInternal): MutableSet<out ProjectInternal> {
+    override fun getAllprojects(referrer: ProjectIdentity, target: ProjectIdentity): MutableSet<out ProjectInternal> {
         return delegate.getAllprojects(referrer, target).mapTo(LinkedHashSet()) {
-            it.wrap(referrer, CrossProjectModelAccessInstance(ALLPROJECTS, target), instantiator)
+            it.wrap(referrer, CrossProjectModelAccessInstance(ALLPROJECTS, target))
         }
     }
 
-    override fun gradleInstanceForProject(referrerProject: ProjectInternal, gradle: GradleInternal): GradleInternal {
-        return CrossProjectConfigurationReportingGradle(gradle, referrerProject)
+    override fun gradleInstanceForProject(referrer: ProjectIdentity, gradle: GradleInternal): GradleInternal {
+        return CrossProjectConfigurationReportingGradle(gradle, referrer)
     }
 
-    override fun taskDependencyUsageTracker(referrerProject: ProjectInternal): TaskDependencyUsageTracker {
-        return ReportingTaskDependencyUsageTracker(referrerProject, coupledProjectsListener, ipProblems)
+    override fun taskDependencyUsageTracker(referrer: ProjectIdentity): TaskDependencyUsageTracker {
+        return ReportingTaskDependencyUsageTracker(referrer, coupledProjectsListener, ipProblems)
     }
 
-    override fun taskGraphForProject(referrerProject: ProjectInternal, taskGraph: TaskExecutionGraphInternal): TaskExecutionGraphInternal {
-        return CrossProjectConfigurationReportingTaskExecutionGraph(taskGraph, referrerProject, ipProblems, this, coupledProjectsListener)
+    override fun taskGraphForProject(referrer: ProjectIdentity, taskGraph: TaskExecutionGraphInternal): TaskExecutionGraphInternal {
+        return CrossProjectConfigurationReportingTaskExecutionGraph(taskGraph, referrer, ipProblems, this, coupledProjectsListener, projectStateLookup)
     }
 
-    override fun parentProjectDynamicInheritedScope(referrerProject: ProjectInternal): HierarchicalDynamicObject? {
-        val parent = referrerProject.parent ?: return null
+    override fun parentProjectDynamicInheritedScope(referrer: ProjectState): HierarchicalDynamicObject? {
+        val parent = referrer.parent ?: return null
         return CrossProjectModelAccessTrackingParentDynamicObject(
-            parent, parent.inheritedScope, referrerProject, ipProblems, coupledProjectsListener
+            parent.identity, parent.fromMutableState { it.inheritedScope }, referrer.identity, ipProblems, coupledProjectsListener
         )
     }
 
     private
     fun ProjectInternal.wrap(
-        referrer: ProjectInternal,
-        access: CrossProjectModelAccessInstance,
-        instantiator: Instantiator
+        referrer: ProjectIdentity,
+        access: CrossProjectModelAccessInstance
     ): ProjectInternal = MutableStateAccessAwareProject.wrap(this, referrer) {
         instantiator.newInstance(
             ProblemReportingProject::class.java,
@@ -167,7 +170,7 @@ class ProblemReportingCrossProjectModelAccess(
     @Suppress("LargeClass")
     open class ProblemReportingProject(
         delegate: ProjectInternal,
-        referrer: ProjectInternal,
+        referrer: ProjectIdentity,
         private val access: CrossProjectModelAccessInstance,
         private val ipProblems: IsolatedProjectsProblemsReporter,
         private val coupledProjectsListener: CoupledProjectsListener,
@@ -566,7 +569,7 @@ class ProblemReportingCrossProjectModelAccess(
                 // Referent is not configured and wasn't invalidated
                 // This can be a case in an incremental sync scenario, when referrer script was changed and since re-configured,
                 // but referent wasn't changed and since wasn't configured.
-                delegate < referrer && delegate.state.isUnconfigured && !buildModelParameters.isInvalidateCoupledProjects -> {
+                isDelegateBeforeReferrer() && delegate.state.isUnconfigured && !buildModelParameters.isInvalidateCoupledProjects -> {
                     reportCrossProjectAccessProblem(accessRef, memberKind) { missedReferentConfigurationMessage() }
                     null
                 }
@@ -580,12 +583,15 @@ class ProblemReportingCrossProjectModelAccess(
 
         private
         fun onProjectsCoupled() {
-            coupledProjectsListener.onProjectReference(referrer.owner, delegate.owner)
+            coupledProjectsListener.onProjectReference(referrer, delegate.projectIdentity)
             // Configure the target project, if it would normally be configured before the referring project
-            if (delegate < referrer && delegate.parent != null && buildModelParameters.isInvalidateCoupledProjects) {
+            if (isDelegateBeforeReferrer() && delegate.parent != null && buildModelParameters.isInvalidateCoupledProjects) {
                 delegate.owner.ensureConfigured()
             }
         }
+
+        private
+        fun isDelegateBeforeReferrer(): Boolean = ProjectOrderingUtil.compare(delegate.projectIdentity, referrer) < 0
 
         @Suppress("ThrowingExceptionsWithoutMessageOrCause")
         private
@@ -624,7 +630,7 @@ class ProblemReportingCrossProjectModelAccess(
             when (access.pattern) {
                 DIRECT -> {
                     text("another project ")
-                    reference(delegate)
+                    reference(delegate.projectIdentity)
                 }
 
                 CHILD -> {
@@ -657,6 +663,6 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         private
-        fun StructuredMessage.Builder.reference(project: ProjectInternal) = reference(project.identityPath.toString())
+        fun StructuredMessage.Builder.reference(identity: ProjectIdentity) = reference(identity.buildTreePath.toString())
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -590,6 +590,9 @@ class ProblemReportingCrossProjectModelAccess(
             }
         }
 
+        /**
+         * Based on vintage configuration order, would the delegate project be configured before the referrer project?
+         */
         private
         fun isDelegateBeforeReferrer(): Boolean = ProjectOrderingUtil.compare(delegate.projectIdentity, referrer) < 0
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -147,7 +147,7 @@ class ProblemReportingCrossProjectModelAccess(
     override fun parentProjectDynamicInheritedScope(referrer: ProjectState): HierarchicalDynamicObject? {
         val parent = referrer.parent ?: return null
         return CrossProjectModelAccessTrackingParentDynamicObject(
-            parent.identity, parent.fromMutableState { it.inheritedScope }, referrer.identity, ipProblems, coupledProjectsListener
+            parent, referrer.identity, ipProblems, coupledProjectsListener
         )
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
@@ -28,7 +29,7 @@ import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReport
  */
 internal
 class ReportingTaskDependencyUsageTracker(
-    private val referrer: ProjectInternal,
+    private val referrer: ProjectIdentity,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val ipProblems: IsolatedProjectsProblemsReporter,
 ) : TaskDependencyUsageTracker {
@@ -40,7 +41,7 @@ class ReportingTaskDependencyUsageTracker(
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrer.identityPath.toString())
+                reference(referrer.buildTreePath.toString())
                 text(" cannot access task dependencies directly")
             }
                 .exception()
@@ -52,7 +53,7 @@ class ReportingTaskDependencyUsageTracker(
     fun checkForCoupledProjects(taskDependencies: Set<Task>) {
         taskDependencies.forEach { task ->
             val otherProject = task.project as ProjectInternal
-            coupledProjectsListener.onProjectReference(referrer.owner, otherProject.owner)
+            coupledProjectsListener.onProjectReference(referrer, otherProject.projectIdentity)
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
@@ -41,7 +41,7 @@ class ReportingTaskDependencyUsageTracker(
         ipProblems.report {
             problem {
                 text("Project ")
-                reference(referrer.buildTreePath.toString())
+                reference(referrer.buildTreePath)
                 text(" cannot access task dependencies directly")
             }
                 .exception()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintEventHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintEventHandler.kt
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheExpirationControl
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.collections.FileCollectionObservationListener
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.properties.GradlePropertiesListener
 import org.gradle.api.internal.properties.GradlePropertyScope
@@ -201,7 +202,7 @@ internal class ConfigurationCacheFingerprintEventHandler(
         delegate?.onChangingModuleResolve(moduleId, expiry)
     }
 
-    override fun onProjectReference(referrer: ProjectState, target: ProjectState) {
+    override fun onProjectReference(referrer: ProjectIdentity, target: ProjectIdentity) {
         delegate?.onProjectReference(referrer, target)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -609,12 +609,12 @@ class ConfigurationCacheFingerprintWriter(
         }
     }
 
-    fun onProjectReference(referrer: ProjectState, target: ProjectState) {
-        if (referrer.identityPath == target.identityPath)
+    fun onProjectReference(referrer: ProjectIdentity, target: ProjectIdentity) {
+        if (referrer == target)
             return
 
         if (host.cacheIntermediateModels) {
-            val dependency = ProjectSpecificFingerprint.CoupledProjects(referrer.identityPath, target.identityPath)
+            val dependency = ProjectSpecificFingerprint.CoupledProjects(referrer.buildTreePath, target.buildTreePath)
             if (projectDependencies.add(dependency)) {
                 projectScopedWriter.write(dependency)
             }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -23,6 +23,7 @@ import org.gradle.internal.configuration.problems.StructuredMessage.Fragment.Ref
 import org.gradle.internal.configuration.problems.StructuredMessage.Fragment.Text
 import org.gradle.internal.problems.failure.Failure
 import org.gradle.problems.Location
+import org.gradle.util.Path
 import kotlin.reflect.KClass
 
 
@@ -119,6 +120,10 @@ data class StructuredMessage(val fragments: List<Fragment>) {
 
         fun reference(name: String): Builder = apply {
             fragments.add(Reference(name))
+        }
+
+        fun reference(path: Path): Builder = apply {
+            fragments.add(Reference(path.asString()))
         }
 
         fun reference(type: Class<*>): Builder = apply {

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
@@ -153,6 +153,18 @@ public final class ProjectIdentity implements DisplayName {
     }
 
     /**
+     * Given a potentially relative path to a project, resolve it to an absolute path within the build,
+     * using this project as the base for resolving relative paths. This is purely a project path operation,
+     * and does not use the build path in any way.
+     *
+     * @param path a path to a project, either absolute or relative to this project
+     * @return the absolute path to the project within the build, i.e. not including the build path
+     */
+    public Path resolveProjectPath(String path) {
+        return projectPath.absolutePath(Path.path(path));
+    }
+
+    /**
      * Returns the display name of this project in a human-readable format.
      * <ul>
      *     <li>For the root project: {@code root project 'projectName'}</li>

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
@@ -153,6 +153,14 @@ public final class ProjectIdentity implements DisplayName {
     }
 
     /**
+     * {@return the nesting level of a project in a multi-project hierarchy}
+     * Does not include the build path, so it is 0 for the root project of each build, 1 for its direct children, etc.
+     */
+    public int getProjectDepth() {
+        return projectPath.segmentCount();
+    }
+
+    /**
      * Given a potentially relative path to a project, resolve it to an absolute path within the build,
      * using this project as the base for resolving relative paths. This is purely a project path operation,
      * and does not use the build path in any way.

--- a/subprojects/core-api/src/test/groovy/org/gradle/api/internal/project/ProjectIdentityTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/api/internal/project/ProjectIdentityTest.groovy
@@ -57,4 +57,17 @@ class ProjectIdentityTest extends Specification {
         identity.displayName == "project ':included:sub'"
         identity.toString() == "project ':included:sub'"
     }
+
+    def "resolveProjectPath does not involve the build path"() {
+        // Use a non-root build path to make any leakage observable.
+        def buildPath = Path.path(":included")
+        def rootIdentity = ProjectIdentity.forRootProject(buildPath, "includedApp")
+        def subIdentity = ProjectIdentity.forSubproject(buildPath, Path.path(":sub"))
+
+        expect:
+        rootIdentity.resolveProjectPath(":other") == Path.path(":other")
+        rootIdentity.resolveProjectPath("other") == Path.path(":other")
+        subIdentity.resolveProjectPath(":other") == Path.path(":other")
+        subIdentity.resolveProjectPath("other") == Path.path(":sub:other")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
@@ -43,87 +43,87 @@ public interface CrossProjectModelAccess {
      *
      * @throws IllegalArgumentException If {@code path} is not absolute.
      */
-    @Nullable ProjectInternal findProject(ProjectInternal referrer, Path path);
+    @Nullable ProjectInternal findProject(ProjectIdentity referrer, Path path);
 
     /**
      * Wrap the given project to ensure mutable state access is correctly handled across project boundaries,
      * according to the current cross-project model access policy.
      *
      * <p>
-     * If possible, callers should prefer {@link #accessFromState(ProjectInternal, ProjectState)},
+     * If possible, callers should prefer {@link #accessFromState(ProjectIdentity, ProjectState)},
      * as it does not require a reference to the mutable state of the project.
      * </p>
      *
      * @param referrer The project from which the return value will be used.
      */
-    ProjectInternal access(ProjectInternal referrer, ProjectInternal project);
+    ProjectInternal access(ProjectIdentity referrer, ProjectInternal project);
 
     /**
-     * Variant of {@link #access(ProjectInternal, ProjectInternal)} that takes a {@link ProjectState},
+     * Variant of {@link #access(ProjectIdentity, ProjectInternal)} that takes a {@link ProjectState},
      * to avoid needing to have a reference to the mutable state of the project in the caller.
      *
      * <p>
-     * This should be preferred over {@code access(ProjectInternal, ProjectInternal)} where possible.
+     * This should be preferred over {@code access(ProjectIdentity, ProjectInternal)} where possible.
      * </p>
      *
      * @param referrer The project from which the return value will be used.
      */
-    ProjectInternal accessFromState(ProjectInternal referrer, ProjectState projectState);
+    ProjectInternal accessFromState(ProjectIdentity referrer, ProjectState projectState);
 
     /**
      * @param referrer The project from which the return value will be used.
      * @param target The project to get the children of.
      */
-    Map<String, Project> getChildProjects(ProjectInternal referrer, ProjectInternal target);
+    Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectState target);
 
     /**
      * @param referrer The project from which the return value will be used.
      * @param target The project to get the subprojects of.
      */
-    Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer, ProjectInternal target);
+    Set<? extends ProjectInternal> getSubprojects(ProjectIdentity referrer, ProjectIdentity target);
 
     /**
      * @param referrer The project from which the return value will be used.
      * @param target The project to get all projects of.
      */
-    Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer, ProjectInternal target);
+    Set<? extends ProjectInternal> getAllprojects(ProjectIdentity referrer, ProjectIdentity target);
 
     /**
-     * Given the request from the referrerProject to access the specified Gradle instance, returns
+     * Given the request from the referrer to access the specified Gradle instance, returns
      * an instance that behaves correctly regarding cross project model access.
      *
-     * @param referrerProject The project that is going to use the Gradle instance
+     * @param referrer The project that is going to use the Gradle instance.
      * @param gradle The Gradle instance that the project has direct access to.
      * @return A Gradle instance that implements correct cross-project model access.
      */
-    GradleInternal gradleInstanceForProject(ProjectInternal referrerProject, GradleInternal gradle);
+    GradleInternal gradleInstanceForProject(ProjectIdentity referrer, GradleInternal gradle);
 
     /**
      * Provides an implementation of a tracker that handles the usages of TaskDependency API in the context
      * of the current project. The tracker checks that the usages for possible violation of cross-project model access restriction.
      *
-     * @param referrerProject The project providing the context.
+     * @param referrer The project providing the context.
      */
     @Nullable
-    TaskDependencyUsageTracker taskDependencyUsageTracker(ProjectInternal referrerProject);
+    TaskDependencyUsageTracker taskDependencyUsageTracker(ProjectIdentity referrer);
 
     /**
      * Provides an implementation of {@code TaskExecutionGraph} such that it handles access to the
      * tasks in the other projects according to the current cross-project model access policy.
      *
-     * @param referrerProject The project that views the task graph.
+     * @param referrer The project that views the task graph.
      * @return A task graph instance that implements correct cross-project model access.
      */
-    TaskExecutionGraphInternal taskGraphForProject(ProjectInternal referrerProject, TaskExecutionGraphInternal taskGraph);
+    TaskExecutionGraphInternal taskGraphForProject(ProjectIdentity referrer, TaskExecutionGraphInternal taskGraph);
 
     /**
      * Produces a {@code DynamicObject} for the inherited scope from the parent project of the specified project, behaving correctly
      * regarding cross-project model access.
      *
-     * @param referrerProject The project that needs to get an inherited scope dynamic object from its parent.
-     * @return Returns a {@code DynamicObject} for the {@code referrerProject}'s parent project, or null if there is no parent project.
+     * @param referrer The project that needs to get an inherited scope dynamic object from its parent.
+     * @return A {@code DynamicObject} for the {@code referrer}'s parent project, or null if there is no parent project.
      * The returned object handles cross-project model access according to the current policy.
      */
     @Nullable
-    HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectInternal referrerProject);
+    HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectState referrer);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -23,8 +23,8 @@ import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.internal.metaobject.HierarchicalDynamicObject;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.invocation.GradleLifecycleActionExecutor;
-import org.jspecify.annotations.Nullable;
 import org.gradle.util.Path;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -48,21 +48,21 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     }
 
     @Override
-    public ProjectInternal access(ProjectInternal referrer, ProjectInternal project) {
+    public ProjectInternal access(ProjectIdentity referrer, ProjectInternal project) {
         return LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor);
     }
 
     @Override
-    public ProjectInternal accessFromState(ProjectInternal referrer, ProjectState projectState) {
+    public ProjectInternal accessFromState(ProjectIdentity referrer, ProjectState projectState) {
         return projectState.fromMutableState(project ->
-            // We purposefully leak mutable state here, as we're not in IP here so it's safe.
+            // We purposefully leak mutable state here, as we're not in IP so it's safe.
             access(referrer, project)
         );
     }
 
     @Override
     @Nullable
-    public ProjectInternal findProject(ProjectInternal referrer, Path path) {
+    public ProjectInternal findProject(ProjectIdentity referrer, Path path) {
         if (!path.isAbsolute()) {
             throw new IllegalArgumentException("Project path must be absolute");
         }
@@ -72,8 +72,8 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     }
 
     @Override
-    public Map<String, Project> getChildProjects(ProjectInternal referrer, ProjectInternal target) {
-        return target.getOwner().getChildProjects().stream().collect(
+    public Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectState target) {
+        return target.getChildProjects().stream().collect(
             Collectors.toMap(
                 ProjectState::getName,
                 projectState -> LifecycleAwareProject.wrap(projectState.getMutableModel(), referrer, instantiator, gradleLifecycleActionExecutor)
@@ -82,40 +82,40 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     }
 
     @Override
-    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer, ProjectInternal target) {
-        return projectRegistry.getSubProjects(target.getPath()).stream()
+    public Set<? extends ProjectInternal> getSubprojects(ProjectIdentity referrer, ProjectIdentity target) {
+        return projectRegistry.getSubProjects(target.getProjectPath().asString()).stream()
             .map(project -> LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor))
             .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
-    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer, ProjectInternal target) {
-        return projectRegistry.getAllProjects(target.getPath()).stream()
+    public Set<? extends ProjectInternal> getAllprojects(ProjectIdentity referrer, ProjectIdentity target) {
+        return projectRegistry.getAllProjects(target.getProjectPath().asString()).stream()
             .map(project -> LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor))
             .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
-    public GradleInternal gradleInstanceForProject(ProjectInternal referrerProject, GradleInternal gradle) {
+    public GradleInternal gradleInstanceForProject(ProjectIdentity referrer, GradleInternal gradle) {
         return gradle;
     }
 
     @Override
     @Nullable
-    public TaskDependencyUsageTracker taskDependencyUsageTracker(ProjectInternal referrerProject) {
+    public TaskDependencyUsageTracker taskDependencyUsageTracker(ProjectIdentity referrer) {
         return null;
     }
 
     @Override
-    public TaskExecutionGraphInternal taskGraphForProject(ProjectInternal referrerProject, TaskExecutionGraphInternal taskGraph) {
+    public TaskExecutionGraphInternal taskGraphForProject(ProjectIdentity referrer, TaskExecutionGraphInternal taskGraph) {
         return taskGraph;
     }
 
     @Override
     @Nullable
-    public HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectInternal referrerProject) {
-        ProjectInternal parent = referrerProject.getParent();
-        return parent != null ? parent.getInheritedScope() : null;
+    public HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectState referrer) {
+        ProjectState parent = referrer.getParent();
+        // We purposefully leak mutable state here, as we're not in IP so it's safe.
+        return parent != null ? parent.fromMutableState(ProjectInternal::getInheritedScope) : null;
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -258,7 +258,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         taskContainer = services.get(TaskContainerInternal.class);
         extensibleDynamicObject = new ExtensibleDynamicObject(this, Project.class, services.get(InstantiatorFactory.class).decorateLenient(services));
 
-        @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(this);
+        @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(owner);
         if (parentInherited != null) {
             extensibleDynamicObject.setParent(parentInherited);
             extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));
@@ -379,17 +379,17 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getRootProject() {
-        return getRootProject(this);
+        return getRootProject(getProjectIdentity());
     }
 
     @Override
-    public ProjectInternal getRootProject(ProjectInternal referrer) {
+    public ProjectInternal getRootProject(ProjectIdentity referrer) {
         return getCrossProjectModelAccess().access(referrer, rootProject);
     }
 
     @Override
     public GradleInternal getGradle() {
-        return getCrossProjectModelAccess().gradleInstanceForProject(this, gradle);
+        return getCrossProjectModelAccess().gradleInstanceForProject(getProjectIdentity(), gradle);
     }
 
     @Inject
@@ -423,12 +423,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     @Nullable
     public ProjectInternal getParent() {
-        return getParent(this);
+        return getParent(getProjectIdentity());
     }
 
     @Nullable
     @Override
-    public ProjectInternal getParent(ProjectInternal referrer) {
+    public ProjectInternal getParent(ProjectIdentity referrer) {
         if (parent == null) {
             return null;
         }
@@ -529,12 +529,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public Map<String, Project> getChildProjects() {
-        return getChildProjects(this);
+        return getChildProjects(getProjectIdentity());
     }
 
     @Override
-    public Map<String, Project> getChildProjects(ProjectInternal referrer) {
-        return getCrossProjectModelAccess().getChildProjects(referrer, this);
+    public Map<String, Project> getChildProjects(ProjectIdentity referrer) {
+        return getCrossProjectModelAccess().getChildProjects(referrer, getOwner());
     }
 
     @Override
@@ -696,11 +696,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal project(String path) {
-        return project(this, path);
+        return project(getProjectIdentity(), path);
     }
 
     @Override
-    public ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException {
+    public ProjectInternal project(ProjectIdentity referrer, String path) throws UnknownProjectException {
         ProjectInternal project = findProject(referrer, path);
         if (project == null) {
             throw new UnknownProjectException(String.format("Project with path '%s' could not be found in %s.", path, this));
@@ -710,63 +710,62 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal findProject(String path) {
-        return findProject(this, path);
+        return findProject(getProjectIdentity(), path);
     }
 
     @Nullable
     @Override
-    public ProjectInternal findProject(ProjectInternal referrer, String path) {
-        Path targetPath = getProjectIdentity().getProjectPath().absolutePath(Path.path(path));
-        return getCrossProjectModelAccess().findProject(referrer, targetPath);
+    public ProjectInternal findProject(ProjectIdentity referrer, String path) {
+        return getCrossProjectModelAccess().findProject(referrer, getProjectIdentity().resolveProjectPath(path));
     }
 
     @Override
     public Set<Project> getAllprojects() {
-        return Cast.uncheckedCast(getAllprojects(this));
+        return Cast.uncheckedCast(getAllprojects(getProjectIdentity()));
     }
 
     @Override
-    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer) {
-        return getCrossProjectModelAccess().getAllprojects(referrer, this);
+    public Set<? extends ProjectInternal> getAllprojects(ProjectIdentity referrer) {
+        return getCrossProjectModelAccess().getAllprojects(referrer, getProjectIdentity());
     }
 
     @Override
     public void allprojects(Closure configureClosure) {
-        allprojects(this, ConfigureUtil.configureUsing(configureClosure));
+        allprojects(getProjectIdentity(), ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public void allprojects(Action<? super Project> action) {
-        allprojects(this, action);
+        allprojects(getProjectIdentity(), action);
     }
 
     @Override
-    public void allprojects(ProjectInternal referrer, Action<? super Project> action) {
+    public void allprojects(ProjectIdentity referrer, Action<? super Project> action) {
         getProjectConfigurator().allprojects(getAllprojects(referrer), action);
     }
 
     @Override
     public Set<Project> getSubprojects() {
-        return Cast.uncheckedCast(getSubprojects(this));
+        return Cast.uncheckedCast(getSubprojects(getProjectIdentity()));
     }
 
     @Override
-    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer) {
-        return getCrossProjectModelAccess().getSubprojects(referrer, this);
+    public Set<? extends ProjectInternal> getSubprojects(ProjectIdentity referrer) {
+        return getCrossProjectModelAccess().getSubprojects(referrer, getProjectIdentity());
     }
 
     @Override
     public void subprojects(Closure configureClosure) {
-        subprojects(this, ConfigureUtil.configureUsing(configureClosure));
+        subprojects(getProjectIdentity(), ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public void subprojects(Action<? super Project> action) {
-        subprojects(this, action);
+        subprojects(getProjectIdentity(), action);
     }
 
     @Override
-    public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+    public void subprojects(ProjectIdentity referrer, Action<? super Project> configureAction) {
         getProjectConfigurator().subprojects(getSubprojects(referrer), configureAction);
     }
 
@@ -1253,16 +1252,16 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public Project project(String path, Closure configureClosure) {
-        return project(this, path, ConfigureUtil.configureUsing(configureClosure));
+        return project(getProjectIdentity(), path, ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public Project project(String path, Action<? super Project> configureAction) {
-        return project(this, path, configureAction);
+        return project(getProjectIdentity(), path, configureAction);
     }
 
     @Override
-    public ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction) {
+    public ProjectInternal project(ProjectIdentity referrer, String path, Action<? super Project> configureAction) {
         ProjectInternal project = project(referrer, path);
         getProjectConfigurator().project(project, configureAction);
         return project;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -604,7 +604,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public int getDepth() {
-        return owner.getDepth();
+        return getProjectIdentity().getProjectDepth();
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -35,7 +35,7 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
     public static ProjectInternal wrap(
         ProjectInternal target,
-        ProjectInternal referrer,
+        ProjectIdentity referrer,
         Instantiator instantiator,
         GradleLifecycleActionExecutor lifecycleActionExecutor
     ) {
@@ -50,7 +50,7 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
     public LifecycleAwareProject(
         ProjectInternal delegate,
-        ProjectInternal referrer,
+        ProjectIdentity referrer,
         GradleLifecycleActionExecutor gradleLifecycleActionExecutor
     ) {
         super(delegate, referrer);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -108,17 +108,17 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     public static <T extends MutableStateAccessAwareProject> ProjectInternal wrap(
         ProjectInternal target,
-        ProjectInternal referrer,
+        ProjectIdentity referrer,
         Supplier<T> wrapperSupplier
     ) {
-        return target == referrer ? target : wrapperSupplier.get();
+        return target.getProjectIdentity().equals(referrer) ? target : wrapperSupplier.get();
     }
 
     protected final ProjectInternal delegate;
-    protected final ProjectInternal referrer;
+    protected final ProjectIdentity referrer;
     private final DynamicObject dynamicObject;
 
-    protected MutableStateAccessAwareProject(ProjectInternal delegate, ProjectInternal referrer) {
+    protected MutableStateAccessAwareProject(ProjectInternal delegate, ProjectIdentity referrer) {
         this.delegate = delegate;
         this.referrer = referrer;
         this.dynamicObject = new HasPropertyMissingDynamicObject(this, Project.class, this::hasPropertyMissing);
@@ -242,7 +242,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Nullable
     @Override
-    public ProjectInternal getParent(ProjectInternal referrer) {
+    public ProjectInternal getParent(ProjectIdentity referrer) {
         return delegate.getParent(referrer);
     }
 
@@ -304,7 +304,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public ProjectInternal getRootProject(ProjectInternal referrer) {
+    public ProjectInternal getRootProject(ProjectIdentity referrer) {
         return delegate.getRootProject(referrer);
     }
 
@@ -337,7 +337,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+    public void subprojects(ProjectIdentity referrer, Action<? super Project> configureAction) {
         delegate.subprojects(referrer, configureAction);
     }
 
@@ -362,7 +362,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public void allprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+    public void allprojects(ProjectIdentity referrer, Action<? super Project> configureAction) {
         delegate.allprojects(referrer, configureAction);
     }
 
@@ -382,12 +382,12 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction) {
+    public ProjectInternal project(ProjectIdentity referrer, String path, Action<? super Project> configureAction) {
         return delegate.project(referrer, path, configureAction);
     }
 
     @Override
-    public ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException {
+    public ProjectInternal project(ProjectIdentity referrer, String path) throws UnknownProjectException {
         return delegate.project(referrer, path);
     }
 
@@ -398,7 +398,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer) {
+    public Set<? extends ProjectInternal> getSubprojects(ProjectIdentity referrer) {
         return delegate.getSubprojects(referrer);
     }
 
@@ -409,7 +409,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public Map<String, Project> getChildProjects(ProjectInternal referrer) {
+    public Map<String, Project> getChildProjects(ProjectIdentity referrer) {
         return delegate.getChildProjects(referrer);
     }
 
@@ -419,7 +419,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer) {
+    public Set<? extends ProjectInternal> getAllprojects(ProjectIdentity referrer) {
         return delegate.getAllprojects(referrer);
     }
 
@@ -430,7 +430,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Nullable
     @Override
-    public ProjectInternal findProject(ProjectInternal referrer, String path) {
+    public ProjectInternal findProject(ProjectIdentity referrer, String path) {
         return delegate.findProject(referrer, path);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -71,12 +71,12 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     ProjectInternal getParent();
 
     @Nullable
-    ProjectInternal getParent(ProjectInternal referrer);
+    ProjectInternal getParent(ProjectIdentity referrer);
 
     @Override
     ProjectInternal getRootProject();
 
-    ProjectInternal getRootProject(ProjectInternal referrer);
+    ProjectInternal getRootProject(ProjectIdentity referrer);
 
     Project evaluate();
 
@@ -95,26 +95,26 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     @Override
     ProjectInternal project(String path) throws UnknownProjectException;
 
-    ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException;
+    ProjectInternal project(ProjectIdentity referrer, String path) throws UnknownProjectException;
 
-    ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction);
+    ProjectInternal project(ProjectIdentity referrer, String path, Action<? super Project> configureAction);
 
     @Override
     @Nullable
     ProjectInternal findProject(String path);
 
     @Nullable
-    ProjectInternal findProject(ProjectInternal referrer, String path);
+    ProjectInternal findProject(ProjectIdentity referrer, String path);
 
-    Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer);
+    Set<? extends ProjectInternal> getSubprojects(ProjectIdentity referrer);
 
-    void subprojects(ProjectInternal referrer, Action<? super Project> configureAction);
+    void subprojects(ProjectIdentity referrer, Action<? super Project> configureAction);
 
-    Map<String, Project> getChildProjects(ProjectInternal referrer);
+    Map<String, Project> getChildProjects(ProjectIdentity referrer);
 
-    Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer);
+    Set<? extends ProjectInternal> getAllprojects(ProjectIdentity referrer);
 
-    void allprojects(ProjectInternal referrer, Action<? super Project> configureAction);
+    void allprojects(ProjectIdentity referrer, Action<? super Project> configureAction);
 
     HierarchicalDynamicObject getInheritedScope();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectOrderingUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectOrderingUtil.java
@@ -32,7 +32,7 @@ public class ProjectOrderingUtil {
             return buildCompare;
         }
 
-        int depthCompare = Integer.compare(left.getProjectPath().segmentCount(), right.getProjectPath().segmentCount());
+        int depthCompare = depthCompare(left, right);
         if (depthCompare != 0) {
             return depthCompare;
         }
@@ -41,11 +41,11 @@ public class ProjectOrderingUtil {
     }
 
     public static int depthCompare(Project left, Project right) {
-        return depthCompare(owner(left), owner(right));
+        return depthCompare(owner(left).getIdentity(), owner(right).getIdentity());
     }
 
-    public static int depthCompare(ProjectState left, ProjectState right) {
-        return Integer.compare(left.getDepth(), right.getDepth());
+    public static int depthCompare(ProjectIdentity left, ProjectIdentity right) {
+        return Integer.compare(left.getProjectDepth(), right.getProjectDepth());
     }
 
     private static ProjectState owner(Project project) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectOrderingUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectOrderingUtil.java
@@ -23,12 +23,16 @@ public class ProjectOrderingUtil {
     }
 
     public static int compare(ProjectState left, ProjectState right) {
-        int buildCompare = left.getOwner().getIdentityPath().compareTo(right.getOwner().getIdentityPath());
+        return compare(left.getIdentity(), right.getIdentity());
+    }
+
+    public static int compare(ProjectIdentity left, ProjectIdentity right) {
+        int buildCompare = left.getBuildPath().compareTo(right.getBuildPath());
         if (buildCompare != 0) {
             return buildCompare;
         }
 
-        int depthCompare = depthCompare(left, right);
+        int depthCompare = Integer.compare(left.getProjectPath().segmentCount(), right.getProjectPath().segmentCount());
         if (depthCompare != 0) {
             return depthCompare;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -73,17 +73,6 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
         return getIdentity().getProjectName();
     }
 
-    /**
-     * Returns the nesting level of a project in a multi-project hierarchy.
-     * <p>
-     * Returns 0 for the root project, 1 for its direct children, etc.
-     * <p>
-     * The depth is computed independently for each build in the build tree.
-     */
-    default int getDepth() {
-        return getProjectPath().segmentCount();
-    }
-
     default DisplayName getDisplayName() {
         return getIdentity();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -538,7 +538,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         // Otherwise, the user is requesting a task from another project. This is IP incompatible.
         // Obtain a wrapped Project instance that emits IP violations and use it to get the requested task.
-        ProjectInternal targetProject = crossProjectModelAccess.findProject(this.project, projectPath);
+        ProjectInternal targetProject = crossProjectModelAccess.findProject(this.project.getProjectIdentity(), projectPath);
         if (targetProject == null) {
             return null;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -324,7 +324,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected TaskDependencyFactory createTaskDependencyFactory(BuildState build, CrossProjectModelAccess crossProjectModelAccess) {
-        @Nullable TaskDependencyUsageTracker tracker = crossProjectModelAccess.taskDependencyUsageTracker(project);
+        @Nullable TaskDependencyUsageTracker tracker = crossProjectModelAccess.taskDependencyUsageTracker(project.getProjectIdentity());
         TaskResolver taskResolver = new ProjectScopedTaskResolver(
             new BuildScopedTaskResolver(build),
             project.getProjectIdentity(),

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -291,6 +291,7 @@ class DefaultProjectTest extends Specification {
         child1State.owner >> buildState
         child1State.displayName >> Describables.of("project ':child1'")
         child1State.fromMutableState(_) >> { Function f -> f.apply(child1) }
+        child1State.parent >> projectState
         child1 = defaultProject("child1", child1State, project, new File("child1"), child1ClassLoaderScope)
         child1State.mutableModel >> child1
         child1State.name >> "child1"
@@ -298,11 +299,13 @@ class DefaultProjectTest extends Specification {
         chilchildState.owner >> buildState
         chilchildState.displayName >> Describables.of("project ':child1:childchild'")
         chilchildState.fromMutableState(_) >> { Function f -> f.apply(childchild) }
+        chilchildState.parent >> child1State
         childchild = defaultProject("childchild", chilchildState, child1, new File("childchild"), child1ClassLoaderScope.createChild("project-childchild", null))
         child2State = Mock(ProjectState)
         child2State.owner >> buildState
         child2State.displayName >> Describables.of("project ':child2'")
         child2State.fromMutableState(_) >> { Function f -> f.apply(child2) }
+        child2State.parent >> projectState
         child2 = defaultProject("child2", child2State, project, new File("child2"), rootProjectClassLoaderScope.createChild("project-child2", null))
         child2State.mutableModel >> child2
         child2State.name >> "child2"
@@ -992,8 +995,8 @@ def scriptMethod(Closure closure) {
 
     def equalsContractForWrappers() {
         when:
-        Project wrapped = LifecycleAwareProject.wrap(project, child1, instantiatorMock, gradleLifecycleActionExecutor)
-        Project overwrapped = LifecycleAwareProject.wrap(wrapped, child1, instantiatorMock, gradleLifecycleActionExecutor)
+        Project wrapped = LifecycleAwareProject.wrap(project, child1.projectIdentity, instantiatorMock, gradleLifecycleActionExecutor)
+        Project overwrapped = LifecycleAwareProject.wrap(wrapped, child1.projectIdentity, instantiatorMock, gradleLifecycleActionExecutor)
         then:
         project == wrapped
         wrapped == project
@@ -1005,7 +1008,7 @@ def scriptMethod(Closure closure) {
 
     def mapUsageForWrappers() {
         given:
-        Project wrapped = LifecycleAwareProject.wrap(project, child1, instantiatorMock, gradleLifecycleActionExecutor)
+        Project wrapped = LifecycleAwareProject.wrap(project, child1.projectIdentity, instantiatorMock, gradleLifecycleActionExecutor)
         def map = [:]
         when:
         map[project] = "foo"
@@ -1024,7 +1027,7 @@ def scriptMethod(Closure closure) {
     }
 
     static boolean assertLifecycleAwareWithReferrer(Project project, Project referrer) {
-        project instanceof LifecycleAwareProject && project.referrer == referrer
+        project instanceof LifecycleAwareProject && project.referrer == ((ProjectInternal) referrer).projectIdentity
     }
 }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -62,6 +62,10 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
     private buildState = Stub(BuildState) {
         getIdentityPath() >> Path.ROOT
     }
+    private projectIdentity = ProjectIdentity.forRootProject(
+        Path.ROOT,
+        "project"
+    )
     private project = Mock(ProjectInternal, name: "<project>") {
         identityPath(_) >> { String name ->
             Path.path(":project").child(name)
@@ -76,14 +80,12 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
             getDepth() >> 0
             getProjectPath() >> Path.path(":project")
             getOwner() >> buildState
+            getIdentity() >> projectIdentity
         }
         getServices() >> serviceRegistry
         getTaskDependencyFactory() >> TestFiles.taskDependencyFactory()
         getObjects() >> Stub(ObjectFactory)
-        getProjectIdentity() >> ProjectIdentity.forRootProject(
-            Path.ROOT,
-            "project"
-        )
+        getProjectIdentity() >> projectIdentity
     } as ProjectInternal
     private final crossProjectModelAccess = Mock(CrossProjectModelAccess)
     private container = new DefaultTaskContainerFactory(


### PR DESCRIPTION
Mostly adjusts referrer to be ProjectIdentity, but also cleans up some target/base usages where trivially possible.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
