### PR TITLE
Deprecate Ant `DirectoryScanner` mutation and add `Settings.fileSystemDefaultExcludes`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
@@ -69,7 +69,7 @@ class ConfigurationCacheFileSystemDefaultExcludesTest extends AbstractConfigurat
         def excludedByBuildScriptFileCopy = file("build/output/${excludedByBuildScriptFileName}")
         excludedByBuildScriptFile.text = "input"
 
-        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExclude(excludedByBuildScriptFileName)
+        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExcludeForBuildScript(excludedByBuildScriptFileName)
 
         when:
         configurationCacheRun spec.copyTask

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
@@ -125,7 +125,23 @@ class DefaultExcludesFixture {
             dir.file(dsl.fileNameFor("settings"))
         }
 
-        static String addDefaultExclude(String excludedFileName) {
+        /**
+         * Snippet to be inserted into a settings.gradle(.kts) file to register an additional default exclude.
+         * Uses the modern Settings.fileSystemDefaultExcludes API.
+         */
+        static String addDefaultExcludeForSettings(String excludedFileName) {
+            """
+            fileSystemDefaultExcludes.add("**/${excludedFileName}")
+            """
+        }
+
+        /**
+         * Snippet to be inserted into a build.gradle(.kts) file to register an additional default exclude.
+         * Uses the deprecated org.apache.tools.ant.DirectoryScanner static-state API because there is no
+         * project-scoped equivalent of Settings.fileSystemDefaultExcludes. This snippet still works during
+         * the deprecation cycle for the few tests that need to exercise this build-script path.
+         */
+        static String addDefaultExcludeForBuildScript(String excludedFileName) {
             """
             ${DirectoryScanner.name}.addDefaultExclude("**/${excludedFileName}")
             """
@@ -146,7 +162,7 @@ class DefaultExcludesFixture {
 
         @Override
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
-            settingsFile(spec.testDirectory, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(spec.testDirectory, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override
@@ -171,7 +187,7 @@ class DefaultExcludesFixture {
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
             TestFile includedBuildDir = spec.testDirectory.file("build-logic")
             settingsFile(spec.testDirectory, dsl) << 'includeBuild("build-logic")'
-            settingsFile(includedBuildDir, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(includedBuildDir, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override
@@ -195,7 +211,7 @@ class DefaultExcludesFixture {
         @Override
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
             TestFile buildSrcDir = spec.testDirectory.file("buildSrc")
-            settingsFile(buildSrcDir, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(buildSrcDir, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -33,6 +33,7 @@ import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.toolchain.management.ToolchainManagement
 import org.gradle.caching.configuration.BuildCacheConfiguration
 import org.gradle.internal.deprecation.DeprecationLogger
@@ -177,4 +178,7 @@ abstract class SettingsDelegate : Settings {
     override fun defaults(action: Action<in SharedModelDefaults>) {
         delegate.defaults(action)
     }
+
+    override fun getFileSystemDefaultExcludes(): SetProperty<String> =
+        delegate.fileSystemDefaultExcludes
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -26,6 +26,7 @@ import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.SharedModelDefaults
 import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.initialization.files.FileSystemDefaultExcludes
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.plugins.ExtensionContainer
@@ -181,4 +182,8 @@ abstract class SettingsDelegate : Settings {
 
     override fun getFileSystemDefaultExcludes(): SetProperty<String> =
         delegate.fileSystemDefaultExcludes
+
+    override fun fileSystemDefaultExcludes(action: Action<in FileSystemDefaultExcludes>) {
+        delegate.fileSystemDefaultExcludes(action)
+    }
 }

--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
@@ -16,6 +16,7 @@
 
 package org.gradle.caching.example;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import com.google.inject.AbstractModule;
@@ -488,7 +489,8 @@ class BuildCacheClientModule extends AbstractModule {
             stat,
             virtualFileSystem,
             locations -> locations.forEach(System.out::println),
-            statisticsCollector
+            statisticsCollector,
+            ImmutableList.of()
         );
     }
 }

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -18,11 +18,27 @@ package org.gradle.internal.vfs
 
 import org.apache.tools.ant.DirectoryScanner
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.Issue
 
 class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
     private static final EXCLUDED_FILE_NAME = "my-excluded-file.txt"
+    private static final DIRECTORY_SCANNER_DEPRECATION =
+        "Mutating org.apache.tools.ant.DirectoryScanner default excludes has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
+        "For example: fileSystemDefaultExcludes.add(\"**/node_modules\"). " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
+    private static final DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION =
+        "Configuring file-system default excludes via both " +
+        "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
+        "Remove the DirectoryScanner calls from your settings script. " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
     private static final DEFAULT_EXCLUDES = [
         "**/%*%",
         "**/.#*",
@@ -86,6 +102,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         def copyOfExcludedFile = outputDir.file(EXCLUDED_FILE_NAME)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -93,7 +110,11 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        if (!GradleContextualExecuter.configCache) {
+            // settingsEvaluated re-runs on every non-CC build, so the deprecation re-fires.
+            // On a CC hit, settings come from cache and the user's DirectoryScanner mutation is not re-executed.
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -103,6 +124,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         settingsFile << addDefaultExclude(EXCLUDED_FILE_NAME)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -110,6 +132,9 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
+        if (!GradleContextualExecuter.configCache) {
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -138,6 +163,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         List<String> defaultExcludesInTask = DEFAULT_EXCLUDES.toSorted()
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         fails "copyTask"
 
         then:
@@ -153,6 +179,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         settingsFile << removeDefaultExclude(defaultExclude)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -160,6 +187,9 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         defaultExcludeFile.text = "changed"
+        if (!GradleContextualExecuter.configCache) {
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -214,6 +244,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         file('input/legacy-excluded.txt').text = "from legacy API"
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -93,6 +93,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -162,6 +163,62 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
+    }
+
+    def "default excludes defined via settings.fileSystemDefaultExcludes are used"() {
+        settingsFile << """
+            fileSystemDefaultExcludes.add('**/${EXCLUDED_FILE_NAME}')
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists()
+
+        when:
+        excludedFile.text = "changed"
+        run "copyTask"
+        then:
+        skipped(":copyTask")
+    }
+
+    def "settings.fileSystemDefaultExcludes can remove a built-in default exclude"() {
+        def defaultExclude = '.gitignore'
+        def defaultExcludeFile = file("input/$defaultExclude")
+        defaultExcludeFile << "some content"
+
+        settingsFile << """
+            fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - '**/${defaultExclude}')
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/$defaultExclude").exists()
+
+        when:
+        defaultExcludeFile.text = "changed"
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+    }
+
+    def "settings.fileSystemDefaultExcludes wins when both APIs configure the defaults"() {
+        // The new Settings API takes precedence; mutations to the legacy DirectoryScanner static state are ignored.
+        settingsFile << """
+            ${DirectoryScanner.name}.addDefaultExclude('**/legacy-excluded.txt')
+            fileSystemDefaultExcludes.add('**/${EXCLUDED_FILE_NAME}')
+        """
+        file('input/legacy-excluded.txt').text = "from legacy API"
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists() // new API exclude applied
+        outputDir.file('legacy-excluded.txt').exists() // legacy mutation ignored
     }
 
     private static String addDefaultExclude(String excludedFileName = EXCLUDED_FILE_NAME) {

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -235,6 +235,125 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         executedAndNotSkipped(":copyTask")
     }
 
+    def "fileSystemDefaultExcludes block supports add and remove"() {
+        def defaultExclude = '.gitignore'
+        file("input/$defaultExclude") << "some content"
+
+        settingsFile << """
+            fileSystemDefaultExcludes {
+                add('**/${EXCLUDED_FILE_NAME}')
+                remove('**/${defaultExclude}')
+            }
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists()                 // added exclude applied
+        file("build/output/$defaultExclude").exists() // built-in exclude removed
+    }
+
+    def "fileSystemDefaultExcludes block can remove multiple built-in excludes at once"() {
+        file("input/.gitignore") << "i"
+        file("input/.gitattributes") << "a"
+
+        settingsFile << """
+            fileSystemDefaultExcludes {
+                remove('**/.gitignore', '**/.gitattributes')
+            }
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").exists()
+        file("build/output/.gitattributes").exists()
+    }
+
+    def "fileSystemDefaultExcludes block can clear all default excludes"() {
+        given:
+        file("input/.gitignore") << "ignored"
+        file("input/.git/config") << "gitdir"
+
+        settingsFile << """
+            fileSystemDefaultExcludes {
+                clear()
+            }
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").exists()
+        file("build/output/.git/config").exists()
+    }
+
+    def "settings.fileSystemDefaultExcludes can clear all built-in default excludes"() {
+        // The andstatus 'include everything' use case: previously required wiping the Ant
+        // DirectoryScanner and adding a dummy entry; fileSystemDefaultExcludes.empty() now does it directly.
+        given:
+        file("input/.gitignore") << "ignored"
+        file("input/.git/config") << "gitdir"
+
+        settingsFile << """
+            fileSystemDefaultExcludes.empty()
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").exists()
+        file("build/output/.git/config").exists()
+
+        when: "nothing changes, the empty set is stable across builds (incl. a configuration-cache hit)"
+        run "copyTask"
+        then:
+        skipped(":copyTask")
+
+        when: "a now-included file changes, the task re-runs"
+        file("input/.gitignore").text = "changed"
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").text == "changed"
+    }
+
+    def "legacy DirectoryScanner mutation can clear all default excludes (deprecated)"() {
+        // The original andstatus idiom: wipe every default exclude via the deprecated Ant API.
+        // Verifies the legacy clear-all path still results in 'include everything', end-to-end.
+        given:
+        file("input/.gitignore") << "ignored"
+        file("input/.git/config") << "gitdir"
+
+        settingsFile << """
+            ${DirectoryScanner.name}.defaultExcludes.each { ${DirectoryScanner.name}.removeDefaultExclude(it) }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").exists()
+        file("build/output/.git/config").exists()
+
+        when: "a now-included file changes, the task re-runs"
+        file("input/.gitignore").text = "changed"
+        if (!GradleContextualExecuter.configCache) {
+            // settingsEvaluated re-runs on every non-CC build, so the deprecation re-fires.
+            // On a CC hit, settings come from cache and the user's DirectoryScanner mutation is not re-executed.
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/.gitignore").text == "changed"
+    }
+
     def "settings.fileSystemDefaultExcludes wins when both APIs configure the defaults"() {
         // The new Settings API takes precedence; mutations to the legacy DirectoryScanner static state are ignored.
         settingsFile << """

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -71,13 +71,13 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
         VirtualFileSystem virtualFileSystem,
         WriteListener writeListener,
         DirectorySnapshotterStatistics.Collector statisticsCollector,
-        String... defaultExcludes
+        ImmutableList<String> defaultExcludes
     ) {
         this.stringInterner = stringInterner;
         this.stat = stat;
         this.writeListener = writeListener;
         this.statisticsCollector = statisticsCollector;
-        this.defaultExcludes = ImmutableList.copyOf(defaultExcludes);
+        this.defaultExcludes = defaultExcludes;
         this.directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, this.defaultExcludes, statisticsCollector);
         this.hasher = hasher;
         this.virtualFileSystem = virtualFileSystem;

--- a/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
+++ b/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.vfs.impl
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.file.FileException
@@ -53,7 +54,8 @@ abstract class AbstractFileSystemAccessTest extends Specification {
         fileSystem::stat,
         TestFiles.virtualFileSystem(),
         updateListener,
-        statisticsCollector
+        statisticsCollector,
+        ImmutableList.of()
     )
 
     void allowFileSystemAccess(boolean allow) {

--- a/platforms/core-runtime/files/build.gradle.kts
+++ b/platforms/core-runtime/files/build.gradle.kts
@@ -8,9 +8,9 @@ description = "Base tools to work with files"
 dependencies {
     api(projects.stdlibJavaExtensions)
 
+    api(libs.guava)
     api(libs.jsr305)
 
-    implementation(libs.guava)
     implementation(libs.slf4jApi)
 
     compileOnly(libs.jspecify)

--- a/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/excludes/GradleDefaultExcludes.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/excludes/GradleDefaultExcludes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.file.excludes;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The built-in set of patterns Gradle excludes by default from file collection
+ * scanning (copy, archive, file collections, etc.).
+ *
+ * <p>Historically these were sourced from {@code org.apache.tools.ant.DirectoryScanner.DEFAULTEXCLUDES}.
+ * Gradle now owns this list directly so it can be evolved independently of Ant and so the
+ * Ant dependency can eventually be removed from Gradle's runtime classpath.</p>
+ */
+@NullMarked
+public final class GradleDefaultExcludes {
+
+    private GradleDefaultExcludes() {
+    }
+
+    /**
+     * The default exclude patterns. Ported verbatim from Ant 1.10.17's
+     * {@code DirectoryScanner.DEFAULTEXCLUDES} to preserve behavioral parity.
+     */
+    public static final ImmutableList<String> DEFAULT_EXCLUDES = ImmutableList.<String>builder().add(
+        // Miscellaneous typical temporary files
+        "**/*~",
+        "**/#*#",
+        "**/.#*",
+        "**/%*%",
+        "**/._*",
+
+        // CVS
+        "**/CVS",
+        "**/CVS/**",
+        "**/.cvsignore",
+
+        // SCCS
+        "**/SCCS",
+        "**/SCCS/**",
+
+        // Visual SourceSafe
+        "**/vssver.scc",
+
+        // Subversion
+        "**/.svn",
+        "**/.svn/**",
+
+        // Git
+        "**/.git",
+        "**/.git/**",
+        "**/.gitattributes",
+        "**/.gitignore",
+        "**/.gitmodules",
+
+        // Mercurial
+        "**/.hg",
+        "**/.hg/**",
+        "**/.hgignore",
+        "**/.hgsub",
+        "**/.hgsubstate",
+        "**/.hgtags",
+
+        // Bazaar
+        "**/.bzr",
+        "**/.bzr/**",
+        "**/.bzrignore",
+
+        // Mac OSX
+        "**/.DS_Store"
+    ).build();
+
+    public static final ImmutableSet<String> DEFAULT_EXCLUDES_SET = ImmutableSet.copyOf(DEFAULT_EXCLUDES);
+}

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -235,6 +235,29 @@ See the [Timestamp for files inside archives](userguide/working_with_files.html#
 Authors of custom [`BuildCacheService`](javadoc/org/gradle/caching/BuildCacheService.html) implementations can now obtain cache entry content as an `InputStream` via [`BuildCacheEntryWriter.getInputStream()`](javadoc/org/gradle/caching/BuildCacheEntryWriter.html#getInputStream()), as an alternative to writing to an `OutputStream` via `writeTo`.
 Consuming an `InputStream` can be more efficient for I/O, especially for asynchronous HTTP clients.
 
+#### `Settings.fileSystemDefaultExcludes` for configuring default file-system excludes
+
+Gradle's [file operations](userguide/working_with_files.html#sec:file_trees) (copy, archive, file collections) automatically exclude common version-control directories and OS metadata files.
+
+Previously, customizing these patterns required importing and mutating [`org.apache.tools.ant.DirectoryScanner`](https://javadoc.io/static/org.apache.ant/ant/1.10.17/org/apache/tools/ant/DirectoryScanner.html), a process-global, static-mutable API inherited from [Apache Ant](https://ant.apache.org/).
+This coupling has been a long-standing source of bugs: `DirectoryScanner` mutations are invisible to the configuration cache, can break tasks like `bootJar` and the [Distribution plugin](userguide/distribution_plugin.html) when excludes are changed mid-build, and behave inconsistently across composite builds.
+It also blocks Gradle's ongoing effort to remove [Ant](userguide/ant.html) from its runtime classpath.
+
+Gradle now provides a [`fileSystemDefaultExcludes`](javadoc/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--) property on [`Settings`](javadoc/org/gradle/api/initialization/Settings.html), giving build authors a safe and idiomatic way to configure these patterns:
+
+```kotlin
+// settings.gradle.kts
+// Add a custom exclude
+fileSystemDefaultExcludes.add("**/node_modules")
+
+// Remove a built-in exclude
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+```
+
+The legacy `DirectoryScanner` mutation is now deprecated and will be removed in Gradle 10.
+
+See the [Working with Files](userguide/working_with_files.html#sec:change_default_excludes) section in the Gradle User Manual for more information.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -247,11 +247,10 @@ Gradle now provides a [`fileSystemDefaultExcludes`](javadoc/org/gradle/api/initi
 
 ```kotlin
 // settings.gradle.kts
-// Add a custom exclude
-fileSystemDefaultExcludes.add("**/node_modules")
-
-// Remove a built-in exclude
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+fileSystemDefaultExcludes {
+    add("**/node_modules")       // add a custom exclude
+    remove("**/.gitignore")      // remove a built-in exclude
+}
 ```
 
 The legacy `DirectoryScanner` mutation is now deprecated and will be removed in Gradle 10.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -240,8 +240,8 @@ Consuming an `InputStream` can be more efficient for I/O, especially for asynchr
 Gradle's [file operations](userguide/working_with_files.html#sec:file_trees) (copy, archive, file collections) automatically exclude common version-control directories and OS metadata files.
 
 Previously, customizing these patterns required importing and mutating [`org.apache.tools.ant.DirectoryScanner`](https://javadoc.io/static/org.apache.ant/ant/1.10.17/org/apache/tools/ant/DirectoryScanner.html), a process-global, static-mutable API inherited from [Apache Ant](https://ant.apache.org/).
-This coupling has been a long-standing source of bugs: `DirectoryScanner` mutations are invisible to the configuration cache, can break tasks like `bootJar` and the [Distribution plugin](userguide/distribution_plugin.html) when excludes are changed mid-build, and behave inconsistently across composite builds.
-It also blocks Gradle's ongoing effort to remove [Ant](userguide/ant.html) from its runtime classpath.
+This coupling — a process-global, static-mutable API — has been a long-standing source of bugs and complexity: keeping it working with the configuration cache and file-system watching required
+dedicated plumbing.
 
 Gradle now provides a [`fileSystemDefaultExcludes`](javadoc/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--) property on [`Settings`](javadoc/org/gradle/api/initialization/Settings.html), giving build authors a safe and idiomatic way to configure these patterns:
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -272,11 +272,10 @@ include::sample[dir="snippets/reference/gradle-types/fileTrees/groovy",files="bu
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable].
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — the same defaults as Ant.
-For the complete default exclude list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — version-control directories such as `**&#47;.git` and OS metadata such as `**&#47;.DS_Store`.
 
 [[sec:change_default_excludes]]
-If those default excludes prove problematic, you can work around the issue by changing the default excludes in the settings script:
+If those default excludes prove problematic, you can change them in the settings script via the link:{javadocPath}/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--[`fileSystemDefaultExcludes`] property:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -272,7 +272,7 @@ include::sample[dir="snippets/reference/gradle-types/fileTrees/groovy",files="bu
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable].
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — version-control directories such as `**&#47;.git` and OS metadata such as `**&#47;.DS_Store`.
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience, such as version-control directories (`**&#47;.git`) and OS metadata files (`**&#47;.DS_Store`).
 
 [[sec:change_default_excludes]]
 If those default excludes prove problematic, you can change them in the settings script via the link:{javadocPath}/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--[`fileSystemDefaultExcludes`] property:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -186,6 +186,30 @@ Since the previous version was 4.0.29, the link:https://groovy-lang.org/changelo
 [[v9_deprecations_9_6]]
 === Deprecations
 
+[[directoryscanner_default_excludes_deprecation]]
+==== Deprecation of configuring default file-system excludes via Ant's `DirectoryScanner`
+
+Configuring Gradle's default file-system exclude patterns by mutating `org.apache.tools.ant.DirectoryScanner` (for example, calling `DirectoryScanner.addDefaultExclude(...)` or `DirectoryScanner.removeDefaultExclude(...)` from `settings.gradle(.kts)`) is now deprecated.
+This direct dependency on Ant's static mutable state has been a long-standing source of fragility (see issues link:https://github.com/gradle/gradle/issues/11176[#11176], link:https://github.com/gradle/gradle/issues/11177[#11177]) and prevents Gradle from removing Ant from its runtime classpath.
+
+Use the new `Settings.fileSystemDefaultExcludes` property instead:
+
+[source,kotlin]
+----
+// settings.gradle.kts
+fileSystemDefaultExcludes.add("**/node_modules")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+----
+
+[source,groovy]
+----
+// settings.gradle
+fileSystemDefaultExcludes.add("**/node_modules")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+----
+
+If both APIs are used in the same build, the `Settings.fileSystemDefaultExcludes` property takes precedence and the `DirectoryScanner` mutation is ignored.
+
 [[deprecated_implicit_lookup_in_parent_projects]]
 ==== Deprecation of implicit lookup of properties and methods in parent projects
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -194,19 +194,26 @@ This direct dependency on Ant's static mutable state has been a long-standing so
 
 Use the new `Settings.fileSystemDefaultExcludes` property instead:
 
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
 [source,kotlin]
 ----
-// settings.gradle.kts
 fileSystemDefaultExcludes.add("**/node_modules")
 fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
 ----
-
+======
+[.multi-language-sample]
+======
+.settings.gradle
 [source,groovy]
 ----
-// settings.gradle
 fileSystemDefaultExcludes.add("**/node_modules")
 fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
 ----
+======
+=====
 
 If both APIs are used in the same build, the `Settings.fileSystemDefaultExcludes` property takes precedence and the `DirectoryScanner` mutation is ignored.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -190,7 +190,7 @@ Since the previous version was 4.0.29, the link:https://groovy-lang.org/changelo
 ==== Deprecation of configuring default file-system excludes via Ant's `DirectoryScanner`
 
 Configuring Gradle's default file-system exclude patterns by mutating `org.apache.tools.ant.DirectoryScanner` (for example, calling `DirectoryScanner.addDefaultExclude(...)` or `DirectoryScanner.removeDefaultExclude(...)` from `settings.gradle(.kts)`) is now deprecated.
-This direct dependency on Ant's static mutable state has been a long-standing source of fragility (see issues link:https://github.com/gradle/gradle/issues/11176[#11176], link:https://github.com/gradle/gradle/issues/11177[#11177]) and prevents Gradle from removing Ant from its runtime classpath.
+This direct dependency on Ant's static mutable state has been a long-standing source of fragility (see issues link:https://github.com/gradle/gradle/issues/11176[#11176], link:https://github.com/gradle/gradle/issues/11177[#11177]).
 
 Use the new `Settings.fileSystemDefaultExcludes` property instead:
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -200,8 +200,10 @@ Use the new `Settings.fileSystemDefaultExcludes` property instead:
 .settings.gradle.kts
 [source,kotlin]
 ----
-fileSystemDefaultExcludes.add("**/node_modules")
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+fileSystemDefaultExcludes {
+    add("**/node_modules")
+    remove("**/.gitignore")
+}
 ----
 ======
 [.multi-language-sample]
@@ -209,8 +211,10 @@ fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
 .settings.gradle
 [source,groovy]
 ----
-fileSystemDefaultExcludes.add("**/node_modules")
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+fileSystemDefaultExcludes {
+    add "**/node_modules"
+    remove "**/.gitignore"
+}
 ----
 ======
 =====

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude('**/.git')
-DirectoryScanner.removeDefaultExclude('**/.git/**')
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
@@ -1,4 +1,6 @@
 // tag::change-default-exclusions[]
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
+fileSystemDefaultExcludes {
+    remove '**/.git', '**/.git/**'
+}
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude("**/.git")
-DirectoryScanner.removeDefaultExclude("**/.git/**")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
@@ -1,4 +1,6 @@
 // tag::change-default-exclusions[]
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
+fileSystemDefaultExcludes {
+    remove("**/.git", "**/.git/**")
+}
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude('**/.git')
-DirectoryScanner.removeDefaultExclude('**/.git/**')
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
@@ -1,4 +1,6 @@
 // tag::change-default-exclusions[]
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
+fileSystemDefaultExcludes {
+    remove '**/.git', '**/.git/**'
+}
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude("**/.git")
-DirectoryScanner.removeDefaultExclude("**/.git/**")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
@@ -1,4 +1,6 @@
 // tag::change-default-exclusions[]
-fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
+fileSystemDefaultExcludes {
+    remove("**/.git", "**/.git/**")
+}
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -29,6 +29,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.declarative.dsl.model.annotations.Adding;
@@ -466,4 +467,21 @@ public interface Settings extends PluginAware, ExtensionAware {
     @Incubating
     @HiddenInDefinition
     void defaults(Action<? super SharedModelDefaults> action);
+
+    /**
+     * Returns the default exclude patterns used when scanning the file system for file collections
+     * (copy, archive, file collections, etc.).
+     *
+     * <p>The set is initialized with Gradle's built-in defaults (entries for common version-control
+     * directories such as <code>**&#47;.git</code> and OS metadata such as <code>**&#47;.DS_Store</code>).
+     * Modify the property in the settings script to customize the patterns for this build.</p>
+     *
+     * <p>Changes after settings evaluation are not honored.</p>
+     *
+     * @return the property controlling the default exclude patterns
+     * @since 9.6.0
+     */
+    @Incubating
+    @HiddenInDefinition
+    SetProperty<String> getFileSystemDefaultExcludes();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -479,7 +479,7 @@ public interface Settings extends PluginAware, ExtensionAware {
      * <p>Changes after settings evaluation are not honored.</p>
      *
      * @return the property controlling the default exclude patterns
-     * @since 9.6.0
+     * @since 9.7.0
      */
     @Incubating
     @HiddenInDefinition

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -23,6 +23,7 @@ import org.gradle.api.UnknownProjectException;
 import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.api.file.BuildLayout;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.initialization.files.FileSystemDefaultExcludes;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.ExtensionAware;
@@ -484,4 +485,26 @@ public interface Settings extends PluginAware, ExtensionAware {
     @Incubating
     @HiddenInDefinition
     SetProperty<String> getFileSystemDefaultExcludes();
+
+    /**
+     * Configures the {@linkplain #getFileSystemDefaultExcludes() default file-system exclude patterns} for
+     * this build using add/remove/clear operations, as a more convenient alternative to mutating the
+     * property directly.
+     *
+     * <p>For example, to include version-control metadata that is excluded by default:</p>
+     * <pre>
+     * fileSystemDefaultExcludes {
+     *     remove("**&#47;.gitignore")
+     *     remove("**&#47;.gitattributes")
+     * }
+     * </pre>
+     *
+     * <p>Changes after settings evaluation are not honored.</p>
+     *
+     * @param action the configuration to apply
+     * @since 9.7.0
+     */
+    @Incubating
+    @HiddenInDefinition
+    void fileSystemDefaultExcludes(Action<? super FileSystemDefaultExcludes> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/files/FileSystemDefaultExcludes.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/files/FileSystemDefaultExcludes.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.initialization.files;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.initialization.Settings;
+
+/**
+ * Configures the {@linkplain Settings#getFileSystemDefaultExcludes() default file-system exclude patterns}
+ * used when scanning the file system for file collections (copy, archive, file collections, etc.).
+ *
+ * <p>Obtained via {@link Settings#fileSystemDefaultExcludes(org.gradle.api.Action)}. Operations are applied,
+ * in order, on top of Gradle's built-in defaults (entries for common version-control directories such as
+ * <code>**&#47;.git</code> and OS metadata such as <code>**&#47;.DS_Store</code>).</p>
+ *
+ * @since 9.7.0
+ */
+@Incubating
+public interface FileSystemDefaultExcludes {
+
+    /**
+     * Adds the given patterns to the default excludes, on top of Gradle's built-in defaults.
+     *
+     * @param patterns the Ant-style patterns to add
+     * @since 9.7.0
+     */
+    void add(String... patterns);
+
+    /**
+     * Removes the given patterns from the default excludes, for example a built-in default such as
+     * <code>**&#47;.gitignore</code>. Removing a pattern that is not currently present has no effect.
+     *
+     * @param patterns the Ant-style patterns to remove
+     * @since 9.7.0
+     */
+    void remove(String... patterns);
+
+    /**
+     * Removes all default excludes, so that no files are excluded by default.
+     *
+     * @since 9.7.0
+     */
+    void clear();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/files/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/files/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes for configuring file-system behavior of a build at settings time.
+ */
+@org.jspecify.annotations.NullMarked
+package org.gradle.api.initialization.files;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -26,6 +26,7 @@ import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.initialization.SharedModelDefaults;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.initialization.files.FileSystemDefaultExcludes;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.internal.FeaturePreviews.Feature;
 import org.gradle.api.internal.GradleInternal;
@@ -64,6 +65,8 @@ import org.jspecify.annotations.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -446,5 +449,42 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     @Override
     public SetProperty<String> getFileSystemDefaultExcludes() {
         return fileSystemDefaultExcludes;
+    }
+
+    @Override
+    public void fileSystemDefaultExcludes(Action<? super FileSystemDefaultExcludes> action) {
+        action.execute(new DefaultFileSystemDefaultExcludes(fileSystemDefaultExcludes));
+    }
+
+    /**
+     * Backs the {@link Settings#fileSystemDefaultExcludes(Action)} block by translating add/remove/clear
+     * operations onto the {@link #getFileSystemDefaultExcludes()} property. Removal is an eager
+     * get-modify-set (the only way to subtract from a collection property); this is safe here because the
+     * block runs once at settings-evaluation time and the property's convention is an immutable constant.
+     */
+    private static class DefaultFileSystemDefaultExcludes implements FileSystemDefaultExcludes {
+
+        private final SetProperty<String> property;
+
+        DefaultFileSystemDefaultExcludes(SetProperty<String> property) {
+            this.property = property;
+        }
+
+        @Override
+        public void add(String... patterns) {
+            property.addAll(patterns);
+        }
+
+        @Override
+        public void remove(String... patterns) {
+            Set<String> resolved = new LinkedHashSet<>(property.get());
+            resolved.removeAll(Arrays.asList(patterns));
+            property.set(resolved);
+        }
+
+        @Override
+        public void clear() {
+            property.empty();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.AbstractPluginAware;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
@@ -48,6 +49,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.Actions;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.management.ToolchainManagementInternal;
 import org.gradle.internal.resource.TextUriResourceLoader;
@@ -93,6 +95,8 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
 
     private final ToolchainManagementInternal toolchainManagement;
 
+    private final SetProperty<String> fileSystemDefaultExcludes;
+
     @SuppressWarnings("this-escape")
     public DefaultSettings(
         ServiceRegistryFactory serviceRegistryFactory,
@@ -115,6 +119,11 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
         this.rootProjectDescriptor = createProjectDescriptor(null, getProjectName(settingsDir), settingsDir);
         this.dependencyResolutionManagement = services.get(DependencyResolutionManagementInternal.class);
         this.toolchainManagement = services.get(ToolchainManagementInternal.class);
+        // Created explicitly from the ObjectFactory rather than as an abstract managed property:
+        // the instantiator used for Settings does not provide a ManagedObjectRegistry, so a
+        // managed SetProperty getter cannot be synthesized here.
+        this.fileSystemDefaultExcludes = services.get(ObjectFactory.class).setProperty(String.class);
+        this.fileSystemDefaultExcludes.convention(GradleDefaultExcludes.DEFAULT_EXCLUDES);
     }
 
     private static String getProjectName(File settingsDir) {
@@ -435,5 +444,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     }
 
     @Override
-    public abstract SetProperty<String> getFileSystemDefaultExcludes();
+    public SetProperty<String> getFileSystemDefaultExcludes() {
+        return fileSystemDefaultExcludes;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.AbstractPluginAware;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
@@ -432,4 +433,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     public void defaults(Action<? super SharedModelDefaults> action) {
         action.execute(getDefaults());
     }
+
+    @Override
+    public abstract SetProperty<String> getFileSystemDefaultExcludes();
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.plugins.ExtraPropertiesExtensionInternal;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
@@ -67,6 +68,7 @@ public class SettingsFactory {
         );
         ((ExtraPropertiesExtensionInternal) settings.getExtensions().getExtraProperties())
             .setGradleProperties(gradleProperties);
+        settings.getFileSystemDefaultExcludes().convention(GradleDefaultExcludes.DEFAULT_EXCLUDES);
         return new SettingsState(settings, serviceRegistryFactory.services);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.plugins.ExtraPropertiesExtensionInternal;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.groovy.scripts.ScriptSource;
-import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
@@ -68,7 +67,6 @@ public class SettingsFactory {
         );
         ((ExtraPropertiesExtensionInternal) settings.getExtensions().getExtraProperties())
             .setGradleProperties(gradleProperties);
-        settings.getFileSystemDefaultExcludes().convention(GradleDefaultExcludes.DEFAULT_EXCLUDES);
         return new SettingsState(settings, serviceRegistryFactory.services);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.file;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.BuildAdapter;
 import org.gradle.api.initialization.Settings;
@@ -26,12 +27,30 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
 import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefaultExcludesProvider {
 
     private ImmutableList<String> currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
+
+    /**
+     * The DirectoryScanner state we last observed or wrote ourselves. Used to detect user-side
+     * mutations to {@link DirectoryScanner} (the deprecated legacy path) without false-positives
+     * from the mirror writes this class performs in {@link #syncDirectoryScanner(Set)}.
+     */
+    private ImmutableSet<String> lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+
+    /**
+     * Accumulated additions across every settings script seen this session. Each Settings has its
+     * own {@code fileSystemDefaultExcludes} property; the historical DirectoryScanner-based path
+     * was process-global, so each script's contribution stacked. Preserve that behavior by
+     * tracking deltas vs the baseline across all scripts and recomputing the resolved set as
+     * {@code baseline + additions - removals}.
+     */
+    private final Set<String> accumulatedAdditions = new LinkedHashSet<>();
+    private final Set<String> accumulatedRemovals = new LinkedHashSet<>();
 
     private final AnonymousListenerBroadcast<FileSystemDefaultExcludesListener> broadcast;
 
@@ -43,6 +62,9 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
                 currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
+                lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                accumulatedAdditions.clear();
+                accumulatedRemovals.clear();
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
             }
         });
@@ -51,10 +73,40 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
             @Override
             public void settingsEvaluated(Settings settings) {
-                currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
-                broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
+                ImmutableSet<String> baseline = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                Set<String> fromSettings = settings.getFileSystemDefaultExcludes().get();
+                ImmutableSet<String> fromAnt = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
+
+                boolean settingsCustomized = !fromSettings.equals(baseline);
+                // Compare against what we last wrote/observed, not against the original baseline:
+                // otherwise our own mirror writes from a previous settings.gradle would look like
+                // user-side Ant mutations and trigger false-positive deprecations.
+                boolean antMutatedByUser = !fromAnt.equals(lastObservedDirectoryScannerState);
+
+                if (settingsCustomized) {
+                    if (antMutatedByUser) {
+                        warnAntMutationIgnored();
+                    }
+                    accumulateDelta(baseline, fromSettings);
+                } else if (antMutatedByUser) {
+                    warnAntMutationDeprecated();
+                    accumulateDelta(lastObservedDirectoryScannerState, fromAnt);
+                }
+
+                Set<String> resolved = new LinkedHashSet<>(GradleDefaultExcludes.DEFAULT_EXCLUDES);
+                resolved.addAll(accumulatedAdditions);
+                resolved.removeAll(accumulatedRemovals);
+
+                syncDirectoryScanner(resolved);
+                applyDefaultExcludes(resolved);
             }
         });
+    }
+
+    private void applyDefaultExcludes(Set<String> resolved) {
+        lastObservedDirectoryScannerState = ImmutableSet.copyOf(resolved);
+        currentDefaultExcludes = ImmutableList.copyOf(resolved);
+        broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
     }
 
     @Override
@@ -64,6 +116,34 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
     @Override
     public void updateCurrentDefaultExcludes(Set<String> excludes) {
+        syncDirectoryScanner(excludes);
+
+        // Re-derive the accumulators from the supplied state so a later settingsEvaluated
+        // call (which is unusual after this point but defensible) stacks correctly on top.
+        accumulatedAdditions.clear();
+        accumulatedRemovals.clear();
+        accumulateDelta(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET, excludes);
+
+        applyDefaultExcludes(excludes);
+    }
+
+    /**
+     * Records the diff between {@code before} and {@code after} into the running accumulators.
+     */
+    private void accumulateDelta(Set<String> before, Set<String> after) {
+        for (String e : after) {
+            if (!before.contains(e)) {
+                accumulatedAdditions.add(e);
+            }
+        }
+        for (String e : before) {
+            if (!after.contains(e)) {
+                accumulatedRemovals.add(e);
+            }
+        }
+    }
+
+    private static void syncDirectoryScanner(Set<String> excludes) {
         for (String oldExclude : DirectoryScanner.getDefaultExcludes()) {
             if (!excludes.contains(oldExclude)) {
                 DirectoryScanner.removeDefaultExclude(oldExclude);

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -22,10 +22,12 @@ import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.BuildAdapter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
 import org.gradle.internal.file.excludes.GradleDefaultExcludes;
+import org.jspecify.annotations.NonNull;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,6 +41,12 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
      * The DirectoryScanner state we last observed or wrote ourselves. Used to detect user-side
      * mutations to {@link DirectoryScanner} (the deprecated legacy path) without false-positives
      * from the mirror writes this class performs in {@link #syncDirectoryScanner(Set)}.
+     *
+     * <p>Initialized to {@link DirectoryScanner#getDefaultExcludes()} immediately after
+     * {@link DirectoryScanner#resetDefaultExcludes()} in {@code afterStart}, so the user-mutation
+     * diff stays correct even if Ant's {@code DEFAULTEXCLUDES} ever drifts from
+     * {@link GradleDefaultExcludes#DEFAULT_EXCLUDES_SET} (the parity test would catch the drift,
+     * but we shouldn't emit false-positive deprecation warnings if it slips through).</p>
      */
     private ImmutableSet<String> lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
 
@@ -62,7 +70,11 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
                 currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
-                lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                // Snapshot the freshly-reset DirectoryScanner state rather than assuming it
+                // matches GradleDefaultExcludes.DEFAULT_EXCLUDES_SET. If Ant's DEFAULTEXCLUDES
+                // ever drifts from our port, the user-mutation diff still works correctly and
+                // we don't emit false-positive deprecations.
+                lastObservedDirectoryScannerState = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
                 accumulatedAdditions.clear();
                 accumulatedRemovals.clear();
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
@@ -72,12 +84,11 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         listenerManager.addListener(new BuildAdapter() {
 
             @Override
-            public void settingsEvaluated(Settings settings) {
-                ImmutableSet<String> baseline = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+            public void settingsEvaluated(@NonNull Settings settings) {
                 Set<String> fromSettings = settings.getFileSystemDefaultExcludes().get();
                 ImmutableSet<String> fromAnt = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
 
-                boolean settingsCustomized = !fromSettings.equals(baseline);
+                boolean settingsCustomized = !fromSettings.equals(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET);
                 // Compare against what we last wrote/observed, not against the original baseline:
                 // otherwise our own mirror writes from a previous settings.gradle would look like
                 // user-side Ant mutations and trigger false-positive deprecations.
@@ -87,7 +98,7 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
                     if (antMutatedByUser) {
                         warnAntMutationIgnored();
                     }
-                    accumulateDelta(baseline, fromSettings);
+                    accumulateDelta(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET, fromSettings);
                 } else if (antMutatedByUser) {
                     warnAntMutationDeprecated();
                     accumulateDelta(lastObservedDirectoryScannerState, fromAnt);
@@ -129,16 +140,26 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
     /**
      * Records the diff between {@code before} and {@code after} into the running accumulators.
+     * A pattern explicitly re-included by a later script is removed from {@code accumulatedRemovals}
+     * so a later script can reverse an earlier script's removal; symmetrically, a pattern explicitly
+     * dropped by a later script is removed from {@code accumulatedAdditions}.
      */
     private void accumulateDelta(Set<String> before, Set<String> after) {
         for (String e : after) {
             if (!before.contains(e)) {
                 accumulatedAdditions.add(e);
+            } else {
+                // A baseline pattern present in `after` means this script wants it kept;
+                // cancel any earlier removal.
+                accumulatedRemovals.remove(e);
             }
         }
         for (String e : before) {
             if (!after.contains(e)) {
                 accumulatedRemovals.add(e);
+                // A baseline pattern absent from `after` means this script wants it gone;
+                // cancel any earlier explicit addition (defensive — additions are non-baseline).
+                accumulatedAdditions.remove(e);
             }
         }
     }
@@ -152,8 +173,24 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         for (String exclude : excludes) {
             DirectoryScanner.addDefaultExclude(exclude);
         }
+    }
 
-        currentDefaultExcludes = ImmutableList.copyOf(excludes);
-        broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
+    private static void warnAntMutationDeprecated() {
+        DeprecationLogger.deprecateAction("Mutating org.apache.tools.ant.DirectoryScanner default excludes")
+            .withAdvice("Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
+                "For example: fileSystemDefaultExcludes.add(\"**/node_modules\").")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
+            .nagUser();
+    }
+
+    private static void warnAntMutationIgnored() {
+        DeprecationLogger.deprecateAction("Configuring file-system default excludes via both " +
+                "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes")
+            .withAdvice("settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
+                "Remove the DirectoryScanner calls from your settings script.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
+            .nagUser();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -24,13 +24,14 @@ import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 
 import java.util.List;
 import java.util.Set;
 
 public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefaultExcludesProvider {
 
-    private ImmutableList<String> currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
+    private ImmutableList<String> currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
 
     private final AnonymousListenerBroadcast<FileSystemDefaultExcludesListener> broadcast;
 
@@ -41,7 +42,7 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             @Override
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
-                currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
+                currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -252,7 +252,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 virtualFileSystem,
                 writeListener,
                 statisticsCollector,
-                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
+                GradleDefaultExcludes.DEFAULT_EXCLUDES
             );
             listenerManager.addListener(defaultFileSystemAccess);
 
@@ -357,7 +357,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 root,
                 writeListener,
                 statisticsCollector,
-                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
+                GradleDefaultExcludes.DEFAULT_EXCLUDES
             );
 
             listenerManager.addListener(buildSessionsScopedVirtualFileSystem);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -19,7 +19,6 @@ package org.gradle.internal.service.scopes;
 import com.google.common.annotations.VisibleForTesting;
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileSystems;
-import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildSessionScopeFileTimeStampInspector;
@@ -60,6 +59,7 @@ import org.gradle.internal.file.DefaultFileSystemDefaultExcludesProvider;
 import org.gradle.internal.file.FileMetadataAccessor;
 import org.gradle.internal.file.FileSystemDefaultExcludesProvider;
 import org.gradle.internal.file.Stat;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
@@ -252,7 +252,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 virtualFileSystem,
                 writeListener,
                 statisticsCollector,
-                DirectoryScanner.getDefaultExcludes()
+                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
             );
             listenerManager.addListener(defaultFileSystemAccess);
 
@@ -357,7 +357,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 root,
                 writeListener,
                 statisticsCollector,
-                DirectoryScanner.getDefaultExcludes()
+                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
             );
 
             listenerManager.addListener(buildSessionsScopedVirtualFileSystem);

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsCommonTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsCommonTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.plugins.DefaultPluginManager
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.problems.ProblemReporter
 import org.gradle.api.problems.Problems
 import org.gradle.configuration.ScriptPluginFactory
@@ -67,6 +68,7 @@ class DefaultSettingsCommonTest extends Specification {
         settingsServices.get(FeatureFlags) >> previews
         settingsServices.get(DefaultPluginManager) >>> [pluginManager, null]
         settingsServices.get(InstantiatorFactory) >> Stub(InstantiatorFactory)
+        settingsServices.get(ObjectFactory) >> TestUtil.objectFactory()
         settingsServices.get(DependencyResolutionManagementInternal) >> Stub(DependencyResolutionManagementInternal)
         settingsServices.get(Problems) >> Stub(Problems) {
             getReporter() >> Stub(ProblemReporter)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProviderTest.groovy
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.file
+
+import org.apache.tools.ant.DirectoryScanner
+import org.gradle.BuildListener
+import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.initialization.RootBuildLifecycleListener
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.event.AnonymousListenerBroadcast
+import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener
+import org.gradle.internal.file.excludes.GradleDefaultExcludes
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter
+import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+/**
+ * Unit coverage for the cross-settings-script accumulator and the property-vs-Ant precedence
+ * rules in {@link DefaultFileSystemDefaultExcludesProvider}. The integration tests only ever
+ * add distinct patterns per build, so the interesting accumulator branches (re-adding a removed
+ * default, cancelling a previous addition, and the "both APIs used" precedence cases) are
+ * exercised here.
+ */
+class DefaultFileSystemDefaultExcludesProviderTest extends Specification {
+
+    private static final List<String> BASELINE = GradleDefaultExcludes.DEFAULT_EXCLUDES
+
+    private final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+
+    @Rule
+    public final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    private final List<Object> registeredListeners = []
+    private final List<List<String>> broadcasts = []
+
+    private DefaultFileSystemDefaultExcludesProvider provider
+
+    def setup() {
+        DeprecationLogger.reset()
+        DeprecationLogger.init(WarningMode.All, Mock(BuildOperationProgressEventEmitter), TestUtil.problemsService(), new NoOpProblemDiagnosticsFactory().newUnlimitedStream())
+
+        def broadcastSource = { List<String> excludes -> broadcasts << excludes } as FileSystemDefaultExcludesListener
+        def broadcaster = Mock(AnonymousListenerBroadcast)
+        broadcaster.getSource() >> broadcastSource
+        def listenerManager = Mock(ListenerManager)
+        listenerManager.createAnonymousBroadcaster(FileSystemDefaultExcludesListener) >> broadcaster
+        listenerManager.addListener(_) >> { args -> registeredListeners << args[0] }
+
+        provider = new DefaultFileSystemDefaultExcludesProvider(listenerManager)
+        afterStart()
+    }
+
+    def cleanup() {
+        // The provider mutates the process-global Ant DirectoryScanner; reset it so tests don't leak.
+        DirectoryScanner.resetDefaultExcludes()
+        DeprecationLogger.reset()
+    }
+
+    def "starts from the Gradle-owned baseline and broadcasts it"() {
+        expect:
+        provider.currentDefaultExcludes as Set == BASELINE as Set
+        broadcasts.last() as Set == BASELINE as Set
+    }
+
+    def "property can add a custom exclude"() {
+        when:
+        settingsEvaluated(baselinePlus("**/node_modules"))
+
+        then:
+        provider.currentDefaultExcludes as Set == baselinePlus("**/node_modules")
+        broadcasts.last() as Set == baselinePlus("**/node_modules")
+        noDeprecationWarnings()
+    }
+
+    def "property can remove a built-in exclude"() {
+        when:
+        settingsEvaluated(baselineMinus("**/.git"))
+
+        then:
+        !provider.currentDefaultExcludes.contains("**/.git")
+        provider.currentDefaultExcludes as Set == baselineMinus("**/.git")
+        noDeprecationWarnings()
+    }
+
+    def "leaving the property at its default is not treated as a customization"() {
+        when:
+        settingsEvaluated(null)
+
+        then:
+        provider.currentDefaultExcludes as Set == BASELINE as Set
+        noDeprecationWarnings()
+    }
+
+    def "additions from multiple settings scripts stack"() {
+        when:
+        settingsEvaluated(baselinePlus("**/a"))
+        settingsEvaluated(baselinePlus("**/b"))
+
+        then:
+        provider.currentDefaultExcludes.containsAll(["**/a", "**/b"])
+        provider.currentDefaultExcludes as Set == baselinePlus("**/a", "**/b")
+    }
+
+    def "a later script can re-include a default that an earlier script removed"() {
+        when: "an earlier script removes a built-in default"
+        settingsEvaluated(baselineMinus("**/.git"))
+
+        then:
+        !provider.currentDefaultExcludes.contains("**/.git")
+
+        when: "a later script keeps the default while customizing something else"
+        settingsEvaluated(baselinePlus("**/keep"))
+
+        then: "the earlier removal is cancelled and the default is back"
+        provider.currentDefaultExcludes.contains("**/.git")
+        provider.currentDefaultExcludes.contains("**/keep")
+    }
+
+    def "a later script can cancel an addition made via the Ant path"() {
+        when: "an earlier script adds an exclude by mutating the DirectoryScanner"
+        DirectoryScanner.addDefaultExclude("**/x")
+        settingsEvaluated(null)
+
+        then:
+        provider.currentDefaultExcludes.contains("**/x")
+
+        when: "a later script removes it again via the DirectoryScanner"
+        DirectoryScanner.removeDefaultExclude("**/x")
+        settingsEvaluated(null)
+
+        then: "the earlier addition is cancelled"
+        !provider.currentDefaultExcludes.contains("**/x")
+        provider.currentDefaultExcludes as Set == BASELINE as Set
+    }
+
+    def "mutating the DirectoryScanner alone is honored but deprecated"() {
+        when:
+        DirectoryScanner.addDefaultExclude("**/antOnly")
+        settingsEvaluated(null)
+
+        then:
+        provider.currentDefaultExcludes.contains("**/antOnly")
+
+        and:
+        def warnings = deprecationWarnings()
+        warnings.size() == 1
+        warnings[0].contains("Mutating org.apache.tools.ant.DirectoryScanner default excludes has been deprecated")
+    }
+
+    def "when both APIs are used the property wins and the DirectoryScanner mutation is ignored"() {
+        when:
+        DirectoryScanner.addDefaultExclude("**/fromAnt")
+        settingsEvaluated(baselinePlus("**/fromProperty"))
+
+        then: "the property contribution is applied, the Ant mutation is dropped"
+        provider.currentDefaultExcludes.contains("**/fromProperty")
+        !provider.currentDefaultExcludes.contains("**/fromAnt")
+
+        and: "the user is told the DirectoryScanner mutation was ignored"
+        def warnings = deprecationWarnings()
+        warnings.size() == 1
+        warnings[0].contains("Configuring file-system default excludes via both")
+    }
+
+    def "restoring from the configuration cache reapplies the stored set"() {
+        when:
+        provider.updateCurrentDefaultExcludes(baselinePlus("**/restored"))
+
+        then:
+        provider.currentDefaultExcludes as Set == baselinePlus("**/restored")
+        broadcasts.last() as Set == baselinePlus("**/restored")
+    }
+
+    def "a settings script evaluated after a configuration-cache restore stacks on the restored set"() {
+        given:
+        provider.updateCurrentDefaultExcludes(baselinePlus("**/restored"))
+
+        when:
+        settingsEvaluated(baselinePlus("**/later"))
+
+        then:
+        provider.currentDefaultExcludes.containsAll(["**/restored", "**/later"])
+    }
+
+    private void afterStart() {
+        (registeredListeners.find { it instanceof RootBuildLifecycleListener } as RootBuildLifecycleListener).afterStart()
+    }
+
+    /**
+     * Drives a {@code settingsEvaluated} callback with a {@code fileSystemDefaultExcludes} property
+     * conventioned to the baseline (mirroring {@code SettingsFactory}). Pass {@code null} to leave the
+     * property at its default (uncustomized); pass an explicit set to customize it.
+     */
+    private void settingsEvaluated(Set<String> propertyValue) {
+        def property = TestUtil.objectFactory().setProperty(String)
+        property.convention(BASELINE)
+        if (propertyValue != null) {
+            property.set(propertyValue)
+        }
+        def settings = Mock(Settings) {
+            getFileSystemDefaultExcludes() >> property
+        }
+        (registeredListeners.find { it instanceof BuildListener } as BuildListener).settingsEvaluated(settings)
+    }
+
+    private List<String> deprecationWarnings() {
+        outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }*.message
+    }
+
+    private void noDeprecationWarnings() {
+        assert deprecationWarnings().isEmpty()
+    }
+
+    private static Set<String> baselinePlus(String... extra) {
+        def result = new LinkedHashSet<String>(BASELINE)
+        result.addAll(extra as List)
+        result
+    }
+
+    private static Set<String> baselineMinus(String... removed) {
+        def result = new LinkedHashSet<String>(BASELINE)
+        result.removeAll(removed as List)
+        result
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProviderTest.groovy
@@ -112,6 +112,31 @@ class DefaultFileSystemDefaultExcludesProviderTest extends Specification {
         noDeprecationWarnings()
     }
 
+    def "property can clear every default exclude"() {
+        when: "the property is set to an empty set (e.g. fileSystemDefaultExcludes.empty())"
+        settingsEvaluated([] as Set)
+
+        then: "nothing is excluded by default and no Ant-quirk workaround is needed"
+        provider.currentDefaultExcludes.isEmpty()
+        broadcasts.last().isEmpty()
+        noDeprecationWarnings()
+    }
+
+    def "removing every default via the DirectoryScanner clears the set and is deprecated"() {
+        when: "an earlier script wipes the Ant default excludes (the legacy 'include everything' idiom)"
+        DirectoryScanner.getDefaultExcludes().each { DirectoryScanner.removeDefaultExclude(it) }
+        settingsEvaluated(null)
+
+        then:
+        provider.currentDefaultExcludes.isEmpty()
+        broadcasts.last().isEmpty()
+
+        and:
+        def warnings = deprecationWarnings()
+        warnings.size() == 1
+        warnings[0].contains("Mutating org.apache.tools.ant.DirectoryScanner default excludes has been deprecated")
+    }
+
     def "additions from multiple settings scripts stack"() {
         when:
         settingsEvaluated(baselinePlus("**/a"))

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.file
+
+import org.apache.tools.ant.DirectoryScanner
+import org.gradle.internal.file.excludes.GradleDefaultExcludes
+import spock.lang.Specification
+
+/**
+ * Behavioral-parity guard for the Gradle-owned port of Ant's default excludes.
+ * If Ant ever changes its DEFAULTEXCLUDES list (e.g. on a version bump),
+ * this test fails so we can review the divergence and decide whether to track it.
+ */
+class GradleDefaultExcludesTest extends Specification {
+
+    def "Gradle default excludes match Ant's DirectoryScanner default excludes verbatim"() {
+        given:
+        DirectoryScanner.resetDefaultExcludes()
+
+        expect:
+        new HashSet<String>(GradleDefaultExcludes.DEFAULT_EXCLUDES) == new HashSet<String>(Arrays.asList(DirectoryScanner.getDefaultExcludes()))
+    }
+
+    def "GradleDefaultExcludes list is immutable"() {
+        when:
+        GradleDefaultExcludes.DEFAULT_EXCLUDES.add("**/foo")
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
@@ -217,7 +218,8 @@ public class TestFiles {
             fileSystem()::stat,
             virtualFileSystem,
             locations -> {},
-            new DirectorySnapshotterStatistics.Collector()
+            new DirectorySnapshotterStatistics.Collector(),
+            ImmutableList.of()
         );
     }
 


### PR DESCRIPTION
## Summary

Decouples Gradle's default file-system exclude patterns from `org.apache.tools.ant.DirectoryScanner` — the deepest entanglement keeping Ant on Gradle's runtime classpath. Refs [#11176](https://github.com/gradle/gradle/issues/11176) and [#11177](https://github.com/gradle/gradle/issues/11177), both open since 2019.

> **Rebased onto `master`** now that the prerequisite internal Ant-usage cleanup ([#37879](https://github.com/gradle/gradle/pull/37879)) has merged. The diff above is exclusively this change.

### What this change does

1. **`GradleDefaultExcludes`** (new constant in `platforms/core-runtime/files`) — verbatim port of Ant 1.10.17's `DirectoryScanner.DEFAULTEXCLUDES`. Gradle now owns the canonical list; a parity test guards against drift if Ant ever updates its list.

2. **`Settings.getFileSystemDefaultExcludes(): SetProperty<String>`** — new `@Incubating` public API (`@since 9.7.0`) giving build authors a first-class way to configure default excludes without importing Ant:
   ```kotlin
   // settings.gradle.kts
   fileSystemDefaultExcludes.add("**/node_modules")
   fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
   ```
   The property is created explicitly from `ObjectFactory` in the `DefaultSettings` constructor rather than as an abstract managed getter: the instantiator used for `Settings` (unlike the one for `Project`/task types) carries no `ManagedObjectRegistry`, so a synthesized managed `SetProperty` would fail at runtime.

3. **Documented deprecation** of `DirectoryScanner.add/removeDefaultExclude` mutations — fires from `DefaultFileSystemDefaultExcludesProvider.settingsEvaluated` via diff against the Gradle-owned baseline. A second warning fires when both APIs are used at once; the new Settings property always wins.

4. **Internal refactor** — `DefaultFileSystemDefaultExcludesProvider` and `VirtualFileSystemServices` now source pre-settings defaults from `GradleDefaultExcludes` rather than `DirectoryScanner`. Contributions from multiple settings scripts (composite/included builds) stack via a delta accumulator, preserving the historical process-global behavior.

5. **Docs migration** — user-guide snippets and prose updated to demonstrate the new API; the link to Ant's manual replaced with a link to the new javadoc. New upgrade-guide section at anchor `directoryscanner_default_excludes_deprecation`.

### Why now

The direction was a committed team intent in 2019 but never scheduled. The intervening years produced a recurring stream of downstream bug reports rooted in the same fragile coupling:

- [#30111](https://github.com/gradle/gradle/issues/30111) (2024) — `DirectoryScanner.removeDefaultExclude()` regression on macOS after 8.9
- [#28802](https://github.com/gradle/gradle/issues/28802) (2024) — Spring Boot `bootJar` broken when changing default excludes
- [#27225](https://github.com/gradle/gradle/issues/27225) (2023) — `DirectoryScanner` mutation breaks configuration cache
- [#26600](https://github.com/gradle/gradle/issues/26600) (2023) — `removeDefaultExclude` doesn't work with Distribution plugin
- [#13665](https://github.com/gradle/gradle/issues/13665), [#13427](https://github.com/gradle/gradle/issues/13427), [#11017](https://github.com/gradle/gradle/issues/11017)

### Deliberate non-goals

- **`PatternSpecFactory` still reads `DirectoryScanner` directly** during the build. To stay binary-behavior-compatible for the deprecation window, `DefaultFileSystemDefaultExcludesProvider` mirrors the resolved value back to `DirectoryScanner` when the new Settings API is used. The follow-up removal PR refactors `PatternSpecFactory` to listen exclusively, after which the mirror can go away.
- **`DirectoryScanner` stays on the runtime classpath** for now — it's still needed by Gradle's public `AntBuilder` API. Removing it is part of the broader Ant-removal arc, tracked separately.
- **Process-global stacking is preserved.** Each `Settings` has its own `fileSystemDefaultExcludes` property, but contributions stack across settings scripts to match the old process-global `DirectoryScanner` behavior — avoiding an additional breaking change. Whether precedence (new property vs Ant mutation) should be evaluated per-settings-script or per-session is called out as open design work.
- **Configuration-cache restore is set-based, not order-preserving.** The existing `ConfigurationCacheState` plumbing (predating this PR) serializes the excludes as an ordered list but restores them into a `Set`. Excludes behave as a set everywhere they're consumed, so this is correct today; tightening it to be order-stable is left as separate follow-up.

## Test plan

- [x] `:core:test --tests "*GradleDefaultExcludesTest*"` — parity guard against `DirectoryScanner.DEFAULTEXCLUDES` + immutability check
- [x] `:core:test --tests "*DefaultFileSystemDefaultExcludesProviderTest*"` — unit coverage for the cross-settings-script accumulator and the property-vs-Ant precedence rules (re-adding a removed default, cancelling an addition, both-APIs-ignored, CC restore)
- [x] `:core:test --tests "*DefaultSettingsTest*"` — `Settings` instantiation incl. the new property
- [x] `:snapshots:forkingIntegTest --tests "*DefaultExcludesIntegrationTest*"` — incl. new tests for the Settings API and the dual-config deprecation
- [x] `:snapshots:configCacheIntegTest --tests "*DefaultExcludesIntegrationTest*"` — same suite under configuration cache
- [x] `:docs:checkDeadInternalLinks` — verifies the new upgrade-guide anchor and updated cross-links
- [x] `sanityCheck` — binary compatibility, architecture tests, etc.
- [ ] Full CI to run
