### PR TITLE
Annotate URL-based repository getUrl() as @Nullable

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -250,6 +250,7 @@ public abstract class DefaultIvyArtifactRepository extends AbstractAuthenticatio
     }
 
     @Override
+    @Nullable
     public URI getUrl() {
         return urlArtifactRepository.getUrl();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -71,6 +71,7 @@ import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.net.URI;
@@ -144,6 +145,7 @@ public abstract class DefaultMavenArtifactRepository extends AbstractAuthenticat
     }
 
     @Override
+    @Nullable
     public URI getUrl() {
         return urlArtifactRepository.getUrl();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
@@ -51,6 +51,7 @@ public class DefaultUrlArtifactRepository {
         this.displayNameSupplier = displayNameSupplier;
     }
 
+    @Nullable
     public URI getUrl() {
         if (url == null) {
             return null;

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -61,6 +61,11 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
 
     final DefaultMavenArtifactRepository repository = newRepo()
 
+    def "url is null by default"() {
+        expect:
+        repository.url == null
+    }
+
     def "creates local repository"() {
         given:
         def file = new File('repo')

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -20,6 +20,7 @@ import org.gradle.api.ActionConfiguration;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 
@@ -49,10 +50,11 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
     /**
      * The base URL of this repository.
      *
-     * @return The URL.
+     * @return The URL, or {@code null} if no URL has been set.
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     URI getUrl();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.Set;
@@ -33,10 +34,11 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
     /**
      * The base URL of this repository. This URL is used to find both POMs and artifact files.
      *
-     * @return The URL.
+     * @return The URL, or {@code null} if no URL has been set.
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     URI getUrl();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/UrlArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/UrlArtifactRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 
@@ -31,9 +32,10 @@ public interface UrlArtifactRepository {
     /**
      * The base URL of this repository.
      *
-     * @return The URL.
+     * @return The URL, or {@code null} if no URL has been set.
      */
     @ToBeReplacedByLazyProperty
+    @Nullable
     URI getUrl();
 
     /**

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,28 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.artifacts.repositories.IvyArtifactRepository",
+            "member": "Method org.gradle.api.artifacts.repositories.IvyArtifactRepository.getUrl()",
+            "acceptation": "Aligning the nullability annotation with the documented runtime behavior: getUrl() returns null when no URL has been configured (#37612).",
+            "changes": [
+                "From non-null returning to null returning breaking change."
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.repositories.MavenArtifactRepository",
+            "member": "Method org.gradle.api.artifacts.repositories.MavenArtifactRepository.getUrl()",
+            "acceptation": "Aligning the nullability annotation with the documented runtime behavior: getUrl() returns null when no URL has been configured (#37612).",
+            "changes": [
+                "From non-null returning to null returning breaking change."
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.repositories.UrlArtifactRepository",
+            "member": "Method org.gradle.api.artifacts.repositories.UrlArtifactRepository.getUrl()",
+            "acceptation": "Aligning the nullability annotation with the documented runtime behavior: getUrl() returns null when no URL has been configured (#37612).",
+            "changes": [
+                "From non-null returning to null returning breaking change."
+            ]
+        }
+    ]
 }

--- a/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
@@ -1,6 +1,9 @@
 Accessors for org.gradle.StartParameter.currentDir don't use symmetrical @Nullable
 Accessors for org.gradle.StartParameter.gradleUserHomeDir don't use symmetrical @Nullable
 Accessors for org.gradle.StartParameter.taskNames don't use symmetrical @Nullable
+Accessors for org.gradle.api.artifacts.repositories.IvyArtifactRepository.url don't use symmetrical @Nullable
+Accessors for org.gradle.api.artifacts.repositories.MavenArtifactRepository.url don't use symmetrical @Nullable
+Accessors for org.gradle.api.artifacts.repositories.UrlArtifactRepository.url don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.AbstractExecTask.executable don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.JavaExec.executable don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.SourceSetOutput.resourcesDir don't use symmetrical @Nullable


### PR DESCRIPTION
Fixes #37612

### Context

In the `@NullMarked` `org.gradle.api.artifacts.repositories` package, `UrlArtifactRepository.getUrl()` (and the overrides on `MavenArtifactRepository` and `IvyArtifactRepository`) is declared as non-nullable, but the implementation in `DefaultUrlArtifactRepository.getUrl()` explicitly returns `null` when no URL has been configured. This causes Kotlin static analysis to flag legitimate `repo.url != null` checks as `Condition is always 'true'`.

This change aligns the annotation with reality: `getUrl()` is marked `@Nullable` on `UrlArtifactRepository`, `MavenArtifactRepository`, and `IvyArtifactRepository`, plus the corresponding `Default*` implementations. Doc comments updated to mention the null case. The setters (`setUrl(URI)` / `setUrl(Object)`) are unchanged — null isn't a valid input.

The accepted-public-api-changes registry is updated to acknowledge the nullability widening on the three public interfaces, and `public-api-symmetrical-accessors-nullability.txt` records the intentional get/set asymmetry (matching the existing precedent for `HttpBuildCache.url`).

A small symmetry test (`DefaultMavenArtifactRepositoryTest.url is null by default`) was added to mirror the existing one on `DefaultIvyArtifactRepositoryTest`.

### Contributor Checklist
- [x] [Reviewed Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits signed off (DCO).
- [x] Code distributable under Apache License 2.0.
- [x] "Allow edit from maintainers" enabled.
- [x] Unit test added for the symmetric Maven default-url behavior; the existing Ivy test (`default values`) already covers that side.
- [ ] Integration tests — n/a (annotation/contract change only, no behavior change).
- [x] User-facing change covered by Javadoc updates.
- [ ] `./gradlew sanityCheck` — not run locally (only JDK 21 available; Gradle build requires JDK 17). Requesting CI verification.
- [ ] `./gradlew :dependency-management:quickTest` — same.
