### PR TITLE
Add getLength() to FilePropertyVisitor.VisitState

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -129,7 +129,7 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             /**
              * Called when visiting a non-directory file.
              * <p>
-             * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+             * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
              */
             void file(VisitState state);
 

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
@@ -56,7 +56,7 @@ public interface FilePropertyVisitor {
     /**
      * Called when visiting a non-directory file.
      * <p>
-     * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+     * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
      */
     void file(VisitState state);
 
@@ -122,5 +122,14 @@ public interface FilePropertyVisitor {
          * Must not be called when the last visited location was a directory.
          */
         byte[] getHashBytes();
+
+        /**
+         * Returns the length in bytes of the last visited file.
+         * <p>
+         * Must not be called when the last visited location was a directory.
+         *
+         * @since 9.6.0
+         */
+        long getLength();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
@@ -24,6 +24,7 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.operations.execution.FilePropertyVisitor;
 import org.jspecify.annotations.NullMarked;
@@ -45,6 +46,7 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     String path;
     HashCode hash;
     int depth;
+    long length;
 
     protected BaseFilePropertyVisitState(Map<String, InputFilePropertySpec> propertySpecsByName) {
         this.propertySpecsByName = propertySpecsByName;
@@ -93,10 +95,16 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     }
 
     @Override
+    public long getLength() {
+        return length;
+    }
+
+    @Override
     public void enterDirectory(DirectorySnapshot physicalSnapshot) {
         this.path = physicalSnapshot.getAbsolutePath();
         this.name = physicalSnapshot.getName();
         this.hash = null;
+        this.length = 0;
 
         if (depth++ == 0) {
             preRoot();
@@ -129,6 +137,7 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         this.path = snapshot.getAbsolutePath();
         this.name = snapshot.getName();
         this.hash = fingerprint.getNormalizedContentHash();
+        this.length = getFileSnapshotLength(snapshot);
 
         boolean isRoot = depth == 0;
         if (isRoot) {
@@ -141,6 +150,19 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
             postRoot();
         }
         return SnapshotVisitResult.CONTINUE;
+    }
+
+    private static long getFileSnapshotLength(FileSystemLocationSnapshot snapshot) {
+        switch (snapshot.getType()) {
+            case RegularFile:
+                return ((RegularFileSnapshot) snapshot).getMetadata().getLength();
+
+            case Missing:
+                return 0;
+
+            default:
+                throw new UnsupportedOperationException("Cannot determine snapshot length for the type " + snapshot.getType());
+        }
     }
 
     @Override
@@ -192,6 +214,11 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         @Override
         public byte[] getHashBytes() {
             throw new UnsupportedOperationException("Cannot query hash for directories");
+        }
+
+        @Override
+        public long getLength() {
+            throw new UnsupportedOperationException("Cannot query length for directories");
         }
 
         @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
@@ -26,11 +26,14 @@ import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.TestSnapshotFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
 import spock.lang.Specification
 
+import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT
+import static org.gradle.internal.file.impl.DefaultFileMetadata.file
 import static org.gradle.internal.fingerprint.DirectorySensitivity.DEFAULT
 import static org.gradle.internal.fingerprint.DirectorySensitivity.IGNORE_DIRECTORIES
 import static org.gradle.internal.fingerprint.LineEndingSensitivity.NORMALIZE_LINE_ENDINGS
@@ -236,5 +239,59 @@ abstract class AbstractSnapshotInputsBuildOperationResultTest<RESULT extends Bas
 
         and:
         0 * visitor._
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "file visitor provides file length"() {
+        given:
+        def visitor = createMockVisitor()
+        def inputFileProperty = Mock(InputFilePropertySpec) {
+            getDirectorySensitivity() >> IGNORE_DIRECTORIES
+            getLineEndingNormalization() >> NORMALIZE_LINE_ENDINGS
+            getNormalizer() >> InputNormalizer.ABSOLUTE_PATH
+            getPropertyName() >> 'foo'
+        }
+        def fileOneSnapshot = new RegularFileSnapshot(
+            '/foo/one.txt', 'one.txt',
+            TestHashCodes.hashCodeFrom(123),
+            file(0, 1024, DIRECT)
+        )
+        def fileTwoSnapshot = new RegularFileSnapshot(
+            '/foo/sub/two.txt', 'two.txt',
+            TestHashCodes.hashCodeFrom(234),
+            file(0, 2048, DIRECT)
+        )
+        def snapshots = directory('/foo', [
+            fileOneSnapshot,
+            directory('/foo/sub', [
+                fileTwoSnapshot
+            ])
+        ])
+        def beforeExecutionState = Mock(BeforeExecutionState) {
+            getInputFileProperties() >> ImmutableSortedMap.of('foo',
+                Mock(CurrentFileCollectionFingerprint) {
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
+                    getFingerprints() >> [
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
+                    ]
+                    getSnapshot() >> snapshots
+                }
+            )
+        }
+        def cachingState = CachingState.enabled(Mock(BuildCacheKey), beforeExecutionState)
+        def buildOpResult = createSnapshotInputsBuildOperationResult(
+            cachingState,
+            [inputFileProperty] as Set
+        )
+
+        when:
+        buildOpResult.visitInputFileProperties(visitor)
+
+        then:
+        1 * visitor.file { it.path == '/foo/one.txt' && it.length == 1024 }
+
+        and:
+        1 * visitor.file { it.path == '/foo/sub/two.txt' && it.length == 2048 }
     }
 }


### PR DESCRIPTION
This PR adds file size reporting to the file property visitor API, enabling consumers (such as the DV plugin) to retrieve file lengths when traversing resolved artifacts during Gradle's snapshot-based build operations.

The change is very small and doesn't have any measurable impact on the performance.

The DV plugin uses the new method to skip system calls for determining the file size on its own (see https://github.com/gradle/dv/pull/64736).
