### PR TITLE
Reduce memory impact of GraphStructure

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ivyservice.ResolutionParameters;
+import org.gradle.api.internal.artifacts.resolver.ResolutionAccess;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
@@ -118,6 +119,11 @@ public interface ConfigurationInternal extends DeprecatableConfiguration, Config
      */
     @Nullable
     ConfigurationInternal getConsistentResolutionSource();
+
+    /**
+     * A handle to the internal view of the results of resolution of this configuration.
+     */
+    ResolutionAccess getResolutionAccess();
 
     /**
      * Test if this configuration can either be declared against or extends another

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -45,7 +45,6 @@ import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
@@ -66,6 +65,7 @@ import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintIntern
 import org.gradle.api.internal.artifacts.ivyservice.ResolutionParameters;
 import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
 import org.gradle.api.internal.artifacts.resolver.DefaultResolutionOutputs;
 import org.gradle.api.internal.artifacts.resolver.ResolutionAccess;
 import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
@@ -85,7 +85,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -135,7 +134,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.UNRESOLVED;
-import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 import static org.gradle.util.internal.ConfigureUtil.configure;
 
 /**
@@ -750,12 +748,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         }
 
         assertThatConsistentResolutionIsPropertyConfigured();
-        ResolvedComponentResult root = consistentResolutionSource.getIncoming().getResolutionResult().getRoot();
+        ResolverResults consistentResolutionResults = consistentResolutionSource.getResolutionAccess().getResults().getValue();
+        GraphStructure structure = consistentResolutionResults.getVisitedGraph().getGraphStructureSource().get();
 
-        ImmutableList.Builder<ResolutionParameters.ModuleVersionLock> locks = ImmutableList.builder();
-        eachElement(root, component -> {
-            if (component.getId() instanceof ModuleComponentIdentifier) {
-                ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) component.getId();
+        GraphStructure.Components components = structure.components();
+        int numComponents = components.count();
+        ImmutableList.Builder<ResolutionParameters.ModuleVersionLock> locks = ImmutableList.builderWithExpectedSize(numComponents);
+        for (int i = 0; i < numComponents; i++) {
+            if (components.id(i) instanceof ModuleComponentIdentifier moduleId) {
                 locks.add(new ResolutionParameters.ModuleVersionLock(
                     moduleId.getModuleIdentifier(),
                     moduleId.getVersion(),
@@ -763,7 +763,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                     true
                 ));
             }
-        }, Actions.doNothing(), new HashSet<>());
+        }
         return locks.build();
     }
 
@@ -1762,6 +1762,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Override
     public ResolutionHost getResolutionHost() {
         return resolutionAccess.getHost();
+    }
+
+    @Override
+    public ResolutionAccess getResolutionAccess() {
+        return resolutionAccess;
     }
 
     private static class DefaultResolutionHost implements ResolutionHost {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
@@ -21,8 +21,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphSt
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedDependencyGraph;
 import org.gradle.api.internal.artifacts.result.ResolvedGraphResult;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.lazy.Lazy;
+import org.jspecify.annotations.Nullable;
 
+import java.lang.ref.SoftReference;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -36,6 +37,12 @@ public class DefaultVisitedGraphResults implements VisitedGraphResults {
     private final Supplier<GraphStructure> graphStructureSource;
     private final Set<UnresolvedDependency> unresolvedDependencies;
 
+    /**
+     * ResolvedGraphResult is a wrapper over the underlying GraphStructure and provides
+     * no additional context. Only hold a soft reference to it to avoid retained memory
+     * if no other references to the wrapper graph exist.
+     */
+    private @Nullable SoftReference<ResolvedGraphResult> resolvedGraphResult = null;
     private final Supplier<ResolvedGraphResult> resolvedGraphResultSource;
 
     public DefaultVisitedGraphResults(
@@ -46,12 +53,21 @@ public class DefaultVisitedGraphResults implements VisitedGraphResults {
         this.graphStructureSource = resolvedDependencyGraph.graphSource();
         this.unresolvedDependencies = unresolvedDependencies;
 
-        this.resolvedGraphResultSource = Lazy.unsafe().of(() ->
-            new ResolvedGraphResult(
+        this.resolvedGraphResultSource = () -> {
+            if (resolvedGraphResult != null) {
+                ResolvedGraphResult value = resolvedGraphResult.get();
+                if (value != null) {
+                    return value;
+                }
+            }
+
+            ResolvedGraphResult value = new ResolvedGraphResult(
                 graphStructureSource.get(),
                 resolvedDependencyGraph.availableVariantsByComponent()
-            )
-        );
+            );
+            this.resolvedGraphResult = new SoftReference<>(value);
+            return value;
+        };
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -16,13 +16,14 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntStack;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
-import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ResolverResults;
@@ -33,7 +34,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Selec
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
-import org.gradle.api.internal.artifacts.result.ResolvedGraphResult;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -57,10 +57,8 @@ import org.gradle.internal.model.ValueCalculator;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -243,64 +241,54 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
     }
 
     private static Set<ComponentIdentifier> computeDependencies(ComponentIdentifier componentId, VisitedGraphResults visitedGraph) {
-        ResolvedGraphResult graph = visitedGraph.getResolvedGraphResultSource().get();
-        GraphStructure.Nodes nodes = graph.structure().nodes();
-        ResolvedComponentResult root = graph.getComponent(nodes.owner(nodes.root()));
-        ResolvedComponentResult targetComponent = findComponent(root, componentId);
+        GraphStructure graph = visitedGraph.getGraphStructureSource().get();
+        GraphStructure.Edges edges = graph.edges();
+        GraphStructure.Components components = graph.components();
+        GraphStructure.Nodes nodes = graph.nodes();
 
-        if (targetComponent == null) {
+        IntSet seen = new IntOpenHashSet();
+        IntStack queue = new IntArrayList();
+
+        // Search through all components to find the target component.
+        int targetComponent = -1;
+        for (int i = 0; i < components.count(); i++) {
+            if (components.id(i).equals(componentId)) {
+                targetComponent = i;
+                break;
+            }
+        }
+
+        if (targetComponent == -1) {
             throw new AssertionError("Could not find component " + componentId + " in provided results.");
         }
 
+        // TODO: This is not quite desired behavior. The purpose of this class is to resolve all
+        //  dependencies of an artifact transform. An artifact transform is derived from the artifacts
+        //  of a _node_ of the graph. We are only given `componentId`, the owning component of the node
+        //  we're interested in. So, we traverse starting from all nodes of that component since we do
+        //  not have enough information to find the node of interest.
+        for (int i = 0; i < nodes.count(); i++) {
+            if (nodes.owner(i) == targetComponent) {
+                queue.push(i);
+                seen.add(i);
+            }
+        }
+
         Set<ComponentIdentifier> buildDependencies = new HashSet<>();
-        collectReachableComponents(buildDependencies, new HashSet<>(), targetComponent.getDependencies());
+        while (!queue.isEmpty()) {
+            int node = queue.popInt();
+            for (int i = edges.start(node); i < edges.end(node); i++) {
+                boolean constraint = edges.constraint(i);
+                int targetNodeIndex = edges.targetNode(i);
+                // Only visit hard, non-failing edges
+                if (!constraint && targetNodeIndex != -1 && seen.add(targetNodeIndex)) {
+                    int owner = nodes.owner(targetNodeIndex);
+                    buildDependencies.add(components.id(owner));
+                    queue.push(targetNodeIndex);
+                }
+            }
+        }
         return buildDependencies;
-    }
-
-    /**
-     * Search the graph for a component with the given identifier, starting from the given root component.
-     *
-     * @return null if the component is not found.
-     */
-    @Nullable
-    public static ResolvedComponentResult findComponent(ResolvedComponentResult rootComponent, ComponentIdentifier componentIdentifier) {
-        Set<ResolvedComponentResult> seen = new HashSet<>();
-        Deque<ResolvedComponentResult> pending = new ArrayDeque<>();
-        pending.push(rootComponent);
-
-        while (!pending.isEmpty()) {
-            ResolvedComponentResult component = pending.pop();
-
-            if (component.getId().equals(componentIdentifier)) {
-                return component;
-            }
-
-            for (DependencyResult d : component.getDependencies()) {
-                if (d instanceof ResolvedDependencyResult) {
-                    ResolvedDependencyResult resolved = (ResolvedDependencyResult) d;
-                    ResolvedComponentResult selected = resolved.getSelected();
-                    if (seen.add(selected)) {
-                        pending.push(selected);
-                    }
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private static void collectReachableComponents(Set<ComponentIdentifier> dependenciesIdentifiers, Set<ComponentIdentifier> visited, Set<? extends DependencyResult> dependencies) {
-        for (DependencyResult dependency : dependencies) {
-            if (dependency instanceof ResolvedDependencyResult && !dependency.isConstraint()) {
-                ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
-                ResolvedComponentResult selected = resolvedDependency.getSelected();
-                dependenciesIdentifiers.add(selected.getId());
-                if (visited.add(selected.getId())) {
-                    // Do not traverse if seen already
-                    collectReachableComponents(dependenciesIdentifiers, visited, selected.getDependencies());
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Ensure we hold a soft reference to ResolvedGraphResult, which ensures the wrapper over GraphStructure is deallocated when other users no longer reference it. This ensures consistent reference identities for ResolutionResult types as long as some code references a live instance of it, while also allowing the wrapper type to be deallocated if no longer referenced.

Also migrate some internal consumers of the dependency graph to use GraphStructure instead of the public wrapper, avoiding allocations of an entire public view of the graph when not necessary. This should particularly improve Android builds, as they both use consistent resolution and artifact transform dependencies.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
