### PR TITLE
Re-use stream thread for waiting for process exit 

### DIFF
--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -30,6 +30,7 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ProcessExecutionException;
 import org.gradle.process.internal.shutdown.ShutdownHooks;
+import org.gradle.process.internal.streams.FinishNotifyingStreamsHandler;
 import org.gradle.process.internal.streams.StreamsHandler;
 import org.jspecify.annotations.Nullable;
 
@@ -503,11 +504,20 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
         }
     }
 
-    private class CompositeStreamsHandler implements StreamsHandler {
+    private class CompositeStreamsHandler implements FinishNotifyingStreamsHandler {
         @Override
         public void connectStreams(Process process, String processName, Executor executor) {
             inputHandler.connectStreams(process, processName, executor);
             outputHandler.connectStreams(process, processName, executor);
+        }
+
+        @Override
+        public void whenStreamsFinished(Runnable callback) {
+            if (outputHandler instanceof FinishNotifyingStreamsHandler) {
+                ((FinishNotifyingStreamsHandler) outputHandler).whenStreamsFinished(callback);
+            } else {
+                throw new IllegalStateException("Output handler does not support whenStreamsFinished callback");
+            }
         }
 
         @Override

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -25,7 +25,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.process.internal.streams.StreamsHandler;
+import org.gradle.process.internal.streams.FinishNotifyingStreamsHandler;
 
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
@@ -47,13 +47,13 @@ public class ExecHandleRunner implements Runnable {
     private final ProcessLauncher processLauncher;
     private final Executor executor;
 
-    private Process process;
-    private boolean aborted;
-    private final StreamsHandler streamsHandler;
+    private volatile Process process;
+    private volatile boolean aborted;
+    private final FinishNotifyingStreamsHandler streamsHandler;
     private volatile BuildOperationRef associatedBuildOperation;
 
     public ExecHandleRunner(
-        DefaultExecHandle execHandle, StreamsHandler streamsHandler, ProcessLauncher processLauncher, Executor executor,
+        DefaultExecHandle execHandle, FinishNotifyingStreamsHandler streamsHandler, ProcessLauncher processLauncher, Executor executor,
         BuildOperationRef associatedBuildOperation
     ) {
         if (execHandle == null) {
@@ -154,33 +154,36 @@ public class ExecHandleRunner implements Runnable {
 
     @Override
     public void run() {
-        // Split the `with` operation so that the `associatedBuildOperation` can be discarded when we wait in `process.waitFor()`
-        try {
-            CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
+        CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
+            try {
                 startProcess();
 
                 execHandle.started();
 
                 LOGGER.debug("waiting until streams are handled...");
                 streamsHandler.start();
-            });
 
-            if (execHandle.isDaemon()) {
-                CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
+                if (execHandle.isDaemon()) {
                     streamsHandler.stop();
                     detached();
-                });
-            } else {
-                int exitValue = process.waitFor();
-                CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
-                    streamsHandler.stop();
-                    completed(exitValue);
-                });
-            }
-        } catch (Throwable t) {
-            CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
+                } else {
+                    streamsHandler.whenStreamsFinished(this::completeProcess);
+                }
+            } catch (Throwable t) {
                 execHandle.failed(t);
+            }
+        });
+    }
+
+    private void completeProcess() {
+        try {
+            int exitValue = process.waitFor();
+            CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> {
+                streamsHandler.stop();
+                completed(exitValue);
             });
+        } catch (Throwable t) {
+            CurrentBuildOperationRef.instance().with(this.associatedBuildOperation, () -> execHandle.failed(t));
         }
     }
 

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
@@ -25,7 +25,6 @@ import org.gradle.internal.operations.CurrentBuildOperationRef;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.CountDownLatch;
 
 public class ExecOutputHandleRunner implements Runnable {
     private final static Logger LOGGER = Logging.getLogger(ExecOutputHandleRunner.class);
@@ -34,20 +33,20 @@ public class ExecOutputHandleRunner implements Runnable {
     private final InputStream inputStream;
     private final OutputStream outputStream;
     private final int bufferSize;
-    private final CountDownLatch completed;
+    private final Runnable onFinished;
     private volatile boolean closed;
     private volatile BuildOperationRef associatedBuildOperation;
 
-    public ExecOutputHandleRunner(String displayName, InputStream inputStream, OutputStream outputStream, CountDownLatch completed) {
-        this(displayName, inputStream, outputStream, 8192, completed);
+    public ExecOutputHandleRunner(String displayName, InputStream inputStream, OutputStream outputStream, Runnable onFinished) {
+        this(displayName, inputStream, outputStream, 8192, onFinished);
     }
 
-    ExecOutputHandleRunner(String displayName, InputStream inputStream, OutputStream outputStream, int bufferSize, CountDownLatch completed) {
+    ExecOutputHandleRunner(String displayName, InputStream inputStream, OutputStream outputStream, int bufferSize, Runnable onFinished) {
         this.displayName = displayName;
         this.inputStream = inputStream;
         this.outputStream = outputStream;
         this.bufferSize = bufferSize;
-        this.completed = completed;
+        this.onFinished = onFinished;
     }
 
     public void associateBuildOperation(BuildOperationRef startupRef) {
@@ -63,7 +62,7 @@ public class ExecOutputHandleRunner implements Runnable {
         try {
             forwardContent();
         } finally {
-            completed.countDown();
+            onFinished.run();
         }
     }
 

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/FinishNotifyingStreamsHandler.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/FinishNotifyingStreamsHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal.streams;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link StreamsHandler} that can report when its asynchronous stream work has finished.
+ */
+@NullMarked
+public interface FinishNotifyingStreamsHandler extends StreamsHandler {
+    /**
+     * Runs the given callback exactly once, after all asynchronous stream work has finished.
+     *
+     * <p>The callback runs on the thread that finishes the last piece of stream work, or on the
+     * calling thread if that work already finished.
+     */
+    void whenStreamsFinished(Runnable callback);
+}

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
@@ -47,7 +47,7 @@ public class ForwardStdinStreamsHandler implements StreamsHandler {
             will run forever. It would be better to ensure that this thread stops when the process does.
          */
         InputStream instr = new DisconnectableInputStream(input);
-        standardInputWriter = new ExecOutputHandleRunner("write standard input to " + processName, instr, process.getOutputStream(), completed);
+        standardInputWriter = new ExecOutputHandleRunner("write standard input to " + processName, instr, process.getOutputStream(), completed::countDown);
     }
 
     @Override

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
@@ -20,17 +20,20 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 
 import java.io.OutputStream;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reads from the process' stdout and stderr (if not merged into stdout) and forwards to {@link OutputStream}.
  */
-public class OutputStreamsForwarder implements StreamsHandler {
+public class OutputStreamsForwarder implements FinishNotifyingStreamsHandler {
     private final OutputStream standardOutput;
     private final OutputStream errorOutput;
     private final boolean readErrorStream;
-    private final CountDownLatch completed;
+    private final AtomicInteger pendingStreams;
+    private final CompletableFuture<Void> streamsFinished = new CompletableFuture<>();
     private Executor executor;
     private volatile ExecOutputHandleRunner standardOutputReader;
     private volatile ExecOutputHandleRunner standardErrorReader;
@@ -39,15 +42,15 @@ public class OutputStreamsForwarder implements StreamsHandler {
         this.standardOutput = standardOutput;
         this.errorOutput = errorOutput;
         this.readErrorStream = readErrorStream;
-        this.completed = new CountDownLatch(readErrorStream ? 2 : 1);
+        this.pendingStreams = new AtomicInteger(readErrorStream ? 2 : 1);
     }
 
     @Override
     public void connectStreams(Process process, String processName, Executor executor) {
         this.executor = executor;
-        standardOutputReader = new ExecOutputHandleRunner("read standard output of " + processName, process.getInputStream(), standardOutput, completed);
+        standardOutputReader = new ExecOutputHandleRunner("read standard output of " + processName, process.getInputStream(), standardOutput, this::streamFinished);
         if (readErrorStream) {
-            standardErrorReader = new ExecOutputHandleRunner("read error output of " + processName, process.getErrorStream(), errorOutput, completed);
+            standardErrorReader = new ExecOutputHandleRunner("read error output of " + processName, process.getErrorStream(), errorOutput, this::streamFinished);
         }
     }
 
@@ -69,11 +72,22 @@ public class OutputStreamsForwarder implements StreamsHandler {
         }
     }
 
+    private void streamFinished() {
+        if (pendingStreams.decrementAndGet() == 0) {
+            streamsFinished.complete(null);
+        }
+    }
+
+    @Override
+    public void whenStreamsFinished(Runnable callback) {
+        CompletableFuture<Void> ignored = streamsFinished.thenRun(callback);
+    }
+
     @Override
     public void stop() {
         try {
-            completed.await();
-        } catch (InterruptedException e) {
+            streamsFinished.get();
+        } catch (InterruptedException | ExecutionException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
     }

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -25,12 +25,11 @@ import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecResult
 import org.gradle.process.ProcessExecutionException
-import org.gradle.process.internal.streams.StreamsHandler
+import org.gradle.process.internal.streams.FinishNotifyingStreamsHandler
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
-
 import org.gradle.util.UsesNativeServices
 import org.gradle.util.internal.GUtil
 import org.gradle.util.internal.TextUtil
@@ -39,6 +38,7 @@ import spock.lang.Ignore
 import spock.lang.Timeout
 
 import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 
 @UsesNativeServices
@@ -219,6 +219,38 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         execHandle.state == ExecHandleState.ABORTED
         and:
         execHandle.waitForFinish().exitValue != 0
+    }
+
+    void "waits for the process to exit before stopping the streams"() {
+        given:
+        def marker = tmpDir.file("outputs-closed")
+        def stdinReady = new CountDownLatch(1)
+        def content = "42\n".bytes
+        def pos = 0
+        def stdin = new InputStream() {
+            @Override
+            int read() {
+                stdinReady.await()
+                pos < content.length ? (content[pos++] & 0xff) : -1
+            }
+        }
+        def execHandle = handle()
+            .args(args(StdinAfterOutputsClosedApp.class, marker.absolutePath))
+            .setStandardInput(stdin)
+            .build()
+
+        when:
+        execHandle.start()
+        def deadline = System.currentTimeMillis() + 30000
+        while (!marker.exists()) {
+            assert System.currentTimeMillis() < deadline
+            Thread.sleep(20)
+        }
+        stdinReady.countDown()
+        def result = execHandle.waitForFinish()
+
+        then:
+        result.exitValue == 42
     }
 
     void "can abort after process has completed"() {
@@ -475,7 +507,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
 
     void "exec handle collaborates with streams handler"() {
         given:
-        def streamsHandler = Mock(StreamsHandler)
+        def streamsHandler = Mock(FinishNotifyingStreamsHandler)
         def execHandle = handle().args(args(TestApp.class)).setDisplayName("foo proc").streamsHandler(streamsHandler).build()
 
         when:
@@ -486,6 +518,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         result.rethrowFailure()
         1 * streamsHandler.connectStreams(_ as Process, "foo proc", _ as Executor)
         1 * streamsHandler.start()
+        1 * streamsHandler.whenStreamsFinished(_) >> { Runnable callback -> callback.run() }
         1 * streamsHandler.stop()
         0 * streamsHandler._
     }
@@ -563,6 +596,20 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
     public static class SlowApp {
         public static void main(String[] args) throws InterruptedException {
             Thread.sleep(10000L)
+        }
+    }
+
+    public static class StdinAfterOutputsClosedApp {
+        public static void main(String[] args) throws Exception {
+            System.out.close()
+            System.err.close()
+            new File(args[0]).createNewFile()
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))
+            String line = reader.readLine()
+            if (line == null) {
+                System.exit(99)
+            }
+            System.exit(Integer.parseInt(line.trim()))
         }
     }
 

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/streams/ExecOutputHandleRunnerTest.groovy
@@ -29,7 +29,7 @@ class ExecOutputHandleRunnerTest extends Specification {
         def input = new ByteArrayInputStream("hello".bytes)
         def output = new ByteArrayOutputStream()
         def completed = new CountDownLatch(1)
-        def runner = new ExecOutputHandleRunner("test", input, output, 4, completed)
+        def runner = new ExecOutputHandleRunner("test", input, output, 4, completed.&countDown)
 
         when:
         runner.run()
@@ -50,7 +50,7 @@ class ExecOutputHandleRunnerTest extends Specification {
         def lineSeparator = SystemProperties.instance.lineSeparator
         def output = new LineBufferingOutputStream(action, lineSeparator)
         def input = new ByteArrayInputStream(text.getBytes("utf-8"))
-        def runner = new ExecOutputHandleRunner("test", input, output, bufferLength, new CountDownLatch(1))
+        def runner = new ExecOutputHandleRunner("test", input, output, bufferLength, {})
 
         when:
         runner.run()

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/streams/OutputStreamsForwarderTest.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/streams/OutputStreamsForwarderTest.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal.streams
+
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicInteger
+
+@Timeout(60)
+class OutputStreamsForwarderTest extends Specification {
+
+    def pending = []
+    def executor = { Runnable task -> pending << task } as Executor
+    def fireCount = new AtomicInteger()
+
+    def process = Stub(Process) {
+        getInputStream() >> new ByteArrayInputStream(new byte[0])
+        getErrorStream() >> new ByteArrayInputStream(new byte[0])
+    }
+
+    OutputStreamsForwarder forwarder(boolean readErrorStream) {
+        def forwarder = new OutputStreamsForwarder(
+            new ByteArrayOutputStream(),
+            new ByteArrayOutputStream(),
+            readErrorStream
+        )
+        forwarder.connectStreams(process, "test process", executor)
+        forwarder.start()
+        forwarder
+    }
+
+    def "fires callback registered before streams finish once both pumps are done"() {
+        def forwarder = forwarder(true)
+        forwarder.whenStreamsFinished { fireCount.incrementAndGet() }
+
+        when:
+        pending[0].run()
+
+        then:
+        fireCount.get() == 0
+
+        when:
+        pending[1].run()
+
+        then:
+        fireCount.get() == 1
+    }
+
+    def "fires callback immediately when registered after streams finished"() {
+        def forwarder = forwarder(true)
+        pending.each { it.run() }
+
+        when:
+        forwarder.whenStreamsFinished { fireCount.incrementAndGet() }
+
+        then:
+        fireCount.get() == 1
+    }
+
+    def "fires each registered callback exactly once"() {
+        def forwarder = forwarder(true)
+        pending.each { it.run() }
+
+        when:
+        forwarder.whenStreamsFinished { fireCount.incrementAndGet() }
+        forwarder.whenStreamsFinished { fireCount.incrementAndGet() }
+
+        then:
+        fireCount.get() == 2
+    }
+
+    def "fires callback when only standard output is read"() {
+        def forwarder = forwarder(false)
+        forwarder.whenStreamsFinished { fireCount.incrementAndGet() }
+
+        when:
+        pending[0].run()
+
+        then:
+        pending.size() == 1
+        fireCount.get() == 1
+    }
+
+    def "finishing streams without a registered callback is a no-op"() {
+        forwarder(true)
+
+        when:
+        pending.each { it.run() }
+
+        then:
+        noExceptionThrown()
+        fireCount.get() == 0
+    }
+}


### PR DESCRIPTION
Part of #25488

This allows us to save the thread normally used for that. Unfortunately, we couldn't just use `Process.onExit()` as it always enqueues a task on the ForkJoinPool, which can lead to deadlocks or slowdowns if all ForkJoinPool threads are occupied blocking on work that requires a process exit to be reaped. The benefit of this is that even on Java 8, we will still save the thread regardless!

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
