### PR TITLE
Introduce IP Diagnostics Mode

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
@@ -16,16 +16,20 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatureIntegrationTest
 
-import static org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME
-
 abstract class AbstractIsolatedProjectsIntegrationTest extends AbstractConfigurationCacheOptInFeatureIntegrationTest {
-    public static final String ENABLE_CLI = "-D${PROPERTY_NAME}=true"
+    public static final String ENABLE_CLI = "-D${StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME}=true"
+    public static final String ENABLE_DIAGNOSTICS = "-D${StartParameterBuildOptions.IsolatedProjectsDiagnosticsOption.PROPERTY_NAME}=true"
     final def fixture = new IsolatedProjectsFixture(this)
 
     void withIsolatedProjects(String... moreExecuterArgs) {
         executer.withArgument(ENABLE_CLI, *moreExecuterArgs)
+    }
+
+    void withIsolatedProjectsDiagnostics(String... moreExecuterArgs) {
+        executer.withArguments(ENABLE_CLI, ENABLE_DIAGNOSTICS, *moreExecuterArgs)
     }
 
     void isolatedProjectsRun(String... tasks) {
@@ -34,5 +38,9 @@ abstract class AbstractIsolatedProjectsIntegrationTest extends AbstractConfigura
 
     void isolatedProjectsFails(String... tasks) {
         fails(ENABLE_CLI, *tasks)
+    }
+
+    void isolatedProjectsDiagnosticsFails(String... tasks) {
+        fails(ENABLE_CLI, ENABLE_DIAGNOSTICS, *tasks)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
@@ -32,6 +32,11 @@ class AbstractIsolatedProjectsToolingApiIntegrationTest extends AbstractIsolated
     }
 
     @Override
+    void withIsolatedProjectsDiagnostics(String... moreExecuterArgs) {
+        executer.withArguments(ENABLE_CLI, ENABLE_DIAGNOSTICS, CONFIGURE_ON_DEMAND_FOR_TOOLING, CACHING_FOR_TOOLING, *moreExecuterArgs)
+    }
+
+    @Override
     GradleExecuter createExecuter() {
         return new ToolingApiBackedGradleExecuter(distribution, temporaryFolder)
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -39,7 +39,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -68,7 +68,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -98,7 +98,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -198,7 +198,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -261,7 +261,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -288,7 +288,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help", ":b:help")
+        isolatedProjectsDiagnosticsFails(":a:help", ":b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -347,7 +347,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help", ":b:help")
+        isolatedProjectsDiagnosticsFails(":a:help", ":b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -375,7 +375,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         when:
         // TODO:isolated expected behavior for incremental configuration
-//        isolatedProjectsFails(":a:help", ":b:help")
+//        isolatedProjectsDiagnosticsFails(":a:help", ":b:help")
         isolatedProjectsRun(":a:help", ":b:help")
 
         then:
@@ -585,7 +585,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":sub:sub-a:help", ":sub:sub-b:help")
+        isolatedProjectsDiagnosticsFails(":sub:sub-a:help", ":sub:sub-b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -617,7 +617,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help")
+        isolatedProjectsDiagnosticsFails(":a:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -722,7 +722,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         when:
         // TODO:isolated should succeed without problems
-        isolatedProjectsFails("something")
+        isolatedProjectsDiagnosticsFails("something")
 
         then:
         outputContains("project name = root")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromKotlinDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromKotlinDslIntegrationTest.groovy
@@ -38,7 +38,7 @@ class IsolatedProjectsAccessFromKotlinDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -68,7 +68,7 @@ class IsolatedProjectsAccessFromKotlinDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsDiagnosticsFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -96,7 +96,7 @@ class IsolatedProjectsAccessFromKotlinDslIntegrationTest extends AbstractIsolate
 
         when:
         // TODO:isolated expected behavior for incremental configuration
-//        isolatedProjectsFails(":a:help")
+//        isolatedProjectsDiagnosticsFails(":a:help")
         isolatedProjectsRun(":a:help")
 
         then:
@@ -128,7 +128,7 @@ class IsolatedProjectsAccessFromKotlinDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help", ":b:help")
+        isolatedProjectsDiagnosticsFails(":a:help", ":b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
@@ -74,8 +74,8 @@ class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegratio
 
         then:
         problems.assertFailureHasProblems(failure) {
-            withProblem("Build file 'sub/build.gradle': line 2: Project ':sub' cannot access 'Project.tasks' functionality on another project ':'")
-            withProblem("Build file 'sub/build.gradle': line 4: Project ':sub' cannot access 'Project.configurations' functionality on another project ':'")
+            withProblem("Build file '${relativePath('sub/build.gradle')}': line 2: Project ':sub' cannot access 'Project.tasks' functionality on another project ':'")
+            withProblem("Build file '${relativePath('sub/build.gradle')}': line 4: Project ':sub' cannot access 'Project.configurations' functionality on another project ':'")
             totalProblemsCount = 2
             problemsWithStackTraceCount = 2
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
@@ -58,6 +58,29 @@ class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegratio
         failure.assertHasDescription("Configuration Cache cannot be disabled when Isolated Projects is enabled.")
     }
 
+    def "diagnostics mode continues execution upon encountering violations"() {
+        settingsFile """
+            include(":sub")
+        """
+
+        buildFile "sub/build.gradle", """
+            rootProject.tasks
+
+            rootProject.configurations
+        """
+
+        when:
+        isolatedProjectsDiagnosticsFails("help")
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withProblem("Build file 'sub/build.gradle': line 2: Project ':sub' cannot access 'Project.tasks' functionality on another project ':'")
+            withProblem("Build file 'sub/build.gradle': line 4: Project ':sub' cannot access 'Project.configurations' functionality on another project ':'")
+            totalProblemsCount = 2
+            problemsWithStackTraceCount = 2
+        }
+    }
+
     @ToBeImplemented("when Isolated Projects becomes incremental for task execution")
     def "projects are configured on demand"() {
         settingsFile << """

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
@@ -33,7 +33,7 @@ class IsolatedProjectsProblemReportingIntegrationTest extends AbstractIsolatedPr
         }
 
         when:
-        isolatedProjectsFails("help")
+        isolatedProjectsDiagnosticsFails("help")
 
         then:
         outputContains("Configuration cache entry discarded with 530 problems.")
@@ -96,7 +96,7 @@ class IsolatedProjectsProblemReportingIntegrationTest extends AbstractIsolatedPr
         """
 
         when:
-        isolatedProjectsFails ':module:help'
+        isolatedProjectsDiagnosticsFails ':module:help'
 
         then:
         failure.assertHasFailures(2)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
@@ -29,7 +29,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
         """
 
         when:
-        withIsolatedProjects()
+        withIsolatedProjectsDiagnostics()
         fetchModelFails()
 
         then:
@@ -40,7 +40,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
         }
 
         when:
-        withIsolatedProjects()
+        withIsolatedProjectsDiagnostics()
         fetchModelFails()
 
         then:
@@ -62,7 +62,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
         """
 
         when:
-        withIsolatedProjects()
+        withIsolatedProjectsDiagnostics()
         fetchModelFails()
 
         then:
@@ -73,7 +73,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
         }
 
         when:
-        withIsolatedProjects()
+        withIsolatedProjectsDiagnostics()
         fetchModelFails()
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
@@ -34,7 +34,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
 
         then:
         fixture.assertModelStoredAndDiscarded {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":a", ":b")
             modelsCreated(":")
             problem("Build file 'build.gradle': line 3: Project ':' cannot access 'Project.plugins' functionality on subprojects via 'allprojects'", 2)
         }
@@ -45,7 +45,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
 
         then:
         fixture.assertModelStoredAndDiscarded {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":a", ":b")
             modelsCreated(":")
             problem("Build file 'build.gradle': line 3: Project ':' cannot access 'Project.plugins' functionality on subprojects via 'allprojects'", 2)
         }
@@ -67,7 +67,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
 
         then:
         fixture.assertModelStoredAndDiscarded {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":a", ":b")
             modelsCreated(":")
             problem("Plugin class 'my.MyPlugin': Project ':' cannot access 'Project.extensions' functionality on subprojects", 2)
         }
@@ -78,7 +78,7 @@ class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends Abst
 
         then:
         fixture.assertModelStoredAndDiscarded {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":a", ":b")
             modelsCreated(":")
             problem("Plugin class 'my.MyPlugin': Project ':' cannot access 'Project.extensions' functionality on subprojects", 2)
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -109,7 +109,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
 
         and:
         fixture.assertModelStored {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":", ":a", ":b")
             modelsCreated(":")
         }
         outputContains("creating model for root project 'root'")
@@ -124,6 +124,25 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         and: "the full build action result is replayed from the Configuration Cache entry"
         fixture.assertModelLoaded()
         outputDoesNotContain("creating model")
+    }
+
+    def "diagnostics mode configures all projects, ignoring configure-on-demand"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        includeProjects("a", "b")
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when: "configure-on-demand=tooling is set by the base fixture, but diagnostics must override it"
+        withIsolatedProjectsDiagnostics()
+        fetchModel()
+
+        then: "every project is configured even though only :'s model is fetched"
+        fixture.assertModelStored {
+            projectsConfigured(":buildSrc", ":", ":a", ":b")
+            modelsCreated(":")
+        }
     }
 
     def "diagnostics mode disables per-project model reuse"() {
@@ -143,7 +162,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
 
         and:
         fixture.assertModelStored {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":", ":a", ":b")
             modelsCreated(":")
         }
         outputContains("creating model for root project 'root'")
@@ -161,7 +180,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
 
         and: "without diagnostics, :buildSrc model would be reused; with diagnostics it is not"
         fixture.assertModelStored {
-            projectConfigured(":buildSrc")
+            projectsConfigured(":buildSrc", ":", ":a", ":b")
             modelsCreated(":")
         }
         outputContains("creating model for root project 'root'")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -92,6 +92,81 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         fixture.assertModelLoaded()
     }
 
+    def "diagnostics mode still allows top-level build action caching"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        includeProjects("a", "b")
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withIsolatedProjectsDiagnostics()
+        def model = fetchModel()
+
+        then:
+        model.message == "It works from project :"
+
+        and:
+        fixture.assertModelStored {
+            projectConfigured(":buildSrc")
+            modelsCreated(":")
+        }
+        outputContains("creating model for root project 'root'")
+
+        when: "repeating an identical request"
+        withIsolatedProjectsDiagnostics()
+        def model2 = fetchModel()
+
+        then:
+        model2.message == "It works from project :"
+
+        and: "the full build action result is replayed from the Configuration Cache entry"
+        fixture.assertModelLoaded()
+        outputDoesNotContain("creating model")
+    }
+
+    def "diagnostics mode disables per-project model reuse"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        includeProjects("a", "b")
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withIsolatedProjectsDiagnostics()
+        def model = fetchModel()
+
+        then:
+        model.message == "It works from project :"
+
+        and:
+        fixture.assertModelStored {
+            projectConfigured(":buildSrc")
+            modelsCreated(":")
+        }
+        outputContains("creating model for root project 'root'")
+
+        when: "invalidating CC by modifying the build script"
+        buildFile << """
+            myExtension.message = 'this is the root project'
+        """
+
+        withIsolatedProjectsDiagnostics()
+        def model2 = fetchModel()
+
+        then:
+        model2.message == "this is the root project"
+
+        and: "without diagnostics, :buildSrc model would be reused; with diagnostics it is not"
+        fixture.assertModelStored {
+            projectConfigured(":buildSrc")
+            modelsCreated(":")
+        }
+        outputContains("creating model for root project 'root'")
+    }
+
     @ToBeImplemented("when Isolated Projects becomes incremental for task execution")
     def "can cache models with tasks"() {
         given:

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParameters.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParameters.kt
@@ -30,6 +30,7 @@ internal sealed class AbstractBuildModelParameters : BuildModelParameters {
         "configureOnDemand" to isConfigureOnDemand,
         "invalidateCoupledProjects" to isInvalidateCoupledProjects,
         "isolatedProjects" to isIsolatedProjects,
+        "isolatedProjectsDiagnostics" to isIsolatedProjectsDiagnostics,
         "modelAsProjectDependency" to isModelAsProjectDependency,
         "modelBuilding" to isModelBuilding,
         "parallelModelBuilding" to isParallelModelBuilding,
@@ -59,6 +60,7 @@ internal class GradleVintageMode(
     override fun isConfigurationCacheParallelLoad(): Boolean = false
 
     override fun isIsolatedProjects(): Boolean = false
+    override fun isIsolatedProjectsDiagnostics(): Boolean = false
     override fun isParallelProjectConfiguration(): Boolean = false
     override fun isInvalidateCoupledProjects(): Boolean = false
     override fun isModelAsProjectDependency(): Boolean = false
@@ -88,6 +90,7 @@ internal class GradleConfigurationCacheMode(
     override fun isConfigurationCacheParallelLoad(): Boolean = configurationCacheParallelLoad
 
     override fun isIsolatedProjects(): Boolean = false
+    override fun isIsolatedProjectsDiagnostics(): Boolean = false
     override fun isParallelProjectConfiguration(): Boolean = false
     override fun isInvalidateCoupledProjects(): Boolean = false
     override fun isModelAsProjectDependency(): Boolean = false
@@ -102,6 +105,7 @@ internal class GradleConfigurationCacheMode(
 
 internal class GradleIsolatedProjectsMode(
     private val modelBuilding: Boolean,
+    private val isolatedProjectsDiagnostics: Boolean,
     private val parallelProjectExecution: Boolean,
     private val configureOnDemand: Boolean,
     private val configurationCacheParallelStore: Boolean,
@@ -123,6 +127,7 @@ internal class GradleIsolatedProjectsMode(
     override fun isConfigurationCacheParallelLoad(): Boolean = true
 
     override fun isIsolatedProjects(): Boolean = true
+    override fun isIsolatedProjectsDiagnostics(): Boolean = isolatedProjectsDiagnostics
     override fun isParallelProjectConfiguration(): Boolean = parallelProjectConfiguration
     override fun isInvalidateCoupledProjects(): Boolean = invalidateCoupledProjects
     override fun isModelAsProjectDependency(): Boolean = modelAsProjectDependency

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -198,14 +198,17 @@ object BuildModelParametersProvider {
         }
         validateIsolatedProjectsCachingOption(options)
 
+        val diagnostics = startParameter.isIsolatedProjectsDiagnostics
         val configureOnDemand = isolatedProjectsConfigureOnDemand.forInvocation(requirements, options)
-        val parallelIsolatedProjects = isolatedProjectsParallel.forInvocation(requirements, options)
+        // In Diagnostics mode, run sequentially so all violations can be collected deterministically.
+        val parallelIsolatedProjects = !diagnostics && isolatedProjectsParallel.forInvocation(requirements, options)
         val parallelConfigurationCacheStore = parallelIsolatedProjects && options[configurationCacheParallelStore]
         val invalidateCoupledProjects = options[invalidateCoupledProjects]
 
         return if (requirements.isCreatesModel) {
             GradleIsolatedProjectsMode(
                 modelBuilding = true,
+                isolatedProjectsDiagnostics = diagnostics,
                 parallelProjectExecution = parallelIsolatedProjects,
                 configureOnDemand = configureOnDemand,
                 configurationCacheParallelStore = parallelConfigurationCacheStore,
@@ -219,6 +222,7 @@ object BuildModelParametersProvider {
         } else {
             GradleIsolatedProjectsMode(
                 modelBuilding = false,
+                isolatedProjectsDiagnostics = diagnostics,
                 parallelProjectExecution = parallelIsolatedProjects,
                 configureOnDemand = configureOnDemand,
                 configurationCacheParallelStore = parallelConfigurationCacheStore,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -213,7 +213,7 @@ object BuildModelParametersProvider {
                 configureOnDemand = configureOnDemand,
                 configurationCacheParallelStore = parallelConfigurationCacheStore,
                 parallelProjectConfiguration = parallelIsolatedProjects,
-                cachingModelBuilding = options[isolatedProjectsCaching].buildingModels,
+                cachingModelBuilding = !diagnostics && options[isolatedProjectsCaching].buildingModels,
                 parallelModelBuilding = parallelIsolatedProjects,
                 invalidateCoupledProjects = invalidateCoupledProjects,
                 modelAsProjectDependency = options[modelProjectDependencies],

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -199,7 +199,8 @@ object BuildModelParametersProvider {
         validateIsolatedProjectsCachingOption(options)
 
         val diagnostics = startParameter.isIsolatedProjectsDiagnostics
-        val configureOnDemand = isolatedProjectsConfigureOnDemand.forInvocation(requirements, options)
+        // In Diagnostics mode, configure all projects to surface all possible violations.
+        val configureOnDemand = !diagnostics && isolatedProjectsConfigureOnDemand.forInvocation(requirements, options)
         // In Diagnostics mode, run sequentially so all violations can be collected deterministically.
         val parallelIsolatedProjects = !diagnostics && isolatedProjectsParallel.forInvocation(requirements, options)
         val parallelConfigurationCacheStore = parallelIsolatedProjects && options[configurationCacheParallelStore]

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -390,7 +390,7 @@ class BuildModelParametersProviderTest extends Specification {
             parallelProjectConfiguration: false,
             parallelModelBuilding: false,
             modelBuilding: models,
-            cachingModelBuilding: models,
+            cachingModelBuilding: false,
             modelAsProjectDependency: models,
         ])
 

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -39,6 +39,7 @@ class BuildModelParametersProviderTest extends Specification {
             configurationCacheParallelLoad: false,
 
             isolatedProjects: false,
+            isolatedProjectsDiagnostics: false,
             parallelProjectConfiguration: false,
             invalidateCoupledProjects: false,
             modelAsProjectDependency: false,
@@ -365,6 +366,39 @@ class BuildModelParametersProviderTest extends Specification {
         true  | true   | "tasks"    | false
         true  | true   | "tooling"  | false
         true  | true   | "false"    | false
+
+        description = tasks && models ? "running tasks and building models" : (tasks ? 'running tasks' : 'building models')
+    }
+
+    def "parameters when isolated projects diagnostics are enabled for #description"() {
+        given:
+        def params = parameters(runsTasks: tasks, createsModel: models) {
+            isolatedProjects = Option.Value.value(true)
+            setIsolatedProjectsDiagnostics(true)
+
+            // In diagnostics mode these knobs are ignored
+            setConfigurationCacheParallel(true)
+            systemPropertiesArgs[BuildModelParametersProvider.isolatedProjectsParallel.propertyName] = "true"
+            systemPropertiesArgs[BuildModelParametersProvider.isolatedProjectsCaching.propertyName] = "tooling"
+        }
+
+        expect:
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
+            isolatedProjectsDiagnostics: true,
+            parallelProjectExecution: false,
+            configurationCacheParallelStore: false,
+            parallelProjectConfiguration: false,
+            parallelModelBuilding: false,
+            modelBuilding: models,
+            cachingModelBuilding: models,
+            modelAsProjectDependency: models,
+        ])
+
+        where:
+        tasks | models
+        true  | false
+        false | true
+        true  | true
 
         description = tasks && models ? "running tasks and building models" : (tasks ? 'running tasks' : 'building models')
     }

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -380,6 +380,7 @@ class BuildModelParametersProviderTest extends Specification {
             setConfigurationCacheParallel(true)
             systemPropertiesArgs[BuildModelParametersProvider.isolatedProjectsParallel.propertyName] = "true"
             systemPropertiesArgs[BuildModelParametersProvider.isolatedProjectsCaching.propertyName] = "tooling"
+            systemPropertiesArgs[BuildModelParametersProvider.isolatedProjectsConfigureOnDemand.propertyName] = "true"
         }
 
         expect:
@@ -389,6 +390,7 @@ class BuildModelParametersProviderTest extends Specification {
             configurationCacheParallelStore: false,
             parallelProjectConfiguration: false,
             parallelModelBuilding: false,
+            configureOnDemand: false,
             modelBuilding: models,
             cachingModelBuilding: false,
             modelAsProjectDependency: models,

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -42,7 +42,7 @@ public interface BuildModelParameters {
      * <ul>
      * <li>Vintage: controlled by {@code --parallel} (or its property)
      * <li>CC: controlled by {@code --parallel} (or its property)
-     * <li>IP: always enabled
+     * <li>IP: always enabled, unless IP Diagnostics mode
      * </ul>
      */
     boolean isParallelProjectExecution();
@@ -64,8 +64,24 @@ public interface BuildModelParameters {
     @Nullable
     String getConfigurationCacheDisabledReason();
 
+    /**
+     * Whether the CC store phase runs in parallel.
+     * <ul>
+     * <li>Vintage: not applicable
+     * <li>CC: controlled by {@code org.gradle.configuration-cache.parallel} property
+     * <li>IP: always enabled, unless IP Diagnostics mode
+     * </ul>
+     */
     boolean isConfigurationCacheParallelStore();
 
+    /**
+     * Whether the CC load phase runs in parallel.
+     * <ul>
+     * <li>Vintage: not applicable
+     * <li>CC: always enabled
+     * <li>IP: always enabled
+     * </ul>
+     */
     boolean isConfigurationCacheParallelLoad();
 
     /**
@@ -74,10 +90,25 @@ public interface BuildModelParameters {
     boolean isIsolatedProjects();
 
     /**
+     * Whether the IP Diagnostics mode is enabled.
+     * <p>
+     * In this mode, the build continues past IP violations to surface as many problems as possible,
+     * trading off parallelism for completeness of the diagnostic report.
+     * <p>
+     * Implies {@link #isIsolatedProjects()}.
+     */
+    boolean isIsolatedProjectsDiagnostics();
+
+    /**
      * Whether projects should be configured in parallel.
      * <p>
      * This should only take effect if {@link #isConfigureOnDemand() configure-on-demand}
      * is not making us skip eager project configuration.
+     * <ul>
+     * <li>Vintage: always disabled
+     * <li>CC: always disabled
+     * <li>IP: always enabled, unless IP Diagnostics mode
+     * </ul>
      */
     boolean isParallelProjectConfiguration();
 
@@ -107,7 +138,7 @@ public interface BuildModelParameters {
      * <ul>
      * <li>Vintage: controlled by {@code --parallel}
      * <li>CC: not applicable, since CC is always disabled for model building invocations
-     * <li>IP: always enabled
+     * <li>IP: always enabled, unless IP Diagnostics mode
      * </ul>
      */
     boolean isParallelModelBuilding();

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -156,6 +156,7 @@ public class BuildActionSerializer {
             encoder.writeSmallInt(startParameter.getConfigurationCacheEntriesPerKey());
             encoder.writeNullableString(startParameter.getConfigurationCacheHeapDumpDir());
             encoder.writeBoolean(startParameter.isConfigurationCacheFineGrainedPropertyTracking());
+            encoder.writeBoolean(startParameter.isIsolatedProjectsDiagnostics());
             encoder.writeBoolean(startParameter.isConfigureOnDemand());
             encoder.writeBoolean(startParameter.isContinuous());
             encoder.writeLong(startParameter.getContinuousBuildQuietPeriod().toMillis());
@@ -256,6 +257,7 @@ public class BuildActionSerializer {
             startParameter.setConfigurationCacheEntriesPerKey(decoder.readSmallInt());
             startParameter.setConfigurationCacheHeapDumpDir(decoder.readNullableString());
             startParameter.setConfigurationCacheFineGrainedPropertyTracking(decoder.readBoolean());
+            startParameter.setIsolatedProjectsDiagnostics(decoder.readBoolean());
             startParameter.setConfigureOnDemand(decoder.readBoolean());
             startParameter.setContinuous(decoder.readBoolean());
             startParameter.setContinuousBuildQuietPeriod(Duration.ofMillis(decoder.readLong()));

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -51,6 +51,7 @@ public class StartParameterInternal extends StartParameter {
     private boolean configurationCacheIntegrityCheckEnabled;
     private @Nullable String configurationCacheHeapDumpDir;
     private boolean configurationCacheFineGrainedPropertyTracking = true;
+    private boolean isolatedProjectsDiagnostics = false;
     private boolean searchUpwards = true;
     private boolean useEmptySettings = false;
     private Duration continuousBuildQuietPeriod = Duration.ofMillis(250);
@@ -98,6 +99,7 @@ public class StartParameterInternal extends StartParameter {
         p.configurationCacheIntegrityCheckEnabled = configurationCacheIntegrityCheckEnabled;
         p.configurationCacheHeapDumpDir = configurationCacheHeapDumpDir;
         p.configurationCacheFineGrainedPropertyTracking = configurationCacheFineGrainedPropertyTracking;
+        p.isolatedProjectsDiagnostics = isolatedProjectsDiagnostics;
         p.searchUpwards = searchUpwards;
         p.useEmptySettings = useEmptySettings;
         p.enableProblemReportGeneration = enableProblemReportGeneration;
@@ -302,6 +304,14 @@ public class StartParameterInternal extends StartParameter {
 
     public boolean isConfigurationCacheFineGrainedPropertyTracking() {
         return configurationCacheFineGrainedPropertyTracking;
+    }
+
+    public boolean isIsolatedProjectsDiagnostics() {
+        return isolatedProjectsDiagnostics;
+    }
+
+    public void setIsolatedProjectsDiagnostics(boolean isolatedProjectsDiagnostics) {
+        this.isolatedProjectsDiagnostics = isolatedProjectsDiagnostics;
     }
 
     public void setContinuousBuildQuietPeriod(Duration continuousBuildQuietPeriod) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -90,6 +90,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new ConfigurationCacheHeapDumpDir(),
         new ConfigurationCacheFineGrainedPropertyTracking(),
         new IsolatedProjectsOption(),
+        new IsolatedProjectsDiagnosticsOption(),
         new ProblemReportGenerationOption(),
         new PropertyUpgradeReportOption(),
         new TaskGraphOption(),
@@ -687,6 +688,19 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
             settings.setIsolatedProjects(Option.Value.value(value));
+        }
+    }
+
+    public static class IsolatedProjectsDiagnosticsOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.diagnostics";
+
+        public IsolatedProjectsDiagnosticsOption() {
+            super(PROPERTY_NAME);
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
+            settings.setIsolatedProjectsDiagnostics(value);
         }
     }
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -463,11 +463,10 @@ In that case the build will fail, and one or more violations will be shown in th
 [[sec:diagnostics_mode]]
 === Diagnostics mode
 
-Diagnostics mode is an opt-in mode that helps you discover Isolated Projects <<sec:constraint_violations,constraint violations>> more efficiently during migration.
-It runs all of <<sec:perf_tasks,configuration>> *sequentially*, so every violation across every project is reported in a single invocation, regardless of where it occurs.
+_Diagnostics_ mode is an *opt-in* mode that helps you discover Isolated Projects <<sec:constraint_violations,constraint violations>> more efficiently during migration.
+It runs all <<sec:perf_tasks,configuration>> *sequentially*, so every violation across every project is reported in a single invocation, regardless of where it occurs.
 
-Enable Diagnostics mode by setting `org.gradle.unsafe.isolated-projects.diagnostics=true` in `gradle.properties`,
-or by passing it on the command line alongside `-Dorg.gradle.unsafe.isolated-projects=true`:
+Enable _Diagnostics_ mode by setting `org.gradle.unsafe.isolated-projects.diagnostics=true` in `gradle.properties`, or by passing it on the command line alongside `-Dorg.gradle.unsafe.isolated-projects=true`:
 
 [source,bash]
 ----
@@ -476,29 +475,25 @@ $ ./gradlew help \
     -Dorg.gradle.unsafe.isolated-projects.diagnostics=true
 ----
 
-Compared to normal Isolated Projects, Diagnostics mode disables several optimizations to maximize the completeness of the violation report:
+Compared to normal Isolated Projects, _Diagnostics_ mode disables several optimizations to maximize the completeness of the violation report:
 
 * Project configuration runs *sequentially* instead of in parallel.
 * Configuration Cache store runs *sequentially*.
 * Per-project model reuse across builds is *disabled*, so every model is rebuilt after an input change.
 * All projects are configured, ignoring any configure-on-demand setting.
 
-These trade-offs make Diagnostics mode to be unsuitable for day-to-day operations.
+These trade-offs make _Diagnostics_ mode unsuitable for day-to-day operations.
 Use it only to enumerate violations, such as during the migration, or to compare against the default Isolated Projects path when investigating a discrepancy.
 
 [NOTE]
 ====
-Diagnostics mode does not affect top-level Configuration Cache reuse.
-If you run the same invocation twice without any input changes, the second run still reuses the cached entry and reports nothing,
-because all violations were already reported on the cache-miss run.
+_Diagnostics_ mode does not affect top-level Configuration Cache reuse.
+If you run the same invocation twice without any input changes, the second run still reuses the cached entry and reports nothing, because all violations were already reported on the cache-miss run.
 Modify a build input (for example, edit a build script) between runs to re-exercise configuration.
 ====
 
-[NOTE]
-====
-Diagnostics mode does not change which patterns count as violations.
-A build that is clean under Isolated Projects is also clean under Diagnostics mode.
-====
+_Diagnostics_ mode does not change which patterns count as violations.
+A build that is clean under Isolated Projects is also clean under _Diagnostics_ mode.
 
 [[sec:ignore_violations]]
 === Temporarily ignoring violations

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -481,6 +481,7 @@ Compared to normal Isolated Projects, Diagnostics mode disables several optimiza
 * Project configuration runs *sequentially* instead of in parallel.
 * Configuration Cache store runs *sequentially*.
 * Per-project model reuse across builds is *disabled*, so every model is rebuilt after an input change.
+* All projects are configured, ignoring any configure-on-demand setting.
 
 These trade-offs make Diagnostics mode to be unsuitable for day-to-day operations.
 Use it only to enumerate violations, such as during the migration, or to compare against the default Isolated Projects path when investigating a discrepancy.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -46,6 +46,9 @@ The feature will enter incubation once Gradle's core has stronger support for th
 
 While the feature is experimental, notable changes are documented here rather than in release notes:
 
+* Gradle 9.6.0
+** Introduced <<sec:diagnostics_mode,Diagnostics mode>> that runs all of configuration sequentially to surface every Isolated Projects violation in a single invocation.
+
 * Gradle 9.4.0
 ** Isolated Projects violations are now deduplicated, making the Configuration Cache HTML reports significantly smaller.
 
@@ -457,6 +460,45 @@ org.gradle.unsafe.isolated-projects=true
 If you have never enabled the feature in the build before, it's likely that the build is not compatible and contains Isolated Projects <<sec:constraint_violations,constraint violations>>.
 In that case the build will fail, and one or more violations will be shown in the error message.
 
+[[sec:diagnostics_mode]]
+=== Diagnostics mode
+
+Diagnostics mode is an opt-in mode that helps you discover Isolated Projects <<sec:constraint_violations,constraint violations>> more efficiently during migration.
+It runs all of <<sec:perf_tasks,configuration>> *sequentially*, so every violation across every project is reported in a single invocation, regardless of where it occurs.
+
+Enable Diagnostics mode by setting `org.gradle.unsafe.isolated-projects.diagnostics=true` in `gradle.properties`,
+or by passing it on the command line alongside `-Dorg.gradle.unsafe.isolated-projects=true`:
+
+[source,bash]
+----
+$ ./gradlew help \
+    -Dorg.gradle.unsafe.isolated-projects=true \
+    -Dorg.gradle.unsafe.isolated-projects.diagnostics=true
+----
+
+Compared to normal Isolated Projects, Diagnostics mode disables several optimizations to maximize the completeness of the violation report:
+
+* Project configuration runs *sequentially* instead of in parallel.
+* Configuration Cache store runs *sequentially*.
+* Per-project model reuse across builds is *disabled*, so every model is rebuilt after an input change.
+
+These trade-offs make Diagnostics mode to be unsuitable for day-to-day operations.
+Use it only to enumerate violations, such as during the migration, or to compare against the default Isolated Projects path when investigating a discrepancy.
+
+[NOTE]
+====
+Diagnostics mode does not affect top-level Configuration Cache reuse.
+If you run the same invocation twice without any input changes, the second run still reuses the cached entry and reports nothing,
+because all violations were already reported on the cache-miss run.
+Modify a build input (for example, edit a build script) between runs to re-exercise configuration.
+====
+
+[NOTE]
+====
+Diagnostics mode does not change which patterns count as violations.
+A build that is clean under Isolated Projects is also clean under Diagnostics mode.
+====
+
 [[sec:ignore_violations]]
 === Temporarily ignoring violations
 
@@ -509,6 +551,9 @@ There can be more violations hidden by laziness, such as in the task configurati
 +
 You can find the Isolated Projects violations in the Configuration Cache HTML report.
 Use the report to pinpoint the incompatible pieces of build logic and plugins.
++
+For builds with many projects, also enable <<sec:diagnostics_mode,Diagnostics mode>>
+to surface violations across every project in a single invocation.
 
 2. Report the violations coming from the community plugins to their maintainers.
 +

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -464,7 +464,7 @@ In that case the build will fail, and one or more violations will be shown in th
 === Diagnostics mode
 
 _Diagnostics_ mode is an *opt-in* mode that helps you discover Isolated Projects <<sec:constraint_violations,constraint violations>> more efficiently during migration.
-It runs all <<sec:perf_tasks,configuration>> *sequentially*, so every violation across every project is reported in a single invocation, regardless of where it occurs.
+It runs configuration of projects *sequentially*, which allows the build to safely continue even after an IP violation is detected.
 
 Enable _Diagnostics_ mode by setting `org.gradle.unsafe.isolated-projects.diagnostics=true` in `gradle.properties`, or by passing it on the command line alongside `-Dorg.gradle.unsafe.isolated-projects=true`:
 
@@ -475,25 +475,29 @@ $ ./gradlew help \
     -Dorg.gradle.unsafe.isolated-projects.diagnostics=true
 ----
 
-Compared to normal Isolated Projects, _Diagnostics_ mode disables several optimizations to maximize the completeness of the violation report:
+Compared to default Isolated Projects behavior, _Diagnostics_ mode disables several optimizations to maximize the completeness and consistency of the violation reporting:
 
 * Project configuration runs *sequentially* instead of in parallel.
 * Configuration Cache store runs *sequentially*.
 * Per-project model reuse across builds is *disabled*, so every model is rebuilt after an input change.
 * All projects are configured, ignoring any configure-on-demand setting.
 
-These trade-offs make _Diagnostics_ mode unsuitable for day-to-day operations.
-Use it only to enumerate violations, such as during the migration, or to compare against the default Isolated Projects path when investigating a discrepancy.
+This mode is intended to be used during the migration or to compare against the default Isolated Projects behavior when investigating a discrepancy.
+Because parallelism and caching are deliberately disabled, builds running in this mode will be slower.
+For these reasons, we generally don't advise enabling this mode persistently or committing it to version control.
 
 [NOTE]
 ====
-_Diagnostics_ mode does not affect top-level Configuration Cache reuse.
-If you run the same invocation twice without any input changes, the second run still reuses the cached entry and reports nothing, because all violations were already reported on the cache-miss run.
-Modify a build input (for example, edit a build script) between runs to re-exercise configuration.
+Configuration Cache reuse is not affected by this mode.
+A cache entry is stored and can be reused only when the invocation is violation-free.
+To re-exercise configuration, change a build input as you would normally.
 ====
 
 _Diagnostics_ mode does not change which patterns count as violations.
 A build that is clean under Isolated Projects is also clean under _Diagnostics_ mode.
+
+Also, if a diagnostic run is free of violation, it doesn't mean that the entire build is guaranteed to be fully compatible with Isolated Projects.
+While the configuration of all projects is ensured, violations can hide behind additional layers of laziness, such as lazy configuration of tasks.
 
 [[sec:ignore_violations]]
 === Temporarily ignoring violations
@@ -539,17 +543,21 @@ It will also not prevent new incompatibilities being accidentally added to your 
 
 This section describes how to start making your build compatible with Isolated Projects.
 
-1. Run `./gradlew help -Dorg.gradle.unsafe.isolated-projects=true` to get the lay of the land
+1. Learn about incompatibilities in basic workflows
 +
-Running the help task makes Gradle configure all projects.
-This way Gradle can detect Isolated Projects violations that are present in any workflow and should be addressed first.
-There can be more violations hidden by laziness, such as in the task configuration logic, but those can be addressed later.
+Run the `help` task with Isolated Projects in the <<sec:diagnostics_mode,Diagnostics mode>>:
++
+[source,bash]
+----
+$ ./gradlew help \
+    -Dorg.gradle.unsafe.isolated-projects=true \
+    -Dorg.gradle.unsafe.isolated-projects.diagnostics=true
+----
++
+This way Gradle can detect Isolated Projects violations that are present in virtually any workflow and should be addressed first.
 +
 You can find the Isolated Projects violations in the Configuration Cache HTML report.
 Use the report to pinpoint the incompatible pieces of build logic and plugins.
-+
-For builds with many projects, also enable <<sec:diagnostics_mode,Diagnostics mode>>
-to surface violations across every project in a single invocation.
 
 2. Report the violations coming from the community plugins to their maintainers.
 +
@@ -560,6 +568,27 @@ It is best to report the incompatibilities as soon as possible so the plugin mai
 +
 Remember that Isolated Projects violations only detect concrete instances of the problem, e.g. one specific project touching some mutable state of another.
 It might not be enough to replace one API call with another to address the problem.
+
+4. Migrate the IDE sync workflow
++
+For IDE sync, the feature flag and <<sec:diagnostics_mode,Diagnostics mode>> must be enabled in the `gradle.properties` file to take effect.
++
+[source,properties]
+----
+org.gradle.unsafe.isolated-projects=true
+org.gradle.unsafe.isolated-projects.diagnostics=true
+----
++
+The IDE sync might exercise other code paths in the build logic or plugins, surfacing new violations that need to be addressed.
++
+Remember to disable _Diagnostics_ mode once the violations are addressed to ensure you are getting the performance improvements.
+
+5. Migrate other workflows
++
+Use the same approach for other scenarios, such as sanity checks and tests.
++
+You may observe different violations depending on which tasks you run.
+This is expected, since incompatible build logic can hide behind lazy task configuration.
 
 [[sec:migration_strategies]]
 === Build-logic refactoring strategies

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -482,6 +482,12 @@ Enables project isolation, which enables configuration caching.
 +
 _Default is `false`._
 
+`org.gradle.unsafe.isolated-projects.diagnostics=(true,false)`::
+Enables <<isolated_projects.adoc#sec:diagnostics_mode,Diagnostics mode>> for Isolated Projects, which runs configuration sequentially to surface every violation in a single invocation.
+Requires `org.gradle.unsafe.isolated-projects=true`.
++
+_Default is `false`._
+
 `org.gradle.vfs.verbose=(true,false)`::
 Configures verbose logging when <<file_system_watching.adoc#sec:daemon_watch_fs,watching the file system>>.
 +

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -478,13 +478,15 @@ An explicit value will override `org.gradle.parallel` in this context.
 _Default is the value of `org.gradle.parallel`._
 
 `org.gradle.unsafe.isolated-projects=(true,false)`::
-Enables project isolation, which enables configuration caching.
+
+Enables <<isolated_projects.adoc#isolated_projects,Isolated Projects>>.
 +
 _Default is `false`._
 
-`org.gradle.unsafe.isolated-projects.diagnostics=(true,false)`::
-Enables <<isolated_projects.adoc#sec:diagnostics_mode,Diagnostics mode>> for Isolated Projects, which runs configuration sequentially to surface every violation in a single invocation.
-Requires `org.gradle.unsafe.isolated-projects=true`.
+`org.gradle.unsafe.isolated-projects.diagnostics=(true,false)`  since-gradle-label:9.6.0[]::
+
+Enables <<isolated_projects.adoc#sec:diagnostics_mode,Diagnostics mode>> for Isolated Projects, which runs project configuration sequentially to surface violations across all projects in a deterministic manner.
+Requires <<isolated_projects.adoc#sec:enable,Isolated Projects>> to be enabled.
 +
 _Default is `false`._
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/34799

Adds an opt-in `org.gradle.unsafe.isolated-projects.diagnostics=true` that disables the IP optimizations which mask or reorder violations: parallel project configuration, parallel CC store, per-project tooling model reuse, and internal configure-on-demand.

**Notes on scope**

- The IP problem severity is unchanged. `onIsolatedProjectsProblem` still reports as `Deferred` in both default and Diagnostics mode. The "fail fast on IP problems" half of the issue is left for a follow-up so that landing the diagnostic surface and changing the default behavior remain separable.
- Top-level Configuration Cache reuse is *preserved* in Diagnostics mode. Violations are caught on the cache-miss run; identical re-runs replay the entry. Users invalidate CC the usual way when they want to re-exercise configuration.
- "Realize all tasks" from the issue's implementation list is not done here. Diagnostics mode inherits whatever the rest of IP does for task realization.

**Test scope**

Existing IP integration tests that depend on collecting *multiple* violations in one invocation (multi-`problem(...)` or `problem(..., count ≥ 2)` assertions) are switched to the diagnostics runner; the rest stay on default IP. New tests cover parameter wiring, end-to-end multi-violation collection, that top-level CC reuse is preserved while per-project model reuse is not, and that all projects are configured even when configure-on-demand would skip some.