### PR TITLE
Restore scanForTestClasses=false bypass of framework detection

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestClassDetectionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestClassDetectionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing.junit.junit4
 
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.testing.junit.AbstractJUnitTestClassDetectionIntegrationTest
+import spock.lang.Issue
 
 abstract class AbstractJUnit4TestClassDetectionIntegrationTest extends AbstractJUnitTestClassDetectionIntegrationTest {
     abstract boolean isSupportsEmptyClassWithRunner()
@@ -85,6 +86,104 @@ abstract class AbstractJUnit4TestClassDetectionIntegrationTest extends AbstractJ
         if (supportsEmptyClassWithRunner) {
             results.testPath('org.gradle.EmptyRunWithSubclass', 'ok').onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
         }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36508")
+    def "scanForTestClasses=false bypasses framework detection so include patterns alone determine which classes execute"() {
+        given:
+        // The parent class with @RunWith lives in a separate source set whose output is packaged
+        // into an archive with a non-.jar extension. javac and the JVM accept it as a classpath
+        // entry, but AbstractTestFrameworkDetector only inspects directories and *.jar files,
+        // so the parent class is invisible to the detector. This mirrors the user's scenario
+        // where the parent class is on the JPMS module path (also invisible to the detector).
+        file('src/parentLib/java/parent/CustomRunner.java') << """
+            package parent;
+
+            import org.junit.runner.*;
+            import org.junit.runner.notification.RunNotifier;
+
+            public class CustomRunner extends Runner {
+                private final Description description;
+
+                public CustomRunner(Class type) throws Exception {
+                    description = Description.createSuiteDescription(type);
+                    description.addChild(Description.createTestDescription(type, "ok"));
+                }
+
+                @Override
+                public Description getDescription() {
+                    return description;
+                }
+
+                @Override
+                public void run(RunNotifier notifier) {
+                    for (Description child : description.getChildren()) {
+                        notifier.fireTestStarted(child);
+                        notifier.fireTestFinished(child);
+                    }
+                }
+            }
+        """.stripIndent()
+        file('src/parentLib/java/parent/AbstractRunWith.java') << """
+            package parent;
+
+            import org.junit.runner.RunWith;
+
+            @RunWith(CustomRunner.class)
+            public abstract class AbstractRunWith {
+            }
+        """.stripIndent()
+        file('src/test/java/example/SubTest.java') << """
+            package example;
+
+            public class SubTest extends parent.AbstractRunWith {
+            }
+        """.stripIndent()
+
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            sourceSets {
+                parentLib {
+                    java.srcDir 'src/parentLib/java'
+                }
+            }
+            dependencies {
+                ${getTestFrameworkDependencies('parentLib')}
+                ${testFrameworkDependencies}
+            }
+            tasks.register('parentLibArchive', Jar) {
+                from sourceSets.parentLib.output
+                archiveExtension = 'zip'
+            }
+            dependencies {
+                testImplementation files(tasks.parentLibArchive)
+            }
+            test.${configureTestFramework}
+        """.stripIndent()
+
+        when:
+        // With the default scanForTestClasses=true, AbstractTestFrameworkDetector visits SubTest.class,
+        // sees no @Test/@RunWith on the class itself, attempts to scan the superclass
+        // parent/AbstractRunWith.class, fails to locate it (the .zip archive is silently skipped),
+        // and silently drops SubTest. failOnNoDiscoveredTests then fires.
+        fails 'test'
+
+        then:
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.")
+
+        when:
+        buildFile << """
+            test {
+                scanForTestClasses = false
+                include '**/SubTest.class'
+            }
+        """.stripIndent()
+        succeeds 'test'
+
+        then:
+        def results = resultsFor(testDirectory)
+        results.testPath('example.SubTest', 'ok').onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
     }
 
     void writeCustomRunnerClass(String className) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestClassDetectionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestClassDetectionIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing.junit.junit4
 
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.testing.junit.AbstractJUnitTestClassDetectionIntegrationTest
-import spock.lang.Issue
 
 abstract class AbstractJUnit4TestClassDetectionIntegrationTest extends AbstractJUnitTestClassDetectionIntegrationTest {
     abstract boolean isSupportsEmptyClassWithRunner()
@@ -86,104 +85,6 @@ abstract class AbstractJUnit4TestClassDetectionIntegrationTest extends AbstractJ
         if (supportsEmptyClassWithRunner) {
             results.testPath('org.gradle.EmptyRunWithSubclass', 'ok').onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
         }
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/36508")
-    def "scanForTestClasses=false bypasses framework detection so include patterns alone determine which classes execute"() {
-        given:
-        // The parent class with @RunWith lives in a separate source set whose output is packaged
-        // into an archive with a non-.jar extension. javac and the JVM accept it as a classpath
-        // entry, but AbstractTestFrameworkDetector only inspects directories and *.jar files,
-        // so the parent class is invisible to the detector. This mirrors the user's scenario
-        // where the parent class is on the JPMS module path (also invisible to the detector).
-        file('src/parentLib/java/parent/CustomRunner.java') << """
-            package parent;
-
-            import org.junit.runner.*;
-            import org.junit.runner.notification.RunNotifier;
-
-            public class CustomRunner extends Runner {
-                private final Description description;
-
-                public CustomRunner(Class type) throws Exception {
-                    description = Description.createSuiteDescription(type);
-                    description.addChild(Description.createTestDescription(type, "ok"));
-                }
-
-                @Override
-                public Description getDescription() {
-                    return description;
-                }
-
-                @Override
-                public void run(RunNotifier notifier) {
-                    for (Description child : description.getChildren()) {
-                        notifier.fireTestStarted(child);
-                        notifier.fireTestFinished(child);
-                    }
-                }
-            }
-        """.stripIndent()
-        file('src/parentLib/java/parent/AbstractRunWith.java') << """
-            package parent;
-
-            import org.junit.runner.RunWith;
-
-            @RunWith(CustomRunner.class)
-            public abstract class AbstractRunWith {
-            }
-        """.stripIndent()
-        file('src/test/java/example/SubTest.java') << """
-            package example;
-
-            public class SubTest extends parent.AbstractRunWith {
-            }
-        """.stripIndent()
-
-        buildFile << """
-            apply plugin: 'java'
-            ${mavenCentralRepository()}
-            sourceSets {
-                parentLib {
-                    java.srcDir 'src/parentLib/java'
-                }
-            }
-            dependencies {
-                ${getTestFrameworkDependencies('parentLib')}
-                ${testFrameworkDependencies}
-            }
-            tasks.register('parentLibArchive', Jar) {
-                from sourceSets.parentLib.output
-                archiveExtension = 'zip'
-            }
-            dependencies {
-                testImplementation files(tasks.parentLibArchive)
-            }
-            test.${configureTestFramework}
-        """.stripIndent()
-
-        when:
-        // With the default scanForTestClasses=true, AbstractTestFrameworkDetector visits SubTest.class,
-        // sees no @Test/@RunWith on the class itself, attempts to scan the superclass
-        // parent/AbstractRunWith.class, fails to locate it (the .zip archive is silently skipped),
-        // and silently drops SubTest. failOnNoDiscoveredTests then fires.
-        fails 'test'
-
-        then:
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.")
-
-        when:
-        buildFile << """
-            test {
-                scanForTestClasses = false
-                include '**/SubTest.class'
-            }
-        """.stripIndent()
-        succeeds 'test'
-
-        then:
-        def results = resultsFor(testDirectory)
-        results.testPath('example.SubTest', 'ok').onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
     }
 
     void writeCustomRunnerClass(String className) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestClassDetectionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestClassDetectionIntegrationTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.testing.junit.junit4
 
+import org.gradle.api.tasks.testing.TestResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.util.internal.VersionNumber
+import spock.lang.Issue
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4
 
@@ -27,5 +29,103 @@ class JUnit4TestClassDetectionIntegrationTest extends AbstractJUnit4TestClassDet
     boolean isSupportsEmptyClassWithRunner() {
         // JUnit 4.0 does not support an empty class with a runner (i.e. the test fails)
         return VersionNumber.parse(version) >= VersionNumber.parse('4.1')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36508")
+    def "scanForTestClasses=false bypasses framework detection so include patterns alone determine which classes execute"() {
+        given:
+        // The parent class with @RunWith lives in a separate source set whose output is packaged
+        // into an archive with a non-.jar extension. javac and the JVM accept it as a classpath
+        // entry, but AbstractTestFrameworkDetector only inspects directories and *.jar files,
+        // so the parent class is invisible to the detector. This mirrors the user's scenario
+        // where the parent class is on the JPMS module path (also invisible to the detector).
+        file('src/parentLib/java/parent/CustomRunner.java') << """
+            package parent;
+
+            import org.junit.runner.*;
+            import org.junit.runner.notification.RunNotifier;
+
+            public class CustomRunner extends Runner {
+                private final Description description;
+
+                public CustomRunner(Class type) throws Exception {
+                    description = Description.createSuiteDescription(type);
+                    description.addChild(Description.createTestDescription(type, "ok"));
+                }
+
+                @Override
+                public Description getDescription() {
+                    return description;
+                }
+
+                @Override
+                public void run(RunNotifier notifier) {
+                    for (Description child : description.getChildren()) {
+                        notifier.fireTestStarted(child);
+                        notifier.fireTestFinished(child);
+                    }
+                }
+            }
+        """.stripIndent()
+        file('src/parentLib/java/parent/AbstractRunWith.java') << """
+            package parent;
+
+            import org.junit.runner.RunWith;
+
+            @RunWith(CustomRunner.class)
+            public abstract class AbstractRunWith {
+            }
+        """.stripIndent()
+        file('src/test/java/example/SubTest.java') << """
+            package example;
+
+            public class SubTest extends parent.AbstractRunWith {
+            }
+        """.stripIndent()
+
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            sourceSets {
+                parentLib {
+                    java.srcDir 'src/parentLib/java'
+                }
+            }
+            dependencies {
+                ${getTestFrameworkDependencies('parentLib')}
+                ${testFrameworkDependencies}
+            }
+            tasks.register('parentLibArchive', Jar) {
+                from sourceSets.parentLib.output
+                archiveExtension = 'zip'
+            }
+            dependencies {
+                testImplementation files(tasks.parentLibArchive)
+            }
+            test.${configureTestFramework}
+        """.stripIndent()
+
+        when:
+        // With the default scanForTestClasses=true, AbstractTestFrameworkDetector visits SubTest.class,
+        // sees no @Test/@RunWith on the class itself, attempts to scan the superclass
+        // parent/AbstractRunWith.class, fails to locate it (the .zip archive is silently skipped),
+        // and silently drops SubTest. failOnNoDiscoveredTests then fires.
+        fails 'test'
+
+        then:
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.")
+
+        when:
+        buildFile << """
+            test {
+                scanForTestClasses = false
+                include '**/SubTest.class'
+            }
+        """.stripIndent()
+        succeeds 'test'
+
+        then:
+        def results = resultsFor(testDirectory)
+        results.testPath('example.SubTest', 'ok').onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
     }
 }

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -104,10 +104,13 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         final FileTree testClassFiles = testExecutionSpec.getCandidateClassFiles();
         final Set<File> testDefinitionDirs = testExecutionSpec.getCandidateTestDefinitionDirs();
 
