### PR TITLE
Fix layout access inside nested feature defaults in settings.gradle.kts

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
@@ -176,10 +176,13 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             def type = projectType("testProjectType") {
                 definition {
                     property "id", String
+                    property "dirForType", DirectoryProperty
                     buildModel {
                         property "id", String
+                        property "dirForType", DirectoryProperty
                         mapping """
                                 model.getId().set(definition.getId());
+                                model.getDirForType().set(definition.getDirForType());
                             """
                     }
                 }
@@ -187,13 +190,13 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             projectFeature("feature") {
                 definition {
                     property "text", String
-                    property "dir", DirectoryProperty
+                    property "dirForFeature", DirectoryProperty
                     buildModel {
                         property "text", String
-                        property "dir", DirectoryProperty
+                        property "dirForFeature", DirectoryProperty
                         mapping """
                                 model.getText().set(definition.getText());
-                                model.getDir().set(definition.getDir());
+                                model.getDirForFeature().set(definition.getDirForFeature());
                             """
                     }
                 }
@@ -208,8 +211,9 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             defaults {
                 testProjectType {
                     feature {
-                        dir = layout.projectDirectory.dir("featureDefaultDir")
+                        dirForFeature = layout.projectDirectory.dir("featureDefaultDir")
                     }
+                    dirForType = layout.projectDirectory.dir("typeDefaultDir")
                 }
             }
         """.stripIndent()
@@ -226,10 +230,11 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
         buildFileForProject("b") << ""
 
         expect:
-        succeeds(":a:printFeatureDefinitionConfiguration")
+        succeeds(":a:printFeatureDefinitionConfiguration", ":a:printTestProjectTypeDefinitionConfiguration")
 
         and:
-        outputContains("definition dir = ${testDirectory.file('a/featureDefaultDir').path}")
+        outputContains("definition dirForFeature = ${testDirectory.file('a/featureDefaultDir').path}")
+        outputContains("definition dirForType = ${testDirectory.file('a/typeDefaultDir').path}")
     }
 
     @SkipDsl(dsl = GradleDsl.DECLARATIVE, because = "The situation is prohibited in Declarative DSL via other means")

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.integtests.fixtures.polyglot.PolyglotTestFixture
 import org.gradle.integtests.fixtures.polyglot.SkipDsl
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.plugin.PluginBuilder
+import spock.lang.Issue
 
 @PolyglotDslTest
 @SkipDsl(dsl = GradleDsl.GROOVY, because = "Groovy DSL is not supported for declarative configuration")
@@ -166,6 +167,69 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
         readOnlyDirectoryProperty()    | "Directory"   | "dir"    | false
         readOnlyRegularFileProperty()  | "RegularFile" | "file"   | true
         readOnlyRegularFileProperty()  | "RegularFile" | "file"   | false
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37805")
+    def "can use project layout inside a nested project feature block in defaults"() {
+        given:
+        testScenario {
+            def type = projectType("testProjectType") {
+                definition {
+                    property "id", String
+                    buildModel {
+                        property "id", String
+                        mapping """
+                                model.getId().set(definition.getId());
+                            """
+                    }
+                }
+            }
+            projectFeature("feature") {
+                definition {
+                    property "text", String
+                    property "dir", DirectoryProperty
+                    buildModel {
+                        property "text", String
+                        property "dir", DirectoryProperty
+                        mapping """
+                                model.getText().set(definition.getText());
+                                model.getDir().set(definition.getDir());
+                            """
+                    }
+                }
+                plugin {
+                    bindsFeatureTo(type)
+                    unsafeDefinition()
+                }
+            }
+        }.prepareToExecute()
+
+        def defaultsConfig = """
+            defaults {
+                testProjectType {
+                    feature {
+                        dir = layout.projectDirectory.dir("featureDefaultDir")
+                    }
+                }
+            }
+        """.stripIndent()
+        settingsFile() << getSettingsFileContent(defaultsConfig)
+
+        buildFileForProject("a") << """
+            testProjectType {
+                id = "a"
+                feature {
+                    text = "hello"
+                }
+            }
+        """ << DeclarativeTestUtils.nonDeclarativeSuffixForKotlinDsl
+        buildFileForProject("b") << ""
+
+        expect:
+        succeeds(":a:printFeatureDefinitionConfiguration")
+
+        and:
+        outputContains("definition dir = ${testDirectory.file('a/featureDefaultDir').path}")
     }
 
     @SkipDsl(dsl = GradleDsl.DECLARATIVE, because = "The situation is prohibited in Declarative DSL via other means")

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/ActionBasedModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/ActionBasedModelDefaultsHandler.kt
@@ -46,15 +46,12 @@ class ActionBasedModelDefaultsHandler(
         }
 
         if (target is DynamicObjectAware && projectFeatureImplementation != null) {
-            sharedModelDefaults.setProjectLayout(projectLayout)
-            try {
+            sharedModelDefaults.withProjectLayout(projectLayout) {
                 projectFeatureImplementation.visitModelDefaults(
                     Cast.uncheckedNonnullCast(ActionBasedDefault::class.java),
                     executeActionVisitor(projectFeatureImplementation, definition)
                 )
                 executeActionVisitor(projectFeatureImplementation, target)
-            } finally {
-                sharedModelDefaults.clearProjectLayout()
             }
         } else {
             throw GradleException("Tried to apply defaults for project feature '$projectFeatureName', got unexpected target object: ${target::class.qualifiedName}")

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/internal/SharedModelDefaultsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/internal/SharedModelDefaultsInternal.java
@@ -22,16 +22,20 @@ import org.gradle.api.initialization.SharedModelDefaults;
 public interface SharedModelDefaultsInternal extends SharedModelDefaults {
 
     /**
-     * Specifies the current project when interpreting defaults configuration
-     * blocks during project evaluation time.
+     * Runs {@code action} with {@code projectLayout} bound as the current project layout for any
+     * {@link org.gradle.api.initialization.SharedModelDefaults#getLayout()} calls made on the same
+     * thread during execution. Restores the previously bound layout (which may be absent) on
+     * completion, including when {@code action} throws.
+     *
+     * <p>Nested calls preserve the outer binding for code that runs after the nested action
+     * returns, so that recursive defaults application (e.g. when a defaults action triggers
+     * application of another project feature whose own defaults are applied) does not strip the
+     * outer scope of its layout binding.</p>
+     *
+     * @param projectLayout the layout to bind for the duration of {@code action}
+     * @param action the action to run while {@code projectLayout} is bound
      */
-    void setProjectLayout(ProjectLayout projectLayout);
-
-    /**
-     * Clears the current project when the interpretation of defaults configuration
-     * blocks is finished during project evaluation time.
-     */
-    void clearProjectLayout();
+    void withProjectLayout(ProjectLayout projectLayout, Runnable action);
 
     /**
      * Processes all registered defaults.  This should be called after all settings evaluated hooks have been applied

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultSharedModelDefaults.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultSharedModelDefaults.java
@@ -49,13 +49,18 @@ public class DefaultSharedModelDefaults implements SharedModelDefaultsInternal, 
     }
 
     @Override
-    public void setProjectLayout(ProjectLayout projectLayout) {
+    public void withProjectLayout(ProjectLayout projectLayout, Runnable action) {
+        ProjectLayout previous = this.projectLayout.get();
         this.projectLayout.set(projectLayout);
-    }
-
-    @Override
-    public void clearProjectLayout() {
-        projectLayout.remove();
+        try {
+            action.run();
+        } finally {
+            if (previous == null) {
+                this.projectLayout.remove();
+            } else {
+                this.projectLayout.set(previous);
+            }
+        }
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultSharedModelDefaultsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultSharedModelDefaultsTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization
+
+import org.gradle.api.GradleException
+import org.gradle.api.file.ProjectLayout
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations
+import spock.lang.Specification
+
+class DefaultSharedModelDefaultsTest extends Specification {
+
+    def featureDeclarations = Mock(ProjectFeatureDeclarations)
+    def defaults = new DefaultSharedModelDefaults(featureDeclarations)
+
+    def "getLayout() throws when no layout is bound"() {
+        when:
+        defaults.getLayout()
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "ProjectLayout should be referenced only inside of project type default configuration blocks"
+    }
+
+    def "withProjectLayout binds the layout for the duration of the action"() {
+        given:
+        def layout = Mock(ProjectLayout)
+        ProjectLayout observed = null
+
+        when:
+        defaults.withProjectLayout(layout) {
+            observed = defaults.getLayout()
+        }
+
+        then:
+        observed.is(layout)
+
+        when:
+        defaults.getLayout()
+
+        then:
+        thrown(GradleException)
+    }
+
+    def "nested withProjectLayout preserves the outer binding after the inner action returns"() {
+        given:
+        def outer = Mock(ProjectLayout)
+        def inner = Mock(ProjectLayout)
+        ProjectLayout duringInner = null
+        ProjectLayout afterInner = null
+
+        when:
+        defaults.withProjectLayout(outer) {
+            defaults.withProjectLayout(inner) {
+                duringInner = defaults.getLayout()
+            }
+            afterInner = defaults.getLayout()
+        }
+
+        then:
+        duringInner.is(inner)
+        afterInner.is(outer)
+
+        when:
+        defaults.getLayout()
+
+        then:
+        thrown(GradleException)
+    }
+
+    def "exception inside a nested action restores the outer binding"() {
+        given:
+        def outer = Mock(ProjectLayout)
+        def inner = Mock(ProjectLayout)
+        ProjectLayout afterCatch = null
+
+        when:
+        defaults.withProjectLayout(outer) {
+            try {
+                defaults.withProjectLayout(inner) {
+                    throw new RuntimeException("boom")
+                }
+            } catch (RuntimeException ignored) {
+            }
+            afterCatch = defaults.getLayout()
+        }
+
+        then:
+        afterCatch.is(outer)
+    }
+
+    def "exception with no prior binding clears the ThreadLocal"() {
+        given:
+        def layout = Mock(ProjectLayout)
+
+        when:
+        defaults.withProjectLayout(layout) {
+            throw new RuntimeException("boom")
+        }
+
+        then:
+        thrown(RuntimeException)
+
+        when:
+        defaults.getLayout()
+
+        then:
+        thrown(GradleException)
+    }
+}


### PR DESCRIPTION
Fixes #37805.                                                                                                                                                                
                                                                                                                                                                               
## Context                                                                                                                                                                   
                                                                                                                                                                               
In a `settings.gradle.kts`, accessing `layout` inside a project-type  default configuration block fails with:
                                                                                                                                                                               
  > ProjectLayout should be referenced only inside of project type                                                                                                             
  > default configuration blocks
                                                                                                                                                                               
…whenever the access sits inside a *nested* project-feature block. For example:                                                                                                                                                                     
                                                                                                                                                                               
```kotlin                                                                                                                                                                  
  defaults {
      kotlinJvmLibrary {
          dokka {                                                                                                                                                              
              sourceSets {                                                                                                                                                     
                  dclDokkaSourceSet("main") {                                                                                                                                  
                      samples = listOf(layout.projectDirectory.dir("..."))                                                                                                     
                  }                                                                                                                                                            
              }                                                                                                                                                                
          }                                                                                                                                                                    
      }           
  }
```

The same content saved as settings.gradle.dcl works correctly. The  asymmetry is because DCL resolves layout via its own DefaultsTopLevelReceiver, while the Kotlin DSL resolves layout through SharedModelDefaults.getLayout() — which is backed by a ThreadLocal<ProjectLayout> set/cleared around defaults application.                                                                                                          
                                                                                                                                                                               
### Root cause                                                                                                                                                                   
                                                                                                                                                                               
ActionBasedModelDefaultsHandler.apply brackets default-action  execution with setProjectLayout(...) / clearProjectLayout() on SharedModelDefaultsInternal. When a Kotlin DSL default action contains  a nested project-feature accessor, the runtime helper applyProjectFeature invokes DefaultProjectFeatureApplicator.registerFeatureApplicationFor, which calls applyDefaultsTo(...) for the inner feature — re-entering  apply. The inner apply's finally calls clearProjectLayout(), removing the ThreadLocal entry that the outer invocation still depends on. After the inner call returns, any subsequent layout.* reference in the outer action body resolves through a now-null ThreadLocal and throws.                                                                                                                                                      
                                                                                                                                                                               
### Fix                                                                                                                                                                          
                                                                                                                                                                               
Replace the unsafe setProjectLayout / clearProjectLayout pair on SharedModelDefaultsInternal with a single scoped method:
```                                                                                                                                                                               
  void withProjectLayout(ProjectLayout projectLayout, Runnable action);
```                                                                                                                                                                               
The implementation captures the previously bound layout, sets the new one, runs the action, and restores the previous binding (or removes the  ThreadLocal entry if there was none) on completion — including when the action throws. The sole caller in ActionBasedModelDefaultsHandler is migrated to the scoped form. This encodes the save/restore invariant in the SPI rather than at the call site, eliminating the class of bug entirely: future callers cannot reintroduce it by forgetting to save the previous binding.                                                                                                                                     
                                                                                                                                                                               
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
