### PR TITLE
Bump :core integ test JVM heap to 1g

### DIFF
--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -293,6 +293,8 @@ tasks.test {
     setForkEvery(200)
 }
 
+integTest.testJvmXmx = "1g"
+
 tasks.compileTestGroovy {
     groovyOptions.isFork = true
     groovyOptions.forkOptions.run {


### PR DESCRIPTION
## Summary

`IntegrationTestExtension.testJvmXmx` defaults to `512m`. That isn't enough for `:core:parallelIntegTest`: when `UserInputHandlingIntegrationTest."does not run out of memory when buffering output during user input with parallel execution"` runs, the test emits ~40MB of stdout, and the integ-test executor JVM OOMs while parsing the captured output in `OutputScrapingExecutionFailure.<init>` (`LogContent.toLines` → `String.substring`), before any assertions can run.

Mirror the existing pattern in `:build-init` (`integTest.testJvmXmx = "1g"`).

## Context

`Gradle_Master_Check_Parallel_7_bucket3` has been failing on `master` since 2026-05-07 — runs 112871111, 112862086, 112695227, 112643636, 112622871, 112527767, 112488559. The inner Gradle build runs to completion (`AbstractUserInputRenderer`'s disk-overflow fix from `0761fceaec1` is in place), then `gradleHandle.waitForFinish()` OOMs constructing the `ExecutionResult`:

```
java.lang.OutOfMemoryError
  at java.util.Arrays.copyOfRange(Arrays.java:3849)
  at java.lang.StringLatin1.newString(StringLatin1.java:760)
  at java.lang.String.substring(String.java:2904)
  at org.gradle.integtests.fixtures.executer.LogContent.toLines(LogContent.java:71)
  at org.gradle.integtests.fixtures.executer.LogContent.ansiCharsToPlainText(LogContent.java:215)
  at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure.<init>(OutputScrapingExecutionFailure.java:71)
  at org.gradle.integtests.fixtures.executer.ParallelForkingGradleHandle$ParallelExecutionResult.<init>(ParallelForkingGradleHandle.java:49)
  ...
  at org.gradle.api.internal.tasks.userinput.UserInputHandlingIntegrationTest.does not run out of memory when buffering output during user input with parallel execution(UserInputHandlingIntegrationTest.groovy:528)
```

- https://ge.gradle.org/s/voxqspxeraog2/failures
- https://ge.gradle.org/s/st2wk5ioeooa4/failures
- https://ge.gradle.org/s/tlzxber7sdtrm/failures