### PR TITLE
Fix Antlr plugin to respect layout.buildDirectory

### DIFF
--- a/platforms/jvm/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
+++ b/platforms/jvm/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
@@ -128,6 +128,29 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
         jar.assertContainsFile("TestGrammarTokenTypes.java")
     }
 
+    @Issue('https://github.com/gradle/gradle/issues/33710')
+    def "antlr respects buildDirectory even when task is realized before reassignment"() {
+        given:
+        buildFile << """
+            apply plugin: "java"
+            apply plugin: "antlr"
+
+            // Force eager realization of the antlr task BEFORE buildDirectory is reassigned.
+            // The task's outputDirectory must still reflect the later buildDirectory value.
+            tasks.getByName('generateGrammarSource')
+
+            layout.buildDirectory = layout.projectDirectory.dir('custom-build')
+        """
+        file("src/main/antlr/TestGrammar.g") << testGrammarSource
+
+        when:
+        succeeds("generateGrammarSource")
+
+        then:
+        file("custom-build/generated-src/antlr/main/TestGrammar.java").exists()
+        !file("build/generated-src/antlr/main/TestGrammar.java").exists()
+    }
+
     private static String getTestGrammarSource() {
         return """ class TestGrammar extends Parser;
         options {

--- a/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.file.FilePathUtil;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.util.List;
 
 import static org.gradle.api.plugins.antlr.internal.AntlrSpec.PACKAGE_ARG;
@@ -83,20 +82,21 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                     //    naming conventions via call to sourceSet.getTaskName()
                     final String taskName = sourceSet.getTaskName("generate", "GrammarSource");
 
-                    // 3) Set up the Antlr output directory
-                    final String outputDirectoryName = project.getBuildDir() + "/generated-src/antlr/" + sourceSet.getName();
-                    final File outputDirectory = new File(outputDirectoryName);
-
-                    // 4) Register a source-generating task, and
+                    // 3) Register a source-generating task, and
                     TaskProvider<AntlrTask> antlrTask = project.getTasks().register(taskName, AntlrTask.class, task -> {
                         task.setDescription("Processes the " + sourceSet.getName() + " Antlr grammars.");
                         task.setGroup("antlr");
-                        // 4.1) set up convention mapping for default sources (allows user to not have to specify)
+                        // 3.1) point the task at the antlr source set
                         task.setSource(antlrSourceSet);
-                        task.setOutputDirectory(outputDirectory);
+                        // 3.2) Use convention mapping so layout.buildDirectory changes are
+                        //      picked up even if the task was realized eagerly.
+                        task.getConventionMapping().map("outputDirectory", () ->
+                            project.getLayout().getBuildDirectory()
+                                .dir("generated-src/antlr/" + sourceSet.getName())
+                                .get().getAsFile());
                     });
 
-                    // 5) Add that task's outputs to the Java source set
+                    // 4) Add that task's outputs to the Java source set
                     sourceSet.getJava().srcDir(antlrTask.map(task -> {
                         String relativeOutputDirectory = project.relativePath(task.getOutputDirectory());
                         return project.file(deriveGeneratedSourceRootDirectory(relativeOutputDirectory, task.getArguments()));

--- a/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -232,7 +232,7 @@ public abstract class AntlrTask extends SourceTask {
             }
             if (rebuildRequired) {
                 try {
-                    getDeleter().ensureEmptyDirectory(outputDirectory);
+                    getDeleter().ensureEmptyDirectory(getOutputDirectory());
                 } catch (IOException ex) {
                     throw UncheckedException.throwAsUncheckedException(ex);
                 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Fixes #33710
`AntlrPlugin` eagerly captured `project.getBuildDir()` at plugin-apply time and assigned the resolved `File` to the task's `outputDirectory`, so any later reassignment of `layout.buildDirectory` was silently
  ignored. Replace the eager assignment with a convention mapping that defers resolution until `outputDirectory` is first read.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
