### PR TITLE
Enable build scan for dependency-submission GitHub action

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -20,6 +20,12 @@ jobs:
         java-version: 17
     - name: Setup Gradle
       uses: gradle/actions/dependency-submission@v6
+      with:
+        # Publish a Build Scan on failure (and success) for debugging; action output `build-scan-url` is set when applicable.
+        build-scan-publish: true
+        build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+        build-scan-terms-of-use-agree: 'yes'
+        additional-arguments: '--stacktrace'
       env:
         # Exclude some projects and configurations that should not contribute to the dependency graph
         DEPENDENCY_GRAPH_EXCLUDE_PROJECTS: ':docs|:internal-performance-testing|:enterprise-plugin-performance|:performance|:internal-integ-testing'


### PR DESCRIPTION
We see frequent failures like [this](https://github.com/gradle/gradle/actions/runs/25851764467/job/75959771519). Enable build scan to see what's wrong in the build.

Something wrong is in build scan publication, but we got [stacktraces this time](https://github.com/gradle/gradle/actions/runs/25904315656/job/76134423137).