### PR TITLE
Fix failing AGP smoke tests

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
@@ -75,6 +75,10 @@ class AndroidProjectCachingSmokeTest extends AbstractAndroidProjectSmokeTest {
         def expectedResults = agpVersion.startsWith("9.0")
             ? AndroidPluginExpectations90.EXPECTED_RESULTS_9_0
             : AndroidPluginExpectations91.EXPECTED_RESULTS_9_1
+        // workaround for com.google.android.gms.oss-licenses-plugin not being compatible with configuration cache
+        if (GradleContextualExecuter.isConfigCache()) {
+            expectedResults.entrySet().removeIf { it.key.contains("Oss") }
+        }
 
         def flakyTaskOutcomes = [
             ':core:datastore-proto:syncDemoDebugLibJars': SUCCESS,

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
@@ -75,10 +75,6 @@ class AndroidProjectCachingSmokeTest extends AbstractAndroidProjectSmokeTest {
         def expectedResults = agpVersion.startsWith("9.0")
             ? AndroidPluginExpectations90.EXPECTED_RESULTS_9_0
             : AndroidPluginExpectations91.EXPECTED_RESULTS_9_1
-        // workaround for com.google.android.gms.oss-licenses-plugin not being compatible with configuration cache
-        if (GradleContextualExecuter.isConfigCache()) {
-            expectedResults.entrySet().removeIf { it.key.contains("Oss") }
-        }
 
         def flakyTaskOutcomes = [
             ':core:datastore-proto:syncDemoDebugLibJars': SUCCESS,
@@ -174,6 +170,8 @@ class AndroidPluginExpectations90 {
         ':app:createDemoDebugCompatibleScreenManifests': SUCCESS,
         ':app:createProdDebugApkListingFileRedirect': SUCCESS,
         ':app:createProdDebugCompatibleScreenManifests': SUCCESS,
+        ':app:demoDebugOssDependencyTask': SUCCESS,
+        ':app:demoDebugOssLicensesTask': SUCCESS,
         ':app:desugarDemoDebugFileDependencies': FROM_CACHE,
         ':app:desugarProdDebugFileDependencies': FROM_CACHE,
         ':app:dexBuilderDemoDebug': FROM_CACHE,
@@ -249,6 +247,8 @@ class AndroidPluginExpectations90 {
         ':app:processProdDebugManifestForPackage': FROM_CACHE,
         ':app:processProdDebugNavigationResources': FROM_CACHE,
         ':app:processProdDebugResources': FROM_CACHE,
+        ':app:prodDebugOssDependencyTask': SUCCESS,
+        ':app:prodDebugOssLicensesTask': SUCCESS,
         ':app:stripDemoDebugDebugSymbols': SUCCESS,
         ':app:stripProdDebugDebugSymbols': SUCCESS,
         ':app:transformDemoDebugClassesWithAsm': FROM_CACHE,
@@ -2379,6 +2379,8 @@ class AndroidPluginExpectations91 {
         ':app:createDemoDebugCompatibleScreenManifests': SUCCESS,
         ':app:createProdDebugApkListingFileRedirect': SUCCESS,
         ':app:createProdDebugCompatibleScreenManifests': SUCCESS,
+        ':app:demoDebugOssDependencyTask': SUCCESS,
+        ':app:demoDebugOssLicensesTask': SUCCESS,
         ':app:desugarDemoDebugFileDependencies': FROM_CACHE,
         ':app:desugarProdDebugFileDependencies': FROM_CACHE,
         ':app:dexBuilderDemoDebug': FROM_CACHE,
@@ -2454,6 +2456,8 @@ class AndroidPluginExpectations91 {
         ':app:processProdDebugManifestForPackage': FROM_CACHE,
         ':app:processProdDebugNavigationResources': FROM_CACHE,
         ':app:processProdDebugResources': FROM_CACHE,
+        ':app:prodDebugOssDependencyTask': SUCCESS,
+        ':app:prodDebugOssLicensesTask': SUCCESS,
         ':app:stripDemoDebugDebugSymbols': SUCCESS,
         ':app:stripProdDebugDebugSymbols': SUCCESS,
         ':app:transformDemoDebugClassesWithAsm': FROM_CACHE,


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5234

The four `:app:*OssDependencyTask`/`*OssLicensesTask` entries were removed in 6aca79645d6 but the tasks still execute during the build, causing the test to fail with "Tasks in surplus" for all AGP versions. The CC workaround that stripped Oss tasks from expected results was also incorrect because CC gets discarded by the licenses plugin and the tasks run anyway.

Verified in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SmokeTest_AndroidProjectSmokeTests/112883100?hideTestsFromDependencies=true