### PR TITLE
Replace weak-LoadingCache and CHM with ClassValue

### DIFF
--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/DefaultBeanStateReaderLookup.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/DefaultBeanStateReaderLookup.kt
@@ -22,7 +22,6 @@ import org.gradle.internal.serialize.graph.BeanStateReaderLookup
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
-import java.util.concurrent.ConcurrentHashMap
 
 
 @ServiceScope(Scope.BuildTree::class)
@@ -33,8 +32,11 @@ class DefaultBeanStateReaderLookup(
 ) : BeanStateReaderLookup {
 
     private
-    val beanStateReaders = ConcurrentHashMap<Class<*>, BeanStateReader>()
+    val beanStateReaders = object : ClassValue<BeanStateReader>() {
+        override fun computeValue(type: Class<*>): BeanStateReader =
+            BeanPropertyReader(type, constructors, instantiatorFactory, objectOpener)
+    }
 
     override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
-        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type, constructors, instantiatorFactory, objectOpener) }
+        beanStateReaders.get(beanType)
 }

--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/DefaultBeanStateWriterLookup.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/DefaultBeanStateWriterLookup.kt
@@ -21,7 +21,6 @@ import org.gradle.internal.serialize.graph.BeanStateWriter
 import org.gradle.internal.serialize.graph.BeanStateWriterLookup
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
-import java.util.concurrent.ConcurrentHashMap
 
 
 @ServiceScope(Scope.BuildTree::class)
@@ -29,8 +28,10 @@ class DefaultBeanStateWriterLookup(
     private val objectOpener: ObjectOpener
 ) : BeanStateWriterLookup {
     private
-    val beanPropertyWriters = ConcurrentHashMap<Class<*>, BeanStateWriter>()
+    val beanPropertyWriters = object : ClassValue<BeanStateWriter>() {
+        override fun computeValue(type: Class<*>): BeanStateWriter = BeanPropertyWriter(type, objectOpener)
+    }
 
     override fun beanStateWriterFor(beanType: Class<*>): BeanStateWriter =
-        beanPropertyWriters.computeIfAbsent(beanType) { type -> BeanPropertyWriter(type, objectOpener) }
+        beanPropertyWriters.get(beanType)
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaSerializationEncodingLookup.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaSerializationEncodingLookup.kt
@@ -23,7 +23,6 @@ import org.gradle.internal.service.scopes.ServiceScope
 import java.io.ObjectOutputStream
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import java.util.concurrent.ConcurrentHashMap
 
 
 /**
@@ -35,14 +34,14 @@ class JavaSerializationEncodingLookup(
     private val objectOpener: ObjectOpener
 ) {
     private
-    val encodings = ConcurrentHashMap<Class<*>, EncodingDetails>()
+    val encodings = object : ClassValue<EncodingDetails>() {
+        override fun computeValue(type: Class<*>): EncodingDetails = calculateEncoding(type)
+    }
 
     /**
      * Returns the proper encoding provider for the given type, or null, if not covered by Java Object serialization.
      */
-    fun encodingFor(type: Class<*>): Encoding? {
-        return encodings.computeIfAbsent(type) { t -> calculateEncoding(t) }.encoding
-    }
+    fun encodingFor(type: Class<*>): Encoding? = encodings.get(type).encoding
 
     private
     fun calculateEncoding(type: Class<*>): EncodingDetails {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/codecs/BindingsBackedCodec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/codecs/BindingsBackedCodec.kt
@@ -26,7 +26,6 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.SerializerCodec
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.withDebugFrame
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 
@@ -52,7 +51,9 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
     }
 
     private
-    val encodings = ConcurrentHashMap<Class<*>, TaggedEncoding>()
+    val encodings = object : ClassValue<TaggedEncoding>() {
+        override fun computeValue(type: Class<*>): TaggedEncoding = computeEncoding(type)
+    }
 
     override suspend fun WriteContext.encode(value: Any?) = when (value) {
         null -> writeSmallInt(NULL_VALUE)
@@ -111,7 +112,7 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
 
     private
     fun taggedEncodingFor(type: Class<*>): TaggedEncoding =
-        encodings.computeIfAbsent(type, ::computeEncoding)
+        encodings.get(type)
 
     private
     fun computeEncoding(type: Class<*>): TaggedEncoding {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/codecs/BindingsBackedCodec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/codecs/BindingsBackedCodec.kt
@@ -26,6 +26,7 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.SerializerCodec
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.withDebugFrame
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 
@@ -51,9 +52,7 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
     }
 
     private
-    val encodings = object : ClassValue<TaggedEncoding>() {
-        override fun computeValue(type: Class<*>): TaggedEncoding = computeEncoding(type)
-    }
+    val encodings = ConcurrentHashMap<Class<*>, TaggedEncoding>()
 
     override suspend fun WriteContext.encode(value: Any?) = when (value) {
         null -> writeSmallInt(NULL_VALUE)
@@ -112,7 +111,7 @@ class BindingsBackedCodec(private val bindings: List<Binding>) : Codec<Any?> {
 
     private
     fun taggedEncodingFor(type: Class<*>): TaggedEncoding =
-        encodings.get(type)
+        encodings.computeIfAbsent(type, ::computeEncoding)
 
     private
     fun computeEncoding(type: Class<*>): TaggedEncoding {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
@@ -24,34 +24,37 @@ import org.gradle.model.internal.inspect.ModelRuleExtractor
 class ModelRuleCachingIntegrationTest extends PersistentBuildProcessIntegrationTest {
 
     def setup() {
+        // A stateless rule source (no managed properties): the extractor caches one
+        // CachedRuleSource per class and reuses the same extracted instance on every call.
+        // It lives in buildSrc so the daemon reuses its class loader, keeping the Class
+        // identity (the cache key) stable across builds.
+        file("buildSrc/src/main/java/org/gradle/integtest/CachingRuleSource.java") << """
+            package org.gradle.integtest;
+
+            import org.gradle.model.RuleSource;
+
+            public class CachingRuleSource extends RuleSource {}
+        """
         buildFile << """
-            def ruleCache = project.services.get($ModelRuleExtractor.name).cache
-            def initialSize = ruleCache.size()
-            gradle.buildFinished { println "### extracted new rules: \${ruleCache.size() > initialSize}" }
+            def extractor = project.services.get($ModelRuleExtractor.name)
+            def ruleSource = extractor.extract(org.gradle.integtest.CachingRuleSource)
+            println "### rule source id: \${System.identityHashCode(ruleSource)}"
         """
     }
 
-    boolean getNewRulesExtracted() {
-        def match = output =~ /.*### extracted new rules: (true|false).*/
-        match[0][1] == "true"
+    private String getExtractedRuleSourceId() {
+        def match = output =~ /### rule source id: (\d+)/
+        match[0][1]
     }
 
-    def "rules extracted from core plugins are reused across builds"() {
-        given:
-        buildFile << '''
-            apply plugin: 'cpp'
-        '''
-
+    def "rule sources are reused across builds in a persistent process"() {
         when:
         run()
-
-        then:
-        newRulesExtracted
-
-        when:
+        def firstId = extractedRuleSourceId
         run()
+        def secondId = extractedRuleSourceId
 
         then:
-        !newRulesExtracted
+        firstId == secondId
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleExtractor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleExtractor.java
@@ -18,12 +18,8 @@ package org.gradle.model.internal.inspect;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
@@ -66,20 +62,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ExecutionException;
 
 @ThreadSafe
 @ServiceScope(Scope.Global.class)
 @SuppressWarnings("deprecation")
 public class ModelRuleExtractor {
-    private final LoadingCache<Class<?>, CachedRuleSource> cache = CacheBuilder.newBuilder()
-            .weakKeys()
-            .build(new CacheLoader<Class<?>, CachedRuleSource>() {
-                @Override
-                public CachedRuleSource load(Class<?> source) {
-                    return doExtract(source);
-                }
-            });
+    private final ClassValue<CachedRuleSource> ruleSourceCache = new ClassValue<CachedRuleSource>() {
+        @Override
+        protected CachedRuleSource computeValue(Class<?> source) {
+            return doExtract(source);
+        }
+    };
 
     private final Iterable<MethodModelRuleExtractor> handlers;
     private final ManagedProxyFactory proxyFactory;
@@ -104,13 +97,7 @@ public class ModelRuleExtractor {
      * @throws org.gradle.model.InvalidModelRuleDeclarationException On badly formed rule source class.
      */
     public <T> ExtractedRuleSource<T> extract(Class<T> source) throws org.gradle.model.InvalidModelRuleDeclarationException {
-        try {
-            return cache.get(source).newInstance(source);
-        } catch (ExecutionException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        } catch (UncheckedExecutionException e) {
-            throw UncheckedException.throwAsUncheckedException(e.getCause());
-        }
+        return ruleSourceCache.get(source).newInstance(source);
     }
 
     private <T> CachedRuleSource doExtract(final Class<T> source) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleSourceDetector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleSourceDetector.java
@@ -18,15 +18,11 @@ package org.gradle.model.internal.inspect;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.gradle.internal.Cast;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -40,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.concurrent.ExecutionException;
 
 @ThreadSafe
 @ServiceScope(Scope.Global.class)
@@ -51,46 +46,40 @@ public class ModelRuleSourceDetector {
 
     private static final Comparator<Class<?>> COMPARE_BY_CLASS_NAME = Comparator.comparing(Class::getName);
 
-    final LoadingCache<Class<?>, Collection<Reference<Class<? extends org.gradle.model.RuleSource>>>> cache = CacheBuilder.newBuilder()
-        .weakKeys()
-        .build(new CacheLoader<Class<?>, Collection<Reference<Class<? extends org.gradle.model.RuleSource>>>>() {
-            @Override
-            public Collection<Reference<Class<? extends org.gradle.model.RuleSource>>> load(@SuppressWarnings("NullableProblems") Class<?> container) {
-                if (isRuleSource(container)) {
-                    Class<? extends org.gradle.model.RuleSource> castClass = Cast.uncheckedCast(container);
-                    return ImmutableSet.of(new WeakReference<>(castClass));
-                }
-
-                Class<?>[] declaredClasses = declaredClassesOf(container);
-                if (declaredClasses.length == 0) {
-                    return Collections.emptySet();
-                }
-
-                Class<?>[] sortedDeclaredClasses = new Class<?>[declaredClasses.length];
-                System.arraycopy(declaredClasses, 0, sortedDeclaredClasses, 0, declaredClasses.length);
-                Arrays.sort(sortedDeclaredClasses, COMPARE_BY_CLASS_NAME);
-
-                ImmutableList.Builder<Reference<Class<? extends org.gradle.model.RuleSource>>> found = ImmutableList.builder();
-                for (Class<?> declaredClass : sortedDeclaredClasses) {
-                    if (isRuleSource(declaredClass)) {
-                        Class<? extends org.gradle.model.RuleSource> castClass = Cast.uncheckedCast(declaredClass);
-                        found.add(new WeakReference<>(castClass));
-                    }
-                }
-
-                return found.build();
+    private final ClassValue<Collection<Reference<Class<? extends org.gradle.model.RuleSource>>>> declaredSourcesCache = new ClassValue<Collection<Reference<Class<? extends org.gradle.model.RuleSource>>>>() {
+        @Override
+        protected Collection<Reference<Class<? extends org.gradle.model.RuleSource>>> computeValue(Class<?> container) {
+            if (isRuleSource(container)) {
+                Class<? extends org.gradle.model.RuleSource> castClass = Cast.uncheckedCast(container);
+                return ImmutableSet.of(new WeakReference<>(castClass));
             }
-        });
+
+            Class<?>[] declaredClasses = declaredClassesOf(container);
+            if (declaredClasses.length == 0) {
+                return Collections.emptySet();
+            }
+
+            Class<?>[] sortedDeclaredClasses = new Class<?>[declaredClasses.length];
+            System.arraycopy(declaredClasses, 0, sortedDeclaredClasses, 0, declaredClasses.length);
+            Arrays.sort(sortedDeclaredClasses, COMPARE_BY_CLASS_NAME);
+
+            ImmutableList.Builder<Reference<Class<? extends org.gradle.model.RuleSource>>> found = ImmutableList.builder();
+            for (Class<?> declaredClass : sortedDeclaredClasses) {
+                if (isRuleSource(declaredClass)) {
+                    Class<? extends org.gradle.model.RuleSource> castClass = Cast.uncheckedCast(declaredClass);
+                    found.add(new WeakReference<>(castClass));
+                }
+            }
+
+            return found.build();
+        }
+    };
 
     // TODO return a richer data structure that provides meta data about how the source was found, for use is diagnostics
     public Iterable<Class<? extends org.gradle.model.RuleSource>> getDeclaredSources(Class<?> container) {
-        try {
-            return FluentIterable.from(cache.get(container))
-                .transform((Function<Reference<Class<? extends org.gradle.model.RuleSource>>, Class<? extends org.gradle.model.RuleSource>>) Reference::get)
-                .filter(Predicates.notNull());
-        } catch (ExecutionException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+        return FluentIterable.from(declaredSourcesCache.get(container))
+            .transform((Function<Reference<Class<? extends org.gradle.model.RuleSource>>, Class<? extends org.gradle.model.RuleSource>>) Reference::get)
+            .filter(Predicates.notNull());
     }
 
     public boolean hasRules(Class<?> container) {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
@@ -755,23 +755,24 @@ ${fullyQualifiedNameOf(ManagedWithNonManageableParents)}
                 }
             }
         ''')
+        def sourceRef = new java.lang.ref.WeakReference<Class<?>>(source)
 
         when:
         extractor.extract(source)
 
         then:
-        extractor.cache.size() == 1
+        sourceRef.get() != null
 
         when:
         cl.clearCache()
         forcefullyClearReferences(source)
         source = null
+        cl = null
 
         then:
         ConcurrentTestUtil.poll(10) {
             System.gc()
-            extractor.cache.cleanUp()
-            extractor.cache.size() == 0
+            sourceRef.get() == null
         }
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleSourceDetectorTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleSourceDetectorTest.groovy
@@ -77,19 +77,19 @@ class ModelRuleSourceDetectorTest extends Specification {
     def "does not hold strong reference"() {
         given:
         def cl = new GroovyClassLoader(getClass().classLoader)
-        addClass(cl, impl)
+        def classRef = addClass(cl, impl)
 
         expect:
-        detector.cache.size() == 1
+        classRef.get() != null
 
         when:
         cl.clearCache()
+        cl = null
 
         then:
         ConcurrentTestUtil.poll(10) {
             System.gc()
-            detector.cache.cleanUp()
-            detector.cache.size() == 0
+            classRef.get() == null
         }
 
         where:
@@ -134,10 +134,10 @@ class ModelRuleSourceDetectorTest extends Specification {
         detector.getDeclaredSources(brokenOuterClass).toList() == []
     }
 
-    private void addClass(GroovyClassLoader cl, String impl) {
+    private java.lang.ref.WeakReference<Class<?>> addClass(GroovyClassLoader cl, String impl) {
         def type = cl.parseClass(impl)
         detector.getDeclaredSources(type)
-        type = null
+        return new java.lang.ref.WeakReference<Class<?>>(type)
     }
 
 }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/JavaPropertyReflectionUtil.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/JavaPropertyReflectionUtil.java
@@ -33,11 +33,15 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.WeakHashMap;
 
 public class JavaPropertyReflectionUtil {
 
-    private static final WeakHashMap<Class<?>, Set<String>> PROPERTY_CACHE = new WeakHashMap<Class<?>, Set<String>>();
+    private static final ClassValue<Set<String>> PROPERTY_CACHE = new ClassValue<Set<String>>() {
+        @Override
+        protected Set<String> computeValue(Class<?> type) {
+            return ClassInspector.inspect(type).getPropertyNames();
+        }
+    };
 
     /**
      * Locates the property with the given name as a readable property. Searches only public properties.
@@ -115,15 +119,7 @@ public class JavaPropertyReflectionUtil {
     }
 
     public static Set<String> propertyNames(Object target) {
-        Class<?> targetType = target.getClass();
-        synchronized (PROPERTY_CACHE) {
-            Set<String> cached = PROPERTY_CACHE.get(targetType);
-            if (cached == null) {
-                cached = ClassInspector.inspect(targetType).getPropertyNames();
-                PROPERTY_CACHE.put(targetType, cached);
-            }
-            return cached;
-        }
+        return PROPERTY_CACHE.get(target.getClass());
     }
 
     public static boolean hasDefaultToString(Object object) {

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -21,14 +21,18 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.gradle.util.internal.ArrayUtils.contains;
 
 class RelevantMethods {
-    private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
     private static final ServiceMethodFactory SERVICE_METHOD_FACTORY = new DefaultServiceMethodFactory();
+
+    private static final ClassValue<RelevantMethods> METHODS_CACHE = new ClassValue<RelevantMethods>() {
+        @Override
+        protected RelevantMethods computeValue(Class<?> type) {
+            return new RelevantMethodsBuilder(type).build();
+        }
+    };
 
     final List<ServiceMethod> decorators;
     final List<ServiceMethod> factories;
@@ -41,12 +45,7 @@ class RelevantMethods {
     }
 
     public static RelevantMethods getMethods(Class<? extends ServiceRegistrationProvider> type) {
-        RelevantMethods relevantMethods = METHODS_CACHE.get(type);
-        if (relevantMethods == null) {
-            relevantMethods = new RelevantMethodsBuilder(type).build();
-            METHODS_CACHE.putIfAbsent(type, relevantMethods);
-        }
-        return relevantMethods;
+        return METHODS_CACHE.get(type);
     }
 
     private static class RelevantMethodsBuilder {
@@ -57,7 +56,7 @@ class RelevantMethods {
 
         private final Set<String> seen = new HashSet<String>();
 
-        public RelevantMethodsBuilder(Class<? extends ServiceRegistrationProvider> type) {
+        public RelevantMethodsBuilder(Class<?> type) {
             this.type = type;
         }
 


### PR DESCRIPTION
These are the easy migrations that can be done without much thought. There are more applicable locations that need more analysis.

The justification is that this is more efficient than a LoadingCache or CHM since it's generally able to load directly from the associated `Class` object, rather than storing a hashmap of them. It also doesn't need to rely on GC to empty out the weak entries -- because the values are stored on the `Class` itself, they are freed automatically.

In some cases we never even cleared the CHM, which could leak class values.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
