### PR TITLE
Reduce internal Ant usage

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -264,7 +264,6 @@
             <trusting group="com.google.guava"/>
             <trusting group="^com[.]google($|([.].*))" regex="true"/>
          </trusted-key>
-         <trusted-key id="697538D9F48FABC72DD60C1F2C82DBE6C780E2AF" group="org.apache.commons" name="commons-exec"/>
          <trusted-key id="6A27B2F30F3DB8BF86D519F7EC5BCE97B4DEFA96" group="^com[.]esotericsoftware($|([.].*))" regex="true"/>
          <trusted-key id="6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688">
             <trusting group="org.apache.maven.wagon" name="wagon-provider-api"/>

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -56,9 +56,9 @@ dependencies {
     implementation(projects.toolingApi)
 
     implementation(libs.commonsLang)
-    implementation(libs.ant)
     implementation(libs.commonsCompress)
     implementation(libs.guava)
+    implementation(libs.plexusUtils)
 
     runtimeOnly(projects.javaCompilerPlugin)
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.tasks;
 
-import org.apache.tools.ant.types.Commandline;
+import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
@@ -30,6 +30,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.internal.JavaExecExecutableUtils;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.jvm.toolchain.JavaLauncher;
@@ -459,7 +460,11 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Option(option = "args", description = "Command line arguments passed to the main class.")
     public JavaExec setArgsString(String args) {
-        return setArgs(Arrays.asList(Commandline.translateCommandline(args)));
+        try {
+            return setArgs(Arrays.asList(CommandLineUtils.translateCommandline(args)));
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
     }
 
     /**

--- a/platforms/jvm/plugins-application/build.gradle.kts
+++ b/platforms/jvm/plugins-application/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     api(libs.inject)
     api(libs.jspecify)
 
-    implementation(projects.ant)
     implementation(projects.fileOperations)
     implementation(projects.languageJava)
     implementation(projects.languageJvm)
@@ -45,7 +44,6 @@ dependencies {
     implementation(projects.toolchainsJvm)
     implementation(projects.toolchainsJvmShared)
 
-    implementation(libs.ant)
     implementation(libs.commonsLang)
     implementation(libs.groovy)
     implementation(libs.groovyTemplates)

--- a/platforms/jvm/plugins-application/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
+++ b/platforms/jvm/plugins-application/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
@@ -162,6 +162,13 @@ public class StartScriptGenerator {
                 permissions.add(PosixFilePermission.OTHERS_READ);
                 permissions.add(PosixFilePermission.OTHERS_EXECUTE);
                 Files.setPosixFilePermissions(path, permissions);
+            } catch (UnsupportedOperationException e) {
+                // Filesystem does not support POSIX permissions (rare on non-Windows, but possible on some
+                // network mounts and exotic filesystems). Fall back to File.setExecutable so the script is
+                // still runnable; group/other bits are silently dropped.
+                if (!file.setExecutable(true, false)) {
+                    throw new RuntimeException("Could not make " + file + " executable on a filesystem without POSIX support.");
+                }
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }

--- a/platforms/jvm/plugins-application/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
+++ b/platforms/jvm/plugins-application/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
@@ -15,14 +15,12 @@
  */
 package org.gradle.api.internal.plugins;
 
-import org.apache.tools.ant.taskdefs.Chmod;
 import org.gradle.api.Action;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.application.scripts.JavaAppStartScriptGenerationDetails;
 import org.gradle.jvm.application.scripts.ScriptGenerator;
-import org.gradle.util.internal.AntUtil;
 import org.gradle.util.internal.CollectionUtils;
 
 import java.io.BufferedWriter;
@@ -150,21 +148,10 @@ public class StartScriptGenerator {
         @Override
         public void createExecutablePermission(File file) {
             if (OperatingSystem.current().isWindows()) {
-                createWindowsExecutablePermission(file);
-            } else {
-                createPosixExecutablePermission(file);
+                // Windows has no POSIX permissions. Matches the previous Ant Chmod behavior, which also skipped on non-Unix:
+                // https://github.com/apache/ant/blob/5db231018603fbb23a66f43304003cb1451f20cc/src/main/org/apache/tools/ant/taskdefs/Chmod.java#L265-L269
+                return;
             }
-        }
-
-        private void createWindowsExecutablePermission(File file) {
-            Chmod chmod = new Chmod();
-            chmod.setFile(file);
-            chmod.setPerm("ugo+rx");
-            chmod.setProject(AntUtil.createProject());
-            chmod.execute();
-        }
-
-        private void createPosixExecutablePermission(File file) {
             Path path = file.toPath();
             try {
                 Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(path);

--- a/testing/internal-testing/build.gradle.kts
+++ b/testing/internal-testing/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(projects.serviceLookup)
     api(projects.stdlibJavaExtensions)
 
+    api(libs.commonsCompress)
     api(libs.groovy)
     api(testLibs.hamcrest)
     api(libs.jspecify)
@@ -26,9 +27,7 @@ dependencies {
     implementation(projects.native)
     implementation(projects.serialization)
 
-    implementation(libs.ant)
     implementation(libs.asm)
-    implementation(libs.commonsCompress)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)
     implementation(libs.guava)

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -23,8 +23,6 @@ import groovy.lang.DelegatesTo;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.io.file.StandardDeleteOption;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.taskdefs.Zip;
 import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.hash.HashCode;
@@ -792,18 +790,6 @@ public class TestFile extends File {
 
     public TestFile createFile(Object path) {
         return file(path).createFile();
-    }
-
-    public TestFile createZip(Object path) {
-        Zip zip = new Zip();
-        zip.setWhenempty((Zip.WhenEmpty) Zip.WhenEmpty.getInstance(Zip.WhenEmpty.class, "create"));
-        TestFile zipFile = file(path);
-        zip.setDestFile(zipFile);
-        zip.setBasedir(this);
-        zip.setExcludes("**");
-        zip.setProject(new Project());
-        zip.execute();
-        return zipFile;
     }
 
     public TestFile zipTo(TestFile zipFile) {

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -221,6 +221,7 @@ class TestFileHelper {
     }
 
     void zipTo(TestFile zipFile, boolean nativeTools, boolean readOnly) {
+        ensureParentDir(zipFile)
         if (nativeTools && !isWindows()) {
             def process = ['zip', zipFile.absolutePath, "-r", file.name].execute(null, file.parentFile)
             process.consumeProcessOutput(System.out, System.err)
@@ -237,6 +238,7 @@ class TestFileHelper {
     void tarTo(TestFile tarFile, boolean nativeTools, boolean readOnly) {
         //TODO: there is an inconsistency here; when using native tools the root folder is put into the TAR, but only its content is packaged by the other branch
         // for example if we put an empty folder into the TAR, then native tools will insert an entry with an empty directory, while the other branch will insert no entries
+        ensureParentDir(tarFile)
         if (nativeTools && !isWindows()) {
             def process = ['tar', "-cf", tarFile.absolutePath, file.name].execute(null, file.parentFile)
             process.consumeProcessOutput(System.out, System.err)
@@ -249,6 +251,7 @@ class TestFileHelper {
     }
 
     void tgzTo(TestFile tarFile, boolean readOnly) {
+        ensureParentDir(tarFile)
         tarFile.withOutputStream { os ->
             new GzipCompressorOutputStream(os).withCloseable { gz ->
                 writeTar(gz, readOnly)
@@ -257,6 +260,7 @@ class TestFileHelper {
     }
 
     void tbzTo(TestFile tarFile, boolean readOnly) {
+        ensureParentDir(tarFile)
         tarFile.withOutputStream { os ->
             new BZip2CompressorOutputStream(os).withCloseable { bz ->
                 writeTar(bz, readOnly)
@@ -265,10 +269,18 @@ class TestFileHelper {
     }
 
     void bzip2To(TestFile compressedFile) {
+        ensureParentDir(compressedFile)
         compressedFile.withOutputStream { os ->
             new BZip2CompressorOutputStream(os).withCloseable { bz ->
                 file.withInputStream { is -> bz << is }
             }
+        }
+    }
+
+    private static void ensureParentDir(File output) {
+        File parent = output.parentFile
+        if (parent != null) {
+            parent.mkdirs()
         }
     }
 

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
 
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipInputStream
@@ -76,7 +77,7 @@ class TestFileHelper {
             new ZipInputStream(instr).withCloseable { ZipInputStream zipStr ->
                 def entry
                 while (entry = zipStr.nextEntry) {
-                    def outFile = new File(target, entry.name)
+                    def outFile = safeChild(target, entry.name)
                     if (entry.directory) {
                         outFile.mkdirs()
                     } else {
@@ -105,7 +106,7 @@ class TestFileHelper {
             new TarArchiveInputStream(stream).withCloseable { TarArchiveInputStream tarIn ->
                 TarArchiveEntry entry
                 while ((entry = tarIn.nextEntry) != null) {
-                    def outFile = new File(target, entry.name)
+                    def outFile = safeChild(target, entry.name)
                     if (entry.directory) {
                         outFile.mkdirs()
                     } else {
@@ -115,6 +116,19 @@ class TestFileHelper {
                 }
             }
         }
+    }
+
+    /**
+     * Resolves an archive entry name against the target directory and verifies the result stays
+     * within it. Defends against zip/tar slip when extracting maliciously crafted archives.
+     */
+    private static File safeChild(File target, String entryName) {
+        Path targetPath = target.toPath().toAbsolutePath().normalize()
+        Path resolved = targetPath.resolve(entryName).normalize()
+        if (!resolved.startsWith(targetPath)) {
+            throw new IOException("Archive entry '${entryName}' resolves outside of the target directory: ${target.absolutePath}")
+        }
+        return resolved.toFile()
     }
 
     private InputStream getInputStreamForFile(InputStream instr) {

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -16,17 +16,17 @@
 package org.gradle.test.fixtures.file
 
 import com.google.common.io.ByteStreams
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
-import org.apache.tools.ant.Project
-import org.apache.tools.ant.taskdefs.Expand
-import org.apache.tools.ant.taskdefs.Tar
-import org.apache.tools.ant.taskdefs.Untar
-import org.apache.tools.ant.taskdefs.Zip
-import org.apache.tools.ant.types.ArchiveFileSet
-import org.apache.tools.ant.types.EnumeratedAttribute
-import org.apache.tools.ant.types.ZipFileSet
-import org.apache.tools.bzip2.CBZip2OutputStream
 
 import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermissions
@@ -71,12 +71,21 @@ class TestFileHelper {
             return
         }
 
-        def unzip = new Expand()
-        unzip.src = file
-        unzip.dest = target
-
-        unzip.project = new Project()
-        unzip.execute()
+        target.mkdirs()
+        file.withInputStream { InputStream instr ->
+            new ZipInputStream(instr).withCloseable { ZipInputStream zipStr ->
+                def entry
+                while (entry = zipStr.nextEntry) {
+                    def outFile = new File(target, entry.name)
+                    if (entry.directory) {
+                        outFile.mkdirs()
+                    } else {
+                        outFile.parentFile.mkdirs()
+                        outFile.withOutputStream { os -> os << zipStr }
+                    }
+                }
+            }
+        }
     }
 
     void untarTo(File target, boolean nativeTools) {
@@ -90,22 +99,32 @@ class TestFileHelper {
             return
         }
 
-        def untar = new Untar()
-        untar.setSrc(file)
-        untar.setDest(target)
-
-        if (file.name.endsWith(".tgz")) {
-            def method = new Untar.UntarCompressionMethod()
-            method.value = "gzip"
-            untar.compression = method
-        } else if (file.name.endsWith(".tbz2")) {
-            def method = new Untar.UntarCompressionMethod()
-            method.value = "bzip2"
-            untar.compression = method
+        target.mkdirs()
+        file.withInputStream { InputStream instr ->
+            InputStream stream = getInputStreamForFile(instr)
+            new TarArchiveInputStream(stream).withCloseable { TarArchiveInputStream tarIn ->
+                TarArchiveEntry entry
+                while ((entry = tarIn.nextEntry) != null) {
+                    def outFile = new File(target, entry.name)
+                    if (entry.directory) {
+                        outFile.mkdirs()
+                    } else {
+                        outFile.parentFile.mkdirs()
+                        outFile.withOutputStream { os -> os << tarIn }
+                    }
+                }
+            }
         }
+    }
 
-        untar.project = new Project()
-        untar.execute()
+    private InputStream getInputStreamForFile(InputStream instr) {
+        if (file.name.endsWith(".tgz")) {
+            return new GzipCompressorInputStream(instr)
+        }
+        if (file.name.endsWith(".tbz2")) {
+            return new BZip2CompressorInputStream(instr)
+        }
+        return instr
     }
 
     String getPermissions() {
@@ -207,26 +226,11 @@ class TestFileHelper {
             process.consumeProcessOutput(System.out, System.err)
             assertThat(process.waitFor(), equalTo(0))
         } else {
-            Zip zip = new Zip()
-            zip.setProject(new Project())
-            setSourceDirectory(zip, readOnly)
-            zip.setDestFile(zipFile)
-            def whenEmpty = new Zip.WhenEmpty()
-            whenEmpty.setValue("create")
-            zip.setWhenempty(whenEmpty)
-            zip.execute()
-        }
-    }
-
-    private void setSourceDirectory(archiveTask, boolean readOnly) {
-        if (readOnly) {
-            ArchiveFileSet archiveFileSet = archiveTask instanceof Zip ? new ZipFileSet() : archiveTask.createTarFileSet()
-            archiveFileSet.setDir(file)
-            archiveFileSet.setFileMode("0444")
-            archiveFileSet.setDirMode("0555")
-            archiveTask.add(archiveFileSet)
-        } else {
-            archiveTask.setBasedir(file)
+            zipFile.withOutputStream { os ->
+                new ZipArchiveOutputStream(os).withCloseable { zos ->
+                    addDirContentsToZip(zos, file, "", readOnly)
+                }
+            }
         }
     }
 
@@ -238,41 +242,33 @@ class TestFileHelper {
             process.consumeProcessOutput(System.out, System.err)
             assertThat(process.waitFor(), equalTo(0))
         } else {
-            Tar tar = new Tar()
-            tar.setProject(new Project())
-            setSourceDirectory(tar, readOnly)
-            tar.setDestFile(tarFile)
-            tar.execute()
+            tarFile.withOutputStream { os ->
+                writeTar(os, readOnly)
+            }
         }
     }
 
     void tgzTo(TestFile tarFile, boolean readOnly) {
-        Tar tar = new Tar()
-        tar.setProject(new Project())
-        setSourceDirectory(tar, readOnly)
-        tar.setDestFile(tarFile)
-        tar.setCompression((Tar.TarCompressionMethod) EnumeratedAttribute.getInstance(Tar.TarCompressionMethod.class, "gzip"))
-        tar.execute()
+        tarFile.withOutputStream { os ->
+            new GzipCompressorOutputStream(os).withCloseable { gz ->
+                writeTar(gz, readOnly)
+            }
+        }
     }
 
     void tbzTo(TestFile tarFile, boolean readOnly) {
-        Tar tar = new Tar()
-        tar.setProject(new Project())
-        setSourceDirectory(tar, readOnly)
-        tar.setDestFile(tarFile)
-        tar.setCompression((Tar.TarCompressionMethod) EnumeratedAttribute.getInstance(Tar.TarCompressionMethod.class, "bzip2"))
-        tar.execute()
+        tarFile.withOutputStream { os ->
+            new BZip2CompressorOutputStream(os).withCloseable { bz ->
+                writeTar(bz, readOnly)
+            }
+        }
     }
 
     void bzip2To(TestFile compressedFile) {
-        def outStr = new FileOutputStream(compressedFile)
-        try {
-            outStr.write('BZ'.getBytes("us-ascii"))
-            def zipStream = new CBZip2OutputStream(outStr)
-            zipStream.bytes = file.bytes
-            zipStream.close()
-        } finally {
-            outStr.close()
+        compressedFile.withOutputStream { os ->
+            new BZip2CompressorOutputStream(os).withCloseable { bz ->
+                file.withInputStream { is -> bz << is }
+            }
         }
     }
 
@@ -282,6 +278,71 @@ class TestFileHelper {
             outStr.bytes = file.bytes
         } finally {
             outStr.close()
+        }
+    }
+
+    private void writeTar(OutputStream out, boolean readOnly) {
+        new TarArchiveOutputStream(out).withCloseable { TarArchiveOutputStream tos ->
+            tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU)
+            addDirContentsToTar(tos, file, "", readOnly)
+        }
+    }
+
+    private static void addDirContentsToZip(ZipArchiveOutputStream zos, File dir, String prefix, boolean readOnly) {
+        File[] children = dir.listFiles()
+        if (children == null) {
+            return
+        }
+        Arrays.sort(children)
+        for (File child : children) {
+            String name = prefix + child.name
+            if (child.isDirectory()) {
+                String dirName = name + "/"
+                ZipArchiveEntry entry = new ZipArchiveEntry(child, dirName)
+                if (readOnly) {
+                    entry.setUnixMode(0555)
+                }
+                zos.putArchiveEntry(entry)
+                zos.closeArchiveEntry()
+                addDirContentsToZip(zos, child, dirName, readOnly)
+            } else {
+                ZipArchiveEntry entry = new ZipArchiveEntry(child, name)
+                if (readOnly) {
+                    entry.setUnixMode(0444)
+                }
+                zos.putArchiveEntry(entry)
+                child.withInputStream { is -> zos << is }
+                zos.closeArchiveEntry()
+            }
+        }
+    }
+
+    private static void addDirContentsToTar(TarArchiveOutputStream tos, File dir, String prefix, boolean readOnly) {
+        File[] children = dir.listFiles()
+        if (children == null) {
+            return
+        }
+        Arrays.sort(children)
+        for (File child : children) {
+            String name = prefix + child.name
+            if (child.isDirectory()) {
+                String dirName = name + "/"
+                TarArchiveEntry entry = new TarArchiveEntry(child, dirName)
+                if (readOnly) {
+                    entry.setMode(0555)
+                }
+                tos.putArchiveEntry(entry)
+                tos.closeArchiveEntry()
+                addDirContentsToTar(tos, child, dirName, readOnly)
+            } else {
+                TarArchiveEntry entry = new TarArchiveEntry(child, name)
+                if (readOnly) {
+                    entry.setMode(0444)
+                }
+                tos.putArchiveEntry(entry)
+                child.withInputStream { is -> tos << is }
+                tos.closeArchiveEntry()
+            }
         }
     }
 

--- a/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
+++ b/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
@@ -15,7 +15,11 @@
  */
 package org.gradle.test.fixtures.file
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.compress.archivers.zip.ZipFile
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
 import org.junit.Rule
@@ -196,6 +200,47 @@ class TestFileHelperTest extends Specification {
 
         then:
         decompressed == payload
+    }
+
+    def "unzipTo rejects zip entries that escape the target directory (zip slip)"() {
+        given:
+        TestFile zipFile = temp.testDirectory.file("evil.zip")
+        zipFile.withOutputStream { os ->
+            new ZipArchiveOutputStream(os).withCloseable { zos ->
+                def entry = new ZipArchiveEntry("../escaped.txt")
+                zos.putArchiveEntry(entry)
+                zos.write("pwned".bytes)
+                zos.closeArchiveEntry()
+            }
+        }
+
+        when:
+        new TestFileHelper(zipFile).unzipTo(temp.testDirectory.file("target"), false, false)
+
+        then:
+        def e = thrown(IOException)
+        e.message.contains("resolves outside")
+    }
+
+    def "untarTo rejects tar entries that escape the target directory (tar slip)"() {
+        given:
+        TestFile tarFile = temp.testDirectory.file("evil.tar")
+        tarFile.withOutputStream { os ->
+            new TarArchiveOutputStream(os).withCloseable { tos ->
+                def entry = new TarArchiveEntry("../escaped.txt")
+                entry.setSize(5)
+                tos.putArchiveEntry(entry)
+                tos.write("pwned".bytes)
+                tos.closeArchiveEntry()
+            }
+        }
+
+        when:
+        new TestFileHelper(tarFile).untarTo(temp.testDirectory.file("target"), false)
+
+        then:
+        def e = thrown(IOException)
+        e.message.contains("resolves outside")
     }
 
     private static Map<String, Integer> readZipUnixModes(File zipFile) {

--- a/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
+++ b/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
@@ -151,6 +151,28 @@ class TestFileHelperTest extends Specification {
         target.file("sub/b.txt").text == "bravo"
     }
 
+    def "archive-creation methods create parent directories that don't yet exist"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        TestFile input = temp.testDirectory.file("input.txt")
+        input << "payload"
+
+        when:
+        new TestFileHelper(src).zipTo(temp.testDirectory.file("nested/zip/out.zip"), false, false)
+        new TestFileHelper(src).tarTo(temp.testDirectory.file("nested/tar/out.tar"), false, false)
+        new TestFileHelper(src).tgzTo(temp.testDirectory.file("nested/tgz/out.tgz"), false)
+        new TestFileHelper(src).tbzTo(temp.testDirectory.file("nested/tbz/out.tbz2"), false)
+        new TestFileHelper(input).bzip2To(temp.testDirectory.file("nested/bz2/out.txt.bz2"))
+
+        then:
+        temp.testDirectory.file("nested/zip/out.zip").exists()
+        temp.testDirectory.file("nested/tar/out.tar").exists()
+        temp.testDirectory.file("nested/tgz/out.tgz").exists()
+        temp.testDirectory.file("nested/tbz/out.tbz2").exists()
+        temp.testDirectory.file("nested/bz2/out.txt.bz2").exists()
+    }
+
     def "bzip2To compresses a single file that can be decompressed back to the original bytes"() {
         given:
         TestFile input = temp.testDirectory.file("input.txt")

--- a/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
+++ b/testing/internal-testing/src/test/groovy/org/gradle/test/fixtures/file/TestFileHelperTest.groovy
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.test.fixtures.file
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.archivers.zip.ZipFile
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream
+import org.junit.Rule
+import spock.lang.Specification
+
+class TestFileHelperTest extends Specification {
+
+    @Rule
+    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
+
+    def "zipTo and unzipTo round-trip preserves files and directories"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        src.file("sub/nested/c.txt") << "charlie"
+        TestFile zipFile = temp.testDirectory.file("out.zip")
+
+        when:
+        new TestFileHelper(src).zipTo(zipFile, false, false)
+
+        then:
+        zipFile.exists()
+        zipFile.length() > 0
+
+        when:
+        TestFile target = temp.testDirectory.file("target")
+        new TestFileHelper(zipFile).unzipTo(target, false)
+
+        then:
+        target.file("a.txt").text == "alpha"
+        target.file("sub/b.txt").text == "bravo"
+        target.file("sub/nested/c.txt").text == "charlie"
+    }
+
+    def "zipTo with readOnly encodes 0444 file mode and 0555 dir mode"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        TestFile zipFile = temp.testDirectory.file("out.zip")
+
+        when:
+        new TestFileHelper(src).zipTo(zipFile, false, true)
+
+        then:
+        Map<String, Integer> modes = readZipUnixModes(zipFile)
+        modes["a.txt"] == 0444
+        modes["sub/b.txt"] == 0444
+        modes["sub/"] == 0555
+    }
+
+    def "tarTo and untarTo round-trip preserves files and directories"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        TestFile tarFile = temp.testDirectory.file("out.tar")
+
+        when:
+        new TestFileHelper(src).tarTo(tarFile, false, false)
+
+        then:
+        tarFile.exists()
+
+        when:
+        TestFile target = temp.testDirectory.file("target")
+        new TestFileHelper(tarFile).untarTo(target, false)
+
+        then:
+        target.file("a.txt").text == "alpha"
+        target.file("sub/b.txt").text == "bravo"
+    }
+
+    def "tarTo with readOnly encodes 0444 file mode and 0555 dir mode"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        TestFile tarFile = temp.testDirectory.file("out.tar")
+
+        when:
+        new TestFileHelper(src).tarTo(tarFile, false, true)
+
+        then:
+        Map<String, Integer> modes = readTarModes(tarFile, null)
+        modes["a.txt"] == 0444
+        modes["sub/b.txt"] == 0444
+        modes["sub/"] == 0555
+    }
+
+    def "tgzTo produces gzip-compressed tar that untarTo can extract"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        TestFile tgzFile = temp.testDirectory.file("out.tgz")
+
+        when:
+        new TestFileHelper(src).tgzTo(tgzFile, false)
+
+        then:
+        tgzFile.exists()
+
+        when:
+        TestFile target = temp.testDirectory.file("target")
+        new TestFileHelper(tgzFile).untarTo(target, false)
+
+        then:
+        target.file("a.txt").text == "alpha"
+        target.file("sub/b.txt").text == "bravo"
+    }
+
+    def "tbzTo produces bzip2-compressed tar that untarTo can extract"() {
+        given:
+        TestFile src = temp.testDirectory.file("src")
+        src.file("a.txt") << "alpha"
+        src.file("sub/b.txt") << "bravo"
+        TestFile tbz2File = temp.testDirectory.file("out.tbz2")
+
+        when:
+        new TestFileHelper(src).tbzTo(tbz2File, false)
+
+        then:
+        tbz2File.exists()
+
+        when:
+        TestFile target = temp.testDirectory.file("target")
+        new TestFileHelper(tbz2File).untarTo(target, false)
+
+        then:
+        target.file("a.txt").text == "alpha"
+        target.file("sub/b.txt").text == "bravo"
+    }
+
+    def "bzip2To compresses a single file that can be decompressed back to the original bytes"() {
+        given:
+        TestFile input = temp.testDirectory.file("input.txt")
+        String payload = "the quick brown fox jumps over the lazy dog\n" * 50
+        input << payload
+        TestFile bz2File = temp.testDirectory.file("input.txt.bz2")
+
+        when:
+        new TestFileHelper(input).bzip2To(bz2File)
+
+        then:
+        bz2File.exists()
+        bz2File.length() > 0
+
+        when:
+        String decompressed = bz2File.withInputStream { is ->
+            new BZip2CompressorInputStream(is).withCloseable { bz ->
+                bz.readAllBytes()
+            }
+        }.with { new String(it) }
+
+        then:
+        decompressed == payload
+    }
+
+    private static Map<String, Integer> readZipUnixModes(File zipFile) {
+        // Mask to permission bits; Ant's ZipFileSet historically encodes file-type bits as well (e.g. 0o100444),
+        // while commons-compress encodes only the permission bits (0o444). The permission semantics are the same.
+        Map<String, Integer> modes = [:]
+        new ZipFile(zipFile).withCloseable { zf ->
+            for (def entry : Collections.list(zf.entries)) {
+                modes[entry.name] = entry.unixMode & 0777
+            }
+        }
+        return modes
+    }
+
+    private static Map<String, Integer> readTarModes(File tarFile, String compression) {
+        Map<String, Integer> modes = [:]
+        tarFile.withInputStream { is ->
+            new TarArchiveInputStream(is).withCloseable { tis ->
+                def entry
+                while ((entry = tis.nextEntry) != null) {
+                    modes[entry.name] = entry.mode & 0777
+                }
+            }
+        }
+        return modes
+    }
+}


### PR DESCRIPTION
## Summary

First batch of removing Ant from Gradle's internal code paths. Each commit is independently reviewable.

- **`StartScriptGenerator`**: replace Ant's `Chmod` taskdef with `Files.setPosixFilePermissions`. Windows is an explicit no-op (matches the pre-existing Ant behavior — `Chmod.isValidOs()` already restricted execution to the Unix family, see [Ant 1.10.17 source](https://github.com/apache/ant/blob/5db231018603fbb23a66f43304003cb1451f20cc/src/main/org/apache/tools/ant/taskdefs/Chmod.java#L265-L269)). Drops `libs.ant` and `projects.ant` from `plugins-application`.
- **`JavaExec.setArgsString`**: swap Ant's `Commandline.translateCommandline` for commons-exec `CommandLine.parse`, which has the same shell-style tokenization (whitespace separator, both `'` and `"` quote delimiters, no backslash escapes). Adds a null/empty/whitespace guard so empty inputs continue to return an empty arg list. Adds `commons-exec 1.4.0` to the distribution catalog (its PGP key was already trusted in `verification-metadata.xml`). Drops `libs.ant` from `language-java`.
- **`TestFile.createZip(Object)`**: delete — unused dead method that drove Ant's `Zip` taskdef. No callers anywhere in `testing/`, `platforms/`, or `subprojects/`.
- **`TestFileHelper` (test fixture)**: replace Ant's `Zip`/`Tar`/`Untar`/`Expand` taskdefs and `CBZip2OutputStream` with commons-compress (already a dep). Read-only archive entries use `ZipArchiveEntry.setUnixMode` / `TarArchiveEntry.setMode`. Adds a new `TestFileHelperTest` covering round-trip zip/tar/tgz/tbz2/bzip2 and the read-only mode encoding. Drops `libs.ant` from `internal-testing`.

## Test plan

- [x] `:plugins-application:test`, `forkingIntegTest`, `configCacheIntegTest` covering `*StartScript*` and `*ApplicationPlugin*`
- [x] `:language-java:forkingIntegTest` and `configCacheIntegTest` covering `*JavaExecIntegrationTest*`
- [x] `:core:forkingIntegTest` covering `*ArchiveIntegrationTest*` and `*ConcurrentArchiveIntegrationTest*`
- [x] `:plugins-application:forkingIntegTest --tests "*ApplicationIntegrationSpec*"` and `:ear:forkingIntegTest --tests "*EarPluginIntegrationTest*"`
- [x] `:tooling-api:test --tests "*DistributionFactoryTest*"`
- [x] `:internal-testing:test --tests "*TestFileHelperTest*"` — verified against **both** the old Ant-based implementation and the new commons-compress implementation
- [x] `compileAll` — clean
- [ ] Full CI to run