### PR TITLE
Update Documentation: clarify SourceSet.java reference in Kotlin DSL primer

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -330,7 +330,8 @@ The link:{kotlinDslPath}/gradle/org.gradle.kotlin.dsl/configure.html[`configure<
 include::sample[dir="snippets/reference/dsl-apis/noAccessors/kotlin",files="build.gradle.kts[tags=project-extension]"]
 ====
 
-Note that `sourceSets` is a Gradle extension on `Project` of type `SourceSetContainer`, and `java` inside the `main` source set is the link:{javadocPath}/org/gradle/api/tasks/SourceSet.html#getJava--[`SourceSet.java`] property (a `SourceDirectorySet`).
+Note that `sourceSets` is a Gradle extension on `Project` of type `SourceSetContainer`.
+In the example above, `java` refers to the link:{javadocPath}/org/gradle/api/tasks/SourceSet.html#getJava--[`SourceSet.java`] property (a `SourceDirectorySet`), not the top-level `JavaPluginExtension`.
 
 You can discover available extensions by either reviewing the documentation for the applied plugins or running `./gradlew kotlinDslAccessorsReport`.
 The report generates the Kotlin code needed to access the model elements contributed by the applied plugins, providing both names and types.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -330,7 +330,7 @@ The link:{kotlinDslPath}/gradle/org.gradle.kotlin.dsl/configure.html[`configure<
 include::sample[dir="snippets/reference/dsl-apis/noAccessors/kotlin",files="build.gradle.kts[tags=project-extension]"]
 ====
 
-Note that `sourceSets` is a Gradle extension on `Project` of type `SourceSetContainer` and `java` is an extension on `Project` of type `JavaPluginExtension`.
+Note that `sourceSets` is a Gradle extension on `Project` of type `SourceSetContainer`, and `java` inside the `main` source set is the link:{javadocPath}/org/gradle/api/tasks/SourceSet.html#getJava--[`SourceSet.java`] property (a `SourceDirectorySet`).
 
 You can discover available extensions by either reviewing the documentation for the applied plugins or running `./gradlew kotlinDslAccessorsReport`.
 The report generates the Kotlin code needed to access the model elements contributed by the applied plugins, providing both names and types.


### PR DESCRIPTION
Fixes #15235

### Context

This PR clarifies the distinction between:

* `sourceSets`
* `java` inside a source set (`SourceSet.java`)
* the top-level `java {}` block (`JavaPluginExtension`)

in the Kotlin DSL primer documentation.

The previous wording could be interpreted as referring to the top-level `java` extension when the surrounding example actually refers to `SourceSet.java`.

### Contributor Checklist

* [x] Review Contribution Guidelines.
* [x] Make sure that all commits are signed off.
* [x] Make sure all contributed code can be distributed under the terms of the Apache License 2.0.
* [x] Check "Allow edit from maintainers" option in pull request.
* [ ] Provide integration tests.
* [ ] Provide unit tests.
* [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
* [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
* [ ] Ensure that tests pass locally.
