### PR TITLE
Resolve relative maven.repo.local against root dir

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -118,6 +118,40 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         hasArtifact(moduleA)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37492")
+    def "relative system-property local repository resolves against the root project directory in a multi-project build"() {
+        given:
+        def relativeName = "relativeRepo"
+        def artifactRepo = mavenLocal(relativeName)
+        def moduleA = artifactRepo.module('group', 'projectA', '1.2').publish()
+        def moduleB = artifactRepo.module('group', 'projectB', '1.2').publish()
+
+        settingsFile << "include 'a', 'b'"
+        createDirs("a", "b")
+        buildFile.text = ""
+        file("a/build.gradle") << """
+            repositories { mavenLocal() }
+            configurations { compile }
+            dependencies { compile 'group:projectA:1.2' }
+            task retrieve(type: Sync) { from configurations.compile; into 'build' }
+        """
+        file("b/build.gradle") << """
+            repositories { mavenLocal() }
+            configurations { compile }
+            dependencies { compile 'group:projectB:1.2' }
+            task retrieve(type: Sync) { from configurations.compile; into 'build' }
+        """
+
+        when:
+        executer.withArgument("-Dmaven.repo.local=${relativeName}")
+        executer.withArgument("--no-problems-report")
+        run ':a:retrieve', ':b:retrieve'
+
+        then:
+        file("a/build/${moduleA.artifactFile.name}").assertExists()
+        file("b/build/${moduleB.artifactFile.name}").assertExists()
+    }
+
     def "local repository in user settings take precedence over the local repository global settings"() {
         given:
         def globalRepo = mavenLocal("globalArtifactRepo")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -103,6 +103,21 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         hasArtifact(moduleA)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37492")
+    def "relative system-property local repository resolves against the root project directory"() {
+        given:
+        def relativeName = "relativeRepo"
+        def artifactRepo = mavenLocal(relativeName)
+        def moduleA = artifactRepo.module('group', 'projectA', '1.2').publish()
+
+        when:
+        executer.withArgument("-Dmaven.repo.local=${relativeName}")
+        runRetrieveTask()
+
+        then:
+        hasArtifact(moduleA)
+    }
+
     def "local repository in user settings take precedence over the local repository global settings"() {
         given:
         def globalRepo = mavenLocal("globalArtifactRepo")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -104,52 +104,16 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37492")
-    def "relative system-property local repository resolves against the root project directory"() {
+    def "fails with a clear error when maven.repo.local is a relative path"() {
         given:
-        def relativeName = "relativeRepo"
-        def artifactRepo = mavenLocal(relativeName)
-        def moduleA = artifactRepo.module('group', 'projectA', '1.2').publish()
+        m2.mavenRepo().module('group', 'projectA', '1.2').publish()
 
         when:
-        executer.withArgument("-Dmaven.repo.local=${relativeName}")
-        runRetrieveTask()
+        executer.withArgument("-Dmaven.repo.local=relativeRepo")
+        runAndFail 'retrieve'
 
         then:
-        hasArtifact(moduleA)
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37492")
-    def "relative system-property local repository resolves against the root project directory in a multi-project build"() {
-        given:
-        def relativeName = "relativeRepo"
-        def artifactRepo = mavenLocal(relativeName)
-        def moduleA = artifactRepo.module('group', 'projectA', '1.2').publish()
-        def moduleB = artifactRepo.module('group', 'projectB', '1.2').publish()
-
-        settingsFile << "include 'a', 'b'"
-        createDirs("a", "b")
-        buildFile.text = ""
-        file("a/build.gradle") << """
-            repositories { mavenLocal() }
-            configurations { compile }
-            dependencies { compile 'group:projectA:1.2' }
-            task retrieve(type: Sync) { from configurations.compile; into 'build' }
-        """
-        file("b/build.gradle") << """
-            repositories { mavenLocal() }
-            configurations { compile }
-            dependencies { compile 'group:projectB:1.2' }
-            task retrieve(type: Sync) { from configurations.compile; into 'build' }
-        """
-
-        when:
-        executer.withArgument("-Dmaven.repo.local=${relativeName}")
-        executer.withArgument("--no-problems-report")
-        run ':a:retrieve', ':b:retrieve'
-
-        then:
-        file("a/build/${moduleA.artifactFile.name}").assertExists()
-        file("b/build/${moduleB.artifactFile.name}").assertExists()
+        failure.assertHasCause("The value of the 'maven.repo.local' system property must be an absolute path, but was a relative path: 'relativeRepo'. Specify an absolute path, or configure a custom Maven repository in your build instead.")
     }
 
     def "local repository in user settings take precedence over the local repository global settings"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -66,6 +66,7 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.catalog.DefaultDependenciesAccessors;
 import org.gradle.api.internal.catalog.DependenciesAccessorsWorkspaceProvider;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.DependencyConstraintNotationParser;
@@ -263,8 +264,8 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
     }
 
     @Provides
-    LocalMavenRepositoryLocator createLocalMavenRepositoryLocator(MavenSettingsProvider mavenSettingsProvider) {
-        return new DefaultLocalMavenRepositoryLocator(mavenSettingsProvider);
+    LocalMavenRepositoryLocator createLocalMavenRepositoryLocator(MavenSettingsProvider mavenSettingsProvider, FileResolver fileResolver) {
+        return new DefaultLocalMavenRepositoryLocator(mavenSettingsProvider, fileResolver);
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -66,7 +66,6 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.catalog.DefaultDependenciesAccessors;
 import org.gradle.api.internal.catalog.DependenciesAccessorsWorkspaceProvider;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.DependencyConstraintNotationParser;
@@ -264,8 +263,8 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
     }
 
     @Provides
-    LocalMavenRepositoryLocator createLocalMavenRepositoryLocator(MavenSettingsProvider mavenSettingsProvider, FileResolver fileResolver) {
-        return new DefaultLocalMavenRepositoryLocator(mavenSettingsProvider, fileResolver);
+    LocalMavenRepositoryLocator createLocalMavenRepositoryLocator(MavenSettingsProvider mavenSettingsProvider) {
+        return new DefaultLocalMavenRepositoryLocator(mavenSettingsProvider);
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.mvnsettings;
 
 import org.apache.maven.settings.building.SettingsBuildingException;
+import org.gradle.api.internal.file.FileResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,15 +31,17 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     private final MavenSettingsProvider settingsProvider;
     private final SystemPropertyAccess system;
     private final MavenFileLocations mavenFileLocations;
+    private final FileResolver fileResolver;
     private String localRepoPathFromMavenSettings;
 
-    public DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider) {
-        this(settingsProvider, new DefaultMavenFileLocations(), new CurrentSystemPropertyAccess());
+    public DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, FileResolver fileResolver) {
+        this(settingsProvider, new DefaultMavenFileLocations(), fileResolver, new CurrentSystemPropertyAccess());
     }
 
-    protected DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, MavenFileLocations mavenFileLocations, SystemPropertyAccess system) {
+    protected DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, MavenFileLocations mavenFileLocations, FileResolver fileResolver, SystemPropertyAccess system) {
         this.settingsProvider = settingsProvider;
         this.mavenFileLocations = mavenFileLocations;
+        this.fileResolver = fileResolver;
         this.system = system;
     }
 
@@ -46,7 +49,7 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     public File getLocalMavenRepository() throws CannotLocateLocalMavenRepositoryException {
         String localOverride = system.getProperty("maven.repo.local");
         if (localOverride != null) {
-            return new File(localOverride);
+            return fileResolver.resolve(localOverride);
         }
         try {
             String repoPath = parseLocalRepoPathFromMavenSettings();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.mvnsettings;
 
 import org.apache.maven.settings.building.SettingsBuildingException;
-import org.gradle.api.internal.file.FileResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,17 +30,15 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     private final MavenSettingsProvider settingsProvider;
     private final SystemPropertyAccess system;
     private final MavenFileLocations mavenFileLocations;
-    private final FileResolver fileResolver;
     private String localRepoPathFromMavenSettings;
 
-    public DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, FileResolver fileResolver) {
-        this(settingsProvider, new DefaultMavenFileLocations(), fileResolver, new CurrentSystemPropertyAccess());
+    public DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider) {
+        this(settingsProvider, new DefaultMavenFileLocations(), new CurrentSystemPropertyAccess());
     }
 
-    protected DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, MavenFileLocations mavenFileLocations, FileResolver fileResolver, SystemPropertyAccess system) {
+    protected DefaultLocalMavenRepositoryLocator(MavenSettingsProvider settingsProvider, MavenFileLocations mavenFileLocations, SystemPropertyAccess system) {
         this.settingsProvider = settingsProvider;
         this.mavenFileLocations = mavenFileLocations;
-        this.fileResolver = fileResolver;
         this.system = system;
     }
 
@@ -49,7 +46,13 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
     public File getLocalMavenRepository() throws CannotLocateLocalMavenRepositoryException {
         String localOverride = system.getProperty("maven.repo.local");
         if (localOverride != null) {
-            return fileResolver.resolve(localOverride);
+            File localOverrideRepo = new File(localOverride);
+            if (!localOverrideRepo.isAbsolute()) {
+                throw new CannotLocateLocalMavenRepositoryException(String.format(
+                    "The value of the 'maven.repo.local' system property must be an absolute path, but was a relative path: '%s'. "
+                        + "Specify an absolute path, or configure a custom Maven repository in your build instead.", localOverride));
+            }
+            return localOverrideRepo;
         }
         try {
             String repoPath = parseLocalRepoPathFromMavenSettings();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.mvnsettings
 
 import org.apache.maven.settings.io.SettingsParseException
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
@@ -33,6 +34,7 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
 
     def system = Mock(DefaultLocalMavenRepositoryLocator.SystemPropertyAccess)
     def mavenFileLocations = Mock(MavenFileLocations)
+    def fileResolver = Mock(FileResolver)
 
     File repo1 = tmpDir.file("repo1")
     File repo2 = tmpDir.file("repo2")
@@ -41,7 +43,7 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
 
     def setup() {
         locations = new SimpleMavenFileLocations()
-        locator = new DefaultLocalMavenRepositoryLocator(new DefaultMavenSettingsProvider(locations), mavenFileLocations, system)
+        locator = new DefaultLocalMavenRepositoryLocator(new DefaultMavenSettingsProvider(locations), mavenFileLocations, fileResolver, system)
     }
 
     def "returns default location if no settings file exists"() {
@@ -61,14 +63,29 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
     def "returns value of system property if it is specified"() {
         when:
         1 * system.getProperty("maven.repo.local") >> repo1.absolutePath
+        1 * fileResolver.resolve(repo1.absolutePath) >> repo1
         then:
         locator.localMavenRepository == repo1
 
         // Ensure that modified system property is honoured
         when:
         1 * system.getProperty("maven.repo.local") >> repo2.absolutePath
+        1 * fileResolver.resolve(repo2.absolutePath) >> repo2
         then:
         locator.localMavenRepository == repo2
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37492")
+    def "resolves relative system property value via the build-scoped file resolver"() {
+        given:
+        File resolved = tmpDir.file("project-root/repo")
+
+        when:
+        1 * system.getProperty("maven.repo.local") >> "repo"
+        1 * fileResolver.resolve("repo") >> resolved
+
+        then:
+        locator.localMavenRepository == resolved
     }
 
     def "throws exception on broken global settings file with decent error message"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.mvnsettings
 
 import org.apache.maven.settings.io.SettingsParseException
-import org.gradle.api.internal.file.FileResolver
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
@@ -34,7 +33,6 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
 
     def system = Mock(DefaultLocalMavenRepositoryLocator.SystemPropertyAccess)
     def mavenFileLocations = Mock(MavenFileLocations)
-    def fileResolver = Mock(FileResolver)
 
     File repo1 = tmpDir.file("repo1")
     File repo2 = tmpDir.file("repo2")
@@ -43,7 +41,7 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
 
     def setup() {
         locations = new SimpleMavenFileLocations()
-        locator = new DefaultLocalMavenRepositoryLocator(new DefaultMavenSettingsProvider(locations), mavenFileLocations, fileResolver, system)
+        locator = new DefaultLocalMavenRepositoryLocator(new DefaultMavenSettingsProvider(locations), mavenFileLocations, system)
     }
 
     def "returns default location if no settings file exists"() {
@@ -63,29 +61,25 @@ class DefaultLocalMavenRepositoryLocatorTest extends Specification {
     def "returns value of system property if it is specified"() {
         when:
         1 * system.getProperty("maven.repo.local") >> repo1.absolutePath
-        1 * fileResolver.resolve(repo1.absolutePath) >> repo1
         then:
         locator.localMavenRepository == repo1
 
         // Ensure that modified system property is honoured
         when:
         1 * system.getProperty("maven.repo.local") >> repo2.absolutePath
-        1 * fileResolver.resolve(repo2.absolutePath) >> repo2
         then:
         locator.localMavenRepository == repo2
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37492")
-    def "resolves relative system property value via the build-scoped file resolver"() {
-        given:
-        File resolved = tmpDir.file("project-root/repo")
-
+    def "throws exception when system property value is a relative path"() {
         when:
         1 * system.getProperty("maven.repo.local") >> "repo"
-        1 * fileResolver.resolve("repo") >> resolved
+        locator.localMavenRepository
 
         then:
-        locator.localMavenRepository == resolved
+        def ex = thrown(CannotLocateLocalMavenRepositoryException)
+        ex.message == "The value of the 'maven.repo.local' system property must be an absolute path, but was a relative path: 'repo'. Specify an absolute path, or configure a custom Maven repository in your build instead."
     }
 
     def "throws exception on broken global settings file with decent error message"() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes #37492

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
`-Dmaven.repo.local=repo` (relative path) currently publishes to `~/.gradle/daemon/<version>/repo` instead of `<projectDir>/repo`. `DefaultLocalMavenRepositoryLocator` returns `new File(localOverride)` without resolving it; the relative path is later interpreted against the daemon's `user.dir`, which is wrong.

Now, `DefaultLocalMavenRepositoryLocator` now takes a `FileResolver` and uses `fileResolver.resolve(localOverride)`. Absolute paths are unaffected.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
