### PR TITLE
Fix Kotlin DSL Dokka page generation warnings

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
@@ -17,6 +17,7 @@
 package gradlebuild.docs;
 
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -96,8 +97,16 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
                 task.getGeneratedClasses().set(project.getLayout().getBuildDirectory().dir("gradle-kotlin-dsl-extensions/classes"));
             });
 
-        NamedDomainObjectContainer<DokkaSourceSetSpec> kotlinSourceSet = getDokkaExtension(project).getDokkaSourceSets();
-        kotlinSourceSet.register("kotlin_dsl", spec -> {
+        NamedDomainObjectContainer<DokkaSourceSetSpec> dokkaSourceSets = getDokkaExtension(project).getDokkaSourceSets();
+        NamedDomainObjectProvider<DokkaSourceSetSpec> javaApi = dokkaSourceSets.register("java_api", spec -> {
+            spec.getDisplayName().set("API");
+            spec.getSourceRoots().from(extension.getDocumentedSource());
+            spec.getClasspath().from(extension.getClasspath());
+            spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));
+            configureSourceLinks(project, extension, spec);
+        });
+
+        dokkaSourceSets.register("kotlin_dsl", spec -> {
             spec.getDisplayName().set("DSL");
             spec.getSourceRoots().from(extension.getKotlinDslSource());
             spec.getSourceRoots().from(runtimeExtensions.flatMap(GradleKotlinDslRuntimeGeneratedSources::getGeneratedSources));
@@ -105,15 +114,7 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
             spec.getClasspath().from(runtimeExtensions.flatMap(GradleKotlinDslRuntimeGeneratedSources::getGeneratedClasses));
             spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));
             configureSourceLinks(project, extension, spec);
-        });
-
-        NamedDomainObjectContainer<DokkaSourceSetSpec> javaSourceSet = getDokkaExtension(project).getDokkaSourceSets();
-        javaSourceSet.register("java_api", spec -> {
-            spec.getDisplayName().set("API");
-            spec.getSourceRoots().from(extension.getDocumentedSource());
-            spec.getClasspath().from(extension.getClasspath());
-            spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));
-            configureSourceLinks(project, extension, spec);
+            spec.getDependentSourceSets().addLater(javaApi.flatMap(DokkaSourceSetSpec::getSourceSetId));
         });
     }
 

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
@@ -36,7 +36,7 @@ class DocsDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 83
+        return 84
     }
 
     @Override


### PR DESCRIPTION
Generating the dokka pages throws a bunch of warning about not being to resolve Java types (run `:docs:dokkaGeneratePublicationHtml`, there are almost 200 of them). This PR fixes that.
There are still a few warning remaining (8), but there is a reason for that (they are  related to `kotlin-dsl` plugin types, which we don't want to expose).

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