-        if (testFramework.getDetector() != null) {
-            TestFrameworkDetector testFrameworkDetector = testFramework.getDetector();
-            testFrameworkDetector.setTestClasses(new ArrayList<>(testExecutionSpec.getTestClassesDirs().getFiles()));
-            testFrameworkDetector.setTestClasspath(classpath.getApplicationClasspath());
+        // When scanForTestClasses is false, the contract is that classes matching the include/exclude patterns
+        // are executed as test classes without inspecting their bytecode. Suppress the framework detector so
+        // that DefaultTestScanner falls back to a filename-only scan.
+        TestFrameworkDetector frameworkDetector = testExecutionSpec.isScanForTestClasses() ? testFramework.getDetector() : null;
+        if (frameworkDetector != null) {
+            frameworkDetector.setTestClasses(new ArrayList<>(testExecutionSpec.getTestClassesDirs().getFiles()));
+            frameworkDetector.setTestClasspath(classpath.getApplicationClasspath());
         }
 
         /*
@@ -119,7 +122,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
             IncubationLogger.incubatingFeatureUsed("Filtering non-class-based tests");
         }
 
-        TestDetector detector = new DefaultTestScanner(testClassFiles, testDefinitionDirs, testFramework.getDetector(), processor);
+        TestDetector detector = new DefaultTestScanner(testClassFiles, testDefinitionDirs, frameworkDetector, processor);
 
         // What is this?
         // In some versions of the Gradle retry plugin, it would retry any test that had any kind of failure associated with it.


### PR DESCRIPTION
## Summary

- Fixes [#36508](https://github.com/gradle/gradle/issues/36508): `Test.setScanForTestClasses(false)` has been a no-op since the 9.3.1 fix in `6d34972daac`, which unconditionally invokes the test framework detector whenever the framework provides one.
- Gate the detector in `DefaultTestExecuter` on `JvmTestExecutionSpec.isScanForTestClasses()`. When the flag is `false`, pass `null` to `DefaultTestScanner` so it falls back to a filename-only scan and emits a `ClassTestDefinition` for every class matching the include/exclude patterns — JUnit then decides at runtime what is actually a test. This restores the documented escape hatch users rely on when their test parent class is invisible to the detector (e.g. Apache Lucene, where the parent lives on the JPMS module path).
- Adds a JUnit4 / JUnit Vintage integration test that reproduces the failure. The test packages a `@RunWith`-bearing parent class into a `.zip` archive — javac and the JVM accept it as a classpath entry, but `AbstractTestFrameworkDetector` only inspects directories and `*.jar` files, mirroring the user's JPMS module-path blind spot. With `scanForTestClasses=true` the build fails with the "did not discover any tests" error; with `scanForTestClasses=false` and an explicit `include`, the test runs.

The deeper "detector silently drops subclasses whose superclass cannot be loaded" behavior is left for a separate change — the documented `scanForTestClasses=false` path now works again, which is the user's preferred remedy.

## Test plan

- [x] New test fails on master and passes with the fix applied (verified by stashing the fix)
- [ ] `:testing-jvm:embeddedIntegTest` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)