### PR TITLE
fix(signing): Improve error message when signatory is not configured (#19417)

### DIFF
--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -228,7 +228,9 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @TaskAction
     public void generate() {
         if (getSignatory() == null) {
-            throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory");
+            throw new InvalidUserDataException("Cannot perform signing task '" + getPath() + "' because it has no configured signatory."
+                + " Please configure a signatory (e.g., PGP or in-memory) in the signing {} block."
+                + " See https://docs.gradle.org/current/userguide/signing_plugin.html for more information.");
         }
 
         for (Signature.Generator signature : sanitizedGenerators().values()) {


### PR DESCRIPTION
## Summary

Fixes #19417

The error message "Cannot perform signing task ':X' because it has no configured signatory" is unhelpful for users who encounter it — most have no idea what a "signatory" is or how to configure one.

## Root Cause

`Sign.java` line 231 throws `InvalidUserDataException` with a terse message that gives no guidance on resolution. Users searching for "no configured signatory" (which is common on Google) find the error but no actionable fix.

## Fix

Extended the error message in `Sign.java` to:
1. Explain that a signatory (PGP or in-memory) must be configured in the `signing {}` block
2. Include a link to the Gradle signing plugin documentation

The test in `NoSigningCredentialsIntegrationSpec.groovy` uses `failureHasCause` which performs substring matching — the existing assertion remains compatible with the new message.

## Changes

- `platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java`: improved error message (`+3 -1` lines)

## Testing

- **Existing test**: `NoSigningCredentialsIntegrationSpec` — `failureHasCause` substring match still passes with new message ✅
- **No signatory configured**: error now includes link to docs ✅
- **Signatory configured**: no change in behavior (condition is behind `if (getSignatory() == null)`) ✅