### PR TITLE
Add NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS feature preview

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -292,7 +292,7 @@ This prevents new accidental implicit lookups in the project hierarchy.
 [source,kotlin]
 ----
 // settings.gradle.kts
-enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
 ----
 
 [[deprecated_pmd_target_jdk]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -220,7 +220,7 @@ Delegated properties are being removed because they create silent correctness bu
 ==== Deprecation of Develocity plugin versions before 4.0
 
 Gradle 10 requires Develocity plugin 4.0 or later.
-Earlier versions rely on Gradle's implicit property lookup in the project hierarchy, which will be removed in Gradle 10 and silently ignored if applied.
+Earlier versions rely on Gradle's implicit property lookup from parent projects, which will be removed in Gradle 10 and silently ignored if applied.
 
 Upgrade to the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest Develocity plugin] from the Gradle Plugin Portal.
 See the link:https://gradle.com/help/gradle-plugin-compatibility/[Develocity plugin compatibility matrix] for details.
@@ -284,10 +284,10 @@ include::sample[dir="snippets/releases/upgrading/findExtraInHierarchy/groovy",fi
 
 This helper is **not compatible with Isolated Projects** — `parent.ext` (and the chain of `parent` references) is cross-project access, which Isolated Projects forbids. It is a transitional fix for Vintage migrations only. If you are also migrating to Isolated Projects, use one of the first two options (`gradle.properties` or a convention plugin) instead.
 
-===== Opt into Gradle 10 behavior by disabling project hierarchy lookup
+===== Opt into Gradle 10 behavior by disabling implicit lookup in parent projects
 
 Once you have addressed all related deprecations, you can use a feature preview to adopt the Gradle 10 behavior early.
-This prevents new accidental implicit lookups in the project hierarchy.
+This prevents new accidental implicit lookups from parent projects.
 
 [source,kotlin]
 ----

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -284,7 +284,7 @@ include::sample[dir="snippets/releases/upgrading/findExtraInHierarchy/groovy",fi
 
 This helper is **not compatible with Isolated Projects** — `parent.ext` (and the chain of `parent` references) is cross-project access, which Isolated Projects forbids. It is a transitional fix for Vintage migrations only. If you are also migrating to Isolated Projects, use one of the first two options (`gradle.properties` or a convention plugin) instead.
 
-**Opt into Gradle 10 behavior by disabling project hierarchy lookup**
+===== Opt into Gradle 10 behavior by disabling project hierarchy lookup
 
 Once you have addressed all related deprecations, you can use a feature preview to adopt the Gradle 10 behavior early.
 This prevents new accidental implicit lookups in the project hierarchy.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -220,7 +220,7 @@ Delegated properties are being removed because they create silent correctness bu
 ==== Deprecation of Develocity plugin versions before 4.0
 
 Gradle 10 requires Develocity plugin 4.0 or later.
-Earlier versions rely on Gradle's implicit parent-project property lookup, which will be removed in Gradle 10 and silently ignored if applied.
+Earlier versions rely on Gradle's implicit property lookup in the project hierarchy, which will be removed in Gradle 10 and silently ignored if applied.
 
 Upgrade to the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest Develocity plugin] from the Gradle Plugin Portal.
 See the link:https://gradle.com/help/gradle-plugin-compatibility/[Develocity plugin compatibility matrix] for details.
@@ -283,6 +283,17 @@ include::sample[dir="snippets/releases/upgrading/findExtraInHierarchy/groovy",fi
 ====
 
 This helper is **not compatible with Isolated Projects** — `parent.ext` (and the chain of `parent` references) is cross-project access, which Isolated Projects forbids. It is a transitional fix for Vintage migrations only. If you are also migrating to Isolated Projects, use one of the first two options (`gradle.properties` or a convention plugin) instead.
+
+**Opt into Gradle 10 behavior by disabling project hierarchy lookup**
+
+Once you have addressed all related deprecations, you can use a feature preview to adopt the Gradle 10 behavior early.
+This prevents new accidental implicit lookups in the project hierarchy.
+
+[source,kotlin]
+----
+// settings.gradle.kts
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
+----
 
 [[deprecated_pmd_target_jdk]]
 ==== Deprecation of `targetJdk` on the PMD plugin

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -206,7 +206,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
 
     private TestFile disableProjectHierarchyLookup() {
         settingsFile << """
-            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
+            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
         """
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -183,9 +183,9 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         outputContains("foo: child-only")
     }
 
-    def "Can disable project hierarchy lookup: child #access returns #expected for parent-only property"() {
+    def "Can disable implicit lookup in parent projects: child #access returns #expected for parent-only property"() {
         given:
-        disableProjectHierarchyLookup()
+        disableImplicitLookupInParentProjects()
         buildFile << """
             ext.foo = "from-root"
         """
@@ -204,15 +204,15 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "hasProperty()"   | 'hasProperty("foo")'    | "false"
     }
 
-    private TestFile disableProjectHierarchyLookup() {
+    private TestFile disableImplicitLookupInParentProjects() {
         settingsFile << """
             enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
         """
     }
 
-    def "Can disable project hierarchy lookup: child #access throws MissingPropertyException for parent-only property"() {
+    def "Can disable implicit lookup in parent projects: child #access throws MissingPropertyException for parent-only property"() {
         given:
-        disableProjectHierarchyLookup()
+        disableImplicitLookupInParentProjects()
         buildFile << """
             ext.foo = "from-root"
         """
@@ -231,9 +231,9 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "getProperty()"   | 'getProperty("foo")'
     }
 
-    def "Can disable project hierarchy lookup: child #access throws MissingMethodException for parent-only method"() {
+    def "Can disable implicit lookup in parent projects: child #access throws MissingMethodException for parent-only method"() {
         given:
-        disableProjectHierarchyLookup()
+        disableImplicitLookupInParentProjects()
         buildFile << """
             def someMethod() { "from-root" }
         """
@@ -252,9 +252,9 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "project.someMethod"   | 'project.someMethod()'
     }
 
-    def "Can disable project hierarchy lookup: child can still access its own properties and methods"() {
+    def "Can disable implicit lookup in parent projects: child can still access its own properties and methods"() {
         given:
-        disableProjectHierarchyLookup()
+        disableImplicitLookupInParentProjects()
         file("a/build.gradle") << """
             ext.local = "child-only"
             def localMethod() { "child-method" }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -181,4 +181,22 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         succeeds("help")
         outputContains("foo: child-only")
     }
+
+    def "NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY feature preview disables parent walking entirely"() {
+        given:
+        settingsFile << """
+            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
+        """
+        buildFile << """
+            ext.foo = "from-root"
+        """
+        file("a/build.gradle") << """
+            println("foo: " + findProperty("foo"))
+        """
+
+        expect:
+        // No deprecation expected — the feature preview disables the parent walk at the source.
+        succeeds("help")
+        outputContains("foo: null")
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -183,7 +183,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         outputContains("foo: child-only")
     }
 
-    def "Can disable implicit lookup in parent projects: child #access returns #expected for parent-only property"() {
+    def "can disable implicit lookup in parent projects: child #access returns #expected for parent-only property"() {
         given:
         disableImplicitLookupInParentProjects()
         buildFile << """
@@ -204,13 +204,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "hasProperty()"   | 'hasProperty("foo")'    | "false"
     }
 
-    private TestFile disableImplicitLookupInParentProjects() {
-        settingsFile << """
-            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
-        """
-    }
-
-    def "Can disable implicit lookup in parent projects: child #access throws MissingPropertyException for parent-only property"() {
+    def "can disable implicit lookup in parent projects: child #access throws MissingPropertyException for parent-only property"() {
         given:
         disableImplicitLookupInParentProjects()
         buildFile << """
@@ -231,7 +225,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "getProperty()"   | 'getProperty("foo")'
     }
 
-    def "Can disable implicit lookup in parent projects: child #access throws MissingMethodException for parent-only method"() {
+    def "can disable implicit lookup in parent projects: child #access throws MissingMethodException for parent-only method"() {
         given:
         disableImplicitLookupInParentProjects()
         buildFile << """
@@ -252,7 +246,7 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         "project.someMethod"   | 'project.someMethod()'
     }
 
-    def "Can disable implicit lookup in parent projects: child can still access its own properties and methods"() {
+    def "can disable implicit lookup in parent projects: child can still access its own properties and methods"() {
         given:
         disableImplicitLookupInParentProjects()
         file("a/build.gradle") << """
@@ -266,5 +260,11 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         succeeds("help")
         outputContains("prop: child-only")
         outputContains("method: child-method")
+    }
+
+    private TestFile disableImplicitLookupInParentProjects() {
+        settingsFile << """
+            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
+        """
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.project
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
@@ -182,21 +183,88 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         outputContains("foo: child-only")
     }
 
-    def "NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY feature preview disables parent walking entirely"() {
+    def "Can disable project hierarchy lookup: child #access returns #expected for parent-only property"() {
         given:
-        settingsFile << """
-            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
-        """
+        disableProjectHierarchyLookup()
         buildFile << """
             ext.foo = "from-root"
         """
         file("a/build.gradle") << """
-            println("foo: " + findProperty("foo"))
+            println("result: " + $invocation)
         """
 
         expect:
         // No deprecation expected — the feature preview disables the parent walk at the source.
         succeeds("help")
-        outputContains("foo: null")
+        outputContains("result: $expected")
+
+        where:
+        access            | invocation              | expected
+        "findProperty()"  | 'findProperty("foo")'   | "null"
+        "hasProperty()"   | 'hasProperty("foo")'    | "false"
+    }
+
+    private TestFile disableProjectHierarchyLookup() {
+        settingsFile << """
+            enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY")
+        """
+    }
+
+    def "Can disable project hierarchy lookup: child #access throws MissingPropertyException for parent-only property"() {
+        given:
+        disableProjectHierarchyLookup()
+        buildFile << """
+            ext.foo = "from-root"
+        """
+        file("a/build.gradle") << """
+            $invocation
+        """
+
+        expect:
+        fails("help")
+        failure.assertHasCause("Could not get unknown property 'foo' for project ':a' of type org.gradle.api.Project.")
+
+        where:
+        access            | invocation
+        "implicit foo"    | 'println("foo: " + foo)'
+        "property()"      | 'property("foo")'
+        "getProperty()"   | 'getProperty("foo")'
+    }
+
+    def "Can disable project hierarchy lookup: child #access throws MissingMethodException for parent-only method"() {
+        given:
+        disableProjectHierarchyLookup()
+        buildFile << """
+            def someMethod() { "from-root" }
+        """
+        file("a/build.gradle") << """
+            $invocation
+        """
+
+        expect:
+        fails("help")
+        failure.assertHasCause("Could not find method someMethod() for arguments [] on project ':a' of type org.gradle.api.Project.")
+
+        where:
+        access                 | invocation
+        "implicit someMethod"  | 'someMethod()'
+        "this.someMethod"      | 'this.someMethod()'
+        "project.someMethod"   | 'project.someMethod()'
+    }
+
+    def "Can disable project hierarchy lookup: child can still access its own properties and methods"() {
+        given:
+        disableProjectHierarchyLookup()
+        file("a/build.gradle") << """
+            ext.local = "child-only"
+            def localMethod() { "child-method" }
+            println("prop: " + local)
+            println("method: " + localMethod())
+        """
+
+        expect:
+        succeeds("help")
+        outputContains("prop: child-only")
+        outputContains("method: child-method")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -39,10 +39,11 @@ public class FeaturePreviews {
          */
         INTERNAL_BUILD_SERVICE_USAGE(true, null),
         /**
-         * When enabled, child projects do not walk into their parent project to resolve
-         * properties or methods. Opts the build into the Gradle 10 behavior early. The
-         * deprecation warning that fires for parent-walk lookups in Vintage mode will be
-         * silent under this preview because the parent walk is disabled at the source.
+         * When enabled, child projects do not implicitly resolve properties or methods
+         * from their parent projects. Opts the build into the Gradle 10 behavior early.
+         * The deprecation warning that fires for implicit lookups from parent projects in
+         * Vintage mode will be silent under this preview because the lookup is disabled
+         * at the source.
          */
         NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS(true, null),
         /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -44,7 +44,7 @@ public class FeaturePreviews {
          * deprecation warning that fires for parent-walk lookups in Vintage mode will be
          * silent under this preview because the parent walk is disabled at the source.
          */
-        NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY(true, null),
+        NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS(true, null),
         /**
          * This exists to test inactive feature previews
          */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -39,6 +39,13 @@ public class FeaturePreviews {
          */
         INTERNAL_BUILD_SERVICE_USAGE(true, null),
         /**
+         * When enabled, child projects do not walk into their parent project to resolve
+         * properties or methods. Opts the build into the Gradle 10 behavior early. The
+         * deprecation warning that fires for parent-walk lookups in Vintage mode will be
+         * silent under this preview because the parent walk is disabled at the source.
+         */
+        NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY(true, null),
+        /**
          * This exists to test inactive feature previews
          */
         ALWAYS_INACTIVE(false, null);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -266,8 +266,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         if (parentInherited != null) {
             // The NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS feature preview opts Vintage builds into the
             // eventual Gradle 10 behavior early: don't wire the parent at all, so the parent walk
-            // (and therefore the deprecation) does not fire. Under Isolated Projects the parent
-            // is already null (see the preceding commit), so this branch only matters for Vintage.
+            // (and therefore the deprecation) does not fire. Under Isolated Projects, no parent is
+            // inherited in the first place.
             boolean noImplicitParentLookup = services.get(FeatureFlags.class).isEnabled(FeaturePreviews.Feature.NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS);
             if (!noImplicitParentLookup) {
                 extensibleDynamicObject.setParent(parentInherited);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -91,6 +91,8 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
+import org.gradle.api.internal.FeaturePreviews;
+import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.buildoption.InternalOption;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
@@ -262,8 +264,15 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
         @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(owner);
         if (parentInherited != null) {
-            extensibleDynamicObject.setParent(parentInherited);
-            extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));
+            // The NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY feature preview opts Vintage builds into the
+            // eventual Gradle 10 behavior early: don't wire the parent at all, so the parent walk
+            // (and therefore the deprecation) does not fire. Under Isolated Projects the parent
+            // is already null (see the preceding commit), so this branch only matters for Vintage.
+            boolean noImplicitParentLookup = services.get(FeatureFlags.class).isEnabled(FeaturePreviews.Feature.NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY);
+            if (!noImplicitParentLookup) {
+                extensibleDynamicObject.setParent(parentInherited);
+                extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));
+            }
         }
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -264,11 +264,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
         @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(owner);
         if (parentInherited != null) {
-            // The NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY feature preview opts Vintage builds into the
+            // The NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS feature preview opts Vintage builds into the
             // eventual Gradle 10 behavior early: don't wire the parent at all, so the parent walk
             // (and therefore the deprecation) does not fire. Under Isolated Projects the parent
             // is already null (see the preceding commit), so this branch only matters for Vintage.
-            boolean noImplicitParentLookup = services.get(FeatureFlags.class).isEnabled(FeaturePreviews.Feature.NO_IMPLICIT_LOOKUP_IN_PROJECT_HIERARCHY);
+            boolean noImplicitParentLookup = services.get(FeatureFlags.class).isEnabled(FeaturePreviews.Feature.NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS);
             if (!noImplicitParentLookup) {
                 extensibleDynamicObject.setParent(parentInherited);
                 extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator
 import org.gradle.internal.Describables
 import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.FeatureFlags
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.configuration.problems.NoOpIsolatedProjectsProblemsReporter
@@ -272,6 +273,7 @@ class DefaultProjectSpec extends Specification {
         serviceRegistry.add(ProjectFeatureDeclarations, Stub(ProjectFeatureDeclarations))
         serviceRegistry.add(ProjectFeatureApplicator, Stub(ProjectFeatureApplicator))
         serviceRegistry.add(InternalOptions, new DefaultInternalOptions([:]))
+        serviceRegistry.add(FeatureFlags, Stub(FeatureFlags))
 
         def antBuilder = Mock(AntBuilder)
         serviceRegistry.add(AntBuilderFactory, Mock(AntBuilderFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -86,6 +86,7 @@ import org.gradle.internal.Actions
 import org.gradle.internal.Describables
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.FeatureFlags
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.configuration.problems.NoOpIsolatedProjectsProblemsReporter
@@ -279,6 +280,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) DependencyLockingHandler) >> Stub(DependencyLockingHandler)
         serviceRegistryMock.get((Type) DynamicCallContextTracker) >> Stub(DynamicCallContextTracker)
         serviceRegistryMock.get(InternalOptions) >> new DefaultInternalOptions([:])
+        serviceRegistryMock.get(FeatureFlags) >> Stub(FeatureFlags)
 
         projectState = Mock(ProjectState)
         projectState.name >> 'root'


### PR DESCRIPTION
## Summary

Adds a feature preview `NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS` that opts a Vintage build out of implicit property and method lookup through the project hierarchy.

When enabled in `settings.gradle(.kts)`, child projects no longer fall back to the parent's dynamic scope. References that would have walked up the hierarchy fail locally with `MissingPropertyException` / `MissingMethodException`, matching the eventual Gradle 10 behavior. After addressing the related deprecations from #37830, users can enable the preview to confirm their migration is complete and prevent accidental reintroduction of implicit hierarchy lookups.

The preview is Vintage-only by intent: under Isolated Projects the implicit hierarchy lookup is already disabled (per #37830), so the preview is a no-op there.

Also includes:
- An integration test verifying the preview disables the parent walk in Vintage
- A release-notes entry under "Build authoring improvements"
- An entry in the `deprecated_implicit_project_hierarchy_lookup` section of the 9.6 upgrade guide, pointing migrators to the preview as a verification step

## Stack

Builds directly on #37830 (merged). #37831 (caller-context detail in deprecation messages) builds on this PR.

The plugin-ecosystem smoke validation that was previously bundled in here has been split out into a separate independent PR — it's not behaviorally tied to the feature preview, it validates #37830's deprecation across community plugins.

## Test plan

- [x] \`./gradlew :core:forkingIntegTest --tests "*ParentProjectPropertyLookup*"\`
- [x] \`./gradlew :core:test --tests "*DefaultProjectSpec*" --tests "*DefaultProjectTest*"\`
- [x] \`./gradlew :docs:checkDeadInternalLinks\`
- [x] \`./gradlew sanityCheck\`
