### PR TITLE
Reduce running time of IP Sync Android perf tests

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -13,7 +13,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.crossbuild.ip.IsolatedProjectsAndroidSyncPerformanceComparisonTest.sync Studio after included build logic refactoring",
+    "testId" : "org.gradle.performance.crossbuild.ip.IsolatedProjectsAndroidSyncPerformanceComparisonTest.sync Studio after build logic ABI change",
     "groups" : [ {
       "testProject" : "android500Kts",
       "coverage" : {
@@ -507,7 +507,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after included build logic refactoring with cold daemon",
+    "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after build logic ABI change with cold daemon",
     "groups" : [ {
       "testProject" : "android500Kts",
       "coverage" : {
@@ -515,7 +515,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after included build logic refactoring with warm daemon",
+    "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after build logic ABI change with warm daemon",
     "groups" : [ {
       "testProject" : "android500Kts",
       "coverage" : {

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -15,7 +15,7 @@
   }, {
     "testId" : "org.gradle.performance.crossbuild.ip.IsolatedProjectsAndroidSyncPerformanceComparisonTest.sync Studio after build logic ABI change",
     "groups" : [ {
-      "testProject" : "android500Kts",
+      "testProject" : "android100Kts",
       "coverage" : {
         "per_day" : [ "linux" ]
       }
@@ -509,7 +509,7 @@
   }, {
     "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after build logic ABI change with cold daemon",
     "groups" : [ {
-      "testProject" : "android500Kts",
+      "testProject" : "android100Kts",
       "coverage" : {
         "per_day" : [ "linux" ]
       }
@@ -517,7 +517,7 @@
   }, {
     "testId" : "org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after build logic ABI change with warm daemon",
     "groups" : [ {
-      "testProject" : "android500Kts",
+      "testProject" : "android100Kts",
       "coverage" : {
         "per_day" : [ "linux" ]
       }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -422,6 +422,14 @@ performanceTest.registerAndroidTestProject("nowInAndroidBuild", ["-Xms4g", "-Xmx
     }
 }
 
+performanceTest.registerAndroidTestProject("android100Kts", ["-Xms4g", "-Xmx4g"], RemoteProject) {
+    setRemoteUriAndRefFromGradleProperty("isolatedProjectsTestbedRef")
+    subdirectory = 'android-100-kts'
+    doLast {
+        setMaxWorkers(outputDirectory, 8)
+    }
+}
+
 // When manually opening the project in Android Studio 2025.3, it recommends this max memory based on the project size
 performanceTest.registerAndroidTestProject("android500Kts", ["-Xms8g", "-Xmx8g"], RemoteProject) {
     setRemoteUriAndRefFromGradleProperty("isolatedProjectsTestbedRef")

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,4 +62,4 @@ largeAndroidBuild2ProjectRef=https://github.com/gradle/perf-android-large-2.git#
 excludeRuleMergingBuildProjectRef=https://github.com/gradle/performance-comparisons.git#b0eb05ab058e55e3aad5935d499c9079284c2592
 springBootAppProjectRef=https://github.com/gradle/performance-comparisons.git#4f5fcfbd5a9f03aae0386e12f0ceddfae8100d5a
 largeNativeBuildProjectRef=https://github.com/gradle/perf-native-large.git#08a06b5f4943a5a892a178baddc27e1884e7c03c
-isolatedProjectsTestbedRef=https://github.com/gradle/isolated-projects-testbed.git#dcf1dbe751bdbf82e766472fe45695a78081af46
+isolatedProjectsTestbedRef=https://github.com/gradle/isolated-projects-testbed.git#85b1eb6330acb64de9899d9bd83cfb1fb6431a7a

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -59,6 +59,9 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
             displayName("moderne")
             invocation {
                 args(
+                    // ensure IP is disabled for sensible comparison for projects that already enabled it
+                    "-Dorg.gradle.unsafe.isolated-projects=false",
+
                     "-Dorg.gradle.parallel=true",
                     "-Dorg.gradle.configuration-cache=true",
                     "-Dorg.gradle.configuration-cache.parallel=true",

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -45,7 +45,7 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
     }
 
     // TODO:isolated introduce cold/warm daemon variation
-    def "sync Studio after included build logic refactoring"() {
+    def "sync Studio after build logic ABI change"() {
         given:
         studioSetup()
         def runner = getRunner() // otherwise, IDEA thinks it's PerformanceTestRunner despite the override

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -67,19 +67,6 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
             }
         }
 
-        // Moderne plus Configure-on-Demand, which is popular in Android world
-        runner.baseline {
-            displayName("moderne-cod")
-            invocation {
-                args(
-                    "-Dorg.gradle.parallel=true",
-                    "-Dorg.gradle.configuration-cache=true",
-                    "-Dorg.gradle.configuration-cache.parallel=true",
-                    "-Dorg.gradle.configureondemand=true",
-                )
-            }
-        }
-
         runner.buildSpec {
             displayName("ip")
             invocation {
@@ -94,16 +81,12 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
 
         then:
         def moderne = buildBaselineResults(result, "moderne")
-        def moderneWithConfigureOnDemand = buildBaselineResults(result, "moderne-cod")
         def ip = result.buildResult("ip")
 
         // TODO:isolated assert that IP is not just faster, but faster with a scaling factor
         // TODO:isolated assert an upper bound of faster to visibly lock-in performance improvements
         println(moderne.getSpeedStatsAgainst("ip", ip))
         !moderne.significantlyFasterThan(ip)
-
-        println(moderneWithConfigureOnDemand.getSpeedStatsAgainst("ip", ip))
-        !moderneWithConfigureOnDemand.significantlyFasterThan(ip)
     }
 
     @Override

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -22,13 +22,13 @@ import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 import org.gradle.performance.results.CrossBuildPerformanceResults
-import org.gradle.profiler.mutations.ApplyAbiChangeToKotlinSourceFileMutator
+import org.gradle.profiler.mutations.ApplyAbiChangeToSourceFileMutator
 
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android500Kts"])
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android100Kts"])
 )
 class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCrossBuildPerformanceTest {
 
@@ -51,7 +51,7 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
         def runner = getRunner() // otherwise, IDEA thinks it's PerformanceTestRunner despite the override
 
         runner.addBuildMutator { settings ->
-            new ApplyAbiChangeToKotlinSourceFileMutator(new File(settings.projectDir, "build-logic/convention/src/main/kotlin/org/example/awesome/utils.kt"))
+            new ApplyAbiChangeToSourceFileMutator(new File(settings.projectDir, "build-logic/convention/src/main/java/org/example/awesome/AwesomeStringUtils.java"))
         }
 
         // 'Moderne' configuration that is used by performance aware teams

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
@@ -51,7 +51,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
         runner.useDaemon = daemon == warm
         // Use multiple warm-ups for cold scenario to warm-up Android Studio itself
         runner.warmUpRuns = 5
-        runner.runs = 20
+        runner.runs = 10
 
         runner.args.addAll([
             // realistic defaults

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.AndroidSyncPerformanceTestFixture
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
-import org.gradle.profiler.mutations.ApplyAbiChangeToKotlinSourceFileMutator
+import org.gradle.profiler.mutations.ApplyAbiChangeToSourceFileMutator
 
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
@@ -43,7 +43,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
     }
 
     @RunFor([
-        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android500Kts"])
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android100Kts"])
     ])
     def "sync Studio after build logic ABI change with #daemon daemon"() {
         studioSetup()
@@ -63,7 +63,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
         ])
 
         runner.addBuildMutator { settings ->
-            new ApplyAbiChangeToKotlinSourceFileMutator(new File(settings.projectDir, "build-logic/convention/src/main/kotlin/org/example/awesome/utils.kt"))
+            new ApplyAbiChangeToSourceFileMutator(new File(settings.projectDir, "build-logic/convention/src/main/java/org/example/awesome/AwesomeStringUtils.java"))
         }
 
         when:

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
@@ -45,7 +45,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
     @RunFor([
         @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android500Kts"])
     ])
-    def "sync Studio after included build logic refactoring with #daemon daemon"() {
+    def "sync Studio after build logic ABI change with #daemon daemon"() {
         studioSetup()
         def runner = getRunner() // otherwise, IDEA thinks it's PerformanceTestRunner despite the override
         runner.useDaemon = daemon == warm


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5197

Steps:
* Use a smaller android-100-kts project, who is a cousine of android-500-kts (see https://github.com/gradle/isolated-projects-testbed/pull/8)
* Use fewer measurement iterations, because previous runs demonstrated stable enough values
* Drop Moderne+CoD baseline  from perf comparison test, because it doesn't differ from the just-Moderne baseline for the current projects/scenarios we are targeting

---

In the updated setup, the `org.gradle.performance.regression.ip.IsolatedProjectsAndroidSyncPerformanceRegressionTest.sync Studio after build logic ABI change with cold daemon` scenario takes ~21m with 5 warmups and 5 iterations. The iterations are now ~14s each, and the main cost comes from the very first warmup that takes ~6m, downloading all dependencies.

See:
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Util_Performance_AdHocPerformanceScenarioLinuxAmd64/112478360
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Util_Performance_AdHocPerformanceScenarioLinuxAmd64/112479124

Let's not include this in the Ready for Nightly just yet and see how it fairs in practice in Ready For Release.