### PR TITLE
Use `:wrapper` in documentation invocation examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,7 @@ This will create a minimal distribution at `packaging/distributions-full/build/d
 
 You can then use it as a Gradle Wrapper local distribution in a Gradle based project by using a `file:/` URL pointing to the built distribution:
 
-    ./gradlew wrapper --gradle-distribution-url=file:/path/to/gradle-<version>-bin.zip
+    ./gradlew :wrapper --gradle-distribution-url=file:/path/to/gradle-<version>-bin.zip
 
 To create a full distribution (includes sources and docs):
 
@@ -360,7 +360,7 @@ To create a full distribution (includes sources and docs):
 
 The full distribution will be created at `packaging/distributions-full/build/distributions/gradle-<version>-all.zip`. You can then use it as a Gradle Wrapper local distribution:
 
-    ./gradlew wrapper --gradle-distribution-url=file:/path/to/gradle-<version>-all.zip
+    ./gradlew :wrapper --gradle-distribution-url=file:/path/to/gradle-<version>-all.zip
 
 ## Our thanks
 

--- a/platforms/documentation/docs/src/docs/release/notes-template.md
+++ b/platforms/documentation/docs/src/docs/release/notes-template.md
@@ -30,7 +30,7 @@ Be sure to check out the [public roadmap](https://roadmap.gradle.org) for insigh
 Switch your build to use Gradle @version@ by updating the [wrapper](userguide/gradle_wrapper.html) in your project:
 
 ```text
-./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper
+./gradlew :wrapper --gradle-version=@version@ && ./gradlew :wrapper
 ```
 
 See the [Gradle 9.x upgrade guide](userguide/upgrading_version_9.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -30,7 +30,7 @@ Be sure to check out the [public roadmap](https://roadmap.gradle.org) for insigh
 Switch your build to use Gradle @version@ by updating the [wrapper](userguide/gradle_wrapper.html) in your project:
 
 ```text
-./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper
+./gradlew :wrapper --gradle-version=@version@ && ./gradlew :wrapper
 ```
 
 See the [Gradle 9.x upgrade guide](userguide/upgrading_version_9.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -64,7 +64,7 @@ Use the `wrapper` task to update your project:
 
 [source, bash]
 ----
-./gradlew wrapper --gradle-version <version>
+./gradlew :wrapper --gradle-version <version>
 ----
 
 You can also install the latest Gradle versions easily using tools like link:https://sdkman.io/[SDKMAN!] or link:https://brew.sh/[Homebrew], depending on your platform.

--- a/platforms/documentation/docs/src/docs/userguide/fundamentals/running-builds/gradle_wrapper_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/fundamentals/running-builds/gradle_wrapper_basics.adoc
@@ -36,7 +36,7 @@ root
 If your project does not include these files, it is likely *not* a Gradle project—or the wrapper has not been set up yet.
 
 TIP: The wrapper is *not* something you download from the internet.
-You must generate it by running `gradle wrapper` from a machine with Gradle <<installation.adoc#installation,installed>>.
+You must generate it by running `gradle :wrapper` from a machine with Gradle <<installation.adoc#installation,installed>>.
 
 The wrapper provides the following benefits:
 
@@ -123,13 +123,13 @@ If you want to view or update the Gradle version of your project, use the comman
 [source, bash]
 ----
 $ ./gradlew --version
-$ ./gradlew wrapper --gradle-version 7.2
+$ ./gradlew :wrapper --gradle-version 7.2
 ----
 
 [source, cmd]
 ----
 $ gradlew.bat --version
-$ gradlew.bat wrapper --gradle-version 7.2
+$ gradlew.bat :wrapper --gradle-version 7.2
 ----
 
 WARNING: Do not edit the wrapper files manually.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
@@ -105,7 +105,7 @@ Using an outdated version means missing out on these gains.
 Upgrading is low-risk since Gradle maintains backward compatibility between minor versions.
 Staying up to date also makes major version upgrades smoother by providing early deprecation warnings.
 
-You can use the <<gradle_wrapper.adoc#gradle_wrapper,Gradle Wrapper>> to update the version of Gradle by running `gradle wrapper --gradle-version X.X` where `X.X` is the desired version.
+You can use the <<gradle_wrapper.adoc#gradle_wrapper,Gradle Wrapper>> to update the version of Gradle by running `gradle :wrapper --gradle-version X.X` where `X.X` is the desired version.
 
 When our reference project is updated to use Gradle 8.13, the build (`./gradlew clean build`) takes *8 seconds*:
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -914,11 +914,11 @@ $ gradle init --type java-library
 [[standardize_and_provision_gradle]]
 === Standardize and provision Gradle
 
-The built-in `gradle wrapper` task generates a script, `gradlew`, that invokes a declared version of Gradle, downloading it beforehand if necessary.
+The built-in `gradle :wrapper` task generates a script, `gradlew`, that invokes a declared version of Gradle, downloading it beforehand if necessary.
 
 [source,bash]
 ----
-$ ./gradlew wrapper --gradle-version=8.1
+$ ./gradlew :wrapper --gradle-version=8.1
 ----
 
 You can also specify `--distribution-type=(bin|all)`, `--gradle-distribution-url`, `--gradle-distribution-sha256-sum` in addition to `--gradle-version`. +

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
@@ -23,7 +23,7 @@ Instead of running `gradle build` using the installed Gradle, you use the Gradle
 
 image::wrapper-workflow.png[]
 
-The Gradle Wrapper isn’t distributed as a standalone download—it’s created using the `gradle wrapper` task.
+The Gradle Wrapper isn’t distributed as a standalone download—it’s created using the `gradle :wrapper` task.
 
 There are three ways to use the Wrapper:
 
@@ -54,7 +54,7 @@ Executing the `wrapper` task generates the necessary Wrapper files in the projec
 
 [source,bash]
 ----
-$ gradle wrapper
+$ gradle :wrapper
 ----
 [source,text]
 ----
@@ -149,7 +149,7 @@ The following command-line execution captures those requirements:
 
 [source,bash,subs="attributes"]
 ----
-$ gradle wrapper --gradle-version {gradleVersion} --distribution-type all
+$ gradle :wrapper --gradle-version {gradleVersion} --distribution-type all
 ----
 [source,text]
 ----
@@ -259,12 +259,12 @@ The following command upgrades the Wrapper to the `latest` version:
 
 [source,bash]
 ----
-$ ./gradlew wrapper --gradle-version latest   // MacOs, Linux
+$ ./gradlew :wrapper --gradle-version latest   // MacOs, Linux
 ----
 
 [source,bash]
 ----
-$ gradlew.bat wrapper --gradle-version latest // Windows
+$ gradlew.bat :wrapper --gradle-version latest // Windows
 ----
 
 [source,text]
@@ -276,11 +276,11 @@ The following command upgrades the Wrapper to a specific version:
 
 [source,bash,subs="attributes"]
 ----
-$ ./gradlew wrapper --gradle-version {gradleVersion} // MacOs, Linux
+$ ./gradlew :wrapper --gradle-version {gradleVersion} // MacOs, Linux
 ----
 [source,bash,subs="attributes"]
 ----
-$ gradlew.bat wrapper --gradle-version {gradleVersion} // Windows
+$ gradlew.bat :wrapper --gradle-version {gradleVersion} // Windows
 ----
 
 [source,text]
@@ -315,7 +315,7 @@ include::sample[dir="snippets/reference/runtime-configuration/customized-task/ko
 include::sample[dir="snippets/reference/runtime-configuration/customized-task/groovy",files="build.gradle[tags=customized-wrapper-task]"]
 ====
 
-With the configuration in place, running `./gradlew wrapper --gradle-version {gradleVersion}` is enough to produce a `distributionUrl` value in the Wrapper properties file that will request the `-all` distribution:
+With the configuration in place, running `./gradlew :wrapper --gradle-version {gradleVersion}` is enough to produce a `distributionUrl` value in the Wrapper properties file that will request the `-all` distribution:
 
 [source,properties,subs="attributes"]
 ----

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins may break with a new major version of Gradle, as these releases can remove public APIs.
 Using the latest version of a plugin increases the likelihood that it is already compatible with the new major Gradle version.
 +
-. Run `gradle wrapper --gradle-version {gradleVersion90}` to update the project to {gradleVersion90}.
+. Run `gradle :wrapper --gradle-version {gradleVersion90}` to update the project to {gradleVersion90}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_major_9]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_4.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_4.adoc
@@ -42,7 +42,7 @@ Some plugins will break with this new version of Gradle, for example because the
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
 In particular, you will need to use at least a 2.x version of the https://plugins.gradle.org/plugin/com.gradleup.shadow[*Shadow Plugin*].
-. Run `gradle wrapper --gradle-version 5.0` to update the project to 5.0
+. Run `gradle :wrapper --gradle-version 5.0` to update the project to 5.0
 . Move to Java 8 or higher if you haven't already. Whereas Gradle 4.x requires Java 7, Gradle 5 requires Java 8 to run.
 . Read the <<#changes_5.0, Upgrading from 4.10>> section and make any necessary changes.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
@@ -32,7 +32,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
-. Run `gradle wrapper --gradle-version 6.0.1` to update the project to 6.0.1.
+. Run `gradle :wrapper --gradle-version 6.0.1` to update the project to 6.0.1.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_6.0]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_6.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_6.adoc
@@ -32,7 +32,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
-. Run `gradle wrapper --gradle-version 7.0.2` to update the project to 7.0.2.
+. Run `gradle :wrapper --gradle-version 7.0.2` to update the project to 7.0.2.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_7.0]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
@@ -32,7 +32,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
-. Run `gradle wrapper --gradle-version 8.0.2` to update the project to 8.0.2.
+. Run `gradle :wrapper --gradle-version 8.0.2` to update the project to 8.0.2.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_8.0]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin tries to use a deprecated part of the API.
 +
-. Run `gradle wrapper --gradle-version {gradleVersion8}` to update the project to {gradleVersion8}.
+. Run `gradle :wrapper --gradle-version {gradleVersion8}` to update the project to {gradleVersion8}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_8.14]]
@@ -48,7 +48,7 @@ The previous step will help you identify potential problems by issuing deprecati
 The Gradle Wrapper JAR has been converted into an executable JAR.
 This means it now includes a `Main-Class` attribute, allowing it to be launched using the `-jar` option instead of specifying a classpath and main class manually.
 
-When you update the wrapper scripts using the `gradle wrapper` or `./gradlew wrapper` command, the wrapper JAR will be updated automatically to reflect this change.
+When you update the wrapper scripts using the `gradle :wrapper` or `./gradlew :wrapper` command, the wrapper JAR will be updated automatically to reflect this change.
 
 [[v8_14_changes_to_settings_defaults]]
 ==== Changes to `Settings` defaults

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin tries to use a deprecated part of the API.
 +
-. Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
+. Run `gradle :wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_9.6.0]]


### PR DESCRIPTION
Fixes #37761

### Context

Wherever the docs and release notes recommend invoking the `wrapper` task, the unqualified form (`gradle wrapper`, `./gradlew wrapper`) only works because of root-project task lookup, which can break under Configure-on-Demand and is fragile under Isolated Projects. Using `:wrapper` makes the recommended invocation unambiguous and forward-compatible.

Invocations updated in 13 files under `platforms/documentation/docs/src/docs/userguide/`, plus the release-notes templates and CONTRIBUTING.md (~27 line changes). Narrative references to "the `wrapper` task" are left unchanged — only the CLI examples are prefixed.

A maintainer (@reinsch82) confirmed the issue is valid in the issue thread.

### Disclosure

AI-assisted: I used an AI tool to help inventory and apply the prefix consistently across the doc set. I reviewed every change manually and verified narrative vs invocation context per the issue's note that "a few examples may legitimately want the unqualified form."

### Contributor Checklist
- [x] [Reviewed Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits signed off (DCO).
- [x] Code distributable under Apache License 2.0.
- [x] "Allow edit from maintainers" enabled.
- [ ] Integration tests — n/a (docs-only change).
- [ ] Unit tests — n/a (docs-only change).
- [x] User Guide updated for the user-facing change.
- [ ] `./gradlew sanityCheck` — not run locally (no JDK 17 + Gradle dist available in my environment); request CI verification.
- [ ] `./gradlew :docs:checkDeadInternalLinks` — same; no link/anchor changes were made.
