### PR TITLE
Set gradleJvm to #JAVA_HOME for IDE sync tests

### DIFF
--- a/testing/smoke-ide-test/build.gradle.kts
+++ b/testing/smoke-ide-test/build.gradle.kts
@@ -70,6 +70,10 @@ tasks {
         group = "Verification"
         maxParallelForks = 1
         systemProperties["org.gradle.integtest.executer"] = "forking"
+        // IDEA resolves gradleJvm=#JAVA_HOME via the IDE process's JAVA_HOME env var.
+        // The TC agent sets JAVA_HOME on the Gradle build, but Test forks don't always
+        // propagate it. Set it explicitly so the spawned IDE inherits a valid value.
+        environment("JAVA_HOME", javaLauncher.get().metadata.installationPath.asFile.absolutePath)
         testClassesDirs = smokeIdeTestSourceSet.output.classesDirs
         classpath = smokeIdeTestSourceSet.runtimeClasspath
         jvmArgumentProviders.add(ideaSystemProperties())

--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
@@ -88,6 +88,8 @@ abstract class AbstractIdeSyncTest extends Specification {
         def outputDir = new File(testDirectory, "profiler-output")
         outputDir.mkdirs()
 
+        setupGradleProjectSettings()
+
         def hasMutators = !buildMutators.isEmpty()
 
         def invocationSettings = ideSyncInvocationSettingsBuilder(ide, new IdeConfiguration(ideInstallDir, ideSandboxDir), hasMutators)
@@ -155,6 +157,34 @@ abstract class AbstractIdeSyncTest extends Specification {
         } finally {
             Logging.resetLogging()
         }
+    }
+
+    /**
+     * IDEA 2025.3.x rejects projects without an explicit gradleJvm by emitting
+     * "Invalid Gradle JDK configuration found" before sync starts. Pre-populate
+     * the project's .idea/gradle.xml so the linked-project settings already have
+     * a JVM (#JAVA_HOME, inherited from the launching JVM) by the time IDEA
+     * validates them. GradleProfilerStartupActivity in gradle-profiler does the
+     * same set, but runs too late on the first sync.
+     */
+    private void setupGradleProjectSettings() {
+        def ideaDir = new File(projectDirectory, ".idea")
+        ideaDir.mkdirs()
+        new File(ideaDir, "gradle.xml").text = """\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project version="4">
+              <component name="GradleSettings">
+                <option name="linkedExternalProjectsSettings">
+                  <GradleProjectSettings>
+                    <option name="distributionType" value="LOCAL" />
+                    <option name="gradleHome" value="${distribution.gradleHomeDir.absolutePath}" />
+                    <option name="externalProjectPath" value="\$PROJECT_DIR\$" />
+                    <option name="gradleJvm" value="#JAVA_HOME" />
+                  </GradleProjectSettings>
+                </option>
+              </component>
+            </project>
+        """.stripIndent()
     }
 
     private static InvocationSettings.InvocationSettingsBuilder ideSyncInvocationSettingsBuilder(


### PR DESCRIPTION
## Summary

- Pre-populate `<project>/.idea/gradle.xml` with `distributionType=LOCAL`, `gradleHome`, and `gradleJvm=#JAVA_HOME` so IDEA has a valid Gradle JVM by the time it validates the linked project.
- Set `JAVA_HOME` explicitly on the `SmokeIdeTest` task so the spawned IDE process can resolve `#JAVA_HOME`.

## Why

`Smoke Ide Tests_FlakyTestQuarantine` on `release` has been failing deterministically with:

```
java.lang.IllegalStateException: Gradle sync has failed with error message:
  'Invalid Gradle JDK configuration found. <a href='#open_external_system_settings'>Open Gradle Settings</a>'
```

Reference: https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_SmokeIdeTests_FlakyTestQuarantine/112975532

`Full Gradle execution time: 0ms` in the stdout shows IDEA aborts before Gradle is invoked. IDEA 2025.3.x now treats a missing `gradleJvm` setting as a hard error rather than auto-detecting. After the gradle-profiler migration (#37800), nothing writes that XML, so the project starts with no Gradle JVM configured. `gradle-profiler`'s `GradleProfilerStartupActivity` does set `gradleJvm=#JAVA_HOME`, but it runs as a `ProjectActivity` — after the JDK validation fires on first sync.

`idea.log` from an intermediate run confirmed both parts of the fix were needed:

```
WARN - LocalGradleExecutionAware - Gradle JVM (#JAVA_HOME) isn't resolved
ExternalSystemJdkException: Invalid Gradle JDK configuration found
```

The `.idea/gradle.xml` was loaded, but `#JAVA_HOME` didn't resolve because the env var wasn't on the IDE process.

## Test plan

- [x] Smoke Ide Tests_FlakyTestQuarantine green on this branch
- [x] Both `IsolatedProjectsJavaProjectSyncTest` and `IsolatedProjectsParallelSyncTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)