### PR TITLE
Fix isolated projects violation when using -x task exclusion

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessIntegrationTest.groovy
@@ -55,4 +55,29 @@ class IsolatedProjectsAccessIntegrationTest extends AbstractIsolatedProjectsInte
         "parent"        | ":sub"
         "parent.parent" | ":"
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/29154")
+    def "exclude task option does not cause isolated projects violation"() {
+        settingsFile """
+            include(":sub")
+        """
+
+        buildFile """
+            task build
+        """
+
+        buildFile "sub/build.gradle", """
+            task test
+            task build { dependsOn test }
+        """
+
+        when:
+        isolatedProjectsRun(":sub:build", "-x", "test")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+        result.assertTasksNotScheduled(":sub:test")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -156,6 +156,20 @@ class DefaultProjectState implements ProjectState, Closeable {
     }
 
     @Override
+    public Set<ProjectState> getAllProjects() {
+        Set<ProjectState> result = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
+        collectAllProjects(this, result);
+        return result;
+    }
+
+    private static void collectAllProjects(ProjectState project, Set<ProjectState> result) {
+        result.add(project);
+        for (ProjectState child : project.getUnorderedChildProjects()) {
+            collectAllProjects(child, result);
+        }
+    }
+
+    @Override
     public boolean hasChildren() {
         return !descriptor.getChildren().isEmpty();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -123,6 +123,11 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
     Iterable<ProjectState> getUnorderedChildProjects();
 
     /**
+     * Returns this project and all projects beneath it in the hierarchy.
+     */
+    Set<ProjectState> getAllProjects();
+
+    /**
      * Checks whether this project has child projects.
      *
      * @return true when this project has child projects.

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -55,7 +55,7 @@ public abstract class DefaultTaskSelector implements TaskSelector {
         if (includeSubprojects) {
             // Try to delay configuring all the subprojects
             getConfigurer().configure(project.getMutableModel());
-            if (taskNameResolver.tryFindUnqualifiedTaskCheaply(taskName, project.getMutableModel())) {
+            if (taskNameResolver.tryFindUnqualifiedTaskCheaply(taskName, project)) {
                 // An exact match in the target project - can just filter tasks by path to avoid configuring subprojects at this point
                 return new TaskPathSpec(project.getMutableModel(), taskName);
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.execution;
 
-import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
@@ -35,14 +34,13 @@ public class TaskNameResolver {
     /**
      * Non-exhaustively searches for at least one task with the given name, by not evaluating projects before searching.
      */
-    public boolean tryFindUnqualifiedTaskCheaply(String name, ProjectInternal project) {
+    public boolean tryFindUnqualifiedTaskCheaply(String name, ProjectState project) {
         // don't evaluate children, see if we know it's without validating it
-        for (Project project1 : project.getAllprojects()) {
-            if (project1.getTasks().getNames().contains(name)) {
+        for (ProjectState current : project.getAllProjects()) {
+            if (current.fromMutableState(p -> p.getTasks().getNames().contains(name))) {
                 return true;
             }
         }
-
         return false;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTaskSelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTaskSelectorTest.groovy
@@ -92,7 +92,7 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
 
         then:
         1 * projectConfigurer.configure(projectModel1)
-        1 * resolver.tryFindUnqualifiedTaskCheaply("b", projectModel1) >> true
+        1 * resolver.tryFindUnqualifiedTaskCheaply("b", project1) >> true
         0 * _
 
         and:
@@ -110,7 +110,7 @@ class DefaultTaskSelectorTest extends AbstractProjectBuilderSpec {
 
         then:
         1 * projectConfigurer.configure(projectModel1)
-        1 * resolver.tryFindUnqualifiedTaskCheaply("b", projectModel1) >> false
+        1 * resolver.tryFindUnqualifiedTaskCheaply("b", project1) >> false
         1 * projectConfigurer.configureHierarchy(projectModel1)
         1 * resolver.selectWithName("b", project1, true) >> selectionResult
         _ * selectionResult.collectTasks(_) >> { it[0] << excluded }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
@@ -262,6 +262,53 @@ class TaskNameResolverTest extends Specification {
         0 * childTasks._
     }
 
+    def "finds task cheaply in root project"() {
+        given:
+        def projectState = projectState()
+        def tasks = projectState.getMutableModel().getTasks()
+
+        when:
+        def result = resolver.tryFindUnqualifiedTaskCheaply('task', projectState)
+
+        then:
+        result
+        1 * tasks.getNames() >> (['task'] as SortedSet)
+    }
+
+    def "finds task cheaply in child project"() {
+        given:
+        def childProjectState = projectState()
+        def childTasks = childProjectState.getMutableModel().getTasks()
+
+        def projectState = projectState([childProjectState] as Set)
+        def tasks = projectState.getMutableModel().getTasks()
+
+        when:
+        def result = resolver.tryFindUnqualifiedTaskCheaply('task', projectState)
+
+        then:
+        result
+        1 * tasks.getNames() >> ([] as SortedSet)
+        1 * childTasks.getNames() >> (['task'] as SortedSet)
+    }
+
+    def "returns false when no task found cheaply"() {
+        given:
+        def childProjectState = projectState()
+        def childTasks = childProjectState.getMutableModel().getTasks()
+
+        def projectState = projectState([childProjectState] as Set)
+        def tasks = projectState.getMutableModel().getTasks()
+
+        when:
+        def result = resolver.tryFindUnqualifiedTaskCheaply('task', projectState)
+
+        then:
+        !result
+        1 * tasks.getNames() >> ([] as SortedSet)
+        1 * childTasks.getNames() >> (['other'] as SortedSet)
+    }
+
     def task(String name, String description = "") {
         Stub(TaskInternal) { TaskInternal task ->
             _ * task.getName() >> name
@@ -278,12 +325,26 @@ class TaskNameResolverTest extends Specification {
     ProjectState projectState(Set<ProjectState> children = []) {
         def state = Mock(ProjectState) {
             getChildProjects() >> children
+            getUnorderedChildProjects() >> children
         }
         def project = Mock(ProjectInternal) {
             getOwner() >> state
             getTasks() >> Mock(TaskContainerInternal)
         }
         _ * state.getMutableModel() >> project
+        _ * state.fromMutableState(_) >> { args -> args[0].apply(project) }
+        _ * state.getAllProjects() >> {
+            def result = new LinkedHashSet<ProjectState>()
+            collectAll(state, result)
+            result
+        }
         state
+    }
+
+    private static void collectAll(ProjectState project, Set<ProjectState> result) {
+        result.add(project)
+        for (ProjectState child : project.getUnorderedChildProjects()) {
+            collectAll(child, result)
+        }
     }
 }


### PR DESCRIPTION
Use `ProjectState` API instead of `Project.getAllprojects()` in `TaskNameResolver.tryFindUnqualifiedTaskCheaply()` to avoid cross-project access violations with isolated projects enabled.

Closes #29154

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
