### PR TITLE
[release8x] Update develocity-conventions-plugin to 0.15.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Compile with Gradle with Build Scan
       if: ${{ matrix.language == 'java' && github.repository_owner == 'gradle' }}
-      run: ./gradlew --init-script .github/workflows/codeql-analysis.init.gradle -DcacheNode=us -S testClasses -Dhttp.keepAlive=false
+      run: ./gradlew --init-script .github/workflows/codeql-analysis.init.gradle -Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false -S testClasses -Dhttp.keepAlive=false
       env:
         # Set the DEVELOCITY_ACCESS_KEY so that Gradle Build Scans are generated
         DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           script: |
             if (context.payload.pull_request && context.payload.pull_request.head.repo.fork) {
-                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -DcacheNode=us --scan')
+                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false --scan')
             } else {
-                core.setOutput('sys-prop-args', '-DcacheNode=us')
+                core.setOutput('sys-prop-args', '-Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false')
             }
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,9 +326,9 @@ For more information on the configuration cache, see the [user manual](https://d
 
 ### Remote build cache
 
-Gradle, Inc runs a set of remote build cache nodes to speed up local builds when developing Gradle. By default, the build is [configured](https://github.com/gradle/gradle-org-conventions-plugin#what-it-does) to use the build cache node in the EU region.
+Gradle Technologies runs a set of remote build cache nodes to speed up local builds when developing Gradle. 
 
-The build cache has anonymous read access, so you don't need to authenticate in order to use it. You can use a different build cache node by specifying `-DcacheNode=us` for a build cache node in the US or `-DcacheNode=au` for a build cache node in Australia.
+The build cache has anonymous read access, so you don't need to authenticate in order to use it. You can select a different edge node by following the instructions in [this doc](https://github.com/gradle/gradle-org-conventions-plugin#change-edge-node-location).
 
 If you are not getting cache hits from the build cache, you may be using the wrong version of Java. A fixed version (Java 11) is required to get remote cache hits.
 

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -40,7 +40,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.develocity").version("4.3.2") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
-    id("io.github.gradle.develocity-conventions-plugin").version("0.14.1")
+    id("io.github.gradle.develocity-conventions-plugin").version("0.15.0")
     id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ plugins {
     id("gradlebuild.build-environment")
     id("gradlebuild.configuration-cache-compatibility")
     id("com.gradle.develocity").version("4.3.2") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
-    id("io.github.gradle.develocity-conventions-plugin").version("0.14.1")
+    id("io.github.gradle.develocity-conventions-plugin").version("0.15.0")
     id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 


### PR DESCRIPTION
## Summary

Backport of https://github.com/gradle/gradle/pull/37969 to `release8x`.

- Bump `io.github.gradle.develocity-conventions-plugin` from `0.14.1` to `0.15.0` (in `settings.gradle.kts` and `build-logic-settings/settings.gradle.kts`)
- Remove `cacheNode` mentions from `CONTRIBUTING.md`; point contributors to the gradle-org-conventions-plugin "change edge node location" docs instead
- Replace `-DcacheNode=us` with `-Ddevelocity.server.url=https://usw-edge.gradle.org -Ddevelocity.edge.discovery=false` in the CodeQL and contributor-PR GitHub Actions workflows

The new plugin version drops support for `cacheNode`, `GRADLE_CACHE_REMOTE_SERVER` and `gradle.cache.remote.server`. With edge nodes, a single edge URL can be used directly as the Develocity server URL.

See https://github.com/gradle/gradle-org-conventions-plugin/pull/127.

## Test plan

- [ ] CodeQL workflow run succeeds with the new system properties
- [ ] Contributor-PR workflow run succeeds with the new system properties (verify on a fork PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)