### PR TITLE
Fix gradlew.bat error handling not terminating script

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -51,7 +51,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-"%COMSPEC%" /c exit 1
+exit /b 1
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
@@ -65,7 +65,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-"%COMSPEC%" /c exit 1
+exit /b 1
 
 :execute
 @rem Setup the command line

--- a/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -52,7 +52,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-"%COMSPEC%" /c exit 1
+exit /b 1
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
@@ -66,7 +66,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-"%COMSPEC%" /c exit 1
+exit /b 1
 
 :execute
 @rem Setup the command line


### PR DESCRIPTION
NOTE: I do not have a windows machine to test this.
This was identified by Seer [here](https://github.com/EmergeTools/hackernews/pull/806#discussion_r3281074659) and from my analysis seems to be valid.

- `"%COMSPEC%" /c exit 1` in `gradlew.bat` spawns a child `cmd.exe` that exits, but the parent batch script continues running. This causes the script to fall through past the error message into `:execute`, attempting to run an undefined `JAVA_EXE` and producing cascading errors instead of a clean exit.
- Replace with `exit /b 1` which correctly terminates the current batch script with exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)