### PR TITLE
Skip scanForTestClasses=false RunWith reproducer on JUnit 4.0

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestClassDetectionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestClassDetectionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing.junit.junit4
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.util.internal.VersionNumber
+import org.junit.Assume
 import spock.lang.Issue
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4
@@ -33,6 +34,10 @@ class JUnit4TestClassDetectionIntegrationTest extends AbstractJUnit4TestClassDet
 
     @Issue("https://github.com/gradle/gradle/issues/36508")
     def "scanForTestClasses=false bypasses framework detection so include patterns alone determine which classes execute"() {
+        // JUnit 4.0's @RunWith lacks @Inherited, so the runner annotation on the parent class
+        // is invisible to SubTest and the scenario can't be exercised.
+        Assume.assumeTrue(supportsEmptyClassWithRunner)
+
         given:
         // The parent class with @RunWith lives in a separate source set whose output is packaged
         // into an archive with a non-.jar extension. javac and the JVM accept it as a classpath


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/5232

## Summary

- The `scanForTestClasses=false bypasses framework detection so include patterns alone determine which classes execute` reproducer in `JUnit4TestClassDetectionIntegrationTest` has been failing on master since #2578 against JUnit 4.0 only.
- Root cause: JUnit 4.0's `@RunWith` is not `@Inherited` (added in 4.1), so `SubTest.getAnnotation(RunWith.class)` returns null. JUnit falls back to the default class runner, finds no `@Test` methods, and fires `testStarted` with the suite description after `testRunStarted` already registered the same description as the root node. `JUnitTestEventAdapter` then trips the `No parent found for TestNode{name=example.SubTest,id=...}` assertion because the root node has no parent.
- Gate the reproducer on the existing `supportsEmptyClassWithRunner` predicate (`version >= 4.1`) via `Assume.assumeTrue`, matching the pattern used elsewhere in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)