### PR TITLE
Use ProjectState instead of Project in GradleBuildTaskIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
@@ -261,13 +261,14 @@ class GradleBuildTaskIntegrationTest extends AbstractIntegrationSpec {
             ${barrier.callFromBuild("child-build-started")}
             ${barrier.callFromBuild("child-build-finished")}
         """
+        def assertRootIsNamedRoot = "assert gradle.parent.owner.rootProject.name == 'root'"
         file('main/build.gradle') << """
-            assert gradle.parent.rootProject.name == 'root'
+            ${assertRootIsNamedRoot}
             task log { }
         """
         file('subprojects/settings.gradle') << ""
         file('subprojects/build.gradle') << """
-            assert gradle.parent.rootProject.name == 'root'
+            ${assertRootIsNamedRoot}
             task log { }
         """
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5217

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
