### PR TITLE
Use Spock 2.4 combined: blocks for cartesian where-tables

### DIFF
--- a/platforms/core-execution/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/platforms/core-execution/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -181,7 +181,10 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash1 == hash2
 
         where:
-        [context, fooPattern] << [SnapshotContext.values(), ['**/foo.properties', '**/f*.properties', 'some/**/f*.properties', 'some/path/to/foo.properties']].combinations()*.flatten()
+        context << SnapshotContext.values()
+
+        combined:
+        fooPattern << ['**/foo.properties', '**/f*.properties', 'some/**/f*.properties', 'some/path/to/foo.properties']
     }
 
     def "can filter multiple files selectively based on pattern (pattern: #fPattern, context: #context)"() {
@@ -212,7 +215,10 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         hash4 == hash6
 
         where:
-        [context, fPattern] << [SnapshotContext.values(), ['**/f*.properties', 'some/**/f*.properties']].combinations()*.flatten()
+        context << SnapshotContext.values()
+
+        combined:
+        fPattern << ['**/f*.properties', 'some/**/f*.properties']
     }
 
     def "multiple filters can be applied to the same file (context: #context)"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
@@ -68,7 +68,10 @@ abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractInteg
         executedAndNotSkipped(":taskWithInputs")
 
         where:
-        [api, pathSensitivity] << [Api.values(), [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]].combinations()
+        api << Api.values()
+
+        combined:
+        pathSensitivity << [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]
     }
 
     def "input directories ignore empty directories by default (#api)"() {
@@ -154,7 +157,10 @@ abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractInteg
         reused(":taskWithInputs")
 
         where:
-        [api, pathSensitivity] << [Api.values(), [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]].combinations()
+        api << Api.values()
+
+        combined:
+        pathSensitivity << [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]
     }
 
     def "Non-empty directories are tracked when empty directories are ignored (#api, #pathSensitivity)"() {
@@ -209,7 +215,10 @@ abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractInteg
         executedAndNotSkipped(":taskWithInputs")
 
         where:
-        [api, pathSensitivity] << [Api.values(), [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]].combinations()
+        api << Api.values()
+
+        combined:
+        pathSensitivity << [PathSensitivity.RELATIVE, PathSensitivity.ABSOLUTE, PathSensitivity.NAME_ONLY]
     }
 
     @ToBeFixedForIsolatedProjects(because = "allprojects, extensive cross-project access")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
@@ -76,7 +76,10 @@ abstract class AbstractLineEndingSensitivityIntegrationSpec extends AbstractInte
         executedAndNotSkipped(":taskWithInputs")
 
         where:
-        [api, pathsensitivity] << [Api.values(), PathSensitivity.values()].combinations()
+        api << Api.values()
+
+        combined:
+        pathsensitivity << PathSensitivity.values()
     }
 
     def "input files properties can ignore line endings when specified (#api, #pathsensitivity)"() {
@@ -114,7 +117,10 @@ abstract class AbstractLineEndingSensitivityIntegrationSpec extends AbstractInte
         executedAndNotSkipped(":taskWithInputs")
 
         where:
-        [api, pathsensitivity] << [Api.values(), PathSensitivity.values()].combinations()
+        api << Api.values()
+
+        combined:
+        pathsensitivity << PathSensitivity.values()
     }
 
     def "runtime classpath properties are sensitive to line endings by default (#api)"() {


### PR DESCRIPTION
The Spock 2.4 upgrade introduced cross-multiplying data providers via
the `combined:` keyword. Replace remaining
`[a, b].combinations()`-driven where-blocks in three specs touched by
recent merges:

- PropertiesFileAwareClasspathResourceHasherTest (#37097 relocated it)
  - "filter properties files by pattern" feature
  - "can filter multiple files selectively based on pattern" feature
- AbstractDirectorySensitivityIntegrationSpec (#37110 touched)
  - 3 where-blocks
- AbstractLineEndingSensitivityIntegrationSpec (#37110 touched)
  - 2 where-blocks

The cartesian product is now expressed declaratively, the
`*.flatten()` workaround is gone, and the readability is closer to
the rest of the codebase's where-table style.

https://spockframework.org/spock/docs/2.4/data_driven_testing.html#_cross_multiplying_data_providers