### PR TITLE
Fix link to gradle community resources in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Gradle!
 This guide explains how to contribute to the core Gradle components, 
 extensions and documentation located in this repository.
 For other extensions and components, see the 
-[Gradle Community Resources](https://gradle.org/resources/).
+[Gradle Community Resources](https://community.gradle.org/#resources).
 
 This guide will help you to...
 


### PR DESCRIPTION
The issue this PR fixes the no longer working link to the gradle community resources in CONTRIBUTING.md. 
<!-- Fixes #? -->

### Context
Why do you believe many users will benefit from this change?
* Its a broken link, and people who are interested in contributing to gradle will have a harder time finding official resources.
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
