### PR TITLE
Fix NPE when computing failure paths through a cyclic dependency graph

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.api.internal.artifacts.verification.DependencyVerificationFixture
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import spock.lang.Issue
 
 /**
  * Tests the behavior of {@link org.gradle.api.artifacts.ArtifactView} when it is configured to be lenient.
@@ -249,6 +250,64 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
         executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         succeeds("resolveLenient")
         outputContains("[]")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36284")
+    def "can read failure messages from lenient artifact view when failing module's reverse-dependency graph contains a cycle"() {
+        // Two transitive modules (modB and modD) directly depend on a missing module ("broken").
+        // The four cycle modules (modA -> modB -> modC -> modD -> modA) form a cycle in the
+        // resolved graph. With this layout, modB and modD are the directDependees of broken,
+        // and modD's only path back to root passes through modC -> modB -> modA, which the
+        // pre-fix DependencyGraphPathResolver could not compute correctly because modC was
+        // popped from the worklist before modB had been resolved.
+        def broken = mavenHttpRepo.module("org", "broken", "1.0")
+        def modA = mavenHttpRepo.module("org", "mod-a", "1.0")
+            .dependsOn("org", "mod-b", "1.0")
+            .publish()
+        def modB = mavenHttpRepo.module("org", "mod-b", "1.0")
+            .dependsOn("org", "mod-c", "1.0")
+            .dependsOn("org", "broken", "1.0")
+            .publish()
+        def modC = mavenHttpRepo.module("org", "mod-c", "1.0")
+            .dependsOn("org", "mod-d", "1.0")
+            .publish()
+        def modD = mavenHttpRepo.module("org", "mod-d", "1.0")
+            .dependsOn("org", "mod-a", "1.0")
+            .dependsOn("org", "broken", "1.0")
+            .publish()
+
+        buildFile.text = """
+            plugins {
+                id("java-library")
+            }
+            repositories {
+                maven { url = '${mavenHttpRepo.uri}' }
+            }
+            dependencies {
+                implementation("org:mod-a:1.0")
+            }
+            tasks.register("printFailures") {
+                def failures = configurations.runtimeClasspath.incoming.artifactView {
+                    lenient = true
+                }.artifacts.failures
+                doLast {
+                    failures.each { println("FAILURE: \${it.message}") }
+                }
+            }
+        """
+
+        expect:
+        modA.pom.expectGet()
+        modB.pom.expectGet()
+        modC.pom.expectGet()
+        modD.pom.expectGet()
+        broken.pom.expectGetMissing()
+        modA.artifact.expectGet()
+        modB.artifact.expectGet()
+        modC.artifact.expectGet()
+        modD.artifact.expectGet()
+        succeeds("printFailures")
+        outputContains("FAILURE: Could not find org:broken:1.0.")
     }
 
     private void withRepo() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
@@ -286,7 +286,7 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
                     lenient = true
                 }.artifacts.failures
                 doLast {
-                    failures.each { println("FAILURE: \${it.message}") }
+                    failures.each { println(it.message) }
                 }
             }
         """
@@ -304,7 +304,7 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
         succeeds("printFailures")
 
         then:
-        outputContains("FAILURE: Could not find org:broken:1.0.")
+        outputContains("Could not find org:broken:1.0.")
     }
 
     private void withRepo() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
@@ -276,18 +276,13 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
             .dependsOn("org", "broken", "1.0")
             .publish()
 
-        buildFile.text = """
-            plugins {
-                id("java-library")
-            }
-            repositories {
-                maven { url = '${mavenHttpRepo.uri}' }
-            }
+        withRepo()
+        buildFile """
             dependencies {
-                implementation("org:mod-a:1.0")
+                deps("org:mod-a:1.0")
             }
             tasks.register("printFailures") {
-                def failures = configurations.runtimeClasspath.incoming.artifactView {
+                def failures = configurations.res.incoming.artifactView {
                     lenient = true
                 }.artifacts.failures
                 doLast {
@@ -296,7 +291,7 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
             }
         """
 
-        expect:
+        when:
         modA.pom.expectGet()
         modB.pom.expectGet()
         modC.pom.expectGet()
@@ -307,6 +302,8 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
         modC.artifact.expectGet()
         modD.artifact.expectGet()
         succeeds("printFailures")
+
+        then:
         outputContains("FAILURE: Could not find org:broken:1.0.")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -242,7 +242,7 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
         // longer chain back to the root component.
         buildFile << """
             plugins {
-                id("java")
+                id("java-library")
             }
 
             ${mavenCentralRepository()}
@@ -253,24 +253,14 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
                 implementation("androidx.room:room-runtime:2.8.3")
             }
 
-            abstract class DependencyGraphPrinter extends DefaultTask {
-                @Internal
-                abstract Property<ArtifactCollection> getAc()
-
-                @TaskAction
-                void action() {
-                    println("Failures: ")
-                    ac.get().failures.each {
-                        println(it.message)
-                    }
-                }
-            }
-
-            tasks.register("dgp", DependencyGraphPrinter) {
-                def collection = configurations.compileClasspath.incoming.artifactView {
+            tasks.register("dgp") {
+                def failures = configurations.compileClasspath.incoming.artifactView {
                     lenient = true
-                }.artifacts
-                ac.set(collection)
+                }.artifacts.failures
+                doLast {
+                    println("Failures: ")
+                    failures.each { println(it.message) }
+                }
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
+import org.gradle.test.preconditions.TestEnvironmentPreconditions
 
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -230,6 +231,51 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds("checkDebugDuplicateClasses")
+    }
+
+    @Requires(TestEnvironmentPreconditions.Online)
+    @Issue("https://github.com/gradle/gradle/issues/36284")
+    def "lenient artifact view exposes failure messages from androidx.room reproducer without NPE"() {
+        // Verbatim reproducer from issue 36284. With the bug, getMessage() throws
+        // NPE because DependencyGraphPathResolver.calculatePaths returns a list
+        // containing a null entry for a directDependee whose incoming edges no
+        // longer chain back to the root component.
+        buildFile << """
+            plugins {
+                id("java")
+            }
+
+            ${mavenCentralRepository()}
+            ${googleRepository()}
+
+            dependencies {
+                implementation("androidx.room:room-sqlite-wrapper:2.8.3")
+                implementation("androidx.room:room-runtime:2.8.3")
+            }
+
+            abstract class DependencyGraphPrinter extends DefaultTask {
+                @Internal
+                abstract Property<ArtifactCollection> getAc()
+
+                @TaskAction
+                void action() {
+                    println("Failures: ")
+                    ac.get().failures.each {
+                        println(it.message)
+                    }
+                }
+            }
+
+            tasks.register("dgp", DependencyGraphPrinter) {
+                def collection = configurations.compileClasspath.incoming.artifactView {
+                    lenient = true
+                }.artifacts
+                ac.set(collection)
+            }
+        """
+
+        expect:
+        succeeds("dgp")
     }
 
     def "depending on a bom of one version and another dependency that upgrades that bom causes unstable graph"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
@@ -19,13 +19,14 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 import org.gradle.api.Describable;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.internal.Describables;
+import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,57 +38,79 @@ public class DependencyGraphPathResolver {
         DependencyGraphNode toNode,
         DomainObjectContext owner
     ) {
-        // Include the shortest path from each version that has a direct dependency on the broken dependency, back to the root
+        // Compute the shortest path from each component that has a direct dependency on the broken
+        // dependency back to the root component. Each search is an independent BFS in the reverse
+        // ("dependents") direction, which is robust against cycles in the resolved graph (e.g.
+        // mutually-dependent KMP variants like room-runtime <-> room-common-jvm).
 
-        Map<ResolvedGraphComponent, List<Describable>> shortestPaths = new LinkedHashMap<>();
-        List<Describable> rootPath = new ArrayList<>();
-        rootPath.add(Describables.of(owner.getDisplayName()));
-        shortestPaths.put(toNode.getOwner(), rootPath);
+        DependencyGraphComponent root = toNode.getOwner();
+        Describable rootDescribable = Describables.of(owner.getDisplayName());
 
         Set<DependencyGraphComponent> directDependees = new LinkedHashSet<>();
         for (DependencyGraphNode node : fromNodes) {
             directDependees.add(node.getOwner());
         }
 
-        Set<DependencyGraphComponent> seen = new HashSet<>();
-        LinkedList<DependencyGraphComponent> queue = new LinkedList<>(directDependees);
-        while (!queue.isEmpty()) {
-            DependencyGraphComponent version = queue.getFirst();
-            if (version == toNode.getOwner()) {
-                queue.removeFirst();
-            } else if (seen.add(version)) {
-                for (DependencyGraphComponent incomingVersion : version.getDependents()) {
-                    queue.add(0, incomingVersion);
-                }
-            } else {
-                queue.remove();
-                List<Describable> shortest = null;
-                for (DependencyGraphComponent incomingVersion : version.getDependents()) {
-                    List<Describable> candidate = shortestPaths.get(incomingVersion);
-                    if (candidate == null) {
-                        continue;
-                    }
-                    if (shortest == null) {
-                        shortest = candidate;
-                    } else if (shortest.size() > candidate.size()) {
-                        shortest = candidate;
-                    }
-
-                }
-                if (shortest == null) {
-                    continue;
-                }
-                List<Describable> path = new ArrayList<>(shortest);
-                path.add(Describables.of(version.getComponentId().getDisplayName()));
-                shortestPaths.put(version, path);
+        List<List<Describable>> paths = new ArrayList<>();
+        for (DependencyGraphComponent dependee : directDependees) {
+            List<Describable> path = shortestPathToRoot(dependee, root, rootDescribable);
+            if (path != null) {
+                paths.add(path);
             }
         }
-
-        List<List<Describable>> paths = new ArrayList<>();
-        for (DependencyGraphComponent version : directDependees) {
-            List<Describable> path = shortestPaths.get(version);
-            paths.add(path);
-        }
         return paths;
+    }
+
+    private static @Nullable List<Describable> shortestPathToRoot(
+        DependencyGraphComponent start,
+        DependencyGraphComponent root,
+        Describable rootDescribable
+    ) {
+        if (start == root) {
+            List<Describable> single = new ArrayList<>(1);
+            single.add(rootDescribable);
+            return single;
+        }
+        Map<DependencyGraphComponent, DependencyGraphComponent> predecessor = new HashMap<>();
+        predecessor.put(start, null);
+        Deque<DependencyGraphComponent> queue = new ArrayDeque<>();
+        queue.add(start);
+        boolean reachedRoot = false;
+        while (!queue.isEmpty()) {
+            DependencyGraphComponent current = queue.removeFirst();
+            if (current == root) {
+                reachedRoot = true;
+                break;
+            }
+            for (DependencyGraphComponent next : current.getDependents()) {
+                if (!predecessor.containsKey(next)) {
+                    predecessor.put(next, current);
+                    queue.addLast(next);
+                }
+            }
+        }
+        if (!reachedRoot) {
+            return null;
+        }
+
+        // Reconstruct the start->root chain by walking predecessors back from root.
+        Deque<DependencyGraphComponent> chain = new ArrayDeque<>();
+        DependencyGraphComponent walk = root;
+        while (walk != null) {
+            chain.addFirst(walk);
+            walk = predecessor.get(walk);
+        }
+
+        // Output format expected by ModuleVersionResolveException#getMessage:
+        // [<rootDisplayName>, <intermediate componentIds...>, <directDependee componentId>]
+        // The chain holds [start, ..., root] so we walk it in reverse, emitting rootDescribable
+        // first and skipping root's componentId.
+        List<Describable> result = new ArrayList<>(chain.size());
+        result.add(rootDescribable);
+        DependencyGraphComponent[] reversed = chain.toArray(new DependencyGraphComponent[0]);
+        for (int i = reversed.length - 2; i >= 0; i--) {
+            result.add(Describables.of(reversed[i].getComponentId().getDisplayName()));
+        }
+        return result;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
@@ -82,6 +82,10 @@ public class DependencyGraphPathResolver {
                 reachedRoot = true;
                 break;
             }
+            // TODO: this walks every dependents edge including constraint edges; constraints
+            //  don't "pull in" a component, so paths that traverse them aren't useful to users.
+            //  Restricting to non-constraint edges would shift many existing test expectations,
+            //  so it is deferred.
             for (DependencyGraphComponent next : current.getDependents()) {
                 if (!predecessor.containsKey(next)) {
                     predecessor.put(next, current);
@@ -93,23 +97,19 @@ public class DependencyGraphPathResolver {
             return null;
         }
 
-        // Reconstruct the start->root chain by walking predecessors back from root.
-        Deque<DependencyGraphComponent> chain = new ArrayDeque<>();
-        DependencyGraphComponent walk = root;
-        while (walk != null) {
-            chain.addFirst(walk);
-            walk = predecessor.get(walk);
+        // Walk predecessors from root back to start; this naturally produces [root, ..., start].
+        List<DependencyGraphComponent> chain = new ArrayList<>();
+        for (DependencyGraphComponent walk = root; walk != null; walk = predecessor.get(walk)) {
+            chain.add(walk);
         }
 
         // Output format expected by ModuleVersionResolveException#getMessage:
-        // [<rootDisplayName>, <intermediate componentIds...>, <directDependee componentId>]
-        // The chain holds [start, ..., root] so we walk it in reverse, emitting rootDescribable
-        // first and skipping root's componentId.
+        // [<rootDisplayName>, <intermediate componentIds...>, <directDependee componentId>].
+        // Substitute rootDescribable for root's componentId, then emit the rest in order.
         List<Describable> result = new ArrayList<>(chain.size());
         result.add(rootDescribable);
-        DependencyGraphComponent[] reversed = chain.toArray(new DependencyGraphComponent[0]);
-        for (int i = reversed.length - 2; i >= 0; i--) {
-            result.add(Describables.of(reversed[i].getComponentId().getDisplayName()));
+        for (int i = 1; i < chain.size(); i++) {
+            result.add(Describables.of(chain.get(i).getComponentId().getDisplayName()));
         }
         return result;
     }


### PR DESCRIPTION
Fixes #36284.

## Summary

`DependencyGraphPathResolver.calculatePaths` could insert `null` entries into the paths it returned to `ModuleVersionResolveException.withIncomingPaths`, causing `getMessage()` to NPE at `path.get(0)` whenever a user inspected failures from a lenient `ArtifactView`. The originally reported reproducer used `androidx.room:room-*:2.8.3`, which is published as Kotlin Multiplatform: variant-aware resolution produces a cycle in the resolved component graph (`room-runtime ↔ room-common-jvm`), and the path resolver's interleaved single-pass traversal couldn't compute shortest paths correctly when the reverse-edge graph contained cycles.

The fix replaces that traversal with an independent BFS in the reverse (`getDependents()`) graph for each directDependee. BFS handles cycles naturally and is O(V+E) per source.

## What changed

- **`DependencyGraphPathResolver.java`** — rewrote `calculatePaths` to do a per-directDependee BFS in the reverse graph, reconstructing the shortest path via a predecessor map. The output format is unchanged (`[rootDisplayName, ...intermediate componentIds, directDependee componentId]`), so existing callers and message-format tests are unaffected.
- **`ResolutionIssuesIntegrationTest`** — added the verbatim androidx.room reproducer from the issue, gated on `TestEnvironmentPreconditions.Online`.
- **`LenientArtifactViewIntegrationTest`** — added a synthetic four-module Maven cycle (`mod-a → mod-b → mod-c → mod-d → mod-a`, with `mod-b` and `mod-d` depending on a missing module) that triggers the same NPE without requiring network access.

## Test plan

- [x] `:dependency-management:embeddedIntegTest --tests "org.gradle.integtests.resolve.LenientArtifactViewIntegrationTest"` passes (synthetic cyclic test).
- [x] `:dependency-management:embeddedIntegTest --tests "org.gradle.integtests.resolve.ResolutionIssuesIntegrationTest"` passes (real androidx.room reproducer + 4 pre-existing tests, 1 `@Ignore` skipped).
- [x] `:dependency-management:test --tests "*.DependencyGraphBuilderTest"` (33 tests exercising `calculatePaths`) passes.
- [x] `:dependency-management:test --tests "*.ModuleVersionResolveExceptionTest" --tests "*.ModuleVersionNotFoundExceptionTest"` passes (message-format tests unchanged).
- [x] Verified the new synthetic test reproduces the NPE when the fix is reverted.