### PR TITLE
Strip $ prompt prefix when copying shell commands

### DIFF
--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/main/resources/clipboard.js
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/main/resources/clipboard.js
@@ -16,14 +16,17 @@ window.onload = function() {
     }
 
     var clipboard = new ClipboardJS('.clipboard', {
-       target: function(b) {
+       text: function(b) {
             var p = b.parentNode;
+            var sourceEl;
             if (p.className.includes("highlight")) {
                 var elems = p.getElementsByTagName("code");
-                if (elems.length > 0)
-                    return elems[0];
+                sourceEl = elems.length > 0 ? elems[0] : p.childNodes[0];
+            } else {
+                sourceEl = p.childNodes[0];
             }
-            return p.childNodes[0];
+            var text = sourceEl.textContent;
+            return text.replace(/^(\$ )/gm, '');
         }
     });
 


### PR DESCRIPTION
When I was following the [steps in this guide](https://docs.gradle.org/current/userguide/gradle_wrapper.html#manually_verifying_the_gradle_wrapper_jar), I couldn't just copy paste the commands in to the terminal because they all had a leading `$`.

Here's a PR to strip the leading `$`