### PR TITLE
Make ProjectConfigurer use ProjectState only

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.project;
 
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
@@ -157,12 +158,12 @@ class DefaultProjectState implements ProjectState, Closeable {
 
     @Override
     public Set<ProjectState> getAllProjects() {
-        Set<ProjectState> result = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
+        ImmutableSortedSet.Builder<ProjectState> result = ImmutableSortedSet.orderedBy(ProjectOrderingUtil::compare);
         collectAllProjects(this, result);
-        return result;
+        return result.build();
     }
 
-    private static void collectAllProjects(ProjectState project, Set<ProjectState> result) {
+    private static void collectAllProjects(ProjectState project, ImmutableSortedSet.Builder<ProjectState> result) {
         result.add(project);
         for (ProjectState child : project.getUnorderedChildProjects()) {
             collectAllProjects(child, result);

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
@@ -16,7 +16,7 @@
 package org.gradle.configuration;
 
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.initialization.ProjectsEvaluatedNotifier;
 import org.gradle.internal.buildtree.BuildModelParameters;
@@ -45,7 +45,7 @@ public class DefaultProjectsPreparer implements ProjectsPreparer {
             return;
         }
 
-        ProjectInternal rootProject = gradle.getOwner().getRootProject().getMutableModel();
+        ProjectState rootProject = gradle.getOwner().getRootProject();
         if (buildModelParameters.isParallelProjectConfiguration()) {
             projectConfigurer.configureHierarchyInParallel(rootProject);
         } else {

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -54,7 +54,7 @@ public abstract class DefaultTaskSelector implements TaskSelector {
     public Spec<Task> getFilter(SelectionContext context, ProjectState project, String taskName, boolean includeSubprojects) {
         if (includeSubprojects) {
             // Try to delay configuring all the subprojects
-            getConfigurer().configure(project.getMutableModel());
+            project.ensureConfigured();
             if (taskNameResolver.tryFindUnqualifiedTaskCheaply(taskName, project)) {
                 // An exact match in the target project - can just filter tasks by path to avoid configuring subprojects at this point
                 return new TaskPathSpec(project.getMutableModel(), taskName);
@@ -68,9 +68,9 @@ public abstract class DefaultTaskSelector implements TaskSelector {
     @Override
     public TaskSelection getSelection(SelectionContext context, ProjectState targetProject, String taskName, boolean includeSubprojects) {
         if (!includeSubprojects) {
-            getConfigurer().configure(targetProject.getMutableModel());
+            targetProject.ensureConfigured();
         } else {
-            getConfigurer().configureHierarchy(targetProject.getMutableModel());
+            getConfigurer().configureHierarchy(targetProject);
         }
 
         TaskSelectionResult tasks = taskNameResolver.selectWithName(taskName, targetProject, includeSubprojects);

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
@@ -17,6 +17,8 @@ package org.gradle.execution;
 
 import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.execution.plan.ExecutionPlan;
 import org.gradle.internal.RunDefaultTasksExecutionRequest;
@@ -33,12 +35,10 @@ import java.util.List;
  */
 public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTasksBuildTaskScheduler.class);
-    private final ProjectConfigurer projectConfigurer;
     private final List<BuiltInCommand> builtInCommands;
     private final BuildTaskScheduler delegate;
 
-    public DefaultTasksBuildTaskScheduler(ProjectConfigurer projectConfigurer, List<BuiltInCommand> builtInCommands, BuildTaskScheduler delegate) {
-        this.projectConfigurer = projectConfigurer;
+    public DefaultTasksBuildTaskScheduler(List<BuiltInCommand> builtInCommands, BuildTaskScheduler delegate) {
         this.builtInCommands = builtInCommands;
         this.delegate = delegate;
     }
@@ -49,11 +49,10 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
 
         if (startParameter.getTaskRequests().size() == 1 && startParameter.getTaskRequests().get(0) instanceof RunDefaultTasksExecutionRequest) {
             // Gather the default tasks from this first group project
-            List<String> defaultTasks = gradle.getDefaultProjectState().fromMutableState(project -> {
-                //so that we don't miss out default tasks
-                projectConfigurer.configure(project);
-                return project.getDefaultTasks();
-            });
+            ProjectState defaultProjectState = gradle.getDefaultProjectState();
+            // so that we don't miss out default tasks
+            defaultProjectState.ensureConfigured();
+            List<String> defaultTasks = defaultProjectState.fromMutableState(ProjectInternal::getDefaultTasks);
             if (defaultTasks.isEmpty()) {
                 defaultTasks = new ArrayList<>();
                 for (BuiltInCommand command : builtInCommands) {

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectConfigurer.java
@@ -16,18 +16,12 @@
 
 package org.gradle.execution;
 
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface ProjectConfigurer {
-    /**
-     * Configures the given project.
-     */
-    void configure(ProjectInternal project);
-
     /**
      * Configures the owned project, discovers tasks and binds model rules.
      */
@@ -36,10 +30,10 @@ public interface ProjectConfigurer {
     /**
      * Configures the given project and all its subprojects.
      */
-    void configureHierarchy(ProjectInternal project);
+    void configureHierarchy(ProjectState projectState);
 
     /**
      * Configures the given project and all its subprojects in parallel.
      */
-    void configureHierarchyInParallel(ProjectInternal project);
+    void configureHierarchyInParallel(ProjectState projectState);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -18,8 +18,6 @@ package org.gradle.execution;
 
 import org.gradle.api.Action;
 import org.gradle.api.BuildCancelledException;
-import org.gradle.api.Project;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.UncheckedException;
@@ -66,11 +64,6 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
     }
 
     @Override
-    public void configure(ProjectInternal project) {
-        project.getOwner().ensureConfigured();
-    }
-
-    @Override
     public void configureFully(ProjectState projectState) {
         projectState.ensureConfigured();
         if (cancellationToken.isCancellationRequested()) {
@@ -80,35 +73,35 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
     }
 
     @Override
-    public void configureHierarchy(ProjectInternal project) {
-        configure(project);
-        for (Project sub : project.getSubprojects()) {
-            configure((ProjectInternal) sub);
+    public void configureHierarchy(ProjectState projectState) {
+        for (ProjectState project : projectState.getAllProjects()) {
+            project.ensureConfigured();
         }
     }
 
     @Override
-    public void configureHierarchyInParallel(ProjectInternal project) {
-        assert project.getParent() == null : "Parallel configuration must start from root!";
+    public void configureHierarchyInParallel(ProjectState projectState) {
+        if (!projectState.isRootProject()) {
+            throw new IllegalArgumentException("Parallel configuration must start from root!");
+        }
 
         if (maxWorkerCount() < 2) {
             // We need at least two workers to configure in parallel
-            configureHierarchy(project);
+            configureHierarchy(projectState);
             return;
         }
 
-        final ProjectState root = project.getOwner();
-        if (!root.hasChildren()) {
+        if (!projectState.hasChildren()) {
             // No hierarchy to configure
-            root.ensureConfigured();
+            projectState.ensureConfigured();
             return;
         }
 
         String strategy = schedulingStrategy();
         if (strategy.equals("jit")) {
-            scheduleProjectsJustInTime(root);
+            scheduleProjectsJustInTime(projectState);
         } else {
-            scheduleProjectsAheadOfTime(project);
+            scheduleProjectsAheadOfTime(projectState);
         }
     }
 
@@ -116,9 +109,9 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
         return internalOptions.getValue(PARALLEL_CONFIGURATION_SCHEDULER);
     }
 
-    private void scheduleProjectsAheadOfTime(ProjectInternal root) {
+    private void scheduleProjectsAheadOfTime(ProjectState root) {
         runAllWithAccessToProjectState(queue -> {
-            for (Project p : root.getAllprojects()) {
+            for (ProjectState p : root.getOwner().getProjects().getAllProjects()) {
                 queue.add(configureOperationFor(p));
             }
         });
@@ -183,16 +176,16 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
         }
     }
 
-    private RunnableBuildOperation configureOperationFor(Project p) {
+    private static RunnableBuildOperation configureOperationFor(ProjectState projectState) {
         return new RunnableBuildOperation() {
             @Override
             public void run(BuildOperationContext context) {
-                configure((ProjectInternal) p);
+                projectState.ensureConfigured();
             }
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return BuildOperationDescriptor.displayName("Configure project " + p.getName());
+                return BuildOperationDescriptor.displayName("Configure project " + projectState.getName());
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -869,8 +869,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, ProjectConfigurer projectConfigurer, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands, ProblemsInternal problemsService) {
-        return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector, builtInCommands, problemsService));
+    BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands, ProblemsInternal problemsService) {
+        return new DefaultTasksBuildTaskScheduler(builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector, builtInCommands, problemsService));
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.configuration
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.StartParameterInternal
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.execution.ProjectConfigurer
 import org.gradle.internal.build.BuildState
@@ -29,7 +28,6 @@ import spock.lang.Specification
 class DefaultProjectsPreparerTest extends Specification {
     def startParameter = Mock(StartParameterInternal)
     def gradle = Mock(GradleInternal)
-    def rootProject = Mock(ProjectInternal)
     def rootProjectState = Mock(ProjectState)
     def buildState = Mock(BuildState)
     def projectConfigurer = Mock(ProjectConfigurer)
@@ -41,7 +39,6 @@ class DefaultProjectsPreparerTest extends Specification {
         gradle.startParameter >> startParameter
         gradle.owner >> buildState
         buildState.rootProject >> rootProjectState
-        rootProjectState.mutableModel >> rootProject
     }
 
     def "configures build for standard mode"() {
@@ -49,7 +46,7 @@ class DefaultProjectsPreparerTest extends Specification {
         configurer.prepareProjects(gradle)
 
         then:
-        1 * projectConfigurer.configureHierarchy(rootProject)
+        1 * projectConfigurer.configureHierarchy(rootProjectState)
     }
 
     def "configures root build for on demand mode"() {
@@ -68,6 +65,6 @@ class DefaultProjectsPreparerTest extends Specification {
         then:
         gradle.rootBuild >> false
         modelParameters.configureOnDemand >> true
-        1 * projectConfigurer.configureHierarchy(rootProject)
+        1 * projectConfigurer.configureHierarchy(rootProjectState)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTaskSelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTaskSelectorTest.groovy
@@ -50,7 +50,6 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
         def filter = selector.getFilter(new TaskSelector.SelectionContext(Path.path(":a:b"), "type"), project1, "b", false)
 
         then:
-        1 * projectConfigurer.configure(projectModel1)
         1 * resolver.selectWithName("b", project1, false) >> selectionResult
         _ * selectionResult.collectTasks(_) >> { it[0] << excluded }
         0 * _
@@ -69,7 +68,6 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
         def filter = selector.getFilter(new TaskSelector.SelectionContext(Path.path(":a:b"), "type"), project1, "b", false)
 
         then:
-        1 * projectConfigurer.configure(projectModel1)
         1 * resolver.selectWithName("b", project1, false) >> null
         1 * resolver.selectAll(project1, false) >> [b1: selectionResult]
         _ * selectionResult.collectTasks(_) >> { it[0] << excluded }
@@ -91,7 +89,6 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
         def filter = selector.getFilter(new TaskSelector.SelectionContext(Path.path(":a:b"), "type"), project1, "b", true)
 
         then:
-        1 * projectConfigurer.configure(projectModel1)
         1 * resolver.tryFindUnqualifiedTaskCheaply("b", project1) >> true
         0 * _
 
@@ -109,9 +106,8 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
         def filter = selector.getFilter(new TaskSelector.SelectionContext(Path.path(":a:b"), "type"), project1, "b", true)
 
         then:
-        1 * projectConfigurer.configure(projectModel1)
         1 * resolver.tryFindUnqualifiedTaskCheaply("b", project1) >> false
-        1 * projectConfigurer.configureHierarchy(projectModel1)
+        1 * projectConfigurer.configureHierarchy(project1)
         1 * resolver.selectWithName("b", project1, true) >> selectionResult
         _ * selectionResult.collectTasks(_) >> { it[0] << excluded }
         0 * _

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
@@ -29,10 +29,9 @@ import spock.lang.Specification
 import java.util.function.Function
 
 class DefaultTasksBuildTaskSchedulerTest extends Specification {
-    final projectConfigurer = Mock(ProjectConfigurer)
     final buildInCommand = Mock(BuiltInCommand)
     final delegate = Mock(BuildTaskScheduler)
-    final action = new DefaultTasksBuildTaskScheduler(projectConfigurer, [buildInCommand], delegate)
+    final action = new DefaultTasksBuildTaskScheduler([buildInCommand], delegate)
     final startParameter = Mock(StartParameterInternal)
     final defaultProject = Mock(ProjectInternal)
     final defaultProjectState = Mock(ProjectState)
@@ -77,6 +76,7 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         action.scheduleRequestedTasks(gradle, selector, plan)
 
         then:
+        1 * defaultProjectState.ensureConfigured()
         1 * startParameter.setTaskNames(['a', 'b'])
         1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
     }


### PR DESCRIPTION
Part of #34469

Using a ProjectState allows removing some usages of `getMutableModel()` which were basically pointless.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
