### PR TITLE
Annotate parent-walk diagnostics with caller-context detail

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslParentProjectPropertyLookupIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslParentProjectPropertyLookupIntegrationTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+
+/**
+ * Verifies that resolving a `val ... by project` delegated property from the parent project
+ * adds the Kotlin delegation caller context to the parent-project lookup deprecation. The
+ * deprecation action stays stable; the caller detail is surfaced in the context.
+ *
+ * @see org.gradle.kotlin.dsl.PropertyDelegate
+ */
+@Requires(
+    TestExecutionPreconditions.NotIsolatedProjects::class,
+    reason = "Under Isolated Projects, parent-project lookup is disabled entirely; no deprecation fires"
+)
+class KotlinDslParentProjectPropertyLookupIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    private
+    val commonUpgradePart =
+        "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#"
+
+    private
+    fun expectParentLookupDeprecation(propertyName: String) {
+        executer.expectDocumentedDeprecationWarning(
+            "Implicit lookup of properties in parent projects has been deprecated. " +
+                "This will fail with an error in Gradle 10. " +
+                "Property '$propertyName' was not declared in project ':a' and was resolved from root project 'root'. " +
+                "This lookup was initiated by 'val ... by project'. " +
+                "${commonUpgradePart}deprecated_implicit_lookup_in_parent_projects"
+        )
+    }
+
+    @Test
+    fun `val by project resolved from parent is deprecated with the Kotlin delegation caller context`() {
+        withSettings(
+            """
+            rootProject.name = "root"
+            include("a")
+            """
+        )
+        withBuildScript(
+            """
+            extra["foo"] = "fromRoot"
+            extra["bar"] = "alsoFromRoot"
+            """
+        )
+        withFile(
+            "a/build.gradle.kts",
+            """
+            @file:Suppress("DEPRECATION")
+
+            val foo: String by project
+            val bar: String? by project
+
+            println("foo=" + foo)
+            println("bar=" + bar)
+            """
+        )
+
+        // The `by project` syntax itself is independently deprecated.
+        executer.expectDocumentedDeprecationWarning(
+            "The 'val name: Type by project' property delegate syntax has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Use 'val property = project.property(name)' instead. " +
+                "${commonUpgradePart}kotlin_dsl_delegated_properties"
+        )
+        executer.expectDocumentedDeprecationWarning(
+            "The 'val name: Type? by project' property delegate syntax has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Use 'val property = project.findProperty(name)' instead. " +
+                "${commonUpgradePart}kotlin_dsl_delegated_properties"
+        )
+        // The parent walk is annotated with the Kotlin-delegation caller context.
+        expectParentLookupDeprecation("foo")
+        expectParentLookupDeprecation("bar")
+
+        val result = build("help")
+
+        assertThat(result.output, containsString("foo=fromRoot"))
+        assertThat(result.output, containsString("bar=alsoFromRoot"))
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyDelegate.kt
@@ -20,6 +20,7 @@ import org.gradle.api.InvalidUserCodeException
 
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.plugins.DslObject
+import org.gradle.internal.extensibility.ExtensibleDynamicObject
 import org.gradle.internal.metaobject.DynamicObject
 import org.gradle.kotlin.dsl.support.uncheckedCast
 
@@ -61,15 +62,32 @@ fun dynamicObjectFor(target: Any): DynamicObject =
 
 @Suppress("DEPRECATION")
 private
+inline fun <T> withKotlinDelegationContext(owner: DynamicObject, action: () -> T): T {
+    if (owner !is ExtensibleDynamicObject) {
+        return action()
+    }
+    val previous = owner.callerContext
+    owner.callerContext = ExtensibleDynamicObject.CallerContext.Instances.KOTLIN_DELEGATION
+    try {
+        return action()
+    } finally {
+        owner.callerContext = previous
+    }
+}
+
+
+@Suppress("DEPRECATION")
+private
 class NullableDynamicPropertyDelegate(
     private val owner: DynamicObject,
     private val name: String
 ) : PropertyDelegate {
 
-    override fun <T> getValue(receiver: Any?, property: KProperty<*>): T {
-        val result = owner.tryGetProperty(name)
-        return uncheckedCast(if (result.isFound) result.value else null)
-    }
+    override fun <T> getValue(receiver: Any?, property: KProperty<*>): T =
+        withKotlinDelegationContext(owner) {
+            val result = owner.tryGetProperty(name)
+            uncheckedCast(if (result.isFound) result.value else null)
+        }
 }
 
 
@@ -82,8 +100,10 @@ class NonNullDynamicPropertyDelegate(
 ) : PropertyDelegate {
 
     override fun <T> getValue(receiver: Any?, property: KProperty<*>): T =
-        owner.tryGetProperty(name).run {
-            if (isFound && value != null) uncheckedCast<T>(value)
-            else throw InvalidUserCodeException("Cannot get non-null property '$name' on ${describeOwner()} as it ${if (isFound) "is null" else "does not exist"}")
+        withKotlinDelegationContext(owner) {
+            owner.tryGetProperty(name).run {
+                if (isFound && value != null) uncheckedCast<T>(value)
+                else throw InvalidUserCodeException("Cannot get non-null property '$name' on ${describeOwner()} as it ${if (isFound) "is null" else "does not exist"}")
+            }
         }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -88,66 +88,41 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
      * When a lookup walks into the parent, the context currently set on the referrer's dynamic
      * object is read to enrich the deprecation message.
      */
-    public abstract static class CallerContext {
-        private CallerContext() {}
-
-        public abstract boolean isExplicitApiCall();
+    public static final class CallerContext {
 
         /**
-         * The API method name (e.g. {@code "property()"}, {@code "findProperty()"}, or
-         * {@code "val ... by project"}). Only valid for explicit API calls.
+         * The phrase describing how the lookup was initiated, slotted into the deprecation message
+         * after {@code "This lookup was initiated by "}. Includes its own quoting where appropriate.
          */
-        public abstract String apiName();
+        private final String description;
+
+        private CallerContext(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
 
         /**
          * Holder class to avoid initialization-order surprises between the outer class and its
-         * private subclasses.
+         * instances.
          */
         public static final class Instances {
             /** {@code project.property("foo")}. */
-            public static final CallerContext PROPERTY = new ExplicitApiCall("property()");
+            public static final CallerContext PROPERTY = new CallerContext("'property()'");
             /** {@code project.findProperty("foo")}. */
-            public static final CallerContext FIND_PROPERTY = new ExplicitApiCall("findProperty()");
+            public static final CallerContext FIND_PROPERTY = new CallerContext("'findProperty()'");
             /** {@code project.hasProperty("foo")}. */
-            public static final CallerContext HAS_PROPERTY = new ExplicitApiCall("hasProperty()");
+            public static final CallerContext HAS_PROPERTY = new CallerContext("'hasProperty()'");
             /** {@code project.getProperty("foo")}. */
-            public static final CallerContext GET_PROPERTY = new ExplicitApiCall("getProperty()");
+            public static final CallerContext GET_PROPERTY = new CallerContext("'getProperty()'");
             /** Kotlin DSL {@code val foo by project} property delegation. */
-            public static final CallerContext KOTLIN_DELEGATION = new ExplicitApiCall("val ... by project");
+            public static final CallerContext KOTLIN_DELEGATION = new CallerContext("'val ... by project'");
             /** Implicit reference in a Groovy build script (e.g. bare {@code foo} or {@code foo()}). */
-            public static final CallerContext BUILD_SCRIPT = new BuildScriptAccess();
+            public static final CallerContext BUILD_SCRIPT = new CallerContext("a dynamic invocation in the build script");
 
             private Instances() {}
-        }
-
-        private static final class ExplicitApiCall extends CallerContext {
-            private final String api;
-
-            ExplicitApiCall(String api) {
-                this.api = api;
-            }
-
-            @Override
-            public boolean isExplicitApiCall() {
-                return true;
-            }
-
-            @Override
-            public String apiName() {
-                return api;
-            }
-        }
-
-        private static final class BuildScriptAccess extends CallerContext {
-            @Override
-            public boolean isExplicitApiCall() {
-                return false;
-            }
-
-            @Override
-            public String apiName() {
-                throw new UnsupportedOperationException();
-            }
         }
     }
 
@@ -402,8 +377,8 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
     private String buildDeprecationContext(String memberKind, String memberName, DynamicObject resolvedParent) {
         String context = capitalize(memberKind) + " '" + memberName + "' was not declared in " + getDisplayName()
             + " and was resolved from " + resolvedParent.getDisplayName() + ".";
-        if (callerContext != null && callerContext.isExplicitApiCall()) {
-            return context + " This lookup was initiated by '" + callerContext.apiName() + "'.";
+        if (callerContext != null) {
+            return context + " This lookup was initiated by " + callerContext.getDescription() + ".";
         }
         return context;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -73,6 +73,83 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
     @Nullable
     private HierarchicalDynamicObject parent;
     private boolean failOnParentAccess;
+    // Thread safety: only accessed while the project lock is held during configuration.
+    // Callers are expected to set/clear this around a single lookup using try/finally.
+    @Nullable
+    private CallerContext callerContext;
+
+    /**
+     * Describes how a property/method lookup was initiated, used to annotate the parent-walk
+     * deprecation message with caller-specific detail.
+     *
+     * <p>External callers set the context on the {@link ExtensibleDynamicObject} of the project
+     * (or script) issuing the lookup via {@link #setCallerContext(CallerContext)} immediately
+     * before invoking a lookup method, and restore the previous value in a {@code finally} block.
+     * When a lookup walks into the parent, the context currently set on the referrer's dynamic
+     * object is read to enrich the deprecation message.
+     */
+    public abstract static class CallerContext {
+        private CallerContext() {}
+
+        public abstract boolean isExplicitApiCall();
+
+        /**
+         * The API method name (e.g. {@code "property()"}, {@code "findProperty()"}, or
+         * {@code "val ... by project"}). Only valid for explicit API calls.
+         */
+        public abstract String apiName();
+
+        /**
+         * Holder class to avoid initialization-order surprises between the outer class and its
+         * private subclasses.
+         */
+        public static final class Instances {
+            /** {@code project.property("foo")}. */
+            public static final CallerContext PROPERTY = new ExplicitApiCall("property()");
+            /** {@code project.findProperty("foo")}. */
+            public static final CallerContext FIND_PROPERTY = new ExplicitApiCall("findProperty()");
+            /** {@code project.hasProperty("foo")}. */
+            public static final CallerContext HAS_PROPERTY = new ExplicitApiCall("hasProperty()");
+            /** {@code project.getProperty("foo")}. */
+            public static final CallerContext GET_PROPERTY = new ExplicitApiCall("getProperty()");
+            /** Kotlin DSL {@code val foo by project} property delegation. */
+            public static final CallerContext KOTLIN_DELEGATION = new ExplicitApiCall("val ... by project");
+            /** Implicit reference in a Groovy build script (e.g. bare {@code foo} or {@code foo()}). */
+            public static final CallerContext BUILD_SCRIPT = new BuildScriptAccess();
+
+            private Instances() {}
+        }
+
+        private static final class ExplicitApiCall extends CallerContext {
+            private final String api;
+
+            ExplicitApiCall(String api) {
+                this.api = api;
+            }
+
+            @Override
+            public boolean isExplicitApiCall() {
+                return true;
+            }
+
+            @Override
+            public String apiName() {
+                return api;
+            }
+        }
+
+        private static final class BuildScriptAccess extends CallerContext {
+            @Override
+            public boolean isExplicitApiCall() {
+                return false;
+            }
+
+            @Override
+            public String apiName() {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
 
     public ExtensibleDynamicObject(Object delegate, Class<?> publicType, InstanceGenerator instanceGenerator) {
         this(delegate, new BeanDynamicObject(delegate, publicType), new DefaultExtensionContainer(instanceGenerator));
@@ -147,6 +224,26 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
      */
     public void setFailOnParentAccess(boolean failOnParentAccess) {
         this.failOnParentAccess = failOnParentAccess;
+    }
+
+    /**
+     * Returns the {@link CallerContext} currently set on this dynamic object via
+     * {@link #setCallerContext(CallerContext)}, or {@code null} if none is active. Callers wrap a
+     * lookup by capturing this value, setting their own context, and restoring the captured value
+     * in a {@code finally} block.
+     */
+    @Nullable
+    public CallerContext getCallerContext() {
+        return callerContext;
+    }
+
+    /**
+     * Sets the {@link CallerContext} for the next property/method lookup. Callers must restore the
+     * previous context (see {@link #getCallerContext()}) in a {@code finally} block after the
+     * lookup completes.
+     */
+    public void setCallerContext(@Nullable CallerContext callerContext) {
+        this.callerContext = callerContext;
     }
 
     public ExtensionContainer getExtensions() {
@@ -296,11 +393,19 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
             );
         }
         DeprecationLogger.deprecateAction("Implicit lookup of " + pluralize(memberKind) + " in parent projects")
-            .withContext(capitalize(memberKind) + " '" + memberName + "' was not declared in " + getDisplayName()
-                + " and was resolved from " + resolvedParent.getDisplayName() + ".")
+            .withContext(buildDeprecationContext(memberKind, memberName, resolvedParent))
             .willBecomeAnErrorInGradle10()
             .withUpgradeGuideSection(9, "deprecated_implicit_lookup_in_parent_projects")
             .nagUser();
+    }
+
+    private String buildDeprecationContext(String memberKind, String memberName, DynamicObject resolvedParent) {
+        String context = capitalize(memberKind) + " '" + memberName + "' was not declared in " + getDisplayName()
+            + " and was resolved from " + resolvedParent.getDisplayName() + ".";
+        if (callerContext != null && callerContext.isExplicitApiCall()) {
+            return context + " This lookup was initiated by '" + callerContext.apiName() + "'.";
+        }
+        return context;
     }
 
     private static String pluralize(String memberKind) {

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/model/SoftwareModelTaskAndBuildScriptIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/model/SoftwareModelTaskAndBuildScriptIntegrationTest.groovy
@@ -82,6 +82,7 @@ println "child: " + doSomething(11)
         executer.expectDocumentedDeprecationWarning("Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '${methodName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptVisibilityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptVisibilityIntegrationTest.groovy
@@ -278,6 +278,7 @@ println project.path + " ok"
         executer.expectDocumentedDeprecationWarning("Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '${methodName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -631,6 +631,7 @@ allprojects {
         executer.expectDocumentedDeprecationWarning("Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property 'foo' was not declared in project ':a:child' and was resolved from project ':a'. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
@@ -122,7 +122,8 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationSpec {
               }
             """
             expectTaskProjectDeprecation()
-            expectParentMethodAccessDeprecation('rootMethod', ':child', "root project 'test'")
+            // The Reporter calls object.rootMethod(...) via the Project, which carries no caller context.
+            expectParentMethodAccessDeprecation('rootMethod', ':child', "root project 'test'", null)
         }
         expectParentMethodAccessDeprecation('rootMethod', ':child', "root project 'test'")
 
@@ -1056,24 +1057,26 @@ task print(type: MyTask) {
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_get_properties")
     }
 
+    private static final String BUILD_SCRIPT_ORIGIN = "a dynamic invocation in the build script"
+
     private void expectParentPropertyAccessDeprecation(String propertyName, String childPath, String parentDisplayName) {
-        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, null)
+        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, BUILD_SCRIPT_ORIGIN)
     }
 
     private void expectExplicitParentPropertyAccessDeprecation(String api, String propertyName, String childPath, String parentDisplayName) {
-        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, "${api}()")
+        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, "'${api}()'")
     }
 
-    private void expectParentMethodAccessDeprecation(String methodName, String childPath, String parentDisplayName) {
-        expectParentLookupDeprecation('method', methodName, childPath, parentDisplayName, null)
+    private void expectParentMethodAccessDeprecation(String methodName, String childPath, String parentDisplayName, String origin = BUILD_SCRIPT_ORIGIN) {
+        expectParentLookupDeprecation('method', methodName, childPath, parentDisplayName, origin)
     }
 
-    private void expectParentLookupDeprecation(String memberKind, String memberName, String childPath, String parentDisplayName, String initiatedBy) {
+    private void expectParentLookupDeprecation(String memberKind, String memberName, String childPath, String parentDisplayName, String origin) {
         def plural = memberKind == 'property' ? 'properties' : 'methods'
         executer.expectDocumentedDeprecationWarning("Implicit lookup of ${plural} in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "${memberKind.capitalize()} '${memberName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
-            (initiatedBy ? "This lookup was initiated by '${initiatedBy}'. " : "") +
+            (origin ? "This lookup was initiated by ${origin}. " : "") +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
@@ -73,10 +73,12 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationSpec {
               }
             """
             expectTaskProjectDeprecation()
-            expectParentPropertyAccessDeprecation('rootProperty', ':child', "root project 'test'")
-            expectParentPropertyAccessDeprecation('property', ':child', "root project 'test'")
+            // Object.rootProperty / object.property access via Reporter goes through getProperty()
+            expectExplicitParentPropertyAccessDeprecation('getProperty', 'rootProperty', ':child', "root project 'test'")
+            expectExplicitParentPropertyAccessDeprecation('getProperty', 'property', ':child', "root project 'test'")
         }
-        expectParentPropertyAccessDeprecation('rootProperty', ':child', "root project 'test'", 2)
+        expectParentPropertyAccessDeprecation('rootProperty', ':child', "root project 'test'")
+        expectExplicitParentPropertyAccessDeprecation('property', 'rootProperty', ':child', "root project 'test'")
         expectScriptGetPropertiesDeprecation(3)
 
         expect:
@@ -1031,7 +1033,7 @@ task print(type: MyTask) {
 
     private void expectTaskProjectDeprecation(int repeated = 1) {
         repeated.times {
-            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. " +
                 "This will fail with an error in Gradle 10. " +
                 "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
@@ -1054,23 +1056,25 @@ task print(type: MyTask) {
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_get_properties")
     }
 
-    private void expectParentPropertyAccessDeprecation(String propertyName, String childPath, String parentDisplayName, int repeated = 1) {
-        repeated.times {
-            executer.expectDocumentedDeprecationWarning("Implicit lookup of properties in parent projects has been deprecated. " +
-                "This will fail with an error in Gradle 10. " +
-                "Property '${propertyName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
-        }
+    private void expectParentPropertyAccessDeprecation(String propertyName, String childPath, String parentDisplayName) {
+        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, null)
     }
 
-    private void expectParentMethodAccessDeprecation(String methodName, String childPath, String parentDisplayName, int repeated = 1) {
-        repeated.times {
-            executer.expectDocumentedDeprecationWarning("Implicit lookup of methods in parent projects has been deprecated. " +
-                "This will fail with an error in Gradle 10. " +
-                "Method '${methodName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
-        }
+    private void expectExplicitParentPropertyAccessDeprecation(String api, String propertyName, String childPath, String parentDisplayName) {
+        expectParentLookupDeprecation('property', propertyName, childPath, parentDisplayName, "${api}()")
+    }
+
+    private void expectParentMethodAccessDeprecation(String methodName, String childPath, String parentDisplayName) {
+        expectParentLookupDeprecation('method', methodName, childPath, parentDisplayName, null)
+    }
+
+    private void expectParentLookupDeprecation(String memberKind, String memberName, String childPath, String parentDisplayName, String initiatedBy) {
+        def plural = memberKind == 'property' ? 'properties' : 'methods'
+        executer.expectDocumentedDeprecationWarning("Implicit lookup of ${plural} in parent projects has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "${memberKind.capitalize()} '${memberName}' was not declared in project '${childPath}' and was resolved from ${parentDisplayName}. " +
+            (initiatedBy ? "This lookup was initiated by '${initiatedBy}'. " : "") +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
@@ -80,6 +80,8 @@ class ParentPropertyLookupFailOnAccessIntegrationTest extends AbstractIntegratio
             println getProperty('foo')
             println hasProperty('foo')
             println fooMethod()
+            println project.hasProperty('foo')
+            println project.getProperty('foo')
         """)
         // `println foo`, `getProperty('foo')`, `hasProperty('foo')` reach the dynamic-object path
         // without explicit caller context, so they emit the implicit-access message.
@@ -91,6 +93,11 @@ class ParentPropertyLookupFailOnAccessIntegrationTest extends AbstractIntegratio
         ['findProperty', 'property'].each { api ->
             expectParentLookupDeprecation('property', 'foo', "${api}()")
         }
+        // `project.getProperty('foo')` and `project.hasProperty('foo')` route to the Project rather
+        // than the script, so they too carry explicit caller context.
+        ['hasProperty', 'getProperty'].each { api ->
+            expectParentLookupDeprecation('property', 'foo', "${api}()")
+        }
         expectParentLookupDeprecation('method', 'fooMethod', null)
 
         expect:
@@ -99,10 +106,11 @@ class ParentPropertyLookupFailOnAccessIntegrationTest extends AbstractIntegratio
 
     private void expectParentLookupDeprecation(String memberKind, String memberName, String initiatedBy) {
         def plural = memberKind == 'property' ? 'properties' : 'methods'
+        def origin = initiatedBy ? "'${initiatedBy}'" : "a dynamic invocation in the build script"
         executer.expectDocumentedDeprecationWarning("Implicit lookup of ${plural} in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "${memberKind.capitalize()} '${memberName}' was not declared in project ':child' and was resolved from root project 'root'. " +
-            (initiatedBy ? "This lookup was initiated by '${initiatedBy}'. " : "") +
+            "This lookup was initiated by ${origin}. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
@@ -81,21 +81,30 @@ class ParentPropertyLookupFailOnAccessIntegrationTest extends AbstractIntegratio
             println hasProperty('foo')
             println fooMethod()
         """)
-        5.times {
-            executer.expectDocumentedDeprecationWarning("Implicit lookup of properties in parent projects has been deprecated. " +
-                "This will fail with an error in Gradle 10. " +
-                "Property 'foo' was not declared in project ':child' and was resolved from root project 'root'. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
+        // `println foo`, `getProperty('foo')`, `hasProperty('foo')` reach the dynamic-object path
+        // without explicit caller context, so they emit the implicit-access message.
+        3.times {
+            expectParentLookupDeprecation('property', 'foo', null)
         }
-        executer.expectDocumentedDeprecationWarning("Implicit lookup of methods in parent projects has been deprecated. " +
-            "This will fail with an error in Gradle 10. " +
-            "Method 'fooMethod' was not declared in project ':child' and was resolved from root project 'root'. " +
-            "Consult the upgrading guide for further information: " +
-            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
+        // `findProperty('foo')` and `property('foo')` are wired with explicit caller context, which
+        // is surfaced in the deprecation context (the action itself stays stable for Develocity).
+        ['findProperty', 'property'].each { api ->
+            expectParentLookupDeprecation('property', 'foo', "${api}()")
+        }
+        expectParentLookupDeprecation('method', 'fooMethod', null)
 
         expect:
         succeeds "help"
+    }
+
+    private void expectParentLookupDeprecation(String memberKind, String memberName, String initiatedBy) {
+        def plural = memberKind == 'property' ? 'properties' : 'methods'
+        executer.expectDocumentedDeprecationWarning("Implicit lookup of ${plural} in parent projects has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "${memberKind.capitalize()} '${memberName}' was not declared in project ':child' and was resolved from root project 'root'. " +
+            (initiatedBy ? "This lookup was initiated by '${initiatedBy}'. " : "") +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
     }
 
     def "succeeds when child defines the property locally even with flag set"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -46,6 +46,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "$COMMON_DEPRECATION_PART"
     }
 
@@ -53,6 +54,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "$COMMON_DEPRECATION_PART"
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -24,24 +24,36 @@ import org.gradle.test.preconditions.TestExecutionPreconditions
 @Requires(value = TestExecutionPreconditions.NotIsolatedProjects, reason = "Under Isolated Projects, parent-project lookup is disabled entirely (see IsolatedProjectsAccessFromGroovyDslIntegrationTest); no deprecation fires")
 class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final String DEPRECATION_DOC_URL = "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects"
+    private static final String COMMON_DEPRECATION_PART = "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects"
 
-    private static final String PROPERTY_DEPRECATION = propertyDeprecation("foo", "project ':a'", "root project 'root'")
+    private static String implicitPropertyDeprecation(String name) {
+        propertyDeprecation(name, "project ':a'", "root project 'root'")
+    }
 
-    private static final String METHOD_DEPRECATION = methodDeprecation("someMethod", "project ':a'", "root project 'root'")
+    private static String implicitMethodDeprecation(String name) {
+        methodDeprecation(name, "project ':a'", "root project 'root'")
+    }
+
+    private static String explicitApiDeprecation(String apiName, String name) {
+        "Implicit lookup of properties in parent projects has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Property '$name' was not declared in project ':a' and was resolved from root project 'root'. " +
+            "This lookup was initiated by '$apiName'. " +
+            "$COMMON_DEPRECATION_PART"
+    }
 
     private static String propertyDeprecation(String name, String lookupProject, String declaringProject) {
         "Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
-            "Consult the upgrading guide for further information: $DEPRECATION_DOC_URL"
+            "$COMMON_DEPRECATION_PART"
     }
 
     private static String methodDeprecation(String name, String lookupProject, String declaringProject) {
         "Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
-            "Consult the upgrading guide for further information: $DEPRECATION_DOC_URL"
+            "$COMMON_DEPRECATION_PART"
     }
 
     def setup() {
@@ -61,79 +73,35 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning(PROPERTY_DEPRECATION)
+        executer.expectDocumentedDeprecationWarning(implicitPropertyDeprecation("foo"))
 
         then:
         succeeds("help")
         outputContains("foo: hello")
     }
 
-    def "explicit findProperty(String) on the child project is deprecated when resolved from parent"() {
+    def "explicit #api on the child project is deprecated when resolved from parent"() {
         given:
         buildFile << """
             ext.foo = "hello"
         """
         file("a/build.gradle") << """
-            println("foo: " + findProperty("foo"))
+            println("result: " + $invocation)
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning(PROPERTY_DEPRECATION)
+        executer.expectDocumentedDeprecationWarning(deprecation)
 
         then:
         succeeds("help")
-        outputContains("foo: hello")
-    }
+        outputContains("result: $expected")
 
-    def "explicit property(String) on the child project is deprecated when resolved from parent"() {
-        given:
-        buildFile << """
-            ext.foo = "hello"
-        """
-        file("a/build.gradle") << """
-            println("foo: " + property("foo"))
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning(PROPERTY_DEPRECATION)
-
-        then:
-        succeeds("help")
-        outputContains("foo: hello")
-    }
-
-    def "explicit getProperty(String) on the child project is deprecated when resolved from parent"() {
-        given:
-        buildFile << """
-            ext.foo = "hello"
-        """
-        file("a/build.gradle") << """
-            println("foo: " + getProperty("foo"))
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning(PROPERTY_DEPRECATION)
-
-        then:
-        succeeds("help")
-        outputContains("foo: hello")
-    }
-
-    def "explicit hasProperty(String) on the child project is deprecated when resolved from parent"() {
-        given:
-        buildFile << """
-            ext.foo = "hello"
-        """
-        file("a/build.gradle") << """
-            println("hasFoo: " + hasProperty("foo"))
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning(PROPERTY_DEPRECATION)
-
-        then:
-        succeeds("help")
-        outputContains("hasFoo: true")
+        where:
+        api              | invocation             | expected | deprecation
+        "findProperty()" | 'findProperty("foo")'  | "hello"  | explicitApiDeprecation("findProperty()", "foo")
+        "property()"     | 'property("foo")'      | "hello"  | explicitApiDeprecation("property()", "foo")
+        "getProperty()"  | 'getProperty("foo")'   | "hello"  | implicitPropertyDeprecation("foo")
+        "hasProperty()"  | 'hasProperty("foo")'   | "true"   | implicitPropertyDeprecation("foo")
     }
 
     def "implicit method invocation from a child project is deprecated"() {
@@ -146,7 +114,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning(METHOD_DEPRECATION)
+        executer.expectDocumentedDeprecationWarning(implicitMethodDeprecation("someMethod"))
 
         then:
         succeeds("help")

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -161,6 +161,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning("Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method 'someMethod' was not declared in project ':sub' and was resolved from root project 'root'. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
 
@@ -260,6 +261,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning("Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property 'pluginClass' was not declared in project ':sub' and was resolved from root project 'root'. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects")
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -150,6 +150,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1160,7 +1161,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @SuppressWarnings("JavadocReference")
     @Nullable
     public Object getProperty(String propertyName) {
-        return property(propertyName);
+        return withCallerContext(ExtensibleDynamicObject.CallerContext.Instances.GET_PROPERTY,
+            () -> extensibleDynamicObject.getProperty(propertyName));
     }
 
     /**
@@ -1183,14 +1185,17 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     @Nullable
     public Object property(String propertyName) throws MissingPropertyException {
-        return extensibleDynamicObject.getProperty(propertyName);
+        return withCallerContext(ExtensibleDynamicObject.CallerContext.Instances.PROPERTY,
+            () -> extensibleDynamicObject.getProperty(propertyName));
     }
 
     @Override
     @Nullable
     public Object findProperty(String propertyName) {
-        DynamicInvokeResult result = extensibleDynamicObject.tryGetProperty(propertyName);
-        return result.isFound() ? result.getValue() : null;
+        return withCallerContext(ExtensibleDynamicObject.CallerContext.Instances.FIND_PROPERTY, () -> {
+            DynamicInvokeResult result = extensibleDynamicObject.tryGetProperty(propertyName);
+            return result.isFound() ? result.getValue() : null;
+        });
     }
 
     @Override
@@ -1200,7 +1205,18 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public boolean hasProperty(String propertyName) {
-        return extensibleDynamicObject.hasProperty(propertyName);
+        return withCallerContext(ExtensibleDynamicObject.CallerContext.Instances.HAS_PROPERTY,
+            () -> extensibleDynamicObject.hasProperty(propertyName));
+    }
+
+    private <T> T withCallerContext(ExtensibleDynamicObject.CallerContext context, Supplier<T> action) {
+        ExtensibleDynamicObject.CallerContext previous = extensibleDynamicObject.getCallerContext();
+        extensibleDynamicObject.setCallerContext(context);
+        try {
+            return action.get();
+        } finally {
+            extensibleDynamicObject.setCallerContext(previous);
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -28,6 +28,7 @@ import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.metaobject.DynamicObjectUtil;
 import org.gradle.internal.scripts.GradleScript;
 import org.gradle.internal.service.ServiceRegistry;
@@ -35,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.PrintStream;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware, GradleScript {
     private StandardOutputCapture standardOutputCapture;
@@ -69,7 +71,7 @@ public abstract class BasicScript extends org.gradle.groovy.scripts.Script imple
 
     @Override
     public Object getProperty(String property) {
-        return dynamicObject.getProperty(property);
+        return withCallerContext(() -> dynamicObject.getProperty(property));
     }
 
     @Override
@@ -89,12 +91,46 @@ public abstract class BasicScript extends org.gradle.groovy.scripts.Script imple
     }
 
     public boolean hasProperty(String property) {
-        return dynamicObject.hasProperty(property);
+        return withCallerContext(() -> dynamicObject.hasProperty(property));
     }
 
     @Override
     public Object invokeMethod(String name, Object args) {
-        return dynamicObject.invokeMethod(name, (Object[]) args);
+        return withCallerContext(() -> dynamicObject.invokeMethod(name, (Object[]) args));
+    }
+
+    /**
+     * Wraps a dynamic-object lookup with the {@link ExtensibleDynamicObject.CallerContext.Instances#BUILD_SCRIPT}
+     * caller context on the underlying project's {@link ExtensibleDynamicObject}, so that any
+     * parent-walk deprecation or Isolated Projects violation can be annotated as originating
+     * from a Groovy build script's implicit lookup rather than an explicit API call.
+     *
+     * <p>Settings and init scripts have no project-level dynamic object; their lookups go
+     * through here unchanged.
+     */
+    private <T> T withCallerContext(Supplier<T> action) {
+        ExtensibleDynamicObject targetDynamicObject = targetExtensibleDynamicObject();
+        if (targetDynamicObject == null) {
+            return action.get();
+        }
+        ExtensibleDynamicObject.CallerContext previous = targetDynamicObject.getCallerContext();
+        targetDynamicObject.setCallerContext(ExtensibleDynamicObject.CallerContext.Instances.BUILD_SCRIPT);
+        try {
+            return action.get();
+        } finally {
+            targetDynamicObject.setCallerContext(previous);
+        }
+    }
+
+    @Nullable
+    private ExtensibleDynamicObject targetExtensibleDynamicObject() {
+        if (target instanceof DynamicObjectAware) {
+            DynamicObject dyn = ((DynamicObjectAware) target).getAsDynamicObject();
+            if (dyn instanceof ExtensibleDynamicObject) {
+                return (ExtensibleDynamicObject) dyn;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -70,6 +70,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         "Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '$methodName' was not declared in project ':child' and was resolved from root project 'test'. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "${DEPRECATED_PARENT_PROPERTY_ACCESS_URL}"
     }
@@ -78,6 +79,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         "Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property '$propertyName' was not declared in project ':child' and was resolved from root project 'test'. " +
+            "This lookup was initiated by a dynamic invocation in the build script. " +
             "Consult the upgrading guide for further information: " +
             "${DEPRECATED_PARENT_PROPERTY_ACCESS_URL}"
     }


### PR DESCRIPTION
## Summary

When a child build script reads a property or method defined on a parent project under Vintage, the parent-walk deprecation says *what* was resolved but not *how* the user reached the lookup site. The same lookup can come from a bare `foo` reference, a Kotlin DSL `val foo by project` delegate, or one of the explicit API methods `project.property("foo")` / `findProperty("foo")` / `getProperty("foo")` / `hasProperty("foo")`.

This PR threads a `CallerContext` through to `ExtensibleDynamicObject` so the deprecation message names the caller. The caller detail is added to the **context**.

For an explicit API call the message gains a trailing sentence:

```
Implicit lookup of properties in parent projects has been deprecated. This will fail with an error in Gradle 10. Property 'foo' was not declared in project ':child' and was resolved from root project 'root'. This lookup was initiated by 'property()'. Consult the upgrading guide ...
```

A bare reference / method invocation keeps the plain message (no trailing sentence):

```
Implicit lookup of properties in parent projects has been deprecated. This will fail with an error in Gradle 10. Property 'foo' was not declared in project ':child' and was resolved from root project 'root'. Consult the upgrading guide ...
```

Vintage-only by design: under Isolated Projects the parent walk is disabled entirely, so no caller context is ever read or rendered there.

## Wiring

- `DefaultProject`'s explicit-API overloads wrap their internal lookup in `withCallerContext(...)` for `PROPERTY`, `FIND_PROPERTY`, `GET_PROPERTY`, `HAS_PROPERTY`.
- `BasicScript` wraps Groovy script-level lookups with `BUILD_SCRIPT` (the bare-reference / method-invocation path).
- `PropertyDelegate.kt` wraps Kotlin DSL `val foo by project` delegate lookups with `KOTLIN_DELEGATION`.
- The context is set on the issuing object's `ExtensibleDynamicObject` immediately before the lookup and restored in a `finally`; `buildDeprecationContext` reads it when the walk resolves from a parent and appends the caller sentence only for explicit API calls.

## Notes

- The base parent-lookup deprecation (message wording, project attribution, upgrade-guide anchor) already lands on `master`; this PR only adds the caller-context detail on top.
- Because `getProperty('foo')` / `hasProperty('foo')` in a Groovy build script resolve to the script's own methods rather than the project's, those reach the lookup via `BUILD_SCRIPT` and render as implicit — only `property('foo')` / `findProperty('foo')` (which route to the project) render the explicit sentence. This is covered by the data-table test in `ParentProjectPropertyLookupIntegrationTest`.

## Test plan

- [x] `./gradlew :core:embeddedIntegTest --tests "*ParentProjectPropertyLookupIntegrationTest*" --tests "*ParentPropertyLookupFailOnAccessIntegrationTest*" --tests "*DynamicObjectIntegrationTest*"`
- [x] `./gradlew :model-core:test --tests "*ExtensibleDynamicObjectTest*"`
- [x] New `KotlinDslParentProjectPropertyLookupIntegrationTest` covers the `val ... by project` caller context