### PR TITLE
Better failure messages when running samples that require no CC

### DIFF
--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -7,6 +7,7 @@ import gradlebuild.integrationtests.configureTestSourceSetInIde
 import gradlebuild.integrationtests.model.GradleDistribution
 import java.io.FileFilter
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
+import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.docs.internal.tasks.CheckLinks
 import org.gradle.docs.samples.internal.tasks.InstallSample
 import org.gradle.internal.os.OperatingSystem
@@ -262,6 +263,24 @@ tasks.named<Test>("docsTest") {
     if (project.configurationCacheEnabledForDocsTests) {
         systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
         systemProperty("org.gradle.integtest.executer", "configCache")
+
+        // Pre-flight: if every --tests pattern targets a configuration-cache snippet sample, those samples
+        // are excluded below and Gradle's default "No tests found" message hides the real cause. Replace it
+        // with a message that names the property the user must clear. Keep the prefix in sync with the
+        // excludeTestsMatching pattern further down.
+        val testTask = this
+        doFirst {
+            val excludedPrefix = "snippet-optimizing-builds-configuration-cache-"
+            val cliPatterns = (testTask.filter as DefaultTestFilter).commandLineIncludePatterns
+            if (cliPatterns.isNotEmpty() && cliPatterns.all { it.contains(excludedPrefix) }) {
+                throw GradleException(
+                    "All --tests filters target configuration-cache snippet samples, which are excluded " +
+                        "from docsTest when enableConfigurationCacheForDocsTests=true.\n" +
+                        "  Filters: ${cliPatterns.joinToString(", ") { "'$it'" }}\n" +
+                        "  Set enableConfigurationCacheForDocsTests=false (or remove it from gradle.properties) to run these samples."
+                )
+            }
+        }
 
         filter {
             // Configuration cache samples enable configuration cache explicitly. We're not going to run them with the configuration cache executer.

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -264,18 +264,29 @@ tasks.named<Test>("docsTest") {
         systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
         systemProperty("org.gradle.integtest.executer", "configCache")
 
-        // Pre-flight: if every --tests pattern targets a configuration-cache snippet sample, those samples
-        // are excluded below and Gradle's default "No tests found" message hides the real cause. Replace it
-        // with a message that names the property the user must clear. Keep the prefix in sync with the
-        // excludeTestsMatching pattern further down.
+        // Single source of truth for groups of tests excluded when docsTest runs with the configCache
+        // executer. Each entry pairs:
+        //   - the excludeTestsMatching glob (used by the filter below), and
+        //   - the telltale substring that identifies a --tests CLI pattern targeting that group
+        //     (used by the pre-flight check below).
+        // Group 1: snippet samples that enable configuration cache explicitly; not re-run by the configCache executer.
+        // Group 2: *WithoutCC* test variants, paired with WithCC counterparts and only meaningful when CC is off.
+        val configCacheExcludedTestGroups = listOf(
+            "org.gradle.docs.samples.*.snippet-optimizing-builds-configuration-cache-*" to "snippet-optimizing-builds-configuration-cache-",
+            "*WithoutCC*" to "WithoutCC",
+        )
+
+        // Pre-flight: if every --tests pattern targets one of the excluded groups above, Gradle's default
+        // "No tests found" message hides the real cause. Replace it with a message that names the property
+        // the user must clear.
         val testTask = this
         doFirst {
-            val excludedPrefix = "snippet-optimizing-builds-configuration-cache-"
             val cliPatterns = (testTask.filter as DefaultTestFilter).commandLineIncludePatterns
-            if (cliPatterns.isNotEmpty() && cliPatterns.all { it.contains(excludedPrefix) }) {
+            val markers = configCacheExcludedTestGroups.map { it.second }
+            if (cliPatterns.isNotEmpty() && cliPatterns.all { p -> markers.any { p.contains(it) } }) {
                 throw GradleException(
-                    "All --tests filters target configuration-cache snippet samples, which are excluded " +
-                        "from docsTest when enableConfigurationCacheForDocsTests=true.\n" +
+                    "All --tests filters target tests that are excluded from docsTest when " +
+                        "enableConfigurationCacheForDocsTests=true.\n" +
                         "  Filters: ${cliPatterns.joinToString(", ") { "'$it'" }}\n" +
                         "  Set enableConfigurationCacheForDocsTests=false (or remove it from gradle.properties) to run these samples."
                 )
@@ -283,9 +294,7 @@ tasks.named<Test>("docsTest") {
         }
 
         filter {
-            // Configuration cache samples enable configuration cache explicitly. We're not going to run them with the configuration cache executer.
-            excludeTestsMatching("org.gradle.docs.samples.*.snippet-optimizing-builds-configuration-cache-*")
-            excludeTestsMatching("*WithoutCC*")
+            configCacheExcludedTestGroups.forEach { (pattern, _) -> excludeTestsMatching(pattern) }
 
             // These tests cover features that are not planned to be supported in the first stable release of the configuration cache.
             val testsForUnsupportedFeatures = listOf(

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -265,15 +265,15 @@ tasks.named<Test>("docsTest") {
         systemProperty("org.gradle.integtest.executer", "configCache")
 
         // Single source of truth for groups of tests excluded when docsTest runs with the configCache
-        // executer. Each entry pairs:
-        //   - the excludeTestsMatching glob (used by the filter below), and
-        //   - the telltale substring that identifies a --tests CLI pattern targeting that group
-        //     (used by the pre-flight check below).
+        // executer. Each entry is a substring marker, used two ways:
+        //   - wrapped as "*${marker}*" for the excludeTestsMatching glob below, and
+        //   - matched directly against --tests CLI patterns in the pre-flight check below.
         // Group 1: snippet samples that enable configuration cache explicitly; not re-run by the configCache executer.
         // Group 2: *WithoutCC* test variants, paired with WithCC counterparts and only meaningful when CC is off.
+        // Keep in sync with SampleFailureMessageFormatter.CONFIG_CACHE_EXCLUDED_MARKERS.
         val configCacheExcludedTestGroups = listOf(
-            "org.gradle.docs.samples.*.snippet-optimizing-builds-configuration-cache-*" to "snippet-optimizing-builds-configuration-cache-",
-            "*WithoutCC*" to "WithoutCC",
+            "snippet-optimizing-builds-configuration-cache-",
+            "WithoutCC",
         )
 
         // Pre-flight: if every --tests pattern targets one of the excluded groups above, Gradle's default
@@ -282,8 +282,7 @@ tasks.named<Test>("docsTest") {
         val testTask = this
         doFirst {
             val cliPatterns = (testTask.filter as DefaultTestFilter).commandLineIncludePatterns
-            val markers = configCacheExcludedTestGroups.map { it.second }
-            if (cliPatterns.isNotEmpty() && cliPatterns.all { p -> markers.any { p.contains(it) } }) {
+            if (cliPatterns.isNotEmpty() && cliPatterns.all { p -> configCacheExcludedTestGroups.any { p.contains(it) } }) {
                 throw GradleException(
                     "All --tests filters target tests that are excluded from docsTest when " +
                         "enableConfigurationCacheForDocsTests=true.\n" +
@@ -294,7 +293,7 @@ tasks.named<Test>("docsTest") {
         }
 
         filter {
-            configCacheExcludedTestGroups.forEach { (pattern, _) -> excludeTestsMatching(pattern) }
+            configCacheExcludedTestGroups.forEach { excludeTestsMatching("*${it}*") }
 
             // These tests cover features that are not planned to be supported in the first stable release of the configuration cache.
             val testsForUnsupportedFeatures = listOf(

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -264,17 +264,16 @@ tasks.named<Test>("docsTest") {
         systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
         systemProperty("org.gradle.integtest.executer", "configCache")
 
-        // Single source of truth for groups of tests excluded when docsTest runs with the configCache
-        // executer. Each entry is a substring marker, used two ways:
+        // Substring markers identifying groups of tests excluded when docsTest runs with the configCache
+        // executer. Loaded from the resource file alongside SampleFailureMessageFormatter, which uses the
+        // same list at test runtime — that file is the single source of truth. Each marker is used two ways:
         //   - wrapped as "*${marker}*" for the excludeTestsMatching glob below, and
         //   - matched directly against --tests CLI patterns in the pre-flight check below.
-        // Group 1: snippet samples that enable configuration cache explicitly; not re-run by the configCache executer.
-        // Group 2: *WithoutCC* test variants, paired with WithCC counterparts and only meaningful when CC is off.
-        // Keep in sync with SampleFailureMessageFormatter.CONFIG_CACHE_EXCLUDED_MARKERS.
-        val configCacheExcludedTestGroups = listOf(
-            "snippet-optimizing-builds-configuration-cache-",
-            "WithoutCC",
-        )
+        val configCacheExcludedTestGroups = providers.fileContents(
+            layout.projectDirectory.file("src/main/resources/non-config-cache-compatible-snippets.txt")
+        ).asText.map { text ->
+            text.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        }.get()
 
         // Pre-flight: if every --tests pattern targets one of the excluded groups above, Gradle's default
         // "No tests found" message hides the real cause. Replace it with a message that names the property

--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesRunner.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesRunner.java
@@ -91,13 +91,10 @@ class IntegrationTestSamplesRunner extends SamplesRunner {
         try {
             runChild(sample, new RunNotifierAdapter());
         } catch (Throwable e) {
-            String extraParameter = "configCache".equals(System.getProperty("org.gradle.integtest.executer")) ?
-                "-PenableConfigurationCacheForDocsTests=true" : "";
-            throw new GradleException(
-                "Sample test run failed.\nTo understand how docsTest works, See:\n" +
-                    "  https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/README.md#testing-docs\n" +
-                    "To reproduce this failure, run:\n" +
-                    "  ./gradlew docs:docsTest --tests '*" + getNormalizedSampleId(sample) + "*' " + extraParameter, e);
+            String sampleId = getNormalizedSampleId(sample);
+            boolean configCacheExecuter = "configCache".equals(System.getProperty("org.gradle.integtest.executer"));
+            String message = SampleFailureMessageFormatter.format(sampleId, configCacheExecuter);
+            throw new GradleException(message, e);
         }
     }
 }

--- a/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
+++ b/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
@@ -15,23 +15,28 @@
  */
 package org.gradle.docs.samples;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
  * Builds the failure message thrown when a {@code docsTest} sample fails.
  * <p>
- * The {@link #CONFIG_CACHE_EXCLUDED_MARKERS} substrings here mirror the {@code excludeTestsMatching}
- * groups in {@code platforms/documentation/docs/build.gradle.kts}: samples whose id contains any of
- * these markers are skipped when {@code enableConfigurationCacheForDocsTests=true}, so the reproduce
- * instructions for those samples must tell the user to clear that property rather than set it.
- * Keep this list in sync with {@code configCacheExcludedTestGroups} in the build script.
+ * The list of "excluded" sample-id substrings is loaded from the classpath resource
+ * {@code /non-config-cache-compatible-snippets.txt}. The same file is read by
+ * {@code platforms/documentation/docs/build.gradle.kts} to wire the {@code excludeTestsMatching}
+ * filter and the pre-flight check on {@code --tests} CLI patterns. That file is the single source
+ * of truth for samples skipped when {@code enableConfigurationCacheForDocsTests=true}.
  */
 public final class SampleFailureMessageFormatter {
 
-    private static final List<String> CONFIG_CACHE_EXCLUDED_MARKERS = List.of(
-        "snippet-optimizing-builds-configuration-cache-",
-        "WithoutCC"
-    );
+    private static final String MARKERS_RESOURCE = "/non-config-cache-compatible-snippets.txt";
+
+    private static final List<String> CONFIG_CACHE_EXCLUDED_MARKERS = loadMarkers();
 
     private static final String BANNER = "**********************************************************************************";
 
@@ -57,5 +62,21 @@ public final class SampleFailureMessageFormatter {
         }
         message.append(BANNER);
         return message.toString();
+    }
+
+    private static List<String> loadMarkers() {
+        try (InputStream in = SampleFailureMessageFormatter.class.getResourceAsStream(MARKERS_RESOURCE)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing classpath resource: " + MARKERS_RESOURCE);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                return reader.lines()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .toList();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load " + MARKERS_RESOURCE, e);
+        }
     }
 }

--- a/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
+++ b/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
@@ -15,18 +15,23 @@
  */
 package org.gradle.docs.samples;
 
+import java.util.List;
+
 /**
  * Builds the failure message thrown when a {@code docsTest} sample fails.
  * <p>
- * The {@link #CONFIG_CACHE_SAMPLE_PREFIX} prefix here mirrors the {@code excludeTestsMatching}
- * filter in {@code platforms/documentation/docs/build.gradle.kts}: samples with that prefix are
- * skipped when {@code enableConfigurationCacheForDocsTests=true}, so the reproduce instructions
- * for those samples must tell the user to clear that property rather than set it. If the build
- * script filter changes, this prefix must change with it.
+ * The {@link #CONFIG_CACHE_EXCLUDED_MARKERS} substrings here mirror the {@code excludeTestsMatching}
+ * groups in {@code platforms/documentation/docs/build.gradle.kts}: samples whose id contains any of
+ * these markers are skipped when {@code enableConfigurationCacheForDocsTests=true}, so the reproduce
+ * instructions for those samples must tell the user to clear that property rather than set it.
+ * Keep this list in sync with {@code configCacheExcludedTestGroups} in the build script.
  */
 public final class SampleFailureMessageFormatter {
 
-    private static final String CONFIG_CACHE_SAMPLE_PREFIX = "snippet-optimizing-builds-configuration-cache-";
+    private static final List<String> CONFIG_CACHE_EXCLUDED_MARKERS = List.of(
+        "snippet-optimizing-builds-configuration-cache-",
+        "WithoutCC"
+    );
 
     private static final String BANNER = "**********************************************************************************";
 
@@ -35,7 +40,7 @@ public final class SampleFailureMessageFormatter {
     }
 
     public static String format(String sampleId, boolean configCacheExecuter) {
-        boolean excludedWhenConfigCacheEnabled = sampleId.startsWith(CONFIG_CACHE_SAMPLE_PREFIX);
+        boolean excludedWhenConfigCacheEnabled = CONFIG_CACHE_EXCLUDED_MARKERS.stream().anyMatch(sampleId::contains);
         String extraParameter = (configCacheExecuter && !excludedWhenConfigCacheEnabled)
             ? " -PenableConfigurationCacheForDocsTests=true"
             : "";

--- a/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
+++ b/platforms/documentation/docs/src/main/java/org/gradle/docs/samples/SampleFailureMessageFormatter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.samples;
+
+/**
+ * Builds the failure message thrown when a {@code docsTest} sample fails.
+ * <p>
+ * The {@link #CONFIG_CACHE_SAMPLE_PREFIX} prefix here mirrors the {@code excludeTestsMatching}
+ * filter in {@code platforms/documentation/docs/build.gradle.kts}: samples with that prefix are
+ * skipped when {@code enableConfigurationCacheForDocsTests=true}, so the reproduce instructions
+ * for those samples must tell the user to clear that property rather than set it. If the build
+ * script filter changes, this prefix must change with it.
+ */
+public final class SampleFailureMessageFormatter {
+
+    private static final String CONFIG_CACHE_SAMPLE_PREFIX = "snippet-optimizing-builds-configuration-cache-";
+
+    private static final String BANNER = "**********************************************************************************";
+
+    private SampleFailureMessageFormatter() {
+        throw new AssertionError("SampleFailureMessageFormatter is a utility class and must not be instantiated");
+    }
+
+    public static String format(String sampleId, boolean configCacheExecuter) {
+        boolean excludedWhenConfigCacheEnabled = sampleId.startsWith(CONFIG_CACHE_SAMPLE_PREFIX);
+        String extraParameter = (configCacheExecuter && !excludedWhenConfigCacheEnabled)
+            ? " -PenableConfigurationCacheForDocsTests=true"
+            : "";
+
+        StringBuilder message = new StringBuilder();
+        message.append("Sample test run failed.\n");
+        message.append("To understand how docsTest works, See:\n");
+        message.append("  https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/README.md#testing-docs\n");
+        message.append(BANNER).append('\n');
+        message.append("To reproduce this failure, run:\n");
+        message.append("  ./gradlew docs:docsTest --tests '*").append(sampleId).append("*'").append(extraParameter).append('\n');
+        if (excludedWhenConfigCacheEnabled) {
+            message.append("  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.\n");
+        }
+        message.append(BANNER);
+        return message.toString();
+    }
+}

--- a/platforms/documentation/docs/src/main/resources/non-config-cache-compatible-snippets.txt
+++ b/platforms/documentation/docs/src/main/resources/non-config-cache-compatible-snippets.txt
@@ -1,0 +1,2 @@
+snippet-optimizing-builds-configuration-cache-
+WithoutCC

--- a/platforms/documentation/docs/src/test/groovy/org/gradle/docs/samples/SampleFailureMessageFormatterTest.groovy
+++ b/platforms/documentation/docs/src/test/groovy/org/gradle/docs/samples/SampleFailureMessageFormatterTest.groovy
@@ -71,6 +71,19 @@ class SampleFailureMessageFormatterTest extends Specification {
         message.contains("  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.")
     }
 
+    def "WithoutCC sample under default executer omits -P flag and shows warning"() {
+        given:
+        def sampleId = "snippet-some-feature_groovy_doSomethingWithoutCC"
+
+        when:
+        def message = SampleFailureMessageFormatter.format(sampleId, false)
+
+        then:
+        message.contains("  ./gradlew docs:docsTest --tests '*${sampleId}*'\n")
+        !message.contains("-PenableConfigurationCacheForDocsTests=true")
+        message.contains("  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.")
+    }
+
     def "message is wrapped by visible asterisk banners on both sides of the reproduce block"() {
         when:
         def message = SampleFailureMessageFormatter.format("snippet-anything_groovy_x", false)

--- a/platforms/documentation/docs/src/test/groovy/org/gradle/docs/samples/SampleFailureMessageFormatterTest.groovy
+++ b/platforms/documentation/docs/src/test/groovy/org/gradle/docs/samples/SampleFailureMessageFormatterTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.samples
+
+import spock.lang.Specification
+
+class SampleFailureMessageFormatterTest extends Specification {
+
+    private static final String BANNER = "**********************************************************************************"
+
+    def "non-config-cache sample under default executer produces plain reproduce command"() {
+        when:
+        def message = SampleFailureMessageFormatter.format("snippet-some-other-area-thing_groovy_doSomething", false)
+
+        then:
+        message == [
+            "Sample test run failed.",
+            "To understand how docsTest works, See:",
+            "  https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/README.md#testing-docs",
+            BANNER,
+            "To reproduce this failure, run:",
+            "  ./gradlew docs:docsTest --tests '*snippet-some-other-area-thing_groovy_doSomething*'",
+            BANNER
+        ].join("\n")
+    }
+
+    def "non-config-cache sample under configCache executer appends -P flag"() {
+        when:
+        def message = SampleFailureMessageFormatter.format("snippet-some-other-area-thing_groovy_doSomething", true)
+
+        then:
+        message.contains("--tests '*snippet-some-other-area-thing_groovy_doSomething*' -PenableConfigurationCacheForDocsTests=true")
+        !message.contains("Remember to set enableConfigurationCacheForDocsTests=false")
+    }
+
+    def "config-cache sample under default executer omits -P flag and shows warning"() {
+        given:
+        def sampleId = "snippet-optimizing-builds-configuration-cache-problems-fixed-reuse_groovy_configurationCacheProblemsFixedReuse"
+
+        when:
+        def message = SampleFailureMessageFormatter.format(sampleId, false)
+
+        then:
+        message.contains("  ./gradlew docs:docsTest --tests '*${sampleId}*'\n")
+        !message.contains("-PenableConfigurationCacheForDocsTests=true")
+        message.contains("  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.")
+    }
+
+    def "config-cache sample under configCache executer still omits -P flag (otherwise test would be filtered out) and shows warning"() {
+        given:
+        def sampleId = "snippet-optimizing-builds-configuration-cache-problems-fixed-reuse_groovy_configurationCacheProblemsFixedReuse"
+
+        when:
+        def message = SampleFailureMessageFormatter.format(sampleId, true)
+
+        then:
+        !message.contains("-PenableConfigurationCacheForDocsTests=true")
+        message.contains("  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.")
+    }
+
+    def "message is wrapped by visible asterisk banners on both sides of the reproduce block"() {
+        when:
+        def message = SampleFailureMessageFormatter.format("snippet-anything_groovy_x", false)
+        def lines = message.split("\n")
+        def bannerIndices = (0..<lines.length).findAll { lines[it] == BANNER }
+
+        then:
+        bannerIndices.size() == 2
+        // The "To reproduce this failure, run:" line must sit strictly between the two banners.
+        def reproIdx = (0..<lines.length).find { lines[it] == "To reproduce this failure, run:" }
+        bannerIndices[0] < reproIdx
+        reproIdx < bannerIndices[1]
+    }
+}


### PR DESCRIPTION
It's easy to forget that the CC must be **disabled** to run certain snippets.

This change generates custom, more informative failure messages when trying (and failing) to run samples/snippets incompatible with the configuration cache.  It also centralizes the logic for generating sample test failure messages into a dedicated utility class.

This will save frustration the next time someone tries to debug a failure message using the generated rerun message, only to find **nothing happen 😡**.

## Rerun test message

Before:
```
org.gradle.api.GradleException: Sample test run failed.
To understand how docsTest works, See:
  https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/README.md#testing-docs
To reproduce this failure, run:
  ./gradlew docs:docsTest --tests '*snippet-optimizing-builds-configuration-cache-problems-fixed-reuse_groovy_sanityCheck*' -PenableConfigurationCacheForDocsTests=true
```

After:
```
org.gradle.api.GradleException: Sample test run failed.
To understand how docsTest works, See:
  https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/README.md#testing-docs
**********************************************************************************
To reproduce this failure, run:
  ./gradlew docs:docsTest --tests '*snippet-optimizing-builds-configuration-cache-problems-fixed-reuse_groovy_sanityCheck*'
  Remember to set enableConfigurationCacheForDocsTests=false or the test will not be found.
**********************************************************************************
```

## No tests found due to CC-filtering

Before:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':docs:docsTest'.
> No tests found for given includes: [*snippet-optimizing-builds-configuration-cache-problems-fixed-reuse*](--tests filter)
```

After:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':docs:docsTest' (registered by plugin class 'org.gradle.docs.internal.DocumentationBasePlugin').
> All --tests filters target configuration-cache snippet samples, which are excluded from docsTest when enableConfigurationCacheForDocsTests=true.
    Filters: '*snippet-optimizing-builds-configuration-cache-problems-fixed-reuse*'
    Set enableConfigurationCacheForDocsTests=false (or remove it from gradle.properties) to run these samples.
```