### PR TITLE
Make ResolutionResult API thread safe

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
@@ -25,6 +25,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.ref.SoftReference;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -42,6 +44,7 @@ public class DefaultVisitedGraphResults implements VisitedGraphResults {
      * no additional context. Only hold a soft reference to it to avoid retained memory
      * if no other references to the wrapper graph exist.
      */
+    private final Lock lock = new ReentrantLock();
     private @Nullable SoftReference<ResolvedGraphResult> resolvedGraphResult = null;
     private final Supplier<ResolvedGraphResult> resolvedGraphResultSource;
 
@@ -54,19 +57,24 @@ public class DefaultVisitedGraphResults implements VisitedGraphResults {
         this.unresolvedDependencies = unresolvedDependencies;
 
         this.resolvedGraphResultSource = () -> {
-            if (resolvedGraphResult != null) {
-                ResolvedGraphResult value = resolvedGraphResult.get();
-                if (value != null) {
-                    return value;
+            lock.lock();
+            try {
+                if (resolvedGraphResult != null) {
+                    ResolvedGraphResult value = resolvedGraphResult.get();
+                    if (value != null) {
+                        return value;
+                    }
                 }
-            }
 
-            ResolvedGraphResult value = new ResolvedGraphResult(
-                graphStructureSource.get(),
-                resolvedDependencyGraph.availableVariantsByComponent()
-            );
-            this.resolvedGraphResult = new SoftReference<>(value);
-            return value;
+                ResolvedGraphResult value = new ResolvedGraphResult(
+                    graphStructureSource.get(),
+                    resolvedDependencyGraph.availableVariantsByComponent()
+                );
+                this.resolvedGraphResult = new SoftReference<>(value);
+                return value;
+            } finally {
+                lock.unlock();
+            }
         };
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -30,9 +30,9 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
+import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -40,12 +40,10 @@ import java.util.Set;
 public class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
 
     private final int index;
-    private final IntList nodeIndices;
     private final ResolvedGraphResult graph;
 
-    private @Nullable ImmutableList<ResolvedVariantResult> variants;
-    private @Nullable Set<? extends DependencyResult> cachedComponentDependencies;
-    private @Nullable List<@Nullable ImmutableList<DependencyResult>> variantDependencies;
+    private final Lazy<ImmutableList<ResolvedVariantResult>> variants;
+    private final Lazy<ComponentDependencies> dependencies;
 
     public DefaultResolvedComponentResult(
         int index,
@@ -53,8 +51,16 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         ResolvedGraphResult graph
     ) {
         this.index = index;
-        this.nodeIndices = nodeIndices;
         this.graph = graph;
+
+        this.variants = Lazy.locking().of(() -> computeVariants(graph, nodeIndices));
+        this.dependencies = Lazy.locking().of(() -> computeDependencies(
+            graph,
+            nodeIndices,
+            // Ideally, we would not leak `this` before the constructor returns, but doing so
+            // would require us to hand-roll locks instead of using `Lazy`
+            this
+        ));
     }
 
     @Override
@@ -85,16 +91,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public Set<? extends DependencyResult> getDependencies() {
-        if (cachedComponentDependencies == null) {
-            ImmutableSet.Builder<DependencyResult> builder = ImmutableSet.builder();
-            for (ResolvedVariantResult variant : getVariants()) {
-                for (DependencyResult dependency : getDependenciesForVariant(variant)) {
-                    builder.add(dependency);
-                }
-            }
-            this.cachedComponentDependencies = builder.build();
-        }
-        return cachedComponentDependencies;
+        return dependencies.get().componentDependencies;
     }
 
     @Override
@@ -119,15 +116,19 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public List<ResolvedVariantResult> getVariants() {
-        if (variants == null) {
-            int size = nodeIndices.size();
-            ImmutableList.Builder<ResolvedVariantResult> builder = ImmutableList.builderWithExpectedSize(size);
-            for (int i = 0; i < size; i++) {
-                builder.add(graph.getVariant(nodeIndices.getInt(i)));
-            }
-            this.variants = builder.build();
+        return variants.get();
+    }
+
+    private static ImmutableList<ResolvedVariantResult> computeVariants(
+        ResolvedGraphResult graph,
+        IntList nodeIndices
+    ) {
+        int size = nodeIndices.size();
+        ImmutableList.Builder<ResolvedVariantResult> builder = ImmutableList.builderWithExpectedSize(size);
+        for (int i = 0; i < size; i++) {
+            builder.add(graph.getVariant(nodeIndices.getInt(i)));
         }
-        return variants;
+        return builder.build();
     }
 
     @Override
@@ -153,51 +154,72 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
             throw new InvalidUserCodeException("Variant '" + variant.getDisplayName() + "' doesn't belong to resolved component '" + this + "'. " + moreInfo + " Most likely you are using a variant from another component to get the dependencies of this component.");
         }
 
-        if (variantDependencies == null) {
-            variantDependencies = new ArrayList<>(selectedVariants.size());
-            for (int i = 0; i < selectedVariants.size(); i++) {
-                variantDependencies.add(null);
-            }
-        }
-
-        ImmutableList<DependencyResult> result = variantDependencies.get(indexInComponent);
-        if (result == null) {
-            GraphStructure.Edges edges = graph.structure().edges();
-
-            int nodeIndex = nodeIndices.getInt(indexInComponent);
-            int start = edges.start(nodeIndex);
-            int end = edges.end(nodeIndex);
-            ImmutableSet.Builder<DependencyResult> builder = ImmutableSet.builderWithExpectedSize(end - start);
-            for (int i = start; i < end; i++) {
-                ComponentSelector selector = edges.selector(i);
-                boolean constraint = edges.constraint(i);
-                int targetNodeIndex = edges.targetNode(i);
-                if (targetNodeIndex != -1) {
-                    int targetComponentIndex = graph.structure().nodes().owner(targetNodeIndex);
-                    builder.add(new DefaultResolvedDependencyResult(
-                        selector,
-                        constraint,
-                        this,
-                        graph.getComponent(targetComponentIndex),
-                        graph.getVariant(targetNodeIndex)
-                    ));
-                } else {
-                    GraphStructure.Edges.EdgeFailure failure = edges.failure(i);
-                    builder.add(new DefaultUnresolvedDependencyResult(
-                        selector,
-                        this,
-                        constraint,
-                        failure.failure(),
-                        failure.reason()
-                    ));
-                }
-            }
-            result = builder.build().asList();
-            variantDependencies.set(indexInComponent, result);
-        }
-
-        return result;
+        return dependencies.get().variantDependencies.get(indexInComponent);
     }
+
+    private static ComponentDependencies computeDependencies(
+        ResolvedGraphResult graph,
+        IntList nodeIndices,
+        ResolvedComponentResult fromComponent
+    ) {
+        ImmutableSet.Builder<DependencyResult> componentDependencies = ImmutableSet.builder();
+        ImmutableList.Builder<ImmutableList<DependencyResult>> allVariantDependencies = ImmutableList.builderWithExpectedSize(nodeIndices.size());
+        for (int i = 0; i < nodeIndices.size(); i++) {
+            int nodeIndex = nodeIndices.getInt(i);
+            ImmutableList<DependencyResult> variantDependencies = computeDependenciesForVariant(graph, fromComponent, nodeIndex);
+            allVariantDependencies.add(variantDependencies);
+            for (DependencyResult dependency : variantDependencies) {
+                componentDependencies.add(dependency);
+            }
+        }
+
+        return new ComponentDependencies(
+            componentDependencies.build(),
+            allVariantDependencies.build()
+        );
+    }
+
+    private static ImmutableList<DependencyResult> computeDependenciesForVariant(
+        ResolvedGraphResult graph,
+        ResolvedComponentResult fromComponent,
+        int nodeIndex
+    ) {
+        GraphStructure.Edges edges = graph.structure().edges();
+
+        int start = edges.start(nodeIndex);
+        int end = edges.end(nodeIndex);
+        ImmutableSet.Builder<DependencyResult> builder = ImmutableSet.builderWithExpectedSize(end - start);
+        for (int i = start; i < end; i++) {
+            ComponentSelector selector = edges.selector(i);
+            boolean constraint = edges.constraint(i);
+            int targetNodeIndex = edges.targetNode(i);
+            if (targetNodeIndex != -1) {
+                int targetComponentIndex = graph.structure().nodes().owner(targetNodeIndex);
+                builder.add(new DefaultResolvedDependencyResult(
+                    selector,
+                    constraint,
+                    fromComponent,
+                    graph.getComponent(targetComponentIndex),
+                    graph.getVariant(targetNodeIndex)
+                ));
+            } else {
+                GraphStructure.Edges.EdgeFailure failure = edges.failure(i);
+                builder.add(new DefaultUnresolvedDependencyResult(
+                    selector,
+                    fromComponent,
+                    constraint,
+                    failure.failure(),
+                    failure.reason()
+                ));
+            }
+        }
+        return builder.build().asList();
+    }
+
+    private record ComponentDependencies(
+        ImmutableSet<? extends DependencyResult> componentDependencies,
+        ImmutableList<ImmutableList<DependencyResult>> variantDependencies
+    ) { }
 
     /**
      * A recursive function that traverses the dependency graph of a given module and acts on each node and edge encountered.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -30,7 +30,6 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
-import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -40,10 +39,11 @@ import java.util.Set;
 public class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
 
     private final int index;
+    private final IntList nodeIndices;
     private final ResolvedGraphResult graph;
 
-    private final Lazy<ImmutableList<ResolvedVariantResult>> variants;
-    private final Lazy<ComponentDependencies> dependencies;
+    private @Nullable ImmutableList<ResolvedVariantResult> variants;
+    private @Nullable ComponentDependencies dependencies;
 
     public DefaultResolvedComponentResult(
         int index,
@@ -51,16 +51,8 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         ResolvedGraphResult graph
     ) {
         this.index = index;
+        this.nodeIndices = nodeIndices;
         this.graph = graph;
-
-        this.variants = Lazy.locking().of(() -> computeVariants(graph, nodeIndices));
-        this.dependencies = Lazy.locking().of(() -> computeDependencies(
-            graph,
-            nodeIndices,
-            // Ideally, we would not leak `this` before the constructor returns, but doing so
-            // would require us to hand-roll locks instead of using `Lazy`
-            this
-        ));
     }
 
     @Override
@@ -91,7 +83,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public Set<? extends DependencyResult> getDependencies() {
-        return dependencies.get().componentDependencies;
+        return getAllDependencies().componentDependencies();
     }
 
     @Override
@@ -115,8 +107,11 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     }
 
     @Override
-    public List<ResolvedVariantResult> getVariants() {
-        return variants.get();
+    public synchronized List<ResolvedVariantResult> getVariants() {
+        if (variants == null) {
+            variants = computeVariants(graph, nodeIndices);
+        }
+        return variants;
     }
 
     private static ImmutableList<ResolvedVariantResult> computeVariants(
@@ -154,10 +149,17 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
             throw new InvalidUserCodeException("Variant '" + variant.getDisplayName() + "' doesn't belong to resolved component '" + this + "'. " + moreInfo + " Most likely you are using a variant from another component to get the dependencies of this component.");
         }
 
-        return dependencies.get().variantDependencies.get(indexInComponent);
+        return getAllDependencies().variantDependencies().get(indexInComponent);
     }
 
-    private static ComponentDependencies computeDependencies(
+    private synchronized ComponentDependencies getAllDependencies() {
+        if (dependencies == null) {
+            dependencies = computeAllDependencies(graph, nodeIndices, this);
+        }
+        return dependencies;
+    }
+
+    private static ComponentDependencies computeAllDependencies(
         ResolvedGraphResult graph,
         IntList nodeIndices,
         ResolvedComponentResult fromComponent

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
 import org.gradle.internal.Describables;
-import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -45,7 +44,7 @@ public class ResolvedGraphResult {
 
     private @Nullable ResolvedComponentResultInternal @Nullable [] components;
     private @Nullable ResolvedVariantResult @Nullable [] variants;
-    private final Lazy<List<Set<ResolvedDependencyResult>>> resolvedEdgesByTarget;
+    private @Nullable List<Set<ResolvedDependencyResult>> resolvedEdgesByTarget;
 
     public ResolvedGraphResult(
         GraphStructure structure,
@@ -55,12 +54,6 @@ public class ResolvedGraphResult {
         this.availableVariantsByComponent = availableVariantsByComponent;
 
         this.nodesByComponent = computeNodeIndices(structure);
-        this.resolvedEdgesByTarget = Lazy.locking().of(() -> computeResolvedEdgesByTarget(
-            structure,
-            // Ideally, we would not leak `this` before the constructor returns, but doing so
-            // would require us to hand-roll locks instead of using `Lazy`
-            this::getComponent
-        ));
     }
 
     /**
@@ -73,53 +66,49 @@ public class ResolvedGraphResult {
     /**
      * Get the component at the given index.
      */
-    public ResolvedComponentResultInternal getComponent(int index) {
-        synchronized (this) {
-            if (components == null) {
-                components = new ResolvedComponentResultInternal[structure.components().count()];
-            }
-            ResolvedComponentResultInternal component = components[index];
-            if (component == null) {
-                component = new DefaultResolvedComponentResult(
-                    index,
-                    nodesByComponent.get(index),
-                    this
-                );
-                components[index] = component;
-            }
-            return component;
+    public synchronized ResolvedComponentResultInternal getComponent(int index) {
+        if (components == null) {
+            components = new ResolvedComponentResultInternal[structure.components().count()];
         }
+        ResolvedComponentResultInternal component = components[index];
+        if (component == null) {
+            component = new DefaultResolvedComponentResult(
+                index,
+                nodesByComponent.get(index),
+                this
+            );
+            components[index] = component;
+        }
+        return component;
     }
 
     /**
      * Get the variant at the given index.
      */
-    public ResolvedVariantResult getVariant(int index) {
-        synchronized (this) {
-            if (variants == null) {
-                variants = new ResolvedVariantResult[structure.nodes().count()];
-            }
-            ResolvedVariantResult variant = variants[index];
-            if (variant == null) {
-                GraphStructure.Nodes nodes = structure.nodes();
-                int externalVariantIndex = nodes.externalVariantIndex(index);
-
-                ResolvedVariantResult externalVariant = null;
-                if (externalVariantIndex != -1) {
-                    externalVariant = getVariant(externalVariantIndex);
-                }
-
-                variant = new DefaultResolvedVariantResult(
-                    structure.components().id(nodes.owner(index)),
-                    Describables.of(nodes.variantName(index)),
-                    nodes.attributes(index),
-                    nodes.capabilities(index).asSet().asList(),
-                    externalVariant
-                );
-                variants[index] = variant;
-            }
-            return variant;
+    public synchronized ResolvedVariantResult getVariant(int index) {
+        if (variants == null) {
+            variants = new ResolvedVariantResult[structure.nodes().count()];
         }
+        ResolvedVariantResult variant = variants[index];
+        if (variant == null) {
+            GraphStructure.Nodes nodes = structure.nodes();
+            int externalVariantIndex = nodes.externalVariantIndex(index);
+
+            ResolvedVariantResult externalVariant = null;
+            if (externalVariantIndex != -1) {
+                externalVariant = getVariant(externalVariantIndex);
+            }
+
+            variant = new DefaultResolvedVariantResult(
+                structure.components().id(nodes.owner(index)),
+                Describables.of(nodes.variantName(index)),
+                nodes.attributes(index),
+                nodes.capabilities(index).asSet().asList(),
+                externalVariant
+            );
+            variants[index] = variant;
+        }
+        return variant;
     }
 
     private static List<IntList> computeNodeIndices(GraphStructure structure) {
@@ -140,8 +129,11 @@ public class ResolvedGraphResult {
     /**
      * Get all incoming edges for the component at the given index.
      */
-    public Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
-        return resolvedEdgesByTarget.get().get(targetComponentIndex);
+    public synchronized Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
+        if (resolvedEdgesByTarget == null) {
+            resolvedEdgesByTarget = computeResolvedEdgesByTarget(structure, this::getComponent);
+        }
+        return resolvedEdgesByTarget.get(targetComponentIndex);
     }
 
     private static List<Set<ResolvedDependencyResult>> computeResolvedEdgesByTarget(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
@@ -23,12 +23,14 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
 import org.gradle.internal.Describables;
+import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.IntFunction;
 
 /**
  * Shared state that all components and variants of a
@@ -43,7 +45,7 @@ public class ResolvedGraphResult {
 
     private @Nullable ResolvedComponentResultInternal @Nullable [] components;
     private @Nullable ResolvedVariantResult @Nullable [] variants;
-    private @Nullable List<Set<ResolvedDependencyResult>> resolvedEdgesByTarget;
+    private final Lazy<List<Set<ResolvedDependencyResult>>> resolvedEdgesByTarget;
 
     public ResolvedGraphResult(
         GraphStructure structure,
@@ -53,6 +55,12 @@ public class ResolvedGraphResult {
         this.availableVariantsByComponent = availableVariantsByComponent;
 
         this.nodesByComponent = computeNodeIndices(structure);
+        this.resolvedEdgesByTarget = Lazy.locking().of(() -> computeResolvedEdgesByTarget(
+            structure,
+            // Ideally, we would not leak `this` before the constructor returns, but doing so
+            // would require us to hand-roll locks instead of using `Lazy`
+            this::getComponent
+        ));
     }
 
     /**
@@ -66,48 +74,52 @@ public class ResolvedGraphResult {
      * Get the component at the given index.
      */
     public ResolvedComponentResultInternal getComponent(int index) {
-        if (components == null) {
-            components = new ResolvedComponentResultInternal[structure.components().count()];
+        synchronized (this) {
+            if (components == null) {
+                components = new ResolvedComponentResultInternal[structure.components().count()];
+            }
+            ResolvedComponentResultInternal component = components[index];
+            if (component == null) {
+                component = new DefaultResolvedComponentResult(
+                    index,
+                    nodesByComponent.get(index),
+                    this
+                );
+                components[index] = component;
+            }
+            return component;
         }
-        ResolvedComponentResultInternal component = components[index];
-        if (component == null) {
-            component = new DefaultResolvedComponentResult(
-                index,
-                nodesByComponent.get(index),
-                this
-            );
-            components[index] = component;
-        }
-        return component;
     }
 
     /**
      * Get the variant at the given index.
      */
     public ResolvedVariantResult getVariant(int index) {
-        if (variants == null) {
-            variants = new ResolvedVariantResult[structure.nodes().count()];
-        }
-        ResolvedVariantResult variant = variants[index];
-        if (variant == null) {
-            GraphStructure.Nodes nodes = structure.nodes();
-            int externalVariantIndex = nodes.externalVariantIndex(index);
-
-            ResolvedVariantResult externalVariant = null;
-            if (externalVariantIndex != -1) {
-                externalVariant = getVariant(externalVariantIndex);
+        synchronized (this) {
+            if (variants == null) {
+                variants = new ResolvedVariantResult[structure.nodes().count()];
             }
+            ResolvedVariantResult variant = variants[index];
+            if (variant == null) {
+                GraphStructure.Nodes nodes = structure.nodes();
+                int externalVariantIndex = nodes.externalVariantIndex(index);
 
-            variant = new DefaultResolvedVariantResult(
-                structure.components().id(nodes.owner(index)),
-                Describables.of(nodes.variantName(index)),
-                nodes.attributes(index),
-                nodes.capabilities(index).asSet().asList(),
-                externalVariant
-            );
-            variants[index] = variant;
+                ResolvedVariantResult externalVariant = null;
+                if (externalVariantIndex != -1) {
+                    externalVariant = getVariant(externalVariantIndex);
+                }
+
+                variant = new DefaultResolvedVariantResult(
+                    structure.components().id(nodes.owner(index)),
+                    Describables.of(nodes.variantName(index)),
+                    nodes.attributes(index),
+                    nodes.capabilities(index).asSet().asList(),
+                    externalVariant
+                );
+                variants[index] = variant;
+            }
+            return variant;
         }
-        return variant;
     }
 
     private static List<IntList> computeNodeIndices(GraphStructure structure) {
@@ -129,23 +141,28 @@ public class ResolvedGraphResult {
      * Get all incoming edges for the component at the given index.
      */
     public Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
-        if (resolvedEdgesByTarget == null) {
-            int count = structure.components().count();
-            this.resolvedEdgesByTarget = new ArrayList<>(count);
-            for (int i = 0; i < count; i++) {
-                resolvedEdgesByTarget.add(new LinkedHashSet<>());
-            }
-            for (int i = 0; i < count; i++) {
-                ResolvedComponentResultInternal component = getComponent(i);
-                for (DependencyResult dependency : component.getDependencies()) {
-                    if (dependency instanceof ResolvedDependencyResult resolved) {
-                        ResolvedComponentResultInternal targetComponent = (ResolvedComponentResultInternal) resolved.getSelected();
-                        resolvedEdgesByTarget.get(targetComponent.index()).add(resolved);
-                    }
+        return resolvedEdgesByTarget.get().get(targetComponentIndex);
+    }
+
+    private static List<Set<ResolvedDependencyResult>> computeResolvedEdgesByTarget(
+        GraphStructure structure,
+        IntFunction<ResolvedComponentResultInternal> componentSource
+    ) {
+        int count = structure.components().count();
+        List<Set<ResolvedDependencyResult>> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            result.add(new LinkedHashSet<>());
+        }
+        for (int i = 0; i < count; i++) {
+            ResolvedComponentResultInternal component = componentSource.apply(i);
+            for (DependencyResult dependency : component.getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult resolved) {
+                    ResolvedComponentResultInternal targetComponent = (ResolvedComponentResultInternal) resolved.getSelected();
+                    result.get(targetComponent.index()).add(resolved);
                 }
             }
         }
-        return resolvedEdgesByTarget.get(targetComponentIndex);
+        return result;
     }
 
     /**


### PR DESCRIPTION
When originally refactored, we expected this API not be accessed concurrently. Unfortunatley in some circumstances -- the github-dependency-graph-gradle-plugin -- reads to instances of a ResolvedComponentResult may execute in parallel, as the plugin uses the internal build operation API backed by DefaultBuildEventsListenerRegistry, which executes code in parallel without acquiring project locks.

We update the ResolutionResult API to be thread safe throughout to avoid data races when lazily calculating values.

Fixes https://github.com/gradle/gradle/issues/37927

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
