### PR TITLE
Remove deprecated DirectoryScanner mutation path (Gradle 10)

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
@@ -69,7 +69,7 @@ class ConfigurationCacheFileSystemDefaultExcludesTest extends AbstractConfigurat
         def excludedByBuildScriptFileCopy = file("build/output/${excludedByBuildScriptFileName}")
         excludedByBuildScriptFile.text = "input"
 
-        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExclude(excludedByBuildScriptFileName)
+        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExcludeForBuildScript(excludedByBuildScriptFileName)
 
         when:
         configurationCacheRun spec.copyTask

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileSystemDefaultExcludesTest.groovy
@@ -55,7 +55,7 @@ class ConfigurationCacheFileSystemDefaultExcludesTest extends AbstractConfigurat
         spec << DefaultExcludesFixture.specs()
     }
 
-    def "default excludes defined in build#dsl are ignoring for snapshotting"() {
+    def "DirectoryScanner mutations from build#dsl are ignored"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
         def spec = new DefaultExcludesFixture.Spec(
@@ -69,7 +69,7 @@ class ConfigurationCacheFileSystemDefaultExcludesTest extends AbstractConfigurat
         def excludedByBuildScriptFileCopy = file("build/output/${excludedByBuildScriptFileName}")
         excludedByBuildScriptFile.text = "input"
 
-        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExcludeForBuildScript(excludedByBuildScriptFileName)
+        getBuildFile(dsl) << DefaultExcludesFixture.DefaultExcludesLocation.addDefaultExcludeViaLegacyAntApi(excludedByBuildScriptFileName)
 
         when:
         configurationCacheRun spec.copyTask

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
@@ -125,7 +125,23 @@ class DefaultExcludesFixture {
             dir.file(dsl.fileNameFor("settings"))
         }
 
-        static String addDefaultExclude(String excludedFileName) {
+        /**
+         * Snippet to be inserted into a settings.gradle(.kts) file to register an additional default exclude.
+         * Uses the modern Settings.fileSystemDefaultExcludes API.
+         */
+        static String addDefaultExcludeForSettings(String excludedFileName) {
+            """
+            fileSystemDefaultExcludes.add("**/${excludedFileName}")
+            """
+        }
+
+        /**
+         * Snippet to be inserted into a build.gradle(.kts) file to register an additional default exclude.
+         * Uses the deprecated org.apache.tools.ant.DirectoryScanner static-state API because there is no
+         * project-scoped equivalent of Settings.fileSystemDefaultExcludes. This snippet still works during
+         * the deprecation cycle for the few tests that need to exercise this build-script path.
+         */
+        static String addDefaultExcludeForBuildScript(String excludedFileName) {
             """
             ${DirectoryScanner.name}.addDefaultExclude("**/${excludedFileName}")
             """
@@ -146,7 +162,7 @@ class DefaultExcludesFixture {
 
         @Override
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
-            settingsFile(spec.testDirectory, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(spec.testDirectory, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override
@@ -171,7 +187,7 @@ class DefaultExcludesFixture {
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
             TestFile includedBuildDir = spec.testDirectory.file("build-logic")
             settingsFile(spec.testDirectory, dsl) << 'includeBuild("build-logic")'
-            settingsFile(includedBuildDir, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(includedBuildDir, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override
@@ -195,7 +211,7 @@ class DefaultExcludesFixture {
         @Override
         void applyDefaultExcludes(AbstractIntegrationSpec spec, GradleDsl dsl) {
             TestFile buildSrcDir = spec.testDirectory.file("buildSrc")
-            settingsFile(buildSrcDir, dsl) << addDefaultExclude(excludedFileName())
+            settingsFile(buildSrcDir, dsl) << addDefaultExcludeForSettings(excludedFileName())
         }
 
         @Override

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/DefaultExcludesFixture.groovy
@@ -136,12 +136,12 @@ class DefaultExcludesFixture {
         }
 
         /**
-         * Snippet to be inserted into a build.gradle(.kts) file to register an additional default exclude.
-         * Uses the deprecated org.apache.tools.ant.DirectoryScanner static-state API because there is no
-         * project-scoped equivalent of Settings.fileSystemDefaultExcludes. This snippet still works during
-         * the deprecation cycle for the few tests that need to exercise this build-script path.
+         * Snippet that mutates {@link org.apache.tools.ant.DirectoryScanner} static state.
+         * Used by tests asserting these mutations are ignored: Gradle no longer reads
+         * DirectoryScanner, so a build-script call to addDefaultExclude has no effect on
+         * Gradle's resolved excludes.
          */
-        static String addDefaultExcludeForBuildScript(String excludedFileName) {
+        static String addDefaultExcludeViaLegacyAntApi(String excludedFileName) {
             """
             ${DirectoryScanner.name}.addDefaultExclude("**/${excludedFileName}")
             """

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -33,6 +33,7 @@ import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.toolchain.management.ToolchainManagement
 import org.gradle.caching.configuration.BuildCacheConfiguration
 import org.gradle.internal.deprecation.DeprecationLogger
@@ -177,4 +178,7 @@ abstract class SettingsDelegate : Settings {
     override fun defaults(action: Action<in SharedModelDefaults>) {
         delegate.defaults(action)
     }
+
+    override fun getFileSystemDefaultExcludes(): SetProperty<String> =
+        delegate.fileSystemDefaultExcludes
 }

--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
@@ -16,6 +16,7 @@
 
 package org.gradle.caching.example;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import com.google.inject.AbstractModule;
@@ -488,7 +489,8 @@ class BuildCacheClientModule extends AbstractModule {
             stat,
             virtualFileSystem,
             locations -> locations.forEach(System.out::println),
-            statisticsCollector
+            statisticsCollector,
+            ImmutableList.of()
         );
     }
 }

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -18,64 +18,11 @@ package org.gradle.internal.vfs
 
 import org.apache.tools.ant.DirectoryScanner
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.Issue
 
-class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
+class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec {
 
     private static final EXCLUDED_FILE_NAME = "my-excluded-file.txt"
-    private static final DIRECTORY_SCANNER_DEPRECATION =
-        "Mutating org.apache.tools.ant.DirectoryScanner default excludes has been deprecated. " +
-        "This is scheduled to be removed in Gradle 10. " +
-        "Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
-        "For example: fileSystemDefaultExcludes.add(\"**/node_modules\"). " +
-        "Consult the upgrading guide for further information: " +
-        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
-    private static final DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION =
-        "Configuring file-system default excludes via both " +
-        "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes has been deprecated. " +
-        "This is scheduled to be removed in Gradle 10. " +
-        "settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
-        "Remove the DirectoryScanner calls from your settings script. " +
-        "Consult the upgrading guide for further information: " +
-        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
-    private static final DEFAULT_EXCLUDES = [
-        "**/%*%",
-        "**/.#*",
-        "**/._*",
-        "**/#*#",
-        "**/*~",
-        "**/.DS_Store",
-
-        "**/CVS",
-        "**/CVS/**",
-        "**/.cvsignore",
-
-        "**/SCCS",
-        "**/SCCS/**",
-
-        "**/.bzr",
-        "**/.bzr/**",
-        "**/.bzrignore",
-
-        "**/vssver.scc",
-
-        "**/.hg",
-        "**/.hg/**",
-        "**/.hgtags",
-        "**/.hgignore",
-        "**/.hgsubstate",
-        "**/.hgsub",
-
-        "**/.svn",
-        "**/.svn/**",
-
-        "**/.git",
-        "**/.git/**",
-        "**/.gitignore",
-        "**/.gitmodules",
-        "**/.gitattributes"
-    ]
 
     def outputDir = file("build/output")
     def excludedFile = file("input/${EXCLUDED_FILE_NAME}")
@@ -90,109 +37,6 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
                 into("build/output")
             }
         """
-    }
-
-    def "default excludes defined in settings.gradle are used"() {
-        settingsFile << addDefaultExclude(EXCLUDED_FILE_NAME)
-
-        def outputDir = file("build/output")
-        file("input/inputFile.txt").text = "input"
-        def excludedFile = file("input/${EXCLUDED_FILE_NAME}")
-        excludedFile.text = "initial"
-        def copyOfExcludedFile = outputDir.file(EXCLUDED_FILE_NAME)
-
-        when:
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        run "copyTask"
-        then:
-        executedAndNotSkipped(":copyTask")
-        !copyOfExcludedFile.exists()
-
-        when:
-        excludedFile.text = "changed"
-        if (!GradleContextualExecuter.configCache) {
-            // settingsEvaluated re-runs on every non-CC build, so the deprecation re-fires.
-            // On a CC hit, settings come from cache and the user's DirectoryScanner mutation is not re-executed.
-            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        }
-        run "copyTask"
-        then:
-        skipped(":copyTask")
-    }
-
-    def "default excludes are reset if nothing is defined in settings"() {
-        settingsFile << addDefaultExclude(EXCLUDED_FILE_NAME)
-
-        when:
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        run "copyTask"
-        then:
-        executedAndNotSkipped(":copyTask")
-        !copyOfExcludedFile.exists()
-
-        when:
-        excludedFile.text = "changed"
-        if (!GradleContextualExecuter.configCache) {
-            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        }
-        run "copyTask"
-        then:
-        skipped(":copyTask")
-
-        when:
-        settingsFile.text = ""
-        excludedFile.text = "changedAgain"
-        run "copyTask"
-        then:
-        executedAndNotSkipped(":copyTask")
-        copyOfExcludedFile.exists()
-    }
-
-    def "fails when default excludes are changed during the build"() {
-        settingsFile << addDefaultExclude(EXCLUDED_FILE_NAME)
-
-        buildFile << """
-            copyTask.doFirst {
-                ant.defaultexcludes remove: '**/${EXCLUDED_FILE_NAME}'
-            }
-            copyTask.doLast {
-                ant.defaultexcludes default: true
-            }
-        """
-        List<String> defaultExcludesFromSettings = (DEFAULT_EXCLUDES  + ['**/' + EXCLUDED_FILE_NAME]).toSorted()
-        List<String> defaultExcludesInTask = DEFAULT_EXCLUDES.toSorted()
-
-        when:
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        fails "copyTask"
-
-        then:
-        failure.assertHasCause "Cannot change default excludes during the build. They were changed from ${defaultExcludesFromSettings} to ${defaultExcludesInTask}. Configure default excludes in the settings script instead."
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/27225")
-    def "default excludes are removed properly"() {
-        def defaultExclude = '.gitignore'
-        def defaultExcludeFile = file("input/$defaultExclude")
-        defaultExcludeFile << "some content"
-
-        settingsFile << removeDefaultExclude(defaultExclude)
-
-        when:
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        run "copyTask"
-        then:
-        executedAndNotSkipped(":copyTask")
-        file("build/output/$defaultExclude").exists()
-
-        when:
-        defaultExcludeFile.text = "changed"
-        if (!GradleContextualExecuter.configCache) {
-            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
-        }
-        run "copyTask"
-        then:
-        executedAndNotSkipped(":copyTask")
     }
 
     def "default excludes defined via settings.fileSystemDefaultExcludes are used"() {
@@ -213,6 +57,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         skipped(":copyTask")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/27225")
     def "settings.fileSystemDefaultExcludes can remove a built-in default exclude"() {
         def defaultExclude = '.gitignore'
         def defaultExcludeFile = file("input/$defaultExclude")
@@ -235,32 +80,39 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         executedAndNotSkipped(":copyTask")
     }
 
-    def "settings.fileSystemDefaultExcludes wins when both APIs configure the defaults"() {
-        // The new Settings API takes precedence; mutations to the legacy DirectoryScanner static state are ignored.
+    def "settings.fileSystemDefaultExcludes reverts to baseline when nothing is configured"() {
         settingsFile << """
-            ${DirectoryScanner.name}.addDefaultExclude('**/legacy-excluded.txt')
             fileSystemDefaultExcludes.add('**/${EXCLUDED_FILE_NAME}')
         """
-        file('input/legacy-excluded.txt').text = "from legacy API"
 
         when:
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
-        !copyOfExcludedFile.exists() // new API exclude applied
-        outputDir.file('legacy-excluded.txt').exists() // legacy mutation ignored
+        !copyOfExcludedFile.exists()
+
+        when:
+        settingsFile.text = ""
+        excludedFile.text = "changed"
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        copyOfExcludedFile.exists()
     }
 
-    private static String addDefaultExclude(String excludedFileName = EXCLUDED_FILE_NAME) {
+    def "mutating Ant's DirectoryScanner from settings is silently ignored"() {
+        // Gradle 10 removed the deprecated DirectoryScanner-mutation path. Calls to
+        // org.apache.tools.ant.DirectoryScanner.add/removeDefaultExclude still compile and
+        // mutate Ant's static state, but Gradle no longer consults it.
+        settingsFile << """
+            ${DirectoryScanner.name}.addDefaultExclude('**/${EXCLUDED_FILE_NAME}')
         """
-            ${DirectoryScanner.name}.addDefaultExclude('**/${ excludedFileName}')
-        """
-    }
 
-    private static String removeDefaultExclude(String defaultExcludedFileName) {
-        """
-            ${DirectoryScanner.name}.removeDefaultExclude('**/${defaultExcludedFileName}')
-        """
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        // Built-in defaults still apply (e.g. .git exclusions); the user's Ant mutation is ignored.
+        copyOfExcludedFile.exists()
     }
 }

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -18,11 +18,27 @@ package org.gradle.internal.vfs
 
 import org.apache.tools.ant.DirectoryScanner
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.Issue
 
 class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
     private static final EXCLUDED_FILE_NAME = "my-excluded-file.txt"
+    private static final DIRECTORY_SCANNER_DEPRECATION =
+        "Mutating org.apache.tools.ant.DirectoryScanner default excludes has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
+        "For example: fileSystemDefaultExcludes.add(\"**/node_modules\"). " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
+    private static final DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION =
+        "Configuring file-system default excludes via both " +
+        "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
+        "Remove the DirectoryScanner calls from your settings script. " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#directoryscanner_default_excludes_deprecation"
     private static final DEFAULT_EXCLUDES = [
         "**/%*%",
         "**/.#*",
@@ -86,6 +102,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         def copyOfExcludedFile = outputDir.file(EXCLUDED_FILE_NAME)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -93,7 +110,11 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
-        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        if (!GradleContextualExecuter.configCache) {
+            // settingsEvaluated re-runs on every non-CC build, so the deprecation re-fires.
+            // On a CC hit, settings come from cache and the user's DirectoryScanner mutation is not re-executed.
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -103,6 +124,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         settingsFile << addDefaultExclude(EXCLUDED_FILE_NAME)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -110,6 +132,9 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
+        if (!GradleContextualExecuter.configCache) {
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -138,6 +163,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         List<String> defaultExcludesInTask = DEFAULT_EXCLUDES.toSorted()
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         fails "copyTask"
 
         then:
@@ -153,6 +179,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         settingsFile << removeDefaultExclude(defaultExclude)
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -160,6 +187,9 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         defaultExcludeFile.text = "changed"
+        if (!GradleContextualExecuter.configCache) {
+            executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
+        }
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
@@ -214,6 +244,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         file('input/legacy-excluded.txt').text = "from legacy API"
 
         when:
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_AND_SETTINGS_DEPRECATION)
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")

--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -93,6 +93,7 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
         when:
         excludedFile.text = "changed"
+        executer.expectDocumentedDeprecationWarning(DIRECTORY_SCANNER_DEPRECATION)
         run "copyTask"
         then:
         skipped(":copyTask")
@@ -162,6 +163,62 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         run "copyTask"
         then:
         executedAndNotSkipped(":copyTask")
+    }
+
+    def "default excludes defined via settings.fileSystemDefaultExcludes are used"() {
+        settingsFile << """
+            fileSystemDefaultExcludes.add('**/${EXCLUDED_FILE_NAME}')
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists()
+
+        when:
+        excludedFile.text = "changed"
+        run "copyTask"
+        then:
+        skipped(":copyTask")
+    }
+
+    def "settings.fileSystemDefaultExcludes can remove a built-in default exclude"() {
+        def defaultExclude = '.gitignore'
+        def defaultExcludeFile = file("input/$defaultExclude")
+        defaultExcludeFile << "some content"
+
+        settingsFile << """
+            fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - '**/${defaultExclude}')
+        """
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        file("build/output/$defaultExclude").exists()
+
+        when:
+        defaultExcludeFile.text = "changed"
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+    }
+
+    def "settings.fileSystemDefaultExcludes wins when both APIs configure the defaults"() {
+        // The new Settings API takes precedence; mutations to the legacy DirectoryScanner static state are ignored.
+        settingsFile << """
+            ${DirectoryScanner.name}.addDefaultExclude('**/legacy-excluded.txt')
+            fileSystemDefaultExcludes.add('**/${EXCLUDED_FILE_NAME}')
+        """
+        file('input/legacy-excluded.txt').text = "from legacy API"
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+        !copyOfExcludedFile.exists() // new API exclude applied
+        outputDir.file('legacy-excluded.txt').exists() // legacy mutation ignored
     }
 
     private static String addDefaultExclude(String excludedFileName = EXCLUDED_FILE_NAME) {

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -71,13 +71,13 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
         VirtualFileSystem virtualFileSystem,
         WriteListener writeListener,
         DirectorySnapshotterStatistics.Collector statisticsCollector,
-        String... defaultExcludes
+        ImmutableList<String> defaultExcludes
     ) {
         this.stringInterner = stringInterner;
         this.stat = stat;
         this.writeListener = writeListener;
         this.statisticsCollector = statisticsCollector;
-        this.defaultExcludes = ImmutableList.copyOf(defaultExcludes);
+        this.defaultExcludes = defaultExcludes;
         this.directorySnapshotter = new DirectorySnapshotter(hasher, stringInterner, this.defaultExcludes, statisticsCollector);
         this.hasher = hasher;
         this.virtualFileSystem = virtualFileSystem;

--- a/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
+++ b/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.vfs.impl
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.file.FileException
@@ -53,7 +54,8 @@ abstract class AbstractFileSystemAccessTest extends Specification {
         fileSystem::stat,
         TestFiles.virtualFileSystem(),
         updateListener,
-        statisticsCollector
+        statisticsCollector,
+        ImmutableList.of()
     )
 
     void allowFileSystemAccess(boolean allow) {

--- a/platforms/core-runtime/files/build.gradle.kts
+++ b/platforms/core-runtime/files/build.gradle.kts
@@ -8,9 +8,9 @@ description = "Base tools to work with files"
 dependencies {
     api(projects.stdlibJavaExtensions)
 
+    api(libs.guava)
     api(libs.jsr305)
 
-    implementation(libs.guava)
     implementation(libs.slf4jApi)
 
     compileOnly(libs.jspecify)

--- a/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/excludes/GradleDefaultExcludes.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/excludes/GradleDefaultExcludes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.file.excludes;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The built-in set of patterns Gradle excludes by default from file collection
+ * scanning (copy, archive, file collections, etc.).
+ *
+ * <p>Historically these were sourced from {@code org.apache.tools.ant.DirectoryScanner.DEFAULTEXCLUDES}.
+ * Gradle now owns this list directly so it can be evolved independently of Ant and so the
+ * Ant dependency can eventually be removed from Gradle's runtime classpath.</p>
+ */
+@NullMarked
+public final class GradleDefaultExcludes {
+
+    private GradleDefaultExcludes() {
+    }
+
+    /**
+     * The default exclude patterns. Ported verbatim from Ant 1.10.17's
+     * {@code DirectoryScanner.DEFAULTEXCLUDES} to preserve behavioral parity.
+     */
+    public static final ImmutableList<String> DEFAULT_EXCLUDES = ImmutableList.<String>builder().add(
+        // Miscellaneous typical temporary files
+        "**/*~",
+        "**/#*#",
+        "**/.#*",
+        "**/%*%",
+        "**/._*",
+
+        // CVS
+        "**/CVS",
+        "**/CVS/**",
+        "**/.cvsignore",
+
+        // SCCS
+        "**/SCCS",
+        "**/SCCS/**",
+
+        // Visual SourceSafe
+        "**/vssver.scc",
+
+        // Subversion
+        "**/.svn",
+        "**/.svn/**",
+
+        // Git
+        "**/.git",
+        "**/.git/**",
+        "**/.gitattributes",
+        "**/.gitignore",
+        "**/.gitmodules",
+
+        // Mercurial
+        "**/.hg",
+        "**/.hg/**",
+        "**/.hgignore",
+        "**/.hgsub",
+        "**/.hgsubstate",
+        "**/.hgtags",
+
+        // Bazaar
+        "**/.bzr",
+        "**/.bzr/**",
+        "**/.bzrignore",
+
+        // Mac OSX
+        "**/.DS_Store"
+    ).build();
+
+    public static final ImmutableSet<String> DEFAULT_EXCLUDES_SET = ImmutableSet.copyOf(DEFAULT_EXCLUDES);
+}

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,6 +79,29 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
+#### `Settings.fileSystemDefaultExcludes` for configuring default file-system excludes
+
+Gradle's [file operations](userguide/working_with_files.html#sec:file_trees) (copy, archive, file collections) automatically exclude common version-control directories and OS metadata files.
+
+Previously, customizing these patterns required importing and mutating [`org.apache.tools.ant.DirectoryScanner`](https://javadoc.io/static/org.apache.ant/ant/1.10.17/org/apache/tools/ant/DirectoryScanner.html), a process-global, static-mutable API inherited from [Apache Ant](https://ant.apache.org/).
+This coupling has been a long-standing source of bugs: `DirectoryScanner` mutations are invisible to the configuration cache, can break tasks like `bootJar` and the [Distribution plugin](userguide/distribution_plugin.html) when excludes are changed mid-build, and behave inconsistently across composite builds.
+It also blocks Gradle's ongoing effort to remove [Ant](userguide/ant.html) from its runtime classpath.
+
+Gradle now provides a [`fileSystemDefaultExcludes`](javadoc/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--) property on [`Settings`](javadoc/org/gradle/api/initialization/Settings.html), giving build authors a safe and idiomatic way to configure these patterns:
+
+```kotlin
+// settings.gradle.kts
+// Add a custom exclude
+fileSystemDefaultExcludes.add("**/node_modules")
+
+// Remove a built-in exclude
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+```
+
+The legacy `DirectoryScanner` mutation is now deprecated and will be removed in Gradle 10.
+
+See the [Working with Files](userguide/working_with_files.html#sec:change_default_excludes) section in the Gradle User Manual for more information.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -272,11 +272,10 @@ include::sample[dir="snippets/reference/gradle-types/fileTrees/groovy",files="bu
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable].
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — the same defaults as Ant.
-For the complete default exclude list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — version-control directories such as `**&#47;.git` and OS metadata such as `**&#47;.DS_Store`.
 
 [[sec:change_default_excludes]]
-If those default excludes prove problematic, you can work around the issue by changing the default excludes in the settings script:
+If those default excludes prove problematic, you can change them in the settings script via the link:{javadocPath}/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--[`fileSystemDefaultExcludes`] property:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/copy/kotlin",files="settings.gradle.kts[tags=change-default-exclusions]"]

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -272,7 +272,7 @@ include::sample[dir="snippets/reference/gradle-types/fileTrees/groovy",files="bu
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable].
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience — version-control directories such as `**&#47;.git` and OS metadata such as `**&#47;.DS_Store`.
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclude patterns for convenience, such as version-control directories (`**&#47;.git`) and OS metadata files (`**&#47;.DS_Store`).
 
 [[sec:change_default_excludes]]
 If those default excludes prove problematic, you can change them in the settings script via the link:{javadocPath}/org/gradle/api/initialization/Settings.html#getFileSystemDefaultExcludes--[`fileSystemDefaultExcludes`] property:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -101,19 +101,26 @@ This direct dependency on Ant's static mutable state has been a long-standing so
 
 Use the new `Settings.fileSystemDefaultExcludes` property instead:
 
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
 [source,kotlin]
 ----
-// settings.gradle.kts
 fileSystemDefaultExcludes.add("**/node_modules")
 fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
 ----
-
+======
+[.multi-language-sample]
+======
+.settings.gradle
 [source,groovy]
 ----
-// settings.gradle
 fileSystemDefaultExcludes.add("**/node_modules")
 fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
 ----
+======
+=====
 
 If both APIs are used in the same build, the `Settings.fileSystemDefaultExcludes` property takes precedence and the `DirectoryScanner` mutation is ignored.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -93,6 +93,30 @@ Since the previous version was 4.0.29, the link:https://groovy-lang.org/changelo
 [[v9_deprecations_9_6]]
 === Deprecations
 
+[[directoryscanner_default_excludes_deprecation]]
+==== Deprecation of configuring default file-system excludes via Ant's `DirectoryScanner`
+
+Configuring Gradle's default file-system exclude patterns by mutating `org.apache.tools.ant.DirectoryScanner` (for example, calling `DirectoryScanner.addDefaultExclude(...)` or `DirectoryScanner.removeDefaultExclude(...)` from `settings.gradle(.kts)`) is now deprecated.
+This direct dependency on Ant's static mutable state has been a long-standing source of fragility (see issues link:https://github.com/gradle/gradle/issues/11176[#11176], link:https://github.com/gradle/gradle/issues/11177[#11177]) and prevents Gradle from removing Ant from its runtime classpath.
+
+Use the new `Settings.fileSystemDefaultExcludes` property instead:
+
+[source,kotlin]
+----
+// settings.gradle.kts
+fileSystemDefaultExcludes.add("**/node_modules")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+----
+
+[source,groovy]
+----
+// settings.gradle
+fileSystemDefaultExcludes.add("**/node_modules")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - "**/.gitignore")
+----
+
+If both APIs are used in the same build, the `Settings.fileSystemDefaultExcludes` property takes precedence and the `DirectoryScanner` mutation is ignored.
+
 [[deprecated_implicit_project_hierarchy_lookup]]
 ==== Deprecation of implicit lookup of properties and methods in the project hierarchy
 

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/groovy/settings.gradle
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude('**/.git')
-DirectoryScanner.removeDefaultExclude('**/.git/**')
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/files/copy/kotlin/settings.gradle.kts
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude("**/.git")
-DirectoryScanner.removeDefaultExclude("**/.git/**")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/groovy/settings.gradle
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude('**/.git')
-DirectoryScanner.removeDefaultExclude('**/.git/**')
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - ['**/.git', '**/.git/**'])
 // end::change-default-exclusions[]
 rootProject.name = 'copy'

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/copy/kotlin/settings.gradle.kts
@@ -1,7 +1,4 @@
 // tag::change-default-exclusions[]
-import org.apache.tools.ant.DirectoryScanner
-
-DirectoryScanner.removeDefaultExclude("**/.git")
-DirectoryScanner.removeDefaultExclude("**/.git/**")
+fileSystemDefaultExcludes.set(fileSystemDefaultExcludes.get() - setOf("**/.git", "**/.git/**"))
 // end::change-default-exclusions[]
 rootProject.name = "copy"

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(projects.io)
     implementation(projects.logging)
 
-    implementation(libs.ant)
     implementation(libs.commonsLang)
     implementation(libs.jsr305)
     implementation(libs.slf4jApi)

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -29,6 +29,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.declarative.dsl.model.annotations.Adding;
@@ -466,4 +467,21 @@ public interface Settings extends PluginAware, ExtensionAware {
     @Incubating
     @HiddenInDefinition
     void defaults(Action<? super SharedModelDefaults> action);
+
+    /**
+     * Returns the default exclude patterns used when scanning the file system for file collections
+     * (copy, archive, file collections, etc.).
+     *
+     * <p>The set is initialized with Gradle's built-in defaults (entries for common version-control
+     * directories such as <code>**&#47;.git</code> and OS metadata such as <code>**&#47;.DS_Store</code>).
+     * Modify the property in the settings script to customize the patterns for this build.</p>
+     *
+     * <p>Changes after settings evaluation are not honored.</p>
+     *
+     * @return the property controlling the default exclude patterns
+     * @since 9.6.0
+     */
+    @Incubating
+    @HiddenInDefinition
+    SetProperty<String> getFileSystemDefaultExcludes();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.tasks.util.internal;
 
-import org.apache.tools.ant.DirectoryScanner;
-import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.file.RelativePathSpec;
 import org.gradle.api.internal.file.pattern.PatternMatcher;
@@ -26,13 +24,12 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -48,12 +45,16 @@ import java.util.Set;
 @ServiceScope(Scope.Global.class)
 public class PatternSpecFactory implements FileSystemDefaultExcludesListener {
     public static final PatternSpecFactory INSTANCE = new PatternSpecFactory();
-    private Set<String> previousDefaultExcludes = new HashSet<String>();
+    private Set<String> currentDefaultExcludes = new HashSet<>(GradleDefaultExcludes.DEFAULT_EXCLUDES);
     private final Map<CaseSensitivity, Spec<FileTreeElement>> defaultExcludeSpecCache = new EnumMap<>(CaseSensitivity.class);
 
     @Override
-    public void onDefaultExcludesChanged(List<String> excludes) {
-        setDefaultExcludesFromSettings(excludes.toArray(new String[0]));
+    public synchronized void onDefaultExcludesChanged(List<String> excludes) {
+        Set<String> newDefaults = new HashSet<>(excludes);
+        if (!currentDefaultExcludes.equals(newDefaults)) {
+            currentDefaultExcludes = newDefaults;
+            defaultExcludeSpecCache.clear();
+        }
     }
 
     public Spec<FileTreeElement> createSpec(PatternSet patternSet) {
@@ -90,40 +91,15 @@ public class PatternSpecFactory implements FileSystemDefaultExcludesListener {
     }
 
     private synchronized Spec<FileTreeElement> getDefaultExcludeSpec(CaseSensitivity caseSensitivity) {
-        Set<String> defaultExcludes = new HashSet<String>(Arrays.asList(DirectoryScanner.getDefaultExcludes()));
-        if (defaultExcludeSpecCache.isEmpty()) {
-            updateDefaultExcludeSpecCache(defaultExcludes);
-        } else if (invalidChangeOfExcludes(defaultExcludes)) {
-            failOnChangedDefaultExcludes(previousDefaultExcludes, defaultExcludes);
+        // Lazy population: do not call createSpec from a field initializer or constructor.
+        // CachingPatternSpecFactory overrides createSpec and relies on its own field that is
+        // not yet initialized at superclass-construction time.
+        Spec<FileTreeElement> spec = defaultExcludeSpecCache.get(caseSensitivity);
+        if (spec == null) {
+            spec = createSpec(currentDefaultExcludes, false, caseSensitivity.isCaseSensitive());
+            defaultExcludeSpecCache.put(caseSensitivity, spec);
         }
-
-        return defaultExcludeSpecCache.get(caseSensitivity);
-    }
-
-    private boolean invalidChangeOfExcludes(Set<String> defaultExcludes) {
-        return !previousDefaultExcludes.equals(defaultExcludes);
-    }
-
-    private void failOnChangedDefaultExcludes(Set<String> excludesFromSettings, Set<String> newDefaultExcludes) {
-        List<String> sortedExcludesFromSettings = new ArrayList<String>(excludesFromSettings);
-        sortedExcludesFromSettings.sort(Comparator.naturalOrder());
-        List<String> sortedNewExcludes = new ArrayList<String>(newDefaultExcludes);
-        sortedNewExcludes.sort(Comparator.naturalOrder());
-        throw new InvalidUserCodeException(String.format("Cannot change default excludes during the build. They were changed from %s to %s. Configure default excludes in the settings script instead.",  sortedExcludesFromSettings, sortedNewExcludes));
-    }
-
-    public synchronized void setDefaultExcludesFromSettings(String[] excludesFromSettings) {
-        Set<String> excludesFromSettingsSet = new HashSet<String>(Arrays.asList(excludesFromSettings));
-        if (!previousDefaultExcludes.equals(excludesFromSettingsSet)) {
-            updateDefaultExcludeSpecCache(excludesFromSettingsSet);
-        }
-    }
-
-    private void updateDefaultExcludeSpecCache(Set<String> defaultExcludes) {
-        previousDefaultExcludes = defaultExcludes;
-        for (CaseSensitivity caseSensitivity : CaseSensitivity.values()) {
-            defaultExcludeSpecCache.put(caseSensitivity, createSpec(defaultExcludes, false, caseSensitivity.isCaseSensitive()));
-        }
+        return spec;
     }
 
     protected Spec<FileTreeElement> createSpec(Collection<String> patterns, boolean include, boolean caseSensitive) {

--- a/subprojects/core-api/src/test/groovy/org/gradle/api/tasks/util/PatternSetTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/api/tasks/util/PatternSetTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.api.tasks.util
 
-import groovy.transform.CompileStatic
-import org.apache.tools.ant.DirectoryScanner
-import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.RelativePath
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
+import org.gradle.internal.file.excludes.GradleDefaultExcludes
 import spock.lang.Issue
 
 import static org.gradle.util.Matchers.strictlyEquals
@@ -33,8 +31,9 @@ class PatternSetTest extends AbstractTestForPatternSet {
     PatternSet patternSet = new PatternSet()
 
     def cleanup() {
-        DirectoryScanner.resetDefaultExcludes()
-        updateSettingsDefaults()
+        // Restore the baseline default excludes so individual tests don't leak state into each other.
+        // PatternSpecFactory.INSTANCE is a global singleton.
+        PatternSpecFactory.INSTANCE.onDefaultExcludesChanged(GradleDefaultExcludes.DEFAULT_EXCLUDES)
     }
 
     def testConstructionFromMap() {
@@ -95,12 +94,9 @@ class PatternSetTest extends AbstractTestForPatternSet {
         excluded file('foo', '.DS_Store')
     }
 
-    def takesGlobalExcludesFromAnt() {
+    def "respects updates to the global default excludes"() {
         when:
-        DirectoryScanner.defaultExcludes.each {
-            DirectoryScanner.removeDefaultExclude(it)
-        }
-        updateSettingsDefaults()
+        PatternSpecFactory.INSTANCE.onDefaultExcludesChanged([])
 
         then:
         included dir('.svn')
@@ -108,28 +104,10 @@ class PatternSetTest extends AbstractTestForPatternSet {
         included file('foo', '.DS_Store')
 
         when:
-        DirectoryScanner.addDefaultExclude('*X*')
-        updateSettingsDefaults()
+        PatternSpecFactory.INSTANCE.onDefaultExcludesChanged(['*X*'])
 
         then:
         excluded file('X')
-    }
-
-    def "fails if default excludes are updated without changing the settings defaults"() {
-        given:
-        def previousExcludes = (DirectoryScanner.defaultExcludes as List).sort()
-        DirectoryScanner.defaultExcludes.each {
-            DirectoryScanner.removeDefaultExclude(it)
-        }
-
-        when:
-        included dir('.svn')
-
-        then:
-        InvalidUserCodeException ex = thrown()
-
-        and:
-        ex.message == "Cannot change default excludes during the build. They were changed from ${previousExcludes} to []. Configure default excludes in the settings script instead."
     }
 
     def createsSpecForIncludePatterns() {
@@ -360,11 +338,11 @@ class PatternSetTest extends AbstractTestForPatternSet {
 
     def "can handle removal of exclude"() {
         when:
-        DirectoryScanner.removeDefaultExclude("**/.gitignore")
-        DirectoryScanner.removeDefaultExclude("**/.git")
-        DirectoryScanner.removeDefaultExclude("**/.git/**")
-
-        updateSettingsDefaults()
+        def excludes = new ArrayList<String>(GradleDefaultExcludes.DEFAULT_EXCLUDES)
+        excludes.remove("**/.gitignore")
+        excludes.remove("**/.git")
+        excludes.remove("**/.git/**")
+        PatternSpecFactory.INSTANCE.onDefaultExcludesChanged(excludes)
 
         then:
         included file('.gitignore')
@@ -397,8 +375,4 @@ class PatternSetTest extends AbstractTestForPatternSet {
         element(false, elements)
     }
 
-    @CompileStatic
-    private static void updateSettingsDefaults() {
-        PatternSpecFactory.INSTANCE.setDefaultExcludesFromSettings(DirectoryScanner.getDefaultExcludes())
-    }
 }

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -100,7 +100,6 @@ dependencies {
     implementation(projects.projectFeaturesApi)
     implementation(projects.workerProcessServices)
 
-    implementation(libs.ant)
     implementation(libs.commonsCompress)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.AbstractPluginAware;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
@@ -431,4 +432,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     public void defaults(Action<? super SharedModelDefaults> action) {
         action.execute(getDefaults());
     }
+
+    @Override
+    public abstract SetProperty<String> getFileSystemDefaultExcludes();
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.plugins.ExtraPropertiesExtensionInternal;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
@@ -67,6 +68,7 @@ public class SettingsFactory {
         );
         ((ExtraPropertiesExtensionInternal) settings.getExtensions().getExtraProperties())
             .setGradleProperties(gradleProperties);
+        settings.getFileSystemDefaultExcludes().convention(GradleDefaultExcludes.DEFAULT_EXCLUDES);
         return new SettingsState(settings, serviceRegistryFactory.services);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.file;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.BuildAdapter;
 import org.gradle.api.initialization.Settings;
@@ -26,12 +27,30 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
 import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefaultExcludesProvider {
 
     private ImmutableList<String> currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
+
+    /**
+     * The DirectoryScanner state we last observed or wrote ourselves. Used to detect user-side
+     * mutations to {@link DirectoryScanner} (the deprecated legacy path) without false-positives
+     * from the mirror writes this class performs in {@link #syncDirectoryScanner(Set)}.
+     */
+    private ImmutableSet<String> lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+
+    /**
+     * Accumulated additions across every settings script seen this session. Each Settings has its
+     * own {@code fileSystemDefaultExcludes} property; the historical DirectoryScanner-based path
+     * was process-global, so each script's contribution stacked. Preserve that behavior by
+     * tracking deltas vs the baseline across all scripts and recomputing the resolved set as
+     * {@code baseline + additions - removals}.
+     */
+    private final Set<String> accumulatedAdditions = new LinkedHashSet<>();
+    private final Set<String> accumulatedRemovals = new LinkedHashSet<>();
 
     private final AnonymousListenerBroadcast<FileSystemDefaultExcludesListener> broadcast;
 
@@ -43,6 +62,9 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
                 currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
+                lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                accumulatedAdditions.clear();
+                accumulatedRemovals.clear();
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
             }
         });
@@ -51,10 +73,40 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
             @Override
             public void settingsEvaluated(Settings settings) {
-                currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
-                broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
+                ImmutableSet<String> baseline = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                Set<String> fromSettings = settings.getFileSystemDefaultExcludes().get();
+                ImmutableSet<String> fromAnt = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
+
+                boolean settingsCustomized = !fromSettings.equals(baseline);
+                // Compare against what we last wrote/observed, not against the original baseline:
+                // otherwise our own mirror writes from a previous settings.gradle would look like
+                // user-side Ant mutations and trigger false-positive deprecations.
+                boolean antMutatedByUser = !fromAnt.equals(lastObservedDirectoryScannerState);
+
+                if (settingsCustomized) {
+                    if (antMutatedByUser) {
+                        warnAntMutationIgnored();
+                    }
+                    accumulateDelta(baseline, fromSettings);
+                } else if (antMutatedByUser) {
+                    warnAntMutationDeprecated();
+                    accumulateDelta(lastObservedDirectoryScannerState, fromAnt);
+                }
+
+                Set<String> resolved = new LinkedHashSet<>(GradleDefaultExcludes.DEFAULT_EXCLUDES);
+                resolved.addAll(accumulatedAdditions);
+                resolved.removeAll(accumulatedRemovals);
+
+                syncDirectoryScanner(resolved);
+                applyDefaultExcludes(resolved);
             }
         });
+    }
+
+    private void applyDefaultExcludes(Set<String> resolved) {
+        lastObservedDirectoryScannerState = ImmutableSet.copyOf(resolved);
+        currentDefaultExcludes = ImmutableList.copyOf(resolved);
+        broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
     }
 
     @Override
@@ -64,6 +116,34 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
     @Override
     public void updateCurrentDefaultExcludes(Set<String> excludes) {
+        syncDirectoryScanner(excludes);
+
+        // Re-derive the accumulators from the supplied state so a later settingsEvaluated
+        // call (which is unusual after this point but defensible) stacks correctly on top.
+        accumulatedAdditions.clear();
+        accumulatedRemovals.clear();
+        accumulateDelta(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET, excludes);
+
+        applyDefaultExcludes(excludes);
+    }
+
+    /**
+     * Records the diff between {@code before} and {@code after} into the running accumulators.
+     */
+    private void accumulateDelta(Set<String> before, Set<String> after) {
+        for (String e : after) {
+            if (!before.contains(e)) {
+                accumulatedAdditions.add(e);
+            }
+        }
+        for (String e : before) {
+            if (!after.contains(e)) {
+                accumulatedRemovals.add(e);
+            }
+        }
+    }
+
+    private static void syncDirectoryScanner(Set<String> excludes) {
         for (String oldExclude : DirectoryScanner.getDefaultExcludes()) {
             if (!excludes.contains(oldExclude)) {
                 DirectoryScanner.removeDefaultExclude(oldExclude);

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -17,17 +17,13 @@
 package org.gradle.internal.file;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.BuildAdapter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.initialization.RootBuildLifecycleListener;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
 import org.gradle.internal.file.excludes.GradleDefaultExcludes;
-import org.jspecify.annotations.NonNull;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -38,23 +34,10 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
     private ImmutableList<String> currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
 
     /**
-     * The DirectoryScanner state we last observed or wrote ourselves. Used to detect user-side
-     * mutations to {@link DirectoryScanner} (the deprecated legacy path) without false-positives
-     * from the mirror writes this class performs in {@link #syncDirectoryScanner(Set)}.
-     *
-     * <p>Initialized to {@link DirectoryScanner#getDefaultExcludes()} immediately after
-     * {@link DirectoryScanner#resetDefaultExcludes()} in {@code afterStart}, so the user-mutation
-     * diff stays correct even if Ant's {@code DEFAULTEXCLUDES} ever drifts from
-     * {@link GradleDefaultExcludes#DEFAULT_EXCLUDES_SET} (the parity test would catch the drift,
-     * but we shouldn't emit false-positive deprecation warnings if it slips through).</p>
-     */
-    private ImmutableSet<String> lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
-
-    /**
      * Accumulated additions across every settings script seen this session. Each Settings has its
-     * own {@code fileSystemDefaultExcludes} property; the historical DirectoryScanner-based path
-     * was process-global, so each script's contribution stacked. Preserve that behavior by
-     * tracking deltas vs the baseline across all scripts and recomputing the resolved set as
+     * own {@code fileSystemDefaultExcludes} property; the historical Ant-based path was
+     * process-global, so each script's contribution stacked. Preserve that behavior by tracking
+     * deltas vs the baseline across all scripts and recomputing the resolved set as
      * {@code baseline + additions - removals}.
      */
     private final Set<String> accumulatedAdditions = new LinkedHashSet<>();
@@ -68,13 +51,7 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         listenerManager.addListener(new RootBuildLifecycleListener() {
             @Override
             public void afterStart() {
-                DirectoryScanner.resetDefaultExcludes();
                 currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
-                // Snapshot the freshly-reset DirectoryScanner state rather than assuming it
-                // matches GradleDefaultExcludes.DEFAULT_EXCLUDES_SET. If Ant's DEFAULTEXCLUDES
-                // ever drifts from our port, the user-mutation diff still works correctly and
-                // we don't emit false-positive deprecations.
-                lastObservedDirectoryScannerState = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
                 accumulatedAdditions.clear();
                 accumulatedRemovals.clear();
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
@@ -84,38 +61,22 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         listenerManager.addListener(new BuildAdapter() {
 
             @Override
-            public void settingsEvaluated(@NonNull Settings settings) {
+            public void settingsEvaluated(Settings settings) {
                 Set<String> fromSettings = settings.getFileSystemDefaultExcludes().get();
-                ImmutableSet<String> fromAnt = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
-
-                boolean settingsCustomized = !fromSettings.equals(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET);
-                // Compare against what we last wrote/observed, not against the original baseline:
-                // otherwise our own mirror writes from a previous settings.gradle would look like
-                // user-side Ant mutations and trigger false-positive deprecations.
-                boolean antMutatedByUser = !fromAnt.equals(lastObservedDirectoryScannerState);
-
-                if (settingsCustomized) {
-                    if (antMutatedByUser) {
-                        warnAntMutationIgnored();
-                    }
+                if (!fromSettings.equals(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET)) {
                     accumulateDelta(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET, fromSettings);
-                } else if (antMutatedByUser) {
-                    warnAntMutationDeprecated();
-                    accumulateDelta(lastObservedDirectoryScannerState, fromAnt);
                 }
 
                 Set<String> resolved = new LinkedHashSet<>(GradleDefaultExcludes.DEFAULT_EXCLUDES);
                 resolved.addAll(accumulatedAdditions);
                 resolved.removeAll(accumulatedRemovals);
 
-                syncDirectoryScanner(resolved);
                 applyDefaultExcludes(resolved);
             }
         });
     }
 
     private void applyDefaultExcludes(Set<String> resolved) {
-        lastObservedDirectoryScannerState = ImmutableSet.copyOf(resolved);
         currentDefaultExcludes = ImmutableList.copyOf(resolved);
         broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
     }
@@ -127,8 +88,6 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
     @Override
     public void updateCurrentDefaultExcludes(Set<String> excludes) {
-        syncDirectoryScanner(excludes);
-
         // Re-derive the accumulators from the supplied state so a later settingsEvaluated
         // call (which is unusual after this point but defensible) stacks correctly on top.
         accumulatedAdditions.clear();
@@ -162,35 +121,5 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
                 accumulatedAdditions.remove(e);
             }
         }
-    }
-
-    private static void syncDirectoryScanner(Set<String> excludes) {
-        for (String oldExclude : DirectoryScanner.getDefaultExcludes()) {
-            if (!excludes.contains(oldExclude)) {
-                DirectoryScanner.removeDefaultExclude(oldExclude);
-            }
-        }
-        for (String exclude : excludes) {
-            DirectoryScanner.addDefaultExclude(exclude);
-        }
-    }
-
-    private static void warnAntMutationDeprecated() {
-        DeprecationLogger.deprecateAction("Mutating org.apache.tools.ant.DirectoryScanner default excludes")
-            .withAdvice("Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
-                "For example: fileSystemDefaultExcludes.add(\"**/node_modules\").")
-            .willBeRemovedInGradle10()
-            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
-            .nagUser();
-    }
-
-    private static void warnAntMutationIgnored() {
-        DeprecationLogger.deprecateAction("Configuring file-system default excludes via both " +
-                "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes")
-            .withAdvice("settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
-                "Remove the DirectoryScanner calls from your settings script.")
-            .willBeRemovedInGradle10()
-            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
-            .nagUser();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -22,10 +22,12 @@ import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.BuildAdapter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
 import org.gradle.internal.file.excludes.GradleDefaultExcludes;
+import org.jspecify.annotations.NonNull;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,6 +41,12 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
      * The DirectoryScanner state we last observed or wrote ourselves. Used to detect user-side
      * mutations to {@link DirectoryScanner} (the deprecated legacy path) without false-positives
      * from the mirror writes this class performs in {@link #syncDirectoryScanner(Set)}.
+     *
+     * <p>Initialized to {@link DirectoryScanner#getDefaultExcludes()} immediately after
+     * {@link DirectoryScanner#resetDefaultExcludes()} in {@code afterStart}, so the user-mutation
+     * diff stays correct even if Ant's {@code DEFAULTEXCLUDES} ever drifts from
+     * {@link GradleDefaultExcludes#DEFAULT_EXCLUDES_SET} (the parity test would catch the drift,
+     * but we shouldn't emit false-positive deprecation warnings if it slips through).</p>
      */
     private ImmutableSet<String> lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
 
@@ -62,7 +70,11 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
                 currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
-                lastObservedDirectoryScannerState = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+                // Snapshot the freshly-reset DirectoryScanner state rather than assuming it
+                // matches GradleDefaultExcludes.DEFAULT_EXCLUDES_SET. If Ant's DEFAULTEXCLUDES
+                // ever drifts from our port, the user-mutation diff still works correctly and
+                // we don't emit false-positive deprecations.
+                lastObservedDirectoryScannerState = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
                 accumulatedAdditions.clear();
                 accumulatedRemovals.clear();
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
@@ -72,12 +84,11 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         listenerManager.addListener(new BuildAdapter() {
 
             @Override
-            public void settingsEvaluated(Settings settings) {
-                ImmutableSet<String> baseline = GradleDefaultExcludes.DEFAULT_EXCLUDES_SET;
+            public void settingsEvaluated(@NonNull Settings settings) {
                 Set<String> fromSettings = settings.getFileSystemDefaultExcludes().get();
                 ImmutableSet<String> fromAnt = ImmutableSet.copyOf(DirectoryScanner.getDefaultExcludes());
 
-                boolean settingsCustomized = !fromSettings.equals(baseline);
+                boolean settingsCustomized = !fromSettings.equals(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET);
                 // Compare against what we last wrote/observed, not against the original baseline:
                 // otherwise our own mirror writes from a previous settings.gradle would look like
                 // user-side Ant mutations and trigger false-positive deprecations.
@@ -87,7 +98,7 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
                     if (antMutatedByUser) {
                         warnAntMutationIgnored();
                     }
-                    accumulateDelta(baseline, fromSettings);
+                    accumulateDelta(GradleDefaultExcludes.DEFAULT_EXCLUDES_SET, fromSettings);
                 } else if (antMutatedByUser) {
                     warnAntMutationDeprecated();
                     accumulateDelta(lastObservedDirectoryScannerState, fromAnt);
@@ -129,16 +140,26 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
 
     /**
      * Records the diff between {@code before} and {@code after} into the running accumulators.
+     * A pattern explicitly re-included by a later script is removed from {@code accumulatedRemovals}
+     * so a later script can reverse an earlier script's removal; symmetrically, a pattern explicitly
+     * dropped by a later script is removed from {@code accumulatedAdditions}.
      */
     private void accumulateDelta(Set<String> before, Set<String> after) {
         for (String e : after) {
             if (!before.contains(e)) {
                 accumulatedAdditions.add(e);
+            } else {
+                // A baseline pattern present in `after` means this script wants it kept;
+                // cancel any earlier removal.
+                accumulatedRemovals.remove(e);
             }
         }
         for (String e : before) {
             if (!after.contains(e)) {
                 accumulatedRemovals.add(e);
+                // A baseline pattern absent from `after` means this script wants it gone;
+                // cancel any earlier explicit addition (defensive — additions are non-baseline).
+                accumulatedAdditions.remove(e);
             }
         }
     }
@@ -152,8 +173,24 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
         for (String exclude : excludes) {
             DirectoryScanner.addDefaultExclude(exclude);
         }
+    }
 
-        currentDefaultExcludes = ImmutableList.copyOf(excludes);
-        broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
+    private static void warnAntMutationDeprecated() {
+        DeprecationLogger.deprecateAction("Mutating org.apache.tools.ant.DirectoryScanner default excludes")
+            .withAdvice("Use settings.fileSystemDefaultExcludes in settings.gradle(.kts) instead. " +
+                "For example: fileSystemDefaultExcludes.add(\"**/node_modules\").")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
+            .nagUser();
+    }
+
+    private static void warnAntMutationIgnored() {
+        DeprecationLogger.deprecateAction("Configuring file-system default excludes via both " +
+                "org.apache.tools.ant.DirectoryScanner and settings.fileSystemDefaultExcludes")
+            .withAdvice("settings.fileSystemDefaultExcludes takes precedence; the DirectoryScanner mutation is ignored. " +
+                "Remove the DirectoryScanner calls from your settings script.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "directoryscanner_default_excludes_deprecation")
+            .nagUser();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -24,13 +24,14 @@ import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 
 import java.util.List;
 import java.util.Set;
 
 public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefaultExcludesProvider {
 
-    private ImmutableList<String> currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
+    private ImmutableList<String> currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
 
     private final AnonymousListenerBroadcast<FileSystemDefaultExcludesListener> broadcast;
 
@@ -41,7 +42,7 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
             @Override
             public void afterStart() {
                 DirectoryScanner.resetDefaultExcludes();
-                currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
+                currentDefaultExcludes = GradleDefaultExcludes.DEFAULT_EXCLUDES;
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -252,7 +252,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 virtualFileSystem,
                 writeListener,
                 statisticsCollector,
-                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
+                GradleDefaultExcludes.DEFAULT_EXCLUDES
             );
             listenerManager.addListener(defaultFileSystemAccess);
 
@@ -357,7 +357,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 root,
                 writeListener,
                 statisticsCollector,
-                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
+                GradleDefaultExcludes.DEFAULT_EXCLUDES
             );
 
             listenerManager.addListener(buildSessionsScopedVirtualFileSystem);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -19,7 +19,6 @@ package org.gradle.internal.service.scopes;
 import com.google.common.annotations.VisibleForTesting;
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.file.FileSystems;
-import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildSessionScopeFileTimeStampInspector;
@@ -60,6 +59,7 @@ import org.gradle.internal.file.DefaultFileSystemDefaultExcludesProvider;
 import org.gradle.internal.file.FileMetadataAccessor;
 import org.gradle.internal.file.FileSystemDefaultExcludesProvider;
 import org.gradle.internal.file.Stat;
+import org.gradle.internal.file.excludes.GradleDefaultExcludes;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
@@ -252,7 +252,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 virtualFileSystem,
                 writeListener,
                 statisticsCollector,
-                DirectoryScanner.getDefaultExcludes()
+                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
             );
             listenerManager.addListener(defaultFileSystemAccess);
 
@@ -357,7 +357,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 root,
                 writeListener,
                 statisticsCollector,
-                DirectoryScanner.getDefaultExcludes()
+                GradleDefaultExcludes.DEFAULT_EXCLUDES.toArray(new String[0])
             );
 
             listenerManager.addListener(buildSessionsScopedVirtualFileSystem);

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.file
+
+import org.apache.tools.ant.DirectoryScanner
+import org.gradle.internal.file.excludes.GradleDefaultExcludes
+import spock.lang.Specification
+
+/**
+ * Behavioral-parity guard for the Gradle-owned port of Ant's default excludes.
+ * If Ant ever changes its DEFAULTEXCLUDES list (e.g. on a version bump),
+ * this test fails so we can review the divergence and decide whether to track it.
+ */
+class GradleDefaultExcludesTest extends Specification {
+
+    def "Gradle default excludes match Ant's DirectoryScanner default excludes verbatim"() {
+        given:
+        DirectoryScanner.resetDefaultExcludes()
+
+        expect:
+        new HashSet<String>(GradleDefaultExcludes.DEFAULT_EXCLUDES) == new HashSet<String>(Arrays.asList(DirectoryScanner.getDefaultExcludes()))
+    }
+
+    def "GradleDefaultExcludes list is immutable"() {
+        when:
+        GradleDefaultExcludes.DEFAULT_EXCLUDES.add("**/foo")
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/GradleDefaultExcludesTest.groovy
@@ -16,24 +16,10 @@
 
 package org.gradle.internal.file
 
-import org.apache.tools.ant.DirectoryScanner
 import org.gradle.internal.file.excludes.GradleDefaultExcludes
 import spock.lang.Specification
 
-/**
- * Behavioral-parity guard for the Gradle-owned port of Ant's default excludes.
- * If Ant ever changes its DEFAULTEXCLUDES list (e.g. on a version bump),
- * this test fails so we can review the divergence and decide whether to track it.
- */
 class GradleDefaultExcludesTest extends Specification {
-
-    def "Gradle default excludes match Ant's DirectoryScanner default excludes verbatim"() {
-        given:
-        DirectoryScanner.resetDefaultExcludes()
-
-        expect:
-        new HashSet<String>(GradleDefaultExcludes.DEFAULT_EXCLUDES) == new HashSet<String>(Arrays.asList(DirectoryScanner.getDefaultExcludes()))
-    }
 
     def "GradleDefaultExcludes list is immutable"() {
         when:
@@ -41,5 +27,18 @@ class GradleDefaultExcludesTest extends Specification {
 
         then:
         thrown(UnsupportedOperationException)
+    }
+
+    def "GradleDefaultExcludes set is immutable"() {
+        when:
+        GradleDefaultExcludes.DEFAULT_EXCLUDES_SET.add("**/foo")
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "DEFAULT_EXCLUDES and DEFAULT_EXCLUDES_SET contain the same patterns"() {
+        expect:
+        new HashSet<>(GradleDefaultExcludes.DEFAULT_EXCLUDES) == GradleDefaultExcludes.DEFAULT_EXCLUDES_SET
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
@@ -217,7 +218,8 @@ public class TestFiles {
             fileSystem()::stat,
             virtualFileSystem,
             locations -> {},
-            new DirectorySnapshotterStatistics.Collector()
+            new DirectorySnapshotterStatistics.Collector(),
+            ImmutableList.of()
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to [#37882](https://github.com/gradle/gradle/pull/37882) (deprecation in 9.6.0). This PR is the **Gradle 10 removal** — the deprecation message in 9.6.0 already promises `willBeRemovedInGradle10()`, and this delivers on that.

**Targets the deprecation PR's branch** so the diff shows only the 2 unique removal commits. Will need to be rebased onto `master` once #37882 merges.

> ⚠️ **Do not merge until #37882 has shipped to users in at least one Gradle release.** Users need a chance to see the deprecation warning before the code path stops working.

## What this PR does

| Commit | What |
|---|---|
| `2a5e2294de7` | Drop `DirectoryScanner` read from `PatternSpecFactory`. Listener-only now. Removes a static-state read from a hot path (every `FileCollection` exclude resolution). |
| `1cf78fc8440` | Remove `DirectoryScanner` mutation deprecation + mirror from `DefaultFileSystemDefaultExcludesProvider`. Build-script calls to `DirectoryScanner.addDefaultExclude(...)` continue to compile (class is still on the classpath via the public `AntBuilder` API) but have no effect on Gradle's resolved excludes. Updates 5 test files accordingly. |

The mid-build mutation safety check (`InvalidUserCodeException("Cannot change default excludes during the build...")`) is also dropped along with the `PatternSpecFactory` read. With Gradle no longer consulting `DirectoryScanner` static state, mid-build mutations are silent no-ops anyway. Mid-build mutations via the new `Settings.fileSystemDefaultExcludes` `SetProperty` are not expected because the property is finalized after settings evaluation.

## What this PR does *not* do

- **Drop `libs.ant` from `:core`.** Ant remains on the runtime classpath for unrelated reasons: the public `AntBuilder` API, `Copy.filter(...)` Ant `FilterReader`s, and the `GradleApiSpecProvider` allowlist that exposes `org.apache.tools.ant.*` to user scripts. Removing those is part of the broader Ant-removal arc (Sterling's `org.gradle.ant-support` plugin design).
- **Update the Gradle 10 upgrade guide.** That document doesn't exist yet; when it's created an entry should be added pointing at the v9 deprecation section.

## Test plan

- [x] `:core-api:compileJava`, `:core:compileJava` clean
- [x] `:core:test --tests "*GradleDefaultExcludesTest*"`
- [x] `:snapshots:forkingIntegTest --tests "*DefaultExcludesIntegrationTest*"` (rewritten — old deprecation tests gone, new "is silently ignored" coverage added)
- [x] `:configuration-cache:embeddedIntegTest --tests "*ConfigurationCacheFileSystemDefaultExcludesTest*"` (fixture renamed; build-script-mutation case kept as negative test)
- [x] `sanityCheck` (binary compatibility ok; no `accepted-public-api-changes.json` entry needed)
- [ ] Full CI

Refs: gradle/gradle#11176, gradle/gradle#11177