### PR TITLE
Fix dependency configurations chart column

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/basics/dependency_configurations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/basics/dependency_configurations.adoc
@@ -62,7 +62,7 @@ The plugin adds many dependency configurations.
 These configurations represent the various classpaths needed for source code compilation, executing tests, and more.
 The configurations below are used to declare dependencies for different purposes:
 
-[cols="~,~,~"]
+[cols="~,~"]
 |===
 |Configuration Name |Description
 


### PR DESCRIPTION
Fix the dependency configurations chart column.

Before:
<img width="591" height="476" alt="PixPin_2026-05-06_21-41-23" src="https://github.com/user-attachments/assets/46e7ea60-3928-44e4-9940-9c5a005308a9" />

After:
<img width="607" height="437" alt="PixPin_2026-05-06_21-40-37" src="https://github.com/user-attachments/assets/da8694e8-021a-4fa0-b062-5ac7dc80a2b3" />

### Context
Closes https://github.com/gradle/gradle/issues/37816
