### PR TITLE
Fix a mixup of API vs runtime elements in feature docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_create_feature_variants_of_a_library.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_create_feature_variants_of_a_library.adoc
@@ -116,8 +116,8 @@ In the example, the feature called "mongodbSupport" automatically creates these 
 
 Additionally, Gradle exposes two variant-specific configurations for external consumption:
 
-* `mongodbSupportRuntimeElements` - used by consumers to fetch the artifacts and API dependencies of this feature
-* `mongodbSupportApiElements` - used by consumers to fetch the artifacts and runtime dependencies of this feature
+* `mongodbSupportApiElements` - used by consumers to fetch the artifacts and API dependencies of this feature
+* `mongodbSupportRuntimeElements` - used by consumers to fetch the artifacts and runtime dependencies of this feature
 
 A feature variant should have a corresponding _source set_ named identically.
 


### PR DESCRIPTION
### Context

Simple doc fix.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
