### PR TITLE
Eliminate cross-project mutable state leaks via DefaultProject

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -88,7 +88,7 @@ class CrossProjectConfigurationReportingGradle(
 
     // Split out so it's clear we're not calling the @ForExternalUse method.
     private fun getCrossProjectRootProject(): ProjectInternal =
-        crossProjectModelAccess.accessFromState(referrerProject, delegate.owner.rootProject)
+        crossProjectModelAccess.access(referrerProject, delegate.owner.rootProject.identity)
 
     override fun rootProject(action: Action<in Project>) {
         delegate.rootProject(action.withCrossProjectModelAccessCheck())
@@ -185,7 +185,7 @@ class CrossProjectConfigurationReportingGradle(
         return Action<Project> {
             val originalProject = this@Action
             check(originalProject is ProjectInternal) { "Expected the projects in the model to be ProjectInternal" }
-            originalAction.execute(crossProjectModelAccess.access(referrerProject, originalProject))
+            originalAction.execute(crossProjectModelAccess.access(referrerProject, originalProject.projectIdentity))
         }
     }
 
@@ -206,11 +206,11 @@ class CrossProjectConfigurationReportingGradle(
         private val crossProjectModelAccess: CrossProjectModelAccess
     ) : ProjectEvaluationListener {
         override fun beforeEvaluate(project: Project) {
-            delegate.beforeEvaluate(crossProjectModelAccess.access(referrerProject, project as ProjectInternal))
+            delegate.beforeEvaluate(crossProjectModelAccess.access(referrerProject, (project as ProjectInternal).projectIdentity))
         }
 
         override fun afterEvaluate(project: Project, state: ProjectState) {
-            delegate.afterEvaluate(crossProjectModelAccess.access(referrerProject, project as ProjectInternal), state)
+            delegate.afterEvaluate(crossProjectModelAccess.access(referrerProject, (project as ProjectInternal).projectIdentity), state)
         }
 
         override fun equals(other: Any?): Boolean =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingClosure.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingClosure.kt
@@ -56,7 +56,7 @@ class CrossProjectModelAccessTrackingClosure<T>(
         private
         fun trackingProjectAccess(crossProjectModelAccess: CrossProjectModelAccess, referrerProject: ProjectIdentity, modelObject: Any): Any =
             when (modelObject) {
-                is ProjectInternal -> crossProjectModelAccess.access(referrerProject, modelObject)
+                is ProjectInternal -> crossProjectModelAccess.access(referrerProject, modelObject.projectIdentity)
                 is GradleInternal -> crossProjectModelAccess.gradleInstanceForProject(referrerProject, modelObject)
                 is TaskExecutionGraphInternal -> crossProjectModelAccess.taskGraphForProject(referrerProject, modelObject)
                 else -> modelObject

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -43,7 +43,6 @@ import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectOrderingUtil
 import org.gradle.api.internal.project.ProjectRegistry
-import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -94,7 +94,7 @@ class ProblemReportingCrossProjectModelAccess(
     gradleLifecycleActionExecutor: GradleLifecycleActionExecutor
 ) : CrossProjectModelAccess {
 
-    private val delegate = DefaultCrossProjectModelAccess(projectRegistry, instantiator, gradleLifecycleActionExecutor)
+    private val delegate = DefaultCrossProjectModelAccess(projectStateLookup, projectRegistry, instantiator, gradleLifecycleActionExecutor)
 
     override fun findProject(referrer: ProjectIdentity, path: Path): ProjectInternal? {
         return delegate.findProject(referrer, path)?.let {
@@ -102,15 +102,11 @@ class ProblemReportingCrossProjectModelAccess(
         }
     }
 
-    override fun access(referrer: ProjectIdentity, project: ProjectInternal): ProjectInternal {
+    override fun access(referrer: ProjectIdentity, target: ProjectIdentity): ProjectInternal {
         // We purposefully leak mutable state here, as we wrap all mutable access with immediate failures in the case of cross-project access,
         // so there's no risk of race conditions.
-        return project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, project.projectIdentity))
-    }
-
-    override fun accessFromState(referrer: ProjectIdentity, projectState: ProjectState): ProjectInternal {
-        return projectState.fromMutableState { project ->
-            access(referrer, project)
+        return projectStateLookup.stateFor(target.buildTreePath).fromMutableState { project ->
+            project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, target))
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -39,7 +39,6 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.DefaultCrossProjectModelAccess
 import org.gradle.api.internal.project.MutableStateAccessAwareProject
-import org.gradle.api.internal.project.ProjectIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectOrderingUtil
@@ -435,10 +434,6 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         override fun getConfigurationTargetIdentifier(): ConfigurationTargetIdentifier {
-            shouldNotBeUsed()
-        }
-
-        override fun getParentIdentifier(): ProjectIdentifier {
             shouldNotBeUsed()
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -110,9 +110,9 @@ class ProblemReportingCrossProjectModelAccess(
         }
     }
 
-    override fun getChildProjects(referrer: ProjectIdentity, target: ProjectState): MutableMap<String, Project> {
+    override fun getChildProjects(referrer: ProjectIdentity, target: ProjectIdentity): MutableMap<String, Project> {
         return delegate.getChildProjects(referrer, target).mapValuesTo(LinkedHashMap()) {
-            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, target.identity))
+            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, target))
         }
     }
 
@@ -140,10 +140,10 @@ class ProblemReportingCrossProjectModelAccess(
         return CrossProjectConfigurationReportingTaskExecutionGraph(taskGraph, referrer, ipProblems, this, coupledProjectsListener, projectStateLookup)
     }
 
-    override fun parentProjectDynamicInheritedScope(referrer: ProjectState): HierarchicalDynamicObject? {
-        val parent = referrer.parent ?: return null
+    override fun parentProjectDynamicInheritedScope(referrer: ProjectIdentity): HierarchicalDynamicObject? {
+        val parent = projectStateLookup.stateFor(referrer.buildTreePath).parent ?: return null
         return CrossProjectModelAccessTrackingParentDynamicObject(
-            parent, referrer.identity, ipProblems, coupledProjectsListener
+            parent, referrer, ipProblems, coupledProjectsListener
         )
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
@@ -46,29 +46,13 @@ public interface CrossProjectModelAccess {
     @Nullable ProjectInternal findProject(ProjectIdentity referrer, Path path);
 
     /**
-     * Wrap the given project to ensure mutable state access is correctly handled across project boundaries,
-     * according to the current cross-project model access policy.
-     *
-     * <p>
-     * If possible, callers should prefer {@link #accessFromState(ProjectIdentity, ProjectState)},
-     * as it does not require a reference to the mutable state of the project.
-     * </p>
+     * Wrap the project identified by {@code target} to ensure mutable state access is correctly handled
+     * across project boundaries, according to the current cross-project model access policy.
      *
      * @param referrer The project from which the return value will be used.
+     * @param target The identity of the project to access.
      */
-    ProjectInternal access(ProjectIdentity referrer, ProjectInternal project);
-
-    /**
-     * Variant of {@link #access(ProjectIdentity, ProjectInternal)} that takes a {@link ProjectState},
-     * to avoid needing to have a reference to the mutable state of the project in the caller.
-     *
-     * <p>
-     * This should be preferred over {@code access(ProjectIdentity, ProjectInternal)} where possible.
-     * </p>
-     *
-     * @param referrer The project from which the return value will be used.
-     */
-    ProjectInternal accessFromState(ProjectIdentity referrer, ProjectState projectState);
+    ProjectInternal access(ProjectIdentity referrer, ProjectIdentity target);
 
     /**
      * @param referrer The project from which the return value will be used.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
@@ -58,7 +58,7 @@ public interface CrossProjectModelAccess {
      * @param referrer The project from which the return value will be used.
      * @param target The project to get the children of.
      */
-    Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectState target);
+    Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectIdentity target);
 
     /**
      * @param referrer The project from which the return value will be used.
@@ -109,5 +109,5 @@ public interface CrossProjectModelAccess {
      * The returned object handles cross-project model access according to the current policy.
      */
     @Nullable
-    HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectState referrer);
+    HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectIdentity referrer);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -31,6 +31,11 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+/**
+ * @implNote This implementation purposefully leaks mutable state across project boundaries.
+ * That is safe because it is only used outside of Isolated Projects mode, where unrestricted
+ * cross-project access is allowed.
+ */
 public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
 
     private final ProjectStateLookup projectStateLookup;
@@ -53,10 +58,7 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     @Override
     public ProjectInternal access(ProjectIdentity referrer, ProjectIdentity target) {
         ProjectState projectState = projectStateLookup.stateFor(target.getBuildTreePath());
-        // We purposefully leak mutable state here, as we're not in IP so it's safe.
-        return projectState.fromMutableState(project ->
-            LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor)
-        );
+        return LifecycleAwareProject.wrap(projectState.getMutableModel(), referrer, instantiator, gradleLifecycleActionExecutor);
     }
 
     @Override
@@ -71,8 +73,9 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     }
 
     @Override
-    public Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectState target) {
-        return target.getChildProjects().stream().collect(
+    public Map<String, Project> getChildProjects(ProjectIdentity referrer, ProjectIdentity target) {
+        ProjectState targetState = projectStateLookup.stateFor(target.getBuildTreePath());
+        return targetState.getChildProjects().stream().collect(
             Collectors.toMap(
                 ProjectState::getName,
                 projectState -> LifecycleAwareProject.wrap(projectState.getMutableModel(), referrer, instantiator, gradleLifecycleActionExecutor)
@@ -112,9 +115,8 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
 
     @Override
     @Nullable
-    public HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectState referrer) {
-        ProjectState parent = referrer.getParent();
-        // We purposefully leak mutable state here, as we're not in IP so it's safe.
+    public HierarchicalDynamicObject parentProjectDynamicInheritedScope(ProjectIdentity referrer) {
+        ProjectState parent = projectStateLookup.stateFor(referrer.getBuildTreePath()).getParent();
         return parent != null ? parent.fromMutableState(ProjectInternal::getInheritedScope) : null;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -33,30 +33,29 @@ import java.util.stream.Collectors;
 
 public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
 
+    private final ProjectStateLookup projectStateLookup;
     private final ProjectRegistry projectRegistry;
     private final Instantiator instantiator;
     private final GradleLifecycleActionExecutor gradleLifecycleActionExecutor;
 
     public DefaultCrossProjectModelAccess(
+        ProjectStateLookup projectStateLookup,
         ProjectRegistry projectRegistry,
         Instantiator instantiator,
         GradleLifecycleActionExecutor gradleLifecycleActionExecutor
     ) {
+        this.projectStateLookup = projectStateLookup;
         this.projectRegistry = projectRegistry;
         this.instantiator = instantiator;
         this.gradleLifecycleActionExecutor = gradleLifecycleActionExecutor;
     }
 
     @Override
-    public ProjectInternal access(ProjectIdentity referrer, ProjectInternal project) {
-        return LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor);
-    }
-
-    @Override
-    public ProjectInternal accessFromState(ProjectIdentity referrer, ProjectState projectState) {
+    public ProjectInternal access(ProjectIdentity referrer, ProjectIdentity target) {
+        ProjectState projectState = projectStateLookup.stateFor(target.getBuildTreePath());
+        // We purposefully leak mutable state here, as we're not in IP so it's safe.
         return projectState.fromMutableState(project ->
-            // We purposefully leak mutable state here, as we're not in IP so it's safe.
-            access(referrer, project)
+            LifecycleAwareProject.wrap(project, referrer, instantiator, gradleLifecycleActionExecutor)
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -190,7 +190,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private final File buildFile;
 
     @Nullable
-    private final ProjectInternal parent;
+    private final ProjectIdentity parentIdentity;
 
     private final String name;
 
@@ -231,7 +231,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     public DefaultProject(
         String name,
-        @Nullable ProjectInternal parent,
         File projectDir,
         File buildFile,
         ScriptSource buildScriptSource,
@@ -246,7 +245,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         this.baseClassLoaderScope = baseClassLoaderScope;
         this.projectDir = projectDir;
         this.buildFile = buildFile;
-        this.parent = parent;
+        ProjectState parent = owner.getParent();
+        this.parentIdentity = parent != null ? parent.getIdentity() : null;
         this.name = name;
         this.state = new ProjectStateInternal();
         this.buildScriptSource = buildScriptSource;
@@ -430,10 +430,10 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Nullable
     @Override
     public ProjectInternal getParent(ProjectIdentity referrer) {
-        if (parent == null) {
+        if (parentIdentity == null) {
             return null;
         }
-        return getCrossProjectModelAccess().access(referrer, parent.getProjectIdentity());
+        return getCrossProjectModelAccess().access(referrer, parentIdentity);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -181,8 +181,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private final ClassLoaderScope baseClassLoaderScope;
     private final ServiceRegistry services;
 
-    private final ProjectInternal rootProject;
-
     private final GradleInternal gradle;
 
     private final ScriptSource buildScriptSource;
@@ -246,8 +244,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         this.owner = owner;
         this.classLoaderScope = selfClassLoaderScope;
         this.baseClassLoaderScope = baseClassLoaderScope;
-        // TODO:isolated mutable model of the current project should NOT keep a direct link to the mutable model of root and parent projects
-        this.rootProject = parent != null ? owner.getOwner().getRootProject().getMutableModel() : this;
         this.projectDir = projectDir;
         this.buildFile = buildFile;
         this.parent = parent;
@@ -386,7 +382,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getRootProject(ProjectIdentity referrer) {
-        return getCrossProjectModelAccess().access(referrer, rootProject.getProjectIdentity());
+        return getCrossProjectModelAccess().access(referrer, owner.getOwner().getRootProject().getIdentity());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -386,7 +386,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getRootProject(ProjectIdentity referrer) {
-        return getCrossProjectModelAccess().access(referrer, rootProject);
+        return getCrossProjectModelAccess().access(referrer, rootProject.getProjectIdentity());
     }
 
     @Override
@@ -437,7 +437,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         if (parent == null) {
             return null;
         }
-        return getCrossProjectModelAccess().access(referrer, parent);
+        return getCrossProjectModelAccess().access(referrer, parent.getProjectIdentity());
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -436,12 +436,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return getCrossProjectModelAccess().access(referrer, parent.getProjectIdentity());
     }
 
-    @Nullable
-    @Override
-    public ProjectIdentifier getParentIdentifier() {
-        return parent;
-    }
-
     @Override
     public DynamicObject getAsDynamicObject() {
         return extensibleDynamicObject;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -260,7 +260,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         taskContainer = services.get(TaskContainerInternal.class);
         extensibleDynamicObject = new ExtensibleDynamicObject(this, Project.class, services.get(InstantiatorFactory.class).decorateLenient(services));
 
-        @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(owner);
+        @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(owner.getIdentity());
         if (parentInherited != null) {
             extensibleDynamicObject.setParent(parentInherited);
             extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));
@@ -539,7 +539,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public Map<String, Project> getChildProjects(ProjectIdentity referrer) {
-        return getCrossProjectModelAccess().getChildProjects(referrer, getOwner());
+        return getCrossProjectModelAccess().getChildProjects(referrer, getProjectIdentity());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
@@ -53,10 +53,10 @@ public class DefaultProjectRegistry implements ProjectRegistry, HoldsProjectStat
     }
 
     private void addProjectToParentSubProjects(ProjectInternal project) {
-        ProjectIdentifier loopProject = project.getParentIdentifier();
-        while (loopProject != null) {
-            subProjects.get(loopProject.getPath()).add(project);
-            loopProject = loopProject.getParentIdentifier();
+        ProjectState ancestor = project.getOwner().getParent();
+        while (ancestor != null) {
+            subProjects.get(ancestor.getProjectPath().asString()).add(project);
+            ancestor = ancestor.getParent();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -47,15 +47,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closeable {
-    private final WorkerLeaseService workerLeaseService;
-    private final Object lock = new Object();
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    @GuardedBy("lock")
     private final Map<Path, ProjectState> projectsByPath = new LinkedHashMap<>();
+    @GuardedBy("lock")
     private final Map<ProjectComponentIdentifier, ProjectState> projectsById = new HashMap<>();
+    @GuardedBy("lock")
     private final Map<BuildIdentifier, DefaultBuildProjectRegistry> projectsByBuild = new HashMap<>();
+
+    private final WorkerLeaseService workerLeaseService;
 
     public DefaultProjectStateRegistry(WorkerLeaseService workerLeaseService) {
         this.workerLeaseService = workerLeaseService;
@@ -63,7 +69,8 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public void registerProjects(BuildState owner, ProjectDescriptorRegistry projectRegistry) {
-        synchronized (lock) {
+        lock.writeLock().lock();
+        try {
             DefaultBuildProjectRegistry buildProjectRegistry = getBuildProjectRegistry(owner);
             if (!buildProjectRegistry.projectsByPath.isEmpty()) {
                 throw new IllegalStateException("Projects for " + owner.getDisplayName() + " have already been registered.");
@@ -74,6 +81,8 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
                 throw new IllegalStateException("No root project found for " + owner.getDisplayName());
             }
             registerAllProjectsRecursively(owner, buildProjectRegistry, null, rootProject);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -127,9 +136,12 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public ProjectState registerProject(BuildState owner, ImmutableProjectDescriptor projectDescriptor) {
-        synchronized (lock) {
+        lock.writeLock().lock();
+        try {
             DefaultBuildProjectRegistry buildProjectRegistry = getBuildProjectRegistry(owner);
             return addProject(owner, buildProjectRegistry, projectDescriptor);
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -160,8 +172,11 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public Collection<ProjectState> getAllProjects() {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             return projectsByPath.values();
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -173,49 +188,64 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public ProjectState stateFor(ProjectComponentIdentifier identifier) {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             ProjectState projectState = projectsById.get(identifier);
             if (projectState == null) {
                 throw new IllegalArgumentException(identifier.getDisplayName() + " not found.");
             }
             return projectState;
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public ProjectState stateFor(Path identityPath) {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             ProjectState projectState = projectsByPath.get(identityPath);
             if (projectState == null) {
                 throw new IllegalArgumentException(identityPath.asString() + " not found.");
             }
             return projectState;
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public @Nullable ProjectState findProject(Path identityPath) {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             return projectsByPath.get(identityPath);
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             BuildProjectRegistry registry = projectsByBuild.get(buildIdentifier);
             if (registry == null) {
                 throw new IllegalArgumentException("Projects for " + buildIdentifier + " have not been registered yet.");
             }
             return registry;
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
     @Nullable
     @Override
     public BuildProjectRegistry findProjectsFor(BuildIdentifier buildIdentifier) {
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             return projectsByBuild.get(buildIdentifier);
+        } finally {
+            lock.readLock().unlock();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/IProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/IProjectFactory.java
@@ -21,7 +21,6 @@ import org.gradle.internal.project.ImmutableProjectDescriptor;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Creates a {@link ProjectInternal} implementation.
@@ -32,7 +31,6 @@ public interface IProjectFactory {
         GradleInternal gradle,
         ImmutableProjectDescriptor projectDescriptor,
         ProjectState owner,
-        @Nullable ProjectInternal parent,
         ServiceRegistryFactory serviceRegistryFactory,
         ClassLoaderScope selfClassLoaderScope,
         ClassLoaderScope baseClassLoaderScope

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -703,12 +703,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.ant(configureAction);
     }
 
-    @Nullable
-    @Override
-    public ProjectIdentifier getParentIdentifier() {
-        return delegate.getParentIdentifier();
-    }
-
     @Override
     public String getBuildTreePath() {
         return delegate.getBuildTreePath();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
@@ -30,7 +30,6 @@ import org.gradle.internal.resource.TextResource;
 import org.gradle.internal.scripts.ProjectScopedScriptResolution;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.util.internal.NameValidator;
-import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -50,7 +49,6 @@ public class ProjectFactory implements IProjectFactory {
         GradleInternal gradle,
         ImmutableProjectDescriptor projectDescriptor,
         ProjectState owner,
-        @Nullable ProjectInternal parent,
         ServiceRegistryFactory serviceRegistryFactory,
         ClassLoaderScope selfClassLoaderScope,
         ClassLoaderScope baseClassLoaderScope
@@ -61,7 +59,6 @@ public class ProjectFactory implements IProjectFactory {
         ScriptSource source = new TextResourceScriptSource(resource);
         DefaultProject project = instantiator.newInstance(DefaultProject.class,
             projectDescriptor.getIdentity().getProjectName(),
-            parent,
             projectDescriptor.getProjectDir(),
             buildFile,
             source,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.internal.project;
 
-import org.jspecify.annotations.Nullable;
-
 import java.io.File;
 
 // TODO need a better name for this
@@ -24,9 +22,6 @@ public interface ProjectIdentifier {
     String getName();
 
     String getPath();
-
-    @Nullable
-    ProjectIdentifier getParentIdentifier();
 
     File getProjectDir();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -71,14 +71,12 @@ public class ProjectLifecycleController implements Closeable {
         IProjectFactory projectFactory
     ) {
         controller.transition(State.NotCreated, State.Created, () -> {
-            ProjectState parent = owner.getParent();
-            ProjectInternal parentModel = parent == null ? null : parent.getMutableModel();
             ServiceRegistryFactory serviceRegistryFactory = domainObject -> {
                 LoggingManagerFactory loggingManagerFactory = buildServices.get(LoggingManagerFactory.class);
                 projectScopeServices = ProjectScopeServices.create(buildServices, (ProjectInternal) domainObject, loggingManagerFactory);
                 return projectScopeServices;
             };
-            project = projectFactory.createProject(build.getMutableModel(), descriptor, owner, parentModel, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
+            project = projectFactory.createProject(build.getMutableModel(), descriptor, owner, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateLookup.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateLookup.java
@@ -41,4 +41,11 @@ public interface ProjectStateLookup {
     @Nullable
     ProjectState findProject(Path identityPath);
 
+    /**
+     * Locates the state object that owns the project with the given identity path.
+     *
+     * @throws IllegalArgumentException if no project with the given identity path is registered.
+     */
+    ProjectState stateFor(Path identityPath) throws IllegalArgumentException;
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -25,7 +25,6 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -38,18 +37,17 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface ProjectStateRegistry extends ProjectStateLookup {
     /**
      * Locates the state object that owns the given public project model. Can use {@link ProjectInternal#getOwner()} instead.
+     *
+     * @throws IllegalArgumentException if no state is registered for the given project.
      */
     ProjectState stateFor(Project project) throws IllegalArgumentException;
 
     /**
      * Locates the state object that owns the project with the given identifier.
+     *
+     * @throws IllegalArgumentException if no project with the given identifier is registered.
      */
     ProjectState stateFor(ProjectComponentIdentifier identifier) throws IllegalArgumentException;
-
-    /**
-     * Locates the state object that owns the project with the identity path.
-     */
-    ProjectState stateFor(Path identityPath) throws IllegalArgumentException;
 
     /**
      * Locates the state objects for all projects of the given build.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -339,7 +339,7 @@ class DefaultProjectSpec extends Specification {
 
         def instantiator = TestUtil.instantiatorFactory().decorateLenient(serviceRegistry)
         def factory = new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(null), scriptResolution)
-        def project = factory.createProject(build, descriptor, container, parent, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
+        def project = factory.createProject(build, descriptor, container, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
         _ * container.mutableModel >> project
         return project
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -112,14 +112,14 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def rootProject = project(":")
         def rootState = registry.stateFor(projectId(":"))
 
-        1 * projectFactory.createProject(_, _, rootState, _, _, _, _) >> rootProject
+        1 * projectFactory.createProject(_, _, rootState, _, _, _) >> rootProject
 
         rootState.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
 
         def project = project("p1")
         def state = registry.stateFor(projectId("p1"))
 
-        1 * projectFactory.createProject(_, _, state, _, _, _, _) >> project
+        1 * projectFactory.createProject(_, _, state, _, _, _) >> project
 
         state.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
 
@@ -864,13 +864,13 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def rootProject = project(':')
         def rootState = registry.stateFor(projectId(buildPath, ':'))
 
-        1 * projectFactory.createProject(_, _, rootState, _, _, _, _) >> rootProject
+        1 * projectFactory.createProject(_, _, rootState, _, _, _) >> rootProject
 
         rootState.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
     }
 
     void createProject(ProjectState state, ProjectInternal project) {
-        1 * projectFactory.createProject(_, _, state, _, _, _, _) >> project
+        1 * projectFactory.createProject(_, _, state, _, _, _) >> project
 
         state.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -349,7 +349,6 @@ class DefaultProjectTest extends Specification {
         def project = TestUtil.instantiatorFactory().decorateLenient().newInstance(
             DefaultProject,
             name,
-            parent,
             rootDir,
             new File(rootDir, 'build.gradle'),
             script,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -136,6 +136,7 @@ class DefaultProjectTest extends Specification {
     ProjectEvaluator projectEvaluator = Mock(ProjectEvaluator)
 
     ProjectRegistry projectRegistry
+    Map<Path, ProjectState> projectStateRegistryByIdentityPath = [:]
 
     File rootDir
     File buildFile
@@ -245,7 +246,10 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) CrossProjectConfigurator) >> crossProjectConfigurator
         serviceRegistryMock.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
         serviceRegistryMock.get(DomainObjectCollectionFactory) >> TestUtil.domainObjectCollectionFactory()
-        serviceRegistryMock.get(CrossProjectModelAccess) >> new DefaultCrossProjectModelAccess(projectRegistry, instantiatorMock, gradleLifecycleActionExecutor)
+        ProjectStateLookup projectStateLookup = Stub(ProjectStateLookup) {
+            stateFor(_ as Path) >> { Path identityPath -> projectStateRegistryByIdentityPath[identityPath] }
+        }
+        serviceRegistryMock.get(CrossProjectModelAccess) >> new DefaultCrossProjectModelAccess(projectStateLookup, projectRegistry, instantiatorMock, gradleLifecycleActionExecutor)
         serviceRegistryMock.get(IsolatedProjectsProblemsReporter) >> new NoOpIsolatedProjectsProblemsReporter()
         serviceRegistryMock.get(GradleLifecycleActionExecutor) >> gradleLifecycleActionExecutor
         serviceRegistryMock.get(ObjectFactory) >> objectFactory
@@ -339,6 +343,8 @@ class DefaultProjectTest extends Specification {
         _ * owner.identityPath >> identity.buildTreePath
         _ * owner.projectPath >> identity.projectPath
         _ * owner.depth >> owner.projectPath.segmentCount()
+
+        projectStateRegistryByIdentityPath[identity.buildTreePath] = owner
 
         def project = TestUtil.instantiatorFactory().decorateLenient().newInstance(
             DefaultProject,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
@@ -77,11 +77,11 @@ class ProjectFactoryTest extends Specification {
         serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
 
         when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, null, serviceRegistryFactory, rootProjectScope, baseScope)
+        def result = factory.createProject(gradle, projectDescriptor, projectState, serviceRegistryFactory, rootProjectScope, baseScope)
 
         then:
         result == project
-        1 * instantiator.newInstance(DefaultProject, "name", null, projectDir, buildFile, { it instanceof TextResourceScriptSource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
+        1 * instantiator.newInstance(DefaultProject, "name", projectDir, buildFile, { it instanceof TextResourceScriptSource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
         1 * projectRegistry.addProject(project)
         1 * dependencyResolutionManagement.configureProject(project)
     }
@@ -92,28 +92,26 @@ class ProjectFactoryTest extends Specification {
         gradle.services >> serviceRegistry
         serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
         when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, null, serviceRegistryFactory, rootProjectScope, baseScope)
+        def result = factory.createProject(gradle, projectDescriptor, projectState, serviceRegistryFactory, rootProjectScope, baseScope)
 
         then:
         result == project
-        1 * instantiator.newInstance(DefaultProject, "name", null, projectDir, buildFile, { it.resource instanceof EmptyFileTextResource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
+        1 * instantiator.newInstance(DefaultProject, "name", projectDir, buildFile, { it.resource instanceof EmptyFileTextResource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
         1 * projectRegistry.addProject(project)
         1 * dependencyResolutionManagement.configureProject(project)
     }
 
     def "creates a child project"() {
-        def parent = Mock(ProjectInternal)
-
         given:
         gradle.projectRegistry >> projectRegistry
         gradle.services >> serviceRegistry
         serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
         when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, parent, serviceRegistryFactory, rootProjectScope, baseScope)
+        def result = factory.createProject(gradle, projectDescriptor, projectState, serviceRegistryFactory, rootProjectScope, baseScope)
 
         then:
         result == project
-        1 * instantiator.newInstance(DefaultProject, "name", parent, projectDir, buildFile, _, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
+        1 * instantiator.newInstance(DefaultProject, "name", projectDir, buildFile, _, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
         1 * projectRegistry.addProject(project)
         1 * dependencyResolutionManagement.configureProject(project)
     }


### PR DESCRIPTION
Stops `DefaultProject` from holding direct references to other projects' mutable state, so the cross-project model boundary is expressed only in terms of `ProjectIdentity`.

- Reshape `CrossProjectModelAccess` so every method takes `ProjectIdentity` instead of `ProjectInternal` / `ProjectState`. The default and isolated-projects implementations resolve identities to states via `ProjectStateLookup`, which now exposes `stateFor(Path)`.
- Drop `DefaultProject`'s `parent` and `rootProject` fields. The parent identity is derived from `owner.getParent()`, and `getRootProject` resolves through `ProjectStateLookup` on demand.
- Retire `ProjectIdentifier.getParentIdentifier()` and walk the `ProjectState` hierarchy in `DefaultProjectRegistry` instead.
- Simplify `IProjectFactory.createProject` / `ProjectFactory.createProject` by dropping the `parent` argument; `DefaultProject` no longer needs it.