### PR TITLE
Only try to run as worker thread in DefaultBuildOperationQueue

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * A queueing mechanism that only executes items once certain conditions are reached.
  */
-// TODO This class, DefaultBuildOperationQueue and ExecutionPlan have many of the same
+// TODO This class, DefaultBuildOperationQueue and DefaultPlanExecutor have many of the same
 // behavior and concerns - we should look for a way to generalize this pattern.
 public class DefaultConditionalExecutionQueue<T> implements WorkerThreadPool, ConditionalExecutionQueue<T> {
     public static final int KEEP_ALIVE_TIME_MS = 2000;

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.lock;
@@ -132,6 +133,21 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, ProjectPar
     @Override
     public void runAsWorkerThread(Runnable action) {
         runAsWorkerThread(Factories.<Void>toFactory(action));
+    }
+
+    @Override
+    public <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
+        Collection<? extends ResourceLock> locks = workerLeaseLockRegistry.getResourceLocksByCurrentThread();
+        if (!locks.isEmpty()) {
+            // Already a worker
+            return Optional.of(action.create());
+        }
+        DefaultWorkerLease lease = newWorkerLease();
+        boolean acquired = coordinationService.withStateLock(tryLock(lease));
+        if (!acquired) {
+            return Optional.empty();
+        }
+        return Optional.of(runAndReleaseLocks(Collections.singletonList(lease), action));
     }
 
     @Override
@@ -275,11 +291,15 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, ProjectPar
      */
     private <T> T withLocksAcquired(Collection<? extends ResourceLock> locksToAcquire, Factory<T> factory) {
         acquireLocksWithoutWorkerLeaseWhileBlocked(locksToAcquire);
-        return resourceLockStatistics.measure("Acquired", locksToAcquire, () -> {
+        return runAndReleaseLocks(locksToAcquire, factory);
+    }
+
+    private <T> T runAndReleaseLocks(Collection<? extends ResourceLock> locksHeld, Factory<T> factory) {
+        return resourceLockStatistics.measure("Acquired", locksHeld, () -> {
             try {
                 return factory.create();
             } finally {
-                releaseLocks(locksToAcquire);
+                releaseLocks(locksHeld);
             }
         });
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WorkerThreadRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WorkerThreadRegistry.java
@@ -21,6 +21,8 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * Allows a thread to enlist in resource locking, for example to lock the mutable state of a project.
  */
@@ -47,6 +49,19 @@ public interface WorkerThreadRegistry {
      * This method blocks until a worker lease is available.
      */
     void runAsWorkerThread(Runnable action);
+
+    /**
+     * Like {@link #runAsWorkerThread(Factory)}, but does not block waiting for a worker lease.
+     *
+     * <p>If the current thread is already a worker, the action is run immediately without re-acquiring a worker lease.
+     *
+     * <p>The factory may not return {@code null}, as there is no way to distinguish a {@code null} return value from the case where no worker lease was available.
+     * An exception will be thrown if the factory returns {@code null}.
+     *
+     * @return {@link Optional#empty()} if no worker lease was available at the moment of the call,
+     * or {@link Optional#of(Object)} with the result of the action if the action was executed.
+     */
+    <T> Optional<T> tryRunAsWorkerThread(Factory<T> action);
 
     /**
      * Runs the given action as an unmanaged worker, if not already a worker. This is basically the same as {@link #runAsWorkerThread(Runnable)} but does not block waiting for a lease.

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -472,4 +472,134 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends AbstractWorkerLeaseServic
         then:
         noExceptionThrown()
     }
+
+    def "try run as worker thread runs the action and returns its result when no contention"() {
+        def registry = workerLeaseService(1)
+
+        when:
+        def result = registry.tryRunAsWorkerThread({ "result" } as Factory)
+
+        then:
+        result.isPresent()
+        result.get() == "result"
+        !registry.workerThread
+
+        cleanup:
+        registry?.stop()
+    }
+
+    def "try run as worker thread is reentrant when the calling thread already holds a lease"() {
+        def registry = workerLeaseService(1)
+
+        def action = {
+            assert registry.workerThread
+            def lease = registry.currentWorkerLease
+            def nested = registry.tryRunAsWorkerThread({
+                assert registry.workerThread
+                assert registry.currentWorkerLease == lease
+                "nested"
+            } as Factory)
+            assert nested.isPresent()
+            assert nested.get() == "nested"
+            "outer"
+        } as Factory
+
+        when:
+        def result = registry.runAsWorkerThread(action)
+
+        then:
+        result == "outer"
+
+        cleanup:
+        registry?.stop()
+    }
+
+    def "try run as worker thread returns empty when no lease is available"() {
+        def registry = workerLeaseService(1)
+
+        when:
+        async {
+            start {
+                registry.runAsWorkerThread {
+                    instant.leaseHeld
+                    thread.blockUntil.tryFinished
+                }
+            }
+            start {
+                thread.blockUntil.leaseHeld
+                def result = registry.tryRunAsWorkerThread({ "should not run" } as Factory)
+                assert !result.isPresent()
+                instant.tryFinished
+            }
+        }
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        registry?.stop()
+    }
+
+    def "try run as worker thread releases the lease after the action completes"() {
+        def registry = workerLeaseService(1)
+
+        when:
+        async {
+            start {
+                def first = registry.tryRunAsWorkerThread({ "first" } as Factory)
+                assert first.isPresent()
+                instant.firstFinished
+            }
+            start {
+                thread.blockUntil.firstFinished
+                def second = registry.tryRunAsWorkerThread({ "second" } as Factory)
+                assert second.isPresent()
+                assert second.get() == "second"
+            }
+        }
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        registry?.stop()
+    }
+
+    def "try run as worker thread releases the lease when the action throws"() {
+        def registry = workerLeaseService(1)
+        def boom = new RuntimeException("boom")
+
+        when:
+        registry.tryRunAsWorkerThread({ throw boom } as Factory)
+
+        then:
+        def thrown = thrown(RuntimeException)
+        thrown.is(boom)
+
+        when:
+        // Lease must have been released — a subsequent call from the same thread should succeed.
+        def result = registry.tryRunAsWorkerThread({ "after" } as Factory)
+
+        then:
+        result.isPresent()
+        result.get() == "after"
+
+        cleanup:
+        registry?.stop()
+    }
+
+    def "try run as worker thread returns empty when the action returns null"() {
+        def registry = workerLeaseService(1)
+
+        when:
+        def result = registry.tryRunAsWorkerThread({ null } as Factory)
+
+        then:
+        !result.isPresent()
+        // Lease still released — verify by running another action.
+        registry.tryRunAsWorkerThread({ "after" } as Factory).get() == "after"
+
+        cleanup:
+        registry?.stop()
+    }
 }

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -588,16 +588,22 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends AbstractWorkerLeaseServic
         registry?.stop()
     }
 
-    def "try run as worker thread returns empty when the action returns null"() {
+    def "try run as worker thread throws when the action returns null and releases the lease"() {
         def registry = workerLeaseService(1)
 
         when:
-        def result = registry.tryRunAsWorkerThread({ null } as Factory)
+        registry.tryRunAsWorkerThread({ null } as Factory)
 
         then:
-        !result.isPresent()
+        thrown(NullPointerException)
+
+        when:
         // Lease still released — verify by running another action.
-        registry.tryRunAsWorkerThread({ "after" } as Factory).get() == "after"
+        def result = registry.tryRunAsWorkerThread({ "after" } as Factory)
+
+        then:
+        result.isPresent()
+        result.get() == "after"
 
         cleanup:
         registry?.stop()

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/ExponentialBackoff.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/ExponentialBackoff.java
@@ -79,7 +79,7 @@ public class ExponentialBackoff<S extends ExponentialBackoff.Signal> {
     }
 
     long backoffPeriodFor(int iteration) {
-        return random.nextInt(Math.min(iteration, CAP_FACTOR)) * slotTime;
+        return (random.nextInt(Math.min(iteration, CAP_FACTOR)) + 1) * slotTime;
     }
 
     public CountdownTimer getTimer() {

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/ExponentialBackoff.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/ExponentialBackoff.java
@@ -79,6 +79,9 @@ public class ExponentialBackoff<S extends ExponentialBackoff.Signal> {
     }
 
     long backoffPeriodFor(int iteration) {
+        // The +1 ensures every retry waits at least one slot. Without it, iteration 1 would
+        // produce a 0ms backoff (since nextInt(1) is always 0), turning the first retry into a
+        // tight loop. Standard exponential-backoff guidance is to always sleep at least one slot.
         return (random.nextInt(Math.min(iteration, CAP_FACTOR)) + 1) * slotTime;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.operations;
 
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.time.ExponentialBackoff;
 import org.gradle.internal.work.DefaultWorkerLimits;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.internal.work.WorkerThreadPool;
@@ -24,8 +25,11 @@ import org.gradle.internal.work.WorkerThreadPoolHelper;
 import org.jspecify.annotations.Nullable;
 
 import javax.annotation.concurrent.GuardedBy;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -256,16 +260,12 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
         private boolean waitForNextOperation() {
             lock.lock();
             try {
-                // If the token was already invalidated (e.g. in runBatch), exit immediately
-                // to avoid becoming a zombie thread stuck in await().
-                if (token != null && !token.isValid()) {
-                    return false;
-                }
-                while (queueState == QueueState.Working && helper.isQueueEmpty()) {
-                    if (helper.isExtraWorker()) {
-                        // We should exit, immediately invalidate our token to ensure the count goes down now.
-                        invalidateIfNeeded();
+                while (true) {
+                    if (shouldExit()) {
                         return false;
+                    }
+                    if (!helper.isQueueEmpty()) {
+                        return true;
                     }
                     try {
                         workAvailable.await();
@@ -273,16 +273,32 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
                         throw UncheckedException.throwAsUncheckedException(e);
                     }
                 }
-                return !helper.isQueueEmpty();
             } finally {
                 lock.unlock();
             }
         }
 
+        @GuardedBy("lock")
+        private boolean shouldExit() {
+            if (token != null && !token.isValid()) {
+                return true;
+            }
+            if (queueState != QueueState.Working && helper.isQueueEmpty()) {
+                return true;
+            }
+            if (helper.isExtraWorker()) {
+                if (token != null) {
+                    token.invalidateIfNeeded();
+                }
+                return true;
+            }
+            return false;
+        }
+
         private void runBatch() {
             int operationsExecuted;
             if (context.requiresWorkerLease()) {
-                operationsExecuted = workerLeases.runAsWorkerThread(this::executePendingWork);
+                operationsExecuted = runBatchWithLeaseRetry();
             } else {
                 operationsExecuted = executePendingWork();
             }
@@ -291,6 +307,34 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             // condition where the pending count is 0, but a child worker lease is still held when
             // the parent lease is released.
             completeOperations(operationsExecuted);
+        }
+
+        private int runBatchWithLeaseRetry() {
+            try {
+                // Retry acquiring the lease forever, or until we `shouldExit()`.
+                return ExponentialBackoff.of(Integer.MAX_VALUE, TimeUnit.MILLISECONDS).retryUntil(() -> {
+                    Optional<Integer> result = workerLeases.tryRunAsWorkerThread(this::executePendingWork);
+                    if (result.isPresent()) {
+                        return ExponentialBackoff.Result.successful(result.get());
+                    }
+                    lock.lock();
+                    try {
+                        if (shouldExit()) {
+                            return ExponentialBackoff.Result.successful(0);
+                        }
+                    } finally {
+                        lock.unlock();
+                    }
+                    return ExponentialBackoff.Result.notSuccessful(0);
+                });
+            } catch (IOException e) {
+                // TODO: Redesign ExponentialBackoff to not have IOException as part of the interface
+                // This would never actually be thrown because our "query" doesn't throw it.
+                throw new AssertionError("Unexpected IOException while trying to acquire worker lease", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
         }
 
         private int executePendingWork() {

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -261,7 +261,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             lock.lock();
             try {
                 while (true) {
-                    if (shouldExit()) {
+                    if (shouldExitWithExtraWorkerInvalidation()) {
                         return false;
                     }
                     if (!helper.isQueueEmpty()) {
@@ -278,8 +278,13 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             }
         }
 
+        /**
+         * Returns {@code true} if this worker should exit, and as a side effect invalidates the
+         * worker token in the extra-worker case so that the worker count drops immediately rather
+         * than waiting for {@link #runOperations()} to complete.
+         */
         @GuardedBy("lock")
-        private boolean shouldExit() {
+        private boolean shouldExitWithExtraWorkerInvalidation() {
             if (token != null && !token.isValid()) {
                 return true;
             }
@@ -311,7 +316,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
 
         private int runBatchWithLeaseRetry() {
             try {
-                // Retry acquiring the lease forever, or until we `shouldExit()`.
+                // Retry acquiring the lease forever, or until we `shouldExitWithExtraWorkerInvalidation()`.
                 return ExponentialBackoff.of(Integer.MAX_VALUE, TimeUnit.MILLISECONDS).retryUntil(() -> {
                     Optional<Integer> result = workerLeases.tryRunAsWorkerThread(this::executePendingWork);
                     if (result.isPresent()) {
@@ -319,7 +324,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
                     }
                     lock.lock();
                     try {
-                        if (shouldExit()) {
+                        if (shouldExitWithExtraWorkerInvalidation()) {
                             return ExponentialBackoff.Result.successful(0);
                         }
                     } finally {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -299,11 +299,12 @@ class DefaultBuildOperationQueueTest extends Specification {
         coordinationService = new DefaultResourceLockCoordinationService()
         workerRegistry = new DefaultWorkerLeaseService(coordinationService, new DefaultWorkerLimits(1), ResourceLockStatistics.NO_OP) {
             @Override
-            <T> T runAsWorkerThread(Factory<T> action) {
+            <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
+                // Called repeatedly from the retry loop; CountDownLatch tolerates extra countDown() calls.
                 if (Thread.currentThread() !== mainThread) {
                     workerAboutToBlockForLease.countDown()
                 }
-                return super.runAsWorkerThread(action)
+                return super.tryRunAsWorkerThread(action)
             }
         }
         workerRegistry.startProjectExecution(true)
@@ -320,7 +321,7 @@ class DefaultBuildOperationQueueTest extends Specification {
         operationQueue.add(new Success())
 
         and:
-        // Wait until the worker is about to block on the lease.
+        // Wait until the worker has tried and failed to acquire a lease.
         // This ensures that the main thread will be needed to progress the queue.
         assert workerAboutToBlockForLease.await(10, TimeUnit.SECONDS)
 
@@ -330,6 +331,48 @@ class DefaultBuildOperationQueueTest extends Specification {
         then:
         executedByMain.get() + executedByOther.get() == 1
         executedByMain.get() == 1
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    def "starved worker exits via shouldExit when the queue is cancelled"() {
+        given:
+        def mainThread = Thread.currentThread()
+        def workerStartedRetrying = new CountDownLatch(1)
+        coordinationService = new DefaultResourceLockCoordinationService()
+        workerRegistry = new DefaultWorkerLeaseService(coordinationService, new DefaultWorkerLimits(1), ResourceLockStatistics.NO_OP) {
+            @Override
+            <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
+                if (Thread.currentThread() !== mainThread) {
+                    workerStartedRetrying.countDown()
+                }
+                return super.tryRunAsWorkerThread(action)
+            }
+        }
+        workerRegistry.startProjectExecution(true)
+        // Hold the only lease on the main thread so the spawned worker is starved.
+        lease = workerRegistry.startWorker()
+        def underlyingExecutor = Executors.newFixedThreadPool(1)
+        def executionContext = new BuildOperationExecutionContext(
+            new ManagedExecutorImpl(underlyingExecutor, new ExecutorPolicy.CatchAndRecordFailures()),
+            1,
+            true
+        )
+        operationQueue = new DefaultBuildOperationQueue(false, workerRegistry, executionContext, new SimpleWorker(), null)
+
+        when:
+        operationQueue.add(new Success())
+        // Wait for the spawned worker to enter its lease-retry loop.
+        assert workerStartedRetrying.await(10, TimeUnit.SECONDS)
+
+        and:
+        operationQueue.cancel()
+
+        and:
+        underlyingExecutor.shutdown()
+        def terminated = underlyingExecutor.awaitTermination(15, TimeUnit.SECONDS)
+
+        then:
+        terminated
     }
 
     static class SynchronizedBuildOperation extends TestBuildOperation {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -284,7 +284,7 @@ class DefaultBuildOperationQueueTest extends Specification {
         given:
         // Slightly modified from setupQueue to allow certain injection points.
         def mainThread = Thread.currentThread()
-        def workerAboutToBlockForLease = new CountDownLatch(1)
+        def workerStartedRetrying = new CountDownLatch(1)
         def executedByMain = new AtomicInteger()
         def executedByOther = new AtomicInteger()
         def recordingWorker = { TestBuildOperation op ->
@@ -302,7 +302,7 @@ class DefaultBuildOperationQueueTest extends Specification {
             <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
                 // Called repeatedly from the retry loop; CountDownLatch tolerates extra countDown() calls.
                 if (Thread.currentThread() !== mainThread) {
-                    workerAboutToBlockForLease.countDown()
+                    workerStartedRetrying.countDown()
                 }
                 return super.tryRunAsWorkerThread(action)
             }
@@ -323,7 +323,7 @@ class DefaultBuildOperationQueueTest extends Specification {
         and:
         // Wait until the worker has tried and failed to acquire a lease.
         // This ensures that the main thread will be needed to progress the queue.
-        assert workerAboutToBlockForLease.await(10, TimeUnit.SECONDS)
+        assert workerStartedRetrying.await(10, TimeUnit.SECONDS)
 
         and:
         operationQueue.waitForCompletion()
@@ -334,7 +334,7 @@ class DefaultBuildOperationQueueTest extends Specification {
     }
 
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
-    def "starved worker exits via shouldExit when the queue is cancelled"() {
+    def "starved worker exits via shouldExitWithExtraWorkerInvalidation when the queue is cancelled"() {
         given:
         def mainThread = Thread.currentThread()
         def workerStartedRetrying = new CountDownLatch(1)

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -92,7 +92,7 @@ class TestWorkerLeaseService implements WorkerLeaseService {
 
     @Override
     <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
-        return Optional.ofNullable(action.create())
+        return Optional.of(action.create())
     }
 
     @Override

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -91,6 +91,11 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
+    <T> Optional<T> tryRunAsWorkerThread(Factory<T> action) {
+        return Optional.ofNullable(action.create())
+    }
+
+    @Override
     void runAsUnmanagedWorkerThread(Runnable action) {
         action.run()
     }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/37753

This introduces as new `tryRunAsWorkerThread` and uses it in `DefaultBuildOperationQueue` to avoid leaving worker runnables hanging. In the future, this should not rely on (only) an exponential backoff, but instead wait for a signal indicating a worker lease is available, or this whole class should be redesigned to move WorkerRunnable (or similar concept) into the context instead, so we don't need to start one for each BuildOperationQueue that is created.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
