### PR TITLE
Coerce T/T[] to ListProperty/SetProperty in Groovy DSL

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -118,7 +118,10 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         where:
         description                              | operation | inputType                       | inputValue                                               | expectedResult
         "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'undefined'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
+        "ListProperty<T> = T"                    | "="       | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'
+        "SetProperty<T> = T"                     | "="       | "SetProperty<MyObject>"         | 'new MyObject("a")'                                      | '[a]'
+        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a"), new MyObject("b")] as MyObject[]'   | '[a, b]'
+        "SetProperty<T> = T[]"                   | "="       | "SetProperty<MyObject>"         | '[new MyObject("a"), new MyObject("b")] as MyObject[]'   | '[a, b]'
         "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
         "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
         "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -31,7 +31,9 @@ import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
@@ -244,11 +246,14 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     public void setFromAnyValue(Object object) {
         if (object instanceof Provider) {
             set(Cast.<Provider<C>>uncheckedCast(object));
-        } else {
-            if (object != null && !(object instanceof Iterable)) {
-                throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using an instance of type %s.", getCollectionType().getName(), object.getClass().getName()));
-            }
+        } else if (object == null || object instanceof Iterable) {
             set(Cast.<Iterable<? extends T>>uncheckedCast(object));
+        } else if (object instanceof Object[] && elementType.isAssignableFrom(object.getClass().getComponentType())) {
+            set(Arrays.asList(Cast.<T[]>uncheckedCast(object)));
+        } else if (elementType.isInstance(object)) {
+            set(Collections.singletonList(Cast.<T>uncheckedCast(object)));
+        } else {
+            throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using an instance of type %s.", getCollectionType().getName(), object.getClass().getName()));
         }
     }
 


### PR DESCRIPTION
Allow assigning a single value or array to a ListProperty<T> or SetProperty<T> via the Groovy DSL. The value is coerced into a one-element list (or array-backed list). Previously these assignments threw IllegalArgumentException.

Enables idiomatic Groovy assignments like:

    task.filter.includePatterns = "Foo"

Iterable, Provider, and null assignments are unchanged.

Issue: #31372



### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
