### PR TITLE
Use exact version when resolving Gradle source distributions

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
@@ -13,7 +13,6 @@ import org.gradle.util.GradleVersion
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.io.File
-import java.util.UUID
 
 class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest() {
 
@@ -356,8 +355,9 @@ class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest(
                     """
                 )
 
-                primaryServer.expectGetMissing("/${repositoryName}/")
-                fallbackServer.expectGetMissing("/${repositoryName}/")
+                val artifactFileName = gradleVersion.artifactFileName
+                primaryServer.expectHeadMissing("/$repositoryName/$artifactFileName")
+                fallbackServer.expectHeadMissing("/$repositoryName/$artifactFileName")
 
                 build(fallbackRepoOverride).apply {
                     assertOutputContains("Could not resolve Gradle distribution sources. See debug logs for details.")
@@ -389,12 +389,8 @@ class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest(
     }
 
     private fun HttpServer.hostAndExpectRequestFor(gradleVersion: GradleVersion, srcDistribution: File) {
-        val rand = UUID.randomUUID()
         val repositoryName = gradleVersion.repositoryName
         val artifactFileName = gradleVersion.artifactFileName
-        val repoDir = file("$rand/${repositoryName}").also { it.mkdirs() }
-        srcDistribution.copyTo(repoDir.resolve(artifactFileName))
-        expectGetDirectoryListing("/${repositoryName}/", repoDir)
         expectHead("/$repositoryName/$artifactFileName", srcDistribution)
         expectGet("/$repositoryName/$artifactFileName", srcDistribution)
     }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -28,8 +28,6 @@ import org.gradle.internal.Try
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.resolver.internal.GradleDistRepoDescriptor
 import org.gradle.kotlin.dsl.resolver.internal.GradleDistRepoDescriptorLocator
-import org.gradle.kotlin.dsl.resolver.internal.GradleDistVersion
-import org.gradle.util.GradleVersion
 import java.io.File
 import kotlin.jvm.optionals.getOrNull
 
@@ -114,9 +112,6 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
             artifact()
         }
         patternLayout {
-            if (repoLocator.gradleVersion.isSnapshot) {
-                ivy("/dummy") // avoids a lookup that interferes with version listing
-            }
             artifact(repo.artifactPattern)
         }
         repo.credentialsApplier(this)
@@ -131,7 +126,7 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
 
     private
     fun DependencyHandler.createDependency() =
-        create("gradle:gradle:${dependencyVersion(repoLocator.gradleVersion)}") {
+        create("gradle:gradle:${repoLocator.gradleVersion.versionString}") {
             artifact {
                 classifier = "src"
                 type = "zip"
@@ -143,40 +138,6 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
         detachedConfiguration(dependency).apply {
             attributes.attribute(artifactType, SOURCE_DIRECTORY)
         }
-
-    private
-    fun dependencyVersion(gradleVersion: GradleDistVersion): String =
-        if (gradleVersion.isSnapshot) toVersionRange(gradleVersion.versionString)
-        else gradleVersion.versionString
-
-    private
-    fun toVersionRange(gradleVersion: String) =
-        "(${minimumGradleVersion()}, $gradleVersion]"
-
-    private
-    fun minimumGradleVersion(): String {
-        val baseVersionString = GradleVersion.version(repoLocator.gradleVersion.versionString).baseVersion.version
-        val (major, minor) = baseVersionString.split('.')
-        return when (minor) {
-            // TODO:kotlin-dsl consider commenting out this clause once the 1st 6.0 snapshot is out
-            "0" -> {
-                // When testing against a `major.0` snapshot we need to take into account
-                // that source distributions matching the major version might not have
-                // been published yet. In that case we adjust the constraint to include
-                // source distributions beginning from the previous major version.
-                "${previous(major)}.0"
-            }
-
-            else -> {
-                // Otherwise include source distributions beginning from the previous minor version only.
-                "$major.${previous(minor)}"
-            }
-        }
-    }
-
-    private
-    fun previous(versionDigit: String) =
-        Integer.parseInt(versionDigit) - 1
 
     private
     val projectInternal

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SourceDistributionResolverSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SourceDistributionResolverSmokeTest.groovy
@@ -40,12 +40,9 @@ class SourceDistributionResolverSmokeTest extends AbstractSmokeTest {
         fallbackServer.start()
 
         withWrapperDistributionUrl("${primaryServer.uri}/$repositoryName/gradle-${gradleVersion.version}-bin.zip")
-        primaryServer.expectGetMissing("/$repositoryName/")
+        primaryServer.expectHeadMissing("/$repositoryName/$artifactFileName")
 
-        def fallbackDir = file("fallback-repo/$repositoryName")
-        fallbackDir.mkdirs()
         buildContext.srcDistribution.copyTo(file("fallback-repo/$repositoryName/$artifactFileName"))
-        fallbackServer.expectGetDirectoryListing("/$repositoryName/", fallbackDir)
         fallbackServer.expectHead("/$repositoryName/$artifactFileName", buildContext.srcDistribution)
         fallbackServer.expectGet("/$repositoryName/$artifactFileName", buildContext.srcDistribution)
         withSourceResolutionAssertionBuildScript("fallback repository")
@@ -103,10 +100,7 @@ class SourceDistributionResolverSmokeTest extends AbstractSmokeTest {
         def fallbackServer = new HttpServer()
         fallbackServer.start()
 
-        def fallbackDir = file("fallback-repo/$repositoryName")
-        fallbackDir.mkdirs()
         buildContext.srcDistribution.copyTo(file("fallback-repo/$repositoryName/$artifactFileName"))
-        fallbackServer.expectGetDirectoryListing("/$repositoryName/", fallbackDir)
         fallbackServer.expectHead("/$repositoryName/$artifactFileName", buildContext.srcDistribution)
         fallbackServer.expectGet("/$repositoryName/$artifactFileName", buildContext.srcDistribution)
         withSourceResolutionAssertionBuildScript("fallback repository")


### PR DESCRIPTION
Snapshot versions no longer use a version range to find the nearest available source distribution. The resolver now requests the exact version, matching the running Gradle distribution. If it is not available, IDE source navigation falls back to decompiled classes.

The rationale is that it is better to provide no sources rather than wrong sources.

This is only about nightlies.

* Fixes https://github.com/gradle/gradle/issues/37819

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
