### PR TITLE
Wrap IsolatedProject around ProjectState

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultIsolatedProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultIsolatedProject.java
@@ -22,44 +22,42 @@ import org.jspecify.annotations.Nullable;
 
 public final class DefaultIsolatedProject implements IsolatedProject {
 
-    private final ProjectInternal project;
-    private final ProjectInternal rootProject;
+    private final ProjectState owner;
 
-    public DefaultIsolatedProject(ProjectInternal project, ProjectInternal rootProject) {
-        this.project = project;
-        this.rootProject = rootProject;
+    public DefaultIsolatedProject(ProjectState owner) {
+        this.owner = owner;
     }
 
     @Override
     public String getName() {
-        return project.getName();
+        return owner.getName();
     }
 
     @Override
     public String getPath() {
-        return project.getPath();
+        return owner.getProjectPath().asString();
     }
 
     @Override
     public String getBuildTreePath() {
-        return project.getBuildTreePath();
+        return owner.getIdentityPath().asString();
     }
 
     @Override
     public Directory getProjectDirectory() {
-        return project.getLayout().getProjectDirectory();
+        // TODO: avoid mutable model access and have a Directory-typed project dir available on ProjectState
+        // This mutable state access is safe, because the project directory is immutable in the layout.
+        return owner.getMutableModel().getLayout().getProjectDirectory();
     }
 
     @Override
     public IsolatedProject getRootProject() {
-        return project.equals(rootProject)
-            ? this
-            : rootProject.getIsolated();
+        return owner.isRootProject() ? this : owner.getOwner().getRootProject().getIsolated();
     }
 
     @Override
     public int hashCode() {
-        return project.hashCode();
+        return owner.getIdentity().hashCode();
     }
 
     @Override
@@ -68,11 +66,11 @@ public final class DefaultIsolatedProject implements IsolatedProject {
             return false;
         }
         DefaultIsolatedProject that = (DefaultIsolatedProject) obj;
-        return this.project.equals(that.project);
+        return this.owner.getIdentity().equals(that.owner.getIdentity());
     }
 
     @Override
     public String toString() {
-        return "DefaultIsolatedProject{" + project + '}';
+        return "DefaultIsolatedProject{" + owner.getDisplayName() + '}';
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -801,7 +801,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public IsolatedProject getIsolated() {
-        return new DefaultIsolatedProject(this, rootProject);
+        return owner.getIsolated();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.project.IsolatedProject;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
@@ -105,6 +106,11 @@ class DefaultProjectState implements ProjectState, Closeable {
     @Override
     public ImmutableProjectDescriptor getDescriptor() {
         return descriptor;
+    }
+
+    @Override
+    public IsolatedProject getIsolated() {
+        return new DefaultIsolatedProject(this);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.project.IsolatedProject;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.model.ModelContainer;
@@ -104,9 +105,15 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
      */
     ImmutableProjectDescriptor getDescriptor();
 
+    IsolatedProject getIsolated();
+
     // endregion
 
     // region Project hierarchy
+
+    default boolean isRootProject() {
+        return getParent() == null;
+    }
 
     /**
      * Returns the parent of this project, as per {@link Project#getParent()}.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultIsolatedProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultIsolatedProjectSpec.groovy
@@ -16,24 +16,28 @@
 
 package org.gradle.api.internal.project
 
-
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class DefaultIsolatedProjectSpec extends Specification {
 
-    def "delegates equals and hashCode to project"() {
+    def "equals and hashCode are based on project identity"() {
         given:
-        def project = Mock(ProjectInternal)
-        def subject = new DefaultIsolatedProject(project, project)
+        def identity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":sub"))
+        def sameIdentity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":sub"))
+        def otherIdentity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":other"))
 
-        when:
-        def hashCode = subject.hashCode()
-        def equality = subject.equals(new DefaultIsolatedProject(project, project))
+        def subject = new DefaultIsolatedProject(stateWithIdentity(identity))
 
-        then:
-        hashCode == 42
-        equality
-        1 * project.hashCode() >> 42
-        1 * project.equals(project) >> true
+        expect:
+        subject.hashCode() == identity.hashCode()
+        subject == new DefaultIsolatedProject(stateWithIdentity(sameIdentity))
+        subject != new DefaultIsolatedProject(stateWithIdentity(otherIdentity))
+    }
+
+    private ProjectState stateWithIdentity(ProjectIdentity identity) {
+        Mock(ProjectState) {
+            getIdentity() >> identity
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -315,11 +315,14 @@ class DefaultProjectSpec extends Specification {
         }
 
         def container = Mock(ProjectState)
+        _ * container.name >> name
         _ * container.projectPath >> identity.projectPath
         _ * container.identityPath >> identity.buildTreePath
         _ * container.owner >> build.owner
         _ * container.displayName >> Describables.of(name)
         _ * container.identity >> identity
+        _ * container.isolated >> { new DefaultIsolatedProject(container) }
+        _ * container.rootProject >> { parent == null }
 
         def descriptor = Mock(ImmutableProjectDescriptor) {
             getIdentity() >> identity
@@ -333,6 +336,8 @@ class DefaultProjectSpec extends Specification {
 
         def instantiator = TestUtil.instantiatorFactory().decorateLenient(serviceRegistry)
         def factory = new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(null), scriptResolution)
-        return factory.createProject(build, descriptor, container, parent, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
+        def project = factory.createProject(build, descriptor, container, parent, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
+        _ * container.mutableModel >> project
+        return project
     }
 }


### PR DESCRIPTION
This is part of the effort to reduce internal use of `Project` mutable models, with the important goal of avoiding references to other projects from within the `Project` implementation.

This PR is a step in that direction. It removes one more reason for the `DefaultProject` to have a reference to `rootProject`.