### PR TITLE
Reduce macOS Docs Test flakes by extending empty-line allowlist

### DIFF
--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
@@ -3,7 +3,7 @@
 > Task :producer:classes
 > Task :producer:jar
 
-> Transform producer.jar (project :producer) with Minify
+> Transform producer.jar (project ':producer') with Minify
 Nothing to minify - using producer.jar unchanged
 
 > Task :resolveRuntimeClasspath

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
@@ -3,7 +3,7 @@
 > Task :producer:classes
 > Task :producer:jar
 
-> Transform producer.jar (project ':producer') with Minify
+> Transform producer.jar (project :producer) with Minify
 Nothing to minify - using producer.jar unchanged
 
 > Task :resolveRuntimeClasspath

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
@@ -32,7 +32,8 @@ class EmptyLineRemovalOutputNormalizer implements OutputNormalizer {
         "incrementalTaskNoChange",
         "publishingMavenSignAndPublish",
         "configurationCacheProblemsFixed",
-        "compileTaskClasspath"
+        "compileTaskClasspath",
+        "artifactTransformMinify"
     ]
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
@@ -28,7 +28,11 @@ class EmptyLineRemovalOutputNormalizer implements OutputNormalizer {
         "multiproject_kotlin_listProjects",
         "multiproject_groovy_listProjects",
         "maven-migration-multi-module_kotlin_project",
-        "maven-migration-multi-module_groovy_projects"
+        "maven-migration-multi-module_groovy_projects",
+        "incrementalTaskNoChange",
+        "publishingMavenSignAndPublish",
+        "configurationCacheProblemsFixed",
+        "compileTaskClasspath"
     ]
 
     @Override


### PR DESCRIPTION
## Summary
- Extends `EmptyLineRemovalOutputNormalizer.SAMPLES_IGNORING_EMPTY_LINE` with sample-name fragments whose macOS Docs Test batches have been intermittently failing on extra/missing blank lines around task headers emitted by Gradle's progress logger: `incrementalTaskNoChange`, `publishingMavenSignAndPublish`, `configurationCacheProblemsFixed`, `compileTaskClasspath`, `artifactTransformMinify`.
- The match uses `contains`, so each fragment covers both the `_groovy_` and `_kotlin_` sample variants.
- The branch's first commit also edited `artifactTransformMinify.out`, but that edit was wrong — `82b1b147682` ("Align ProjectIdentity and Project display names") intentionally added single quotes around `':producer'` to match Project's display name, and the runtime still emits the quoted form. The second commit reverts that edit and treats `artifactTransformMinify` as the same blank-line flake category.

## Test plan
- [ ] Monitor next Docs Test - Macos runs for flake reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)