### PR TITLE
Recommend managed properties for plugin extensions

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/tutorials/developing-plugins/part2_add_extension.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/tutorials/developing-plugins/part2_add_extension.adoc
@@ -100,6 +100,11 @@ include::sample[dir="snippets/tutorials/developing-plugins/plugin-tutorial/groov
 Now, let's define the class that holds the configurable properties for our plugin.
 We'll use Gradle's `Property<T>` type for these properties, as this makes them configurable lazily and fully compatible with the Configuration Cache.
 
+Declare the extension as an `abstract class` with `abstract` property getters.
+These are <<properties_providers.adoc#managed_properties,managed properties>>: Gradle generates the implementation at runtime through class decoration and creates the `Property<T>` instances for you, so there is no need to write a constructor or to inject an `ObjectFactory` manually.
+
+TIP: An extension that carries no custom logic can also be declared as an `interface` with abstract getters. Gradle will fully instantiate it for you in the same way.
+
 Create a new file called `plugin/src/main/kotlin/org/example/SlackExtension.kt` and add the following code:
 
 ====

--- a/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/groovy/plugin/src/main/groovy/org/example/SlackExtension.groovy
+++ b/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/groovy/plugin/src/main/groovy/org/example/SlackExtension.groovy
@@ -1,8 +1,6 @@
 package org.example
 
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import javax.inject.Inject
 
 /**
  * The SlackExtension class defines a custom extension for the plugin.
@@ -13,22 +11,20 @@ import javax.inject.Inject
  *     channel = "#general"
  *     message = "Hello from Gradle!"
  * }
+ *
+ * The abstract getters are Gradle managed properties: Gradle generates the
+ * implementation at runtime through class decoration and creates the
+ * `Property<T>` instances automatically. There is no need to declare a
+ * constructor or to inject an `ObjectFactory` manually.
  */
 abstract class SlackExtension {
 
     // The Slack API token used to authenticate requests
-    final Property<String> token
+    abstract Property<String> getToken()
 
     // The name or ID of the Slack channel to send the message to
-    final Property<String> channel
+    abstract Property<String> getChannel()
 
     // The message content to send to the channel
-    final Property<String> message
-
-    @Inject
-    SlackExtension(ObjectFactory objects) {
-        this.token = objects.property(String)
-        this.channel = objects.property(String)
-        this.message = objects.property(String)
-    }
+    abstract Property<String> getMessage()
 }

--- a/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/kotlin/plugin/src/main/kotlin/org/example/SlackExtension.kt
+++ b/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/kotlin/plugin/src/main/kotlin/org/example/SlackExtension.kt
@@ -1,8 +1,6 @@
 package org.example
 
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import javax.inject.Inject
 
 /**
  * The SlackExtension class defines a custom extension for the plugin.
@@ -13,15 +11,20 @@ import javax.inject.Inject
  *     channel = "#general"
  *     message = "Hello from Gradle!"
  * }
+ *
+ * The `abstract val` declarations are Gradle managed properties: Gradle
+ * generates the implementation at runtime through class decoration and
+ * creates the `Property<T>` instances automatically. There is no need to
+ * declare a constructor or to inject an `ObjectFactory` manually.
  */
-abstract class SlackExtension @Inject constructor(objects: ObjectFactory) {
+abstract class SlackExtension {
 
     // The Slack API token used to authenticate requests
-    val token: Property<String> = objects.property(String::class.java)
+    abstract val token: Property<String>
 
     // The name or ID of the Slack channel to send the message to
-    val channel: Property<String> = objects.property(String::class.java)
+    abstract val channel: Property<String>
 
     // The message content to send to the channel
-    val message: Property<String> = objects.property(String::class.java)
+    abstract val message: Property<String>
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes #37053

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
The SlackExtension sample used @Inject ObjectFactory and objects.property(...), contradicting the recommended pattern at properties_providers.adoc#managed_properties. Switch the Kotlin and Groovy samples to abstract Property getters and update the surrounding prose to explain managed properties instead of dependency injection.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
