### PR TITLE
Fix NPE due to null path in lenient ArtifactView resolution

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
+import org.gradle.test.preconditions.TestEnvironmentPreconditions
 
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -282,5 +283,59 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(":dependencies", "--configuration", "compileClasspath")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36284")
+    @Requires(TestEnvironmentPreconditions.Online)
+    def "lenient ArtifactView failures expose messages without NPE for androidx.room artifacts"() {
+        // Reproducer for the user-reported scenario: iterating
+        // ArtifactCollection.failures and reading `.message` on each
+        // ModuleVersionResolveException previously NPE'd at
+        // ModuleVersionResolveException.getMessage() line 111 because
+        // DependencyGraphPathResolver.calculatePaths could return a paths
+        // collection containing a null element when a direct dependee's
+        // module had returned to "pending" state and lost all its
+        // constraint-only incoming edges.
+        buildFile << """
+            plugins {
+                id("java")
+            }
+
+            ${mavenCentralRepository()}
+            ${googleRepository()}
+
+            dependencies {
+                implementation("androidx.room:room-sqlite-wrapper:2.8.3")
+                implementation("androidx.room:room-runtime:2.8.3")
+            }
+
+            abstract class DependencyGraphPrinter extends DefaultTask {
+                @Internal
+                abstract Property<ArtifactCollection> getAc()
+
+                @TaskAction
+                void action() {
+                    println("Failures:")
+                    ac.get().failures.each {
+                        // Pre-fix: this throws NPE from
+                        // ModuleVersionResolveException.getMessage().
+                        // Post-fix: messages render with the "Required by:"
+                        // tail omitting any unreachable direct dependees.
+                        println(it.message)
+                    }
+                }
+            }
+
+            tasks.register("dgp", DependencyGraphPrinter) { task ->
+                def artifactCollection = configurations.compileClasspath.incoming.artifactView {
+                    lenient = true
+                }.artifacts
+                task.ac.set(artifactCollection)
+            }
+        """
+
+        expect:
+        succeeds("dgp")
+        outputContains("Failures:")
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
@@ -32,6 +32,24 @@ import java.util.Set;
 
 public class DependencyGraphPathResolver {
 
+    /**
+     * Calculates the shortest "incoming path" from each direct dependee of a broken dependency
+     * back to the resolution root, used to render the "Required by:" tail in
+     * {@link org.gradle.internal.resolve.ModuleVersionResolveException#getMessage}.
+     *
+     * <p>Some direct dependees can have an empty {@code getDependents()} chain at the time
+     * this runs — most commonly because the dependee's module was pushed back to "pending"
+     * state during resolution and {@code ModuleResolveState.clearIncomingAttachedConstraints}
+     * removed all of its constraint-only incoming edges. That is intentional engine design
+     * (the module is "no longer part of the graph"), so the back-link is genuinely gone by
+     * the time path resolution runs. The handling for that case is documented at the
+     * relevant assembly site below; see
+     * <a href="https://github.com/gradle/gradle/issues/36284">issue 36284</a> for details.
+     *
+     * <p><b>Contract:</b> the returned collection's element lists are guaranteed non-null
+     * and non-empty. Direct dependees whose path back to the root cannot be reconstructed
+     * are omitted — there is no entry for them rather than a null entry.
+     */
     public static Collection<List<Describable>> calculatePaths(
         List<DependencyGraphNode> fromNodes,
         DependencyGraphNode toNode,
@@ -86,7 +104,15 @@ public class DependencyGraphPathResolver {
         List<List<Describable>> paths = new ArrayList<>();
         for (DependencyGraphComponent version : directDependees) {
             List<Describable> path = shortestPaths.get(version);
-            paths.add(path);
+            // Skip direct dependees whose path back to root could not be reconstructed
+            // (typically because the dependee's module returned to "pending" state during
+            // resolution and ModuleResolveState.clearIncomingAttachedConstraints removed
+            // its constraint-only incoming edges — see issue 36284). Including null here
+            // would break consumers like ModuleVersionResolveException.getMessage(); the
+            // failure's "Required by:" tail simply omits these dependees.
+            if (path != null) {
+                paths.add(path);
+            }
         }
         return paths;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Objects;
 
 @Contextual
 public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoStackTrace {
@@ -91,10 +92,23 @@ public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoS
 
     /**
      * Creates a copy of this exception, with the given incoming paths.
+     *
+     * <p>Each incoming path must be non-null and non-empty. Null elements are
+     * rejected with {@link NullPointerException}; empty paths are rejected with
+     * {@link IllegalArgumentException}. This contract is enforced fail-fast at
+     * the producer site to prevent latent NPEs in {@link #getMessage()} when
+     * the resulting message is rendered to the user — see
+     * <a href="https://github.com/gradle/gradle/issues/36284">issue 36284</a>.
      */
     public ModuleVersionResolveException withIncomingPaths(Collection<? extends List<Describable>> paths) {
         ModuleVersionResolveException copy = createCopy();
-        copy.paths.addAll(paths);
+        for (List<Describable> path : paths) {
+            Objects.requireNonNull(path, "incoming path must not be null");
+            if (path.isEmpty()) {
+                throw new IllegalArgumentException("incoming path must not be empty");
+            }
+            copy.paths.add(path);
+        }
         copy.initCauses(getCauses());
         copy.setStackTrace(getStackTrace());
         return copy;

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolverTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph
+
+import org.gradle.api.internal.DomainObjectContext
+import spock.lang.Specification
+
+class DependencyGraphPathResolverTest extends Specification {
+
+    /**
+     * Reproducer for https://github.com/gradle/gradle/issues/36284.
+     *
+     * When a direct dependee's upward {@code getDependents()} BFS cannot reach
+     * the seeded root, {@code calculatePaths} silently appends {@code null} to
+     * its returned collection. That null then flows into
+     * {@code ModuleVersionResolveException.withIncomingPaths(...)} and a later
+     * {@code getMessage()} call dereferences {@code path.get(0)} → NPE.
+     *
+     * The fix belongs upstream: this method must never return a collection
+     * containing null elements, regardless of graph topology.
+     */
+    def "does not return null path entries when a direct dependee cannot trace back to the root"() {
+        given:
+        def owner = Stub(DomainObjectContext) {
+            getDisplayName() >> "root project"
+        }
+        def rootComp = Stub(DependencyGraphComponent)
+        def toNode = Stub(DependencyGraphNode) {
+            getOwner() >> rootComp
+        }
+        def directComp = Stub(DependencyGraphComponent) {
+            // Empty dependents — the upward BFS from this direct dependee
+            // never reaches rootComp, so calculatePaths cannot reconstruct a
+            // path. This is the topology that triggers issue 36284.
+            getDependents() >> []
+        }
+        def fromNode = Stub(DependencyGraphNode) {
+            getOwner() >> directComp
+        }
+
+        when:
+        def paths = DependencyGraphPathResolver.calculatePaths([fromNode], toNode, owner)
+
+        then:
+        // Every path element must be non-null — regression guard for issue 36284.
+        paths.every { it != null }
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
@@ -61,4 +61,31 @@ Required by:
     org:a:1.2 > org:b:5 > org:c:1.0
     org:a:1.2 > org:c:1.0''')
     }
+
+    // The two methods below enforce the non-null AND non-empty path-element contract.
+    // The contract is fail-fast at the producer site so any future regression that
+    // reintroduces a degenerate path surfaces here rather than latently in getMessage().
+    // See https://github.com/gradle/gradle/issues/36284.
+
+    def "withIncomingPaths rejects collections containing null elements"() {
+        Describable a = Describables.of("org:a:1.2")
+        def exception = new ModuleVersionResolveException(DefaultModuleComponentSelector.newSelector(mid("a", "b"), "c"), new RuntimeException())
+
+        when:
+        exception.withIncomingPaths([[a], null])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "withIncomingPaths rejects collections containing empty path elements"() {
+        Describable a = Describables.of("org:a:1.2")
+        def exception = new ModuleVersionResolveException(DefaultModuleComponentSelector.newSelector(mid("a", "b"), "c"), new RuntimeException())
+
+        when:
+        exception.withIncomingPaths([[a], []])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
 }


### PR DESCRIPTION
When a consumer iterates `ArtifactCollection.failures` produced by a lenient `ArtifactView` and calls `Throwable.getMessage()` on each failure, Gradle throws `NullPointerException: Cannot invoke "java.util.List.get(int)" because "path" is null` from `ModuleVersionResolveException.getMessage()` (line 111). This fixes that behavior upstream — calculatePaths must never return a
collection containing null elements — not as a guard inside
getMessage().

Adds a unit test on DependencyGraphPathResolver.calculatePaths that
synthesizes the topology where a direct dependee's upward
getDependents() BFS cannot reach the seeded root. In that case the
final assembly loop appends null to the returned paths collection,
which later flows into ModuleVersionResolveException.withIncomingPaths
and triggers an NPE in getMessage() at user-facing iteration time
(e.g. ArtifactCollection.failures.forEach { println it.message }).

Also adds an integration test reproducer "lenient ArtifactView failures expose messages without NPE for androidx.room artifacts" in `ResolutionIssuesIntegrationTest`

Issue: #36284