### PR TITLE
Update develocity-conventions-plugin to 0.15.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Compile with Gradle with Build Scan
       if: ${{ matrix.language == 'java' && github.repository_owner == 'gradle' }}
-      run: ./gradlew --init-script .github/workflows/codeql-analysis.init.gradle -Ddevelocity.edge.discovery=false -DcacheNode=us -S testClasses -Dhttp.keepAlive=false
+      run: ./gradlew --init-script .github/workflows/codeql-analysis.init.gradle -Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false -S testClasses -Dhttp.keepAlive=false
       env:
         # Set the DEVELOCITY_ACCESS_KEY so that a Build Scan is generated
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           script: |
             if (context.payload.pull_request && context.payload.pull_request.head.repo.fork) {
-                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -Ddevelocity.edge.discovery=false -DcacheNode=us --scan')
+                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false --scan')
             } else {
                 core.setOutput('sys-prop-args', '')
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,9 +336,9 @@ For more information on the configuration cache, see the [user manual](https://d
 
 ### Remote build cache
 
-Gradle Technologies runs a set of remote build cache nodes to speed up local builds when developing Gradle. By default, the build is [configured](https://github.com/gradle/gradle-org-conventions-plugin#what-it-does) to use the build cache node in the EU region.
+Gradle Technologies runs a set of remote build cache nodes to speed up local builds when developing Gradle. 
 
-The build cache has anonymous read access, so you don't need to authenticate in order to use it. You can use a different build cache node by specifying `-Ddevelocity.edge.discovery=false -DcacheNode=us` for a build cache node in the US or `-Ddevelocity.edge.discovery=false -DcacheNode=au` for a build cache node in Australia.
+The build cache has anonymous read access, so you don't need to authenticate in order to use it. You can select a different edge node by following the instructions in [this doc](https://github.com/gradle/gradle-org-conventions-plugin#change-edge-node-location).
 
 If you are not getting cache hits from the build cache, you may be using the wrong version of Java. A fixed version (Java 11) is required to get remote cache hits.
 

--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -25,7 +25,7 @@ commonsIo = { module = "commons-io:commons-io", version = "2.14.0" }
 commonsLang3 = { module = "org.apache.commons:commons-lang3", version = "3.20.0" }
 dependencyAnalysisPlugin = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version = "3.4.0" }
 detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version = "1.23.7" }
-develocityConventions = { module = "io.github.gradle.develocity-conventions-plugin:io.github.gradle.develocity-conventions-plugin.gradle.plugin", version = "0.14.1" }
+develocityConventions = { module = "io.github.gradle.develocity-conventions-plugin:io.github.gradle.develocity-conventions-plugin.gradle.plugin", version = "0.15.0" }
 develocityPlugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version.ref = "develocity" }
 docbook = { module = "net.sf.docbook:docbook-xsl", version = "1.75.2" }
 dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }


### PR DESCRIPTION
## Summary

- Update `io.github.gradle.develocity-conventions-plugin` from `0.14.1` to `0.15.0`
- Remove `cacheNode` mentions from `CONTRIBUTING.md`; point contributors to the Develocity location settings instead
- Replace `-DcacheNode=us` with `-Ddevelocity.server.url=https://usw-edge.gradle.org` in the CodeQL and contributor-PR GitHub Actions workflows (keeping `-Ddevelocity.edge.discovery=false`)

The new plugin version drops support for `cacheNode`, `GRADLE_CACHE_REMOTE_SERVER` and `gradle.cache.remote.server`, and adds support for the `DEVELOCITY_SERVER_URL` environment variable (with the corresponding `develocity.server.url` system property). With edge nodes, a single edge URL can be used directly as the Develocity server URL, so the cache-specific properties are no longer needed.
