### PR TITLE
Provide stable JUnit XML class for non-class tests

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -456,6 +456,12 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
             // If the parent is a Class, it should be safe to use its name here.
             String result = nameGetter.apply(parentDescriptor);
             return result != null ? result : JUnitPlatformSupport.UNKNOWN;
+        } else if (parentDescriptor != null) {
+            // Non-class-based test (e.g. Cucumber FileSource). Use the parent container's name
+            // (typically the relative path to the source file produced by extractClassOrResourceName)
+            // so that Build Scans and the test-retry filter receive a stable, non-empty identifier.
+            String result = nameGetter.apply(parentDescriptor);
+            return result != null && !result.isEmpty() ? result : JUnitPlatformSupport.NON_CLASS;
         } else {
             return JUnitPlatformSupport.NON_CLASS;
         }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
@@ -150,7 +150,88 @@ class CucumberNonClassBasedTestingIntegrationTest extends AbstractIntegrationSpe
         result.testPath(":src/test/resources/helloworld.feature:Say hello /two/three").onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
     }
 
-    private writeCucumberStepDefinitions(String path = "src/test/java") {
+    @Issue("https://github.com/gradle/gradle/issues/37850")
+    def "test-retry plugin can filter a failed Cucumber scenario by class+method name"() {
+        given:
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                }
+            }
+        """
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'org.gradle.test-retry' version '1.6.4'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing.suites.test {
+                useJUnitJupiter()
+
+                dependencies {
+                    implementation("io.cucumber:cucumber-java:7.15.0")
+                    runtimeOnly("io.cucumber:cucumber-junit-platform-engine:7.15.0")
+                }
+
+                targets.all {
+                    testTask.configure {
+                        testDefinitionDirs.from("src/test/resources")
+                        retry {
+                            maxRetries = 1
+                        }
+                    }
+                }
+            }
+        """
+
+        writeCucumberFeatureFiles()
+        writeAlwaysFailingCucumberStepDefinitions()
+
+        when:
+        // The scenario always fails; we expect the build to fail. The point of this test is to verify
+        // that the test-retry plugin can *identify* the failed scenario (className non-empty) and
+        // call TestFilter.includeTest() without tripping DefaultTestFilter.validateName.
+        // Before the fix, this would throw "Selected test name cannot be null or empty." on the
+        // attempted retry, masking the actual scenario failure.
+        fails("test")
+
+        then:
+        // The retry plugin successfully formed a className+methodName pair from the descriptor —
+        // the scenario name shows up in the retry plugin's output, proving the className contract.
+        failure.assertHasErrorOutput("helloworld.feature")
+        failure.assertHasErrorOutput("Say hello /two/three")
+        // Pre-fix regression marker; must not appear.
+        failure.assertNotOutput("Selected test name cannot be null or empty")
+    }
+
+    private writeAlwaysFailingCucumberStepDefinitions(String path = "src/test/java") {
+        def stepDefFile = file("$path/HelloStepdefs.java")
+        stepDefFile.parentFile.mkdirs()
+
+        stepDefFile.text = """
+            import io.cucumber.java.en.Given;
+            import io.cucumber.java.en.Then;
+            import io.cucumber.java.en.When;
+
+            public class HelloStepdefs {
+                @Given("^I have a hello app with Howdy and /four")
+                public void I_have_a_hello_app_with() { }
+
+                @When("^I ask it to say hi and /five/six/seven")
+                public void I_ask_it_to_say_hi() { }
+
+                @Then("^it should answer with Howdy World")
+                public void it_should_answer_with() {
+                    throw new AssertionError("Intentional failure to trigger test-retry");
+                }
+            }
+        """
+    }
+
+private writeCucumberStepDefinitions(String path = "src/test/java") {
         def stepDefFile = file("$path/HelloStepdefs.java")
         stepDefFile.parentFile.mkdirs()
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.nonclassbased
 
+import groovy.xml.XmlSlurper
 import org.gradle.api.internal.tasks.testing.report.VerifiesGenericTestReportResults
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -141,13 +142,13 @@ class CucumberNonClassBasedTestingIntegrationTest extends AbstractIntegrationSpe
         succeeds("test")
 
         then:
-        // Before the fix, the className on each Cucumber scenario descriptor was the
-        // empty string `JUnitPlatformSupport.NON_CLASS`, which broke Build Scan reporting ("N/A") and made
-        // `DefaultTestFilter.validateName` throw "Selected test name cannot be null or empty." when the
-        // test-retry plugin tried to rerun a failed scenario. The className must be a stable, non-empty
-        // identifier; here we assert the scenario is reachable under its feature file path.
-        def result = resultsFor()
-        result.testPath(":src/test/resources/helloworld.feature:Say hello /two/three").onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
+        // Every testcase in the JUnit XML must have a non-empty `classname`
+        // attribute.  Pre-fix this was `JUnitPlatformSupport.NON_CLASS` = "", which broke Build
+        // Scan reporting and the test-retry plugin's filter contract.
+        def xml = new XmlSlurper().parse(file("build/test-results/test/TEST-helloworld.feature.xml"))
+        def classnames = xml.testcase.collect { it.@classname.text() }
+        assert !classnames.isEmpty()
+        assert classnames.every { it == "helloworld.feature" }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37850")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing.nonclassbased
 import org.gradle.api.internal.tasks.testing.report.VerifiesGenericTestReportResults
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 import static org.gradle.testing.nonclassbased.AbstractNonClassBasedTestingIntegrationTest.DEFAULT_DEFINITIONS_LOCATION
 
@@ -103,6 +104,48 @@ class CucumberNonClassBasedTestingIntegrationTest extends AbstractIntegrationSpe
         succeeds("test")
 
         then:
+        def result = resultsFor()
+        result.testPath(":src/test/resources/helloworld.feature:Say hello /two/three").onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37850")
+    def "Cucumber scenario class name in JUnit XML is the feature file path so it can drive test-retry filters"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing.suites.test {
+                useJUnitJupiter()
+
+                dependencies {
+                    implementation("io.cucumber:cucumber-java:7.15.0")
+                    runtimeOnly("io.cucumber:cucumber-junit-platform-engine:7.15.0")
+                }
+
+                targets.all {
+                    testTask.configure {
+                        testDefinitionDirs.from("src/test/resources")
+                    }
+                }
+            }
+        """
+
+        writeCucumberFeatureFiles()
+        writeCucumberStepDefinitions()
+
+        when:
+        succeeds("test")
+
+        then:
+        // Before the fix, the className on each Cucumber scenario descriptor was the
+        // empty string `JUnitPlatformSupport.NON_CLASS`, which broke Build Scan reporting ("N/A") and made
+        // `DefaultTestFilter.validateName` throw "Selected test name cannot be null or empty." when the
+        // test-retry plugin tried to rerun a failed scenario. The className must be a stable, non-empty
+        // identifier; here we assert the scenario is reachable under its feature file path.
         def result = resultsFor()
         result.testPath(":src/test/resources/helloworld.feature:Say hello /two/three").onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
     }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/CucumberNonClassBasedTestingIntegrationTest.groovy
@@ -200,6 +200,9 @@ class CucumberNonClassBasedTestingIntegrationTest extends AbstractIntegrationSpe
         fails("test")
 
         then:
+        def result = resultsFor()
+        result.testPath(":src/test/resources/helloworld.feature:Hello World /one").onlyRoot().assertHasResult(TestResult.ResultType.FAILURE)
+
         // The retry plugin successfully formed a className+methodName pair from the descriptor —
         // the scenario name shows up in the retry plugin's output, proving the className contract.
         failure.assertHasErrorOutput("helloworld.feature")


### PR DESCRIPTION
Previously, non-class-based tests, such as Cucumber scenarios, produced empty or generic class names in JUnit XML reports. This caused the test-retry plugin to fail due to
invalid empty identifiers.

This change ensures a stable, non-empty identifier, typically the parent container's name (e.g., the feature file path), is used for these test entries.

Fixes #37850.