### PR TITLE
Update Documentation: use Kafka for virtual platform alignment example

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_align_dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_align_dependency_versions.adoc
@@ -72,13 +72,14 @@ If no public BOM exists, you can create a **virtual platform**.
 
 In this case, Gradle builds the platform **dynamically** based on the modules being used.
 For this, you must define <<component_metadata_rules.adoc#component-metadata-rules,**component metadata rules**>>:
+The following example aligns Apache Kafka modules because Kafka does not publish a consumer BOM, and otherwise `kafka-streams` could remain on an older version than `kafka-clients`.
 
 ====
 include::sample[dir="snippets/how-to/dependency-management/dependency-management/aligning-versions/kotlin",files="build.gradle.kts[tags=dependency-full-platform]"]
 include::sample[dir="snippets/how-to/dependency-management/dependency-management/aligning-versions/groovy",files="build.gradle[tags=dependency-full-platform]"]
 ====
 
-This ensures that all **Jackson modules align to the same version**, even if brought in transitively.
+This ensures that all **Kafka modules align to the same version**, even if brought in transitively.
 
 Running `./gradlew dependencies --configuration runtimeClasspath` showcases the aligned dependencies:
 

--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/groovy/build.gradle
@@ -22,20 +22,18 @@ dependencies {
 // end::dependency-full-bom[]
 
 // tag::dependency-full-platform[]
-abstract class JacksonAlignmentRule implements ComponentMetadataRule {
+abstract class KafkaAlignmentRule implements ComponentMetadataRule {
     void execute(ComponentMetadataContext ctx) {
-        ctx.details.run {
-            if (id.group.startsWith("com.fasterxml.jackson")) {
-                belongsTo("com.fasterxml.jackson:jackson-virtual-platform:${id.version}")
-            }
+        if (ctx.details.id.group == "org.apache.kafka") {
+            ctx.details.belongsTo("org.apache.kafka:kafka-virtual-platform:${ctx.details.id.version}")
         }
     }
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.8.9'
-    implementation 'io.vertx:vertx-core:3.5.3'
+    implementation 'org.apache.kafka:kafka-streams:3.6.0'
+    implementation 'org.apache.kafka:kafka-clients:3.7.0'
 
-    components.all(JacksonAlignmentRule)
+    components.all(KafkaAlignmentRule)
 }
 // end::dependency-full-platform[]

--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/kotlin/build.gradle.kts
@@ -22,20 +22,20 @@ dependencies {
 // end::dependency-full-bom[]
 
 // tag::dependency-full-platform[]
-abstract class JacksonAlignmentRule : ComponentMetadataRule {
+abstract class KafkaAlignmentRule : ComponentMetadataRule {
     override fun execute(ctx: ComponentMetadataContext) {
         ctx.details.run {
-            if (id.group.startsWith("com.fasterxml.jackson")) {
-                belongsTo("com.fasterxml.jackson:jackson-virtual-platform:${id.version}")
+            if (id.group == "org.apache.kafka") {
+                belongsTo("org.apache.kafka:kafka-virtual-platform:${id.version}")
             }
         }
     }
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.8.9")
-    implementation("io.vertx:vertx-core:3.5.3")
+    implementation("org.apache.kafka:kafka-streams:3.6.0")
+    implementation("org.apache.kafka:kafka-clients:3.7.0")
 
-    components.all<JacksonAlignmentRule>()
+    components.all<KafkaAlignmentRule>()
 }
 // end::dependency-full-platform[]

--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/tests/dependencies-platform.out
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/aligning-versions/tests/dependencies-platform.out
@@ -5,12 +5,22 @@ Root project 'how_to_align_dependency_versions'
 ------------------------------------------------------------
 
 runtimeClasspath - Runtime classpath of source set 'main'.
-+--- com.fasterxml.jackson.core:jackson-databind:2.8.9 -> 2.9.5
-|    +--- com.fasterxml.jackson.core:jackson-annotations:2.9.0 -> 2.9.5
-|    \--- com.fasterxml.jackson.core:jackson-core:2.9.5
-\--- io.vertx:vertx-core:3.5.3
-     +--- io.netty:netty-common:4.1.19.Final
-     ...
-     |    \--- io.netty:netty-transport:4.1.19.Final (*)
-     +--- com.fasterxml.jackson.core:jackson-core:2.9.5
-     \--- com.fasterxml.jackson.core:jackson-databind:2.9.5 (*)
++--- org.apache.kafka:kafka-streams:3.6.0 -> 3.7.0
+|    +--- org.slf4j:slf4j-api:1.7.36
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0
+|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.16.0 (c)
+|    |         \--- com.fasterxml.jackson.core:jackson-databind:2.16.0 (c)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.16.0
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.0 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.16.0
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.16.0 (*)
+|    +--- org.apache.kafka:kafka-clients:3.7.0
+|    |    +--- com.github.luben:zstd-jni:1.5.5-6
+|    |    +--- org.lz4:lz4-java:1.8.0
+|    |    +--- org.xerial.snappy:snappy-java:1.1.10.5
+|    |    \--- org.slf4j:slf4j-api:1.7.36
+|    \--- org.rocksdb:rocksdbjni:7.9.2
+\--- org.apache.kafka:kafka-clients:3.7.0 (*)


### PR DESCRIPTION

<!-- Fixes #? -->
Fixes #21583

### Context

This updates the consumer-side virtual platform example to use Apache Kafka modules instead of Jackson. Kafka gives the section a clearer case for manual alignment: there is no Kafka consumer BOM at `org.apache.kafka:kafka-bom:3.7.0`, and the Kafka module metadata does not publish a platform relationship for these modules.

The example now shows `kafka-streams:3.6.0` aligning to `3.7.0` when `kafka-clients:3.7.0` is also present and the component metadata rule adds a virtual platform.

AI assistance: OpenAI GPT-5 helped with issue triage, wording, and verification planning. I reviewed the patch and validation output before submitting.

Validation:

- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 gradle --no-daemon dependencies --configuration runtimeClasspath` in the Groovy `aligning-versions` snippet directory
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 gradle --no-daemon dependencies --configuration runtimeClasspath` in the Kotlin `aligning-versions` snippet directory
- Checked Maven Central responses for the Kafka BOM and Kafka module metadata used by the example

I did not run `./gradlew sanityCheck` or a subproject `quickTest` because this is a focused documentation/snippet update.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
