### PR TITLE
Revert enrich file visitor with size info on `release` branch

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -129,7 +129,7 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             /**
              * Called when visiting a non-directory file.
              * <p>
-             * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
+             * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
              */
             void file(VisitState state);
 

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
@@ -56,7 +56,7 @@ public interface FilePropertyVisitor {
     /**
      * Called when visiting a non-directory file.
      * <p>
-     * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
+     * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
      */
     void file(VisitState state);
 
@@ -122,14 +122,5 @@ public interface FilePropertyVisitor {
          * Must not be called when the last visited location was a directory.
          */
         byte[] getHashBytes();
-
-        /**
-         * Returns the length in bytes of the last visited file.
-         * <p>
-         * Must not be called when the last visited location was a directory.
-         *
-         * @since 9.6
-         */
-        long getLength();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
@@ -24,7 +24,6 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
-import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.operations.execution.FilePropertyVisitor;
 import org.jspecify.annotations.NullMarked;
@@ -46,7 +45,6 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     String path;
     HashCode hash;
     int depth;
-    long length;
 
     protected BaseFilePropertyVisitState(Map<String, InputFilePropertySpec> propertySpecsByName) {
         this.propertySpecsByName = propertySpecsByName;
@@ -95,16 +93,10 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     }
 
     @Override
-    public long getLength() {
-        return length;
-    }
-
-    @Override
     public void enterDirectory(DirectorySnapshot physicalSnapshot) {
         this.path = physicalSnapshot.getAbsolutePath();
         this.name = physicalSnapshot.getName();
         this.hash = null;
-        this.length = 0;
 
         if (depth++ == 0) {
             preRoot();
@@ -137,9 +129,6 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         this.path = snapshot.getAbsolutePath();
         this.name = snapshot.getName();
         this.hash = fingerprint.getNormalizedContentHash();
-        this.length = snapshot instanceof RegularFileSnapshot
-            ? ((RegularFileSnapshot) snapshot).getMetadata().getLength()
-            : 0;
 
         boolean isRoot = depth == 0;
         if (isRoot) {
@@ -203,11 +192,6 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         @Override
         public byte[] getHashBytes() {
             throw new UnsupportedOperationException("Cannot query hash for directories");
-        }
-
-        @Override
-        public long getLength() {
-            throw new UnsupportedOperationException("Cannot query length for directories");
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
@@ -137,7 +137,9 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         this.path = snapshot.getAbsolutePath();
         this.name = snapshot.getName();
         this.hash = fingerprint.getNormalizedContentHash();
-        this.length = getFileSnapshotLength(snapshot);
+        this.length = snapshot instanceof RegularFileSnapshot
+            ? ((RegularFileSnapshot) snapshot).getMetadata().getLength()
+            : 0;
 
         boolean isRoot = depth == 0;
         if (isRoot) {
@@ -150,19 +152,6 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
             postRoot();
         }
         return SnapshotVisitResult.CONTINUE;
-    }
-
-    private static long getFileSnapshotLength(FileSystemLocationSnapshot snapshot) {
-        switch (snapshot.getType()) {
-            case RegularFile:
-                return ((RegularFileSnapshot) snapshot).getMetadata().getLength();
-
-            case Missing:
-                return 0;
-
-            default:
-                throw new UnsupportedOperationException("Cannot determine snapshot length for the type " + snapshot.getType());
-        }
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
@@ -241,7 +241,7 @@ abstract class AbstractSnapshotInputsBuildOperationResultTest<RESULT extends Bas
         0 * visitor._
     }
 
-    @Requires(UnitTestPreconditions.NotWindows)
+    @Requires(OsTestPreconditions.NotWindows)
     def "file visitor provides file length"() {
         given:
         def visitor = createMockVisitor()

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
@@ -26,14 +26,11 @@ import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.hash.TestHashCodes
-import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.TestSnapshotFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Specification
 
-import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT
-import static org.gradle.internal.file.impl.DefaultFileMetadata.file
 import static org.gradle.internal.fingerprint.DirectorySensitivity.DEFAULT
 import static org.gradle.internal.fingerprint.DirectorySensitivity.IGNORE_DIRECTORIES
 import static org.gradle.internal.fingerprint.LineEndingSensitivity.NORMALIZE_LINE_ENDINGS
@@ -239,59 +236,5 @@ abstract class AbstractSnapshotInputsBuildOperationResultTest<RESULT extends Bas
 
         and:
         0 * visitor._
-    }
-
-    @Requires(OsTestPreconditions.NotWindows)
-    def "file visitor provides file length"() {
-        given:
-        def visitor = createMockVisitor()
-        def inputFileProperty = Mock(InputFilePropertySpec) {
-            getDirectorySensitivity() >> IGNORE_DIRECTORIES
-            getLineEndingNormalization() >> NORMALIZE_LINE_ENDINGS
-            getNormalizer() >> InputNormalizer.ABSOLUTE_PATH
-            getPropertyName() >> 'foo'
-        }
-        def fileOneSnapshot = new RegularFileSnapshot(
-            '/foo/one.txt', 'one.txt',
-            TestHashCodes.hashCodeFrom(123),
-            file(0, 1024, DIRECT)
-        )
-        def fileTwoSnapshot = new RegularFileSnapshot(
-            '/foo/sub/two.txt', 'two.txt',
-            TestHashCodes.hashCodeFrom(234),
-            file(0, 2048, DIRECT)
-        )
-        def snapshots = directory('/foo', [
-            fileOneSnapshot,
-            directory('/foo/sub', [
-                fileTwoSnapshot
-            ])
-        ])
-        def beforeExecutionState = Mock(BeforeExecutionState) {
-            getInputFileProperties() >> ImmutableSortedMap.of('foo',
-                Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> TestHashCodes.hashCodeFrom(345)
-                    getFingerprints() >> [
-                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
-                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
-                    ]
-                    getSnapshot() >> snapshots
-                }
-            )
-        }
-        def cachingState = CachingState.enabled(Mock(BuildCacheKey), beforeExecutionState)
-        def buildOpResult = createSnapshotInputsBuildOperationResult(
-            cachingState,
-            [inputFileProperty] as Set
-        )
-
-        when:
-        buildOpResult.visitInputFileProperties(visitor)
-
-        then:
-        1 * visitor.file { it.path == '/foo/one.txt' && it.length == 1024 }
-
-        and:
-        1 * visitor.file { it.path == '/foo/sub/two.txt' && it.length == 2048 }
     }
 }


### PR DESCRIPTION
This PR reverts [this PR](https://github.com/gradle/gradle/pull/37568).

The addition introduced in that PR is not urgent and should therefore not be part of a patch version.
