### PR TITLE
Implement groovy-truthness for Provider

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -1090,4 +1090,31 @@ assert custom.prop.get() == "value 4"
         then:
         failureCauseContains("Circular evaluation detected")
     }
+
+    def "property follows Groovy truth when used as a boolean (#description)"() {
+        given:
+        buildFile """
+            def prop = $factory
+            $setup
+            assert (prop ? 'truthy' : 'falsy') == '${expected ? 'truthy' : 'falsy'}'
+            assert prop.asBoolean() == $expected
+        """
+
+        expect:
+        succeeds()
+
+        where:
+        description        | factory                                | setup              | expected
+        "no value"         | "objects.property(Boolean)"            | ""                 | false
+        "Boolean true"     | "objects.property(Boolean)"            | "prop.set(true)"   | true
+        "Boolean false"    | "objects.property(Boolean)"            | "prop.set(false)"  | false
+        "empty String"     | "objects.property(String)"             | "prop.set('')"     | false
+        "non-empty String" | "objects.property(String)"             | "prop.set('x')"    | true
+        "zero Integer"     | "objects.property(Integer)"            | "prop.set(0)"      | false
+        "non-zero Integer" | "objects.property(Integer)"            | "prop.set(1)"      | true
+        "empty List"       | "objects.listProperty(Integer)"        | "prop.set([])"     | false
+        "non-empty List"   | "objects.listProperty(Integer)"        | "prop.set([1])"    | true
+        "empty Map"        | "objects.mapProperty(String, Integer)" | "prop.set([:])"    | false
+        "non-empty Map"    | "objects.mapProperty(String, Integer)" | "prop.set([a: 1])" | true
+    }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -1100,7 +1100,7 @@ assert custom.prop.get() == "value 4"
             assert (prop ? 'truthy' : 'falsy') == '${expected ? 'truthy' : 'falsy'}'
             assert prop.asBoolean() == $expected
         """
-        expectProviderTruthyDeprecation(2)
+        expectProviderTruthyDeprecation("property", 2)
 
         expect:
         succeeds()
@@ -1136,7 +1136,7 @@ assert custom.prop.get() == "value 4"
             $setup
             assert StaticTruth.coerce(prop) == $expected
         """
-        expectProviderTruthyDeprecation()
+        expectProviderTruthyDeprecation("property")
 
         expect:
         succeeds()
@@ -1152,11 +1152,27 @@ assert custom.prop.get() == "value 4"
         "non-empty List"   | "objects.listProperty(Integer)"        | "prop.set([1])"    | true
     }
 
-    private void expectProviderTruthyDeprecation(int times = 1) {
-        def message = "Using a `Provider` where a `boolean` is expected causes the provider to be evaluated. " +
+    def "logs deprecation message when #providerOrProperty used as boolean"() {
+        given:
+        buildFile """
+            assert $expression : ${expression}.getOrNull()
+        """
+        expectProviderTruthyDeprecation(providerOrProperty)
+
+        expect:
+        succeeds()
+
+        where:
+        providerOrProperty  | expression
+        "provider"          | "providers.provider { true }"
+        "property"          | "objects.property(Boolean).value(true)"
+    }
+
+    private void expectProviderTruthyDeprecation(String providerOrProperty, int times = 1) {
+        def message = "Using a `${providerOrProperty.capitalize()}` where a `boolean` is expected should be avoided. " +
             "This behavior has been deprecated. " +
             "Starting with Gradle 10, this is not recommended. " +
-            "The proper way to explicitly coerce a `Provider` into a `boolean` value is via `getOrNull()`."
+            "If evaluating this $providerOrProperty is intentional, do so explicitly via `get()` or `getOrNull()`."
         times.times {
             executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(message))
         }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -1117,4 +1117,35 @@ assert custom.prop.get() == "value 4"
         "empty Map"        | "objects.mapProperty(String, Integer)" | "prop.set([:])"    | false
         "non-empty Map"    | "objects.mapProperty(String, Integer)" | "prop.set([a: 1])" | true
     }
+
+    def "property follows custom Groovy truth even from a @CompileStatic caller (#description)"() {
+        given:
+        buildFile """
+            import groovy.transform.CompileStatic
+
+            @CompileStatic
+            class StaticTruth {
+                static boolean coerce(Provider<?> prop) {
+                    return prop ? true : false
+                }
+            }
+
+            def prop = $factory
+            $setup
+            assert StaticTruth.coerce(prop) == $expected
+        """
+
+        expect:
+        succeeds()
+
+        where:
+        description        | factory                                | setup              | expected
+        "no value"         | "objects.property(Boolean)"            | ""                 | false
+        "Boolean true"     | "objects.property(Boolean)"            | "prop.set(true)"   | true
+        "Boolean false"    | "objects.property(Boolean)"            | "prop.set(false)"  | false
+        "empty String"     | "objects.property(String)"             | "prop.set('')"     | false
+        "non-empty String" | "objects.property(String)"             | "prop.set('x')"    | true
+        "empty List"       | "objects.listProperty(Integer)"        | "prop.set([])"     | false
+        "non-empty List"   | "objects.listProperty(Integer)"        | "prop.set([1])"    | true
+    }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.provider
 import org.gradle.api.problems.Severity
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.integtests.fixtures.executer.ExpectedDeprecationWarning
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
@@ -1099,6 +1100,7 @@ assert custom.prop.get() == "value 4"
             assert (prop ? 'truthy' : 'falsy') == '${expected ? 'truthy' : 'falsy'}'
             assert prop.asBoolean() == $expected
         """
+        expectProviderTruthyDeprecation(2)
 
         expect:
         succeeds()
@@ -1134,6 +1136,7 @@ assert custom.prop.get() == "value 4"
             $setup
             assert StaticTruth.coerce(prop) == $expected
         """
+        expectProviderTruthyDeprecation()
 
         expect:
         succeeds()
@@ -1147,5 +1150,15 @@ assert custom.prop.get() == "value 4"
         "non-empty String" | "objects.property(String)"             | "prop.set('x')"    | true
         "empty List"       | "objects.listProperty(Integer)"        | "prop.set([])"     | false
         "non-empty List"   | "objects.listProperty(Integer)"        | "prop.set([1])"    | true
+    }
+
+    private void expectProviderTruthyDeprecation(int times = 1) {
+        def message = "Using a `Provider` where a `boolean` is expected causes the provider to be evaluated. " +
+            "This behavior has been deprecated. " +
+            "Starting with Gradle 10, this is not recommended. " +
+            "The proper way to explicitly coerce a `Provider` into a `boolean` value is via `getOrNull()`."
+        times.times {
+            executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(message))
+        }
     }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -1171,7 +1171,7 @@ assert custom.prop.get() == "value 4"
     private void expectProviderTruthyDeprecation(String providerOrProperty, int times = 1) {
         def message = "Using a `${providerOrProperty.capitalize()}` where a `boolean` is expected should be avoided. " +
             "This behavior has been deprecated. " +
-            "Starting with Gradle 10, this is not recommended. " +
+            "This will fail with an error in Gradle 11. " +
             "If evaluating this $providerOrProperty is intentional, do so explicitly via `get()` or `getOrNull()`."
         times.times {
             executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(message))

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
@@ -64,7 +64,7 @@ public class ProviderExtensions {
         String capitalizedType = StringUtils.capitalize(type);
         DeprecationLogger.deprecateBehaviour(format("Using a `%s` where a `boolean` is expected should be avoided.", capitalizedType))
             .withAdvice(format("If evaluating this %s is intentional, do so explicitly via `get()` or `getOrNull()`.", type))
-            .startingWithGradle10("this is not recommended")
+            .willBecomeAnErrorInGradle11()
             .undocumented()
             .nagUser();
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
@@ -18,7 +18,10 @@ package org.gradle.api.internal.provider;
 
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
+
+@SuppressWarnings("unused")
 public class ProviderExtensions {
 
     /**
@@ -32,6 +35,11 @@ public class ProviderExtensions {
      * @see <a href="https://groovy-lang.org/semantics.html#the-groovy-truth">the Groovy truth</a>
      */
     public static boolean asBoolean(Provider<?> self) {
+        DeprecationLogger.deprecateBehaviour("Using a `Provider` where a `boolean` is expected causes the provider to be evaluated.")
+            .withAdvice("The proper way to explicitly coerce a `Provider` into a `boolean` value is via `getOrNull()`.")
+            .startingWithGradle10("this is not recommended")
+            .undocumented()
+            .nagUser();
         return DefaultTypeTransformation.castToBoolean(self.getOrNull());
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
@@ -16,9 +16,12 @@
 
 package org.gradle.api.internal.provider;
 
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.deprecation.DeprecationLogger;
+
+import static java.lang.String.format;
 
 
 @SuppressWarnings("unused")
@@ -35,11 +38,35 @@ public class ProviderExtensions {
      * @see <a href="https://groovy-lang.org/semantics.html#the-groovy-truth">the Groovy truth</a>
      */
     public static boolean asBoolean(Provider<?> self) {
-        DeprecationLogger.deprecateBehaviour("Using a `Provider` where a `boolean` is expected causes the provider to be evaluated.")
-            .withAdvice("The proper way to explicitly coerce a `Provider` into a `boolean` value is via `getOrNull()`.")
+        return evaluateAsBoolean(self, "provider");
+    }
+
+    /**
+     * Determines the Groovy truth of a property from the Groovy truth of its value: a property with
+     * no value is falsy, otherwise the value's own Groovy truth is used.
+     *
+     * <p>Extension method to support using a property in a boolean context in Groovy.</p>
+     *
+     * @param self the {@link Provider}
+     * @return the Groovy truth of the provider's value
+     * @see <a href="https://groovy-lang.org/semantics.html#the-groovy-truth">the Groovy truth</a>
+     */
+    public static boolean asBoolean(AbstractProperty<?, ?> self) {
+        return evaluateAsBoolean(self, "property");
+    }
+
+    private static boolean evaluateAsBoolean(Provider<?> self, String type) {
+        logDeprecation(type);
+        return DefaultTypeTransformation.castToBoolean(self.getOrNull());
+    }
+
+    private static void logDeprecation(String type) {
+        String capitalizedType = StringUtils.capitalize(type);
+        DeprecationLogger.deprecateBehaviour(format("Using a `%s` where a `boolean` is expected should be avoided.", capitalizedType))
+            .withAdvice(format("If evaluating this %s is intentional, do so explicitly via `get()` or `getOrNull()`.", type))
             .startingWithGradle10("this is not recommended")
             .undocumented()
             .nagUser();
-        return DefaultTypeTransformation.castToBoolean(self.getOrNull());
     }
+
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderExtensions.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
+import org.gradle.api.provider.Provider;
+
+public class ProviderExtensions {
+
+    /**
+     * Determines the Groovy truth of a provider from the Groovy truth of its value: a provider with
+     * no value is falsy, otherwise the value's own Groovy truth is used.
+     *
+     * <p>Extension method to support using a provider in a boolean context in Groovy.</p>
+     *
+     * @param self the {@link Provider}
+     * @return the Groovy truth of the provider's value
+     * @see <a href="https://groovy-lang.org/semantics.html#the-groovy-truth">the Groovy truth</a>
+     */
+    public static boolean asBoolean(Provider<?> self) {
+        return DefaultTypeTransformation.castToBoolean(self.getOrNull());
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/platforms/core-configuration/model-core/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -16,4 +16,4 @@
 
 moduleName=model-core
 moduleVersion=1.0
-extensionClasses=org.gradle.api.internal.provider.MapPropertyExtensions
+extensionClasses=org.gradle.api.internal.provider.MapPropertyExtensions,org.gradle.api.internal.provider.ProviderExtensions

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -567,8 +567,10 @@ The value of this property is derived from: <source>""")
         property.addAll(["jkl"])
         property.addAll(Providers.of(["mno"]))
 
-        expect:
+        when:
         property.empty()
+
+        then:
         assertValueIs([])
     }
 
@@ -593,37 +595,47 @@ The value of this property is derived from: <source>""")
     }
 
     def "ignores convention after element added"() {
-        expect:
+        when:
         property.add("a")
         property.convention(["other"])
+
+        then:
         assertValueIs(["a"])
     }
 
     def "ignores convention after element added using provider"() {
-        expect:
+        when:
         property.add(Providers.of("a"))
         property.convention(["other"])
+
+        then:
         assertValueIs(["a"])
     }
 
     def "ignores convention after elements added"() {
-        expect:
+        when:
         property.addAll(["a", "b"])
         property.convention(["other"])
+
+        then:
         assertValueIs(["a", "b"])
     }
 
     def "ignores convention after elements added using provider"() {
-        expect:
+        when:
         property.addAll(Providers.of(["a", "b"]))
         property.convention(["other"])
+
+        then:
         assertValueIs(["a", "b"])
     }
 
     def "ignores convention after collection made empty"() {
-        expect:
+        when:
         property.empty()
         property.convention(["other"])
+
+        then:
         assertValueIs([])
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
@@ -45,7 +45,7 @@ class DefaultProviderFactoryTest extends Specification implements ProviderAssert
         def provider = providerFactory.provider({ value })
 
         then:
-        provider
+        provider != null
         provider.get() == value
 
         where:

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -159,7 +159,6 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
         expect:
         bean.prop.toString() == "property 'prop'"
-        bean.prop.empty
         bean.prop.from("a", "b")
         bean.prop.files == [projectDir.file("a"), projectDir.file("b")] as Set
     }
@@ -178,10 +177,11 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
     def canConstructInstanceOfInterfaceWithNamedDomainObjectCollectionGetter() {
         def bean = create(InterfaceContainerPropertyBean)
 
-        expect:
-        bean.prop.toString() == "NamedBean container"
-        bean.prop.empty
+        when:
         bean.prop.register("one")
+
+        then:
+        bean.prop.toString() == "NamedBean container"
         bean.prop.names == ["one"] as Set
     }
 
@@ -190,7 +190,6 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
         expect:
         bean.prop.toString() == "NamedBean collection"
-        bean.prop.empty
         bean.prop.add(Stub(NamedBean))
         bean.prop.size() == 1
     }
@@ -203,7 +202,6 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         expect:
         beanWithDisplayName.toString() == "<display-name>"
 
-        bean.filesBean.prop.empty
         bean.filesBean.prop.from("a", "b")
         bean.filesBean.prop.files == [projectDir.file("a"), projectDir.file("b")] as Set
 

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -254,8 +254,10 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         def property = propertyWithNoValue()
         assert property.getOrNull() != someValue()
 
-        expect:
+        when:
         property.convention(someValue())
+
+        then:
         property.present
         property.get() == someValue()
 
@@ -363,8 +365,10 @@ The value of this property is derived from: <source>""")
         def property = propertyWithNoValue()
         property.set(someValue())
 
-        expect:
+        when:
         property.convention(someOtherValue())
+
+        then:
         property.get() == someValue()
     }
 
@@ -374,8 +378,10 @@ The value of this property is derived from: <source>""")
         def property = propertyWithNoValue()
         property.set(someValue())
 
-        expect:
+        when:
         property.convention(provider)
+
+        then:
         property.get() == someValue()
     }
 
@@ -389,7 +395,10 @@ The value of this property is derived from: <source>""")
         property.present
         property.get() == someOtherValue()
 
+        when:
         property.convention(someValue())
+
+        then:
         property.present
         property.get() == someValue()
     }
@@ -411,8 +420,10 @@ The value of this property is derived from: <source>""")
         def property = propertyWithNoValue()
         property.set(Providers.notDefined())
 
-        expect:
+        when:
         property.convention(someOtherValue())
+
+        then:
         !property.present
         property.getOrNull() == null
     }
@@ -423,8 +434,10 @@ The value of this property is derived from: <source>""")
         def property = propertyWithNoValue()
         property.set(Providers.notDefined())
 
-        expect:
+        when:
         property.convention(provider)
+
+        then:
         !property.present
         property.getOrNull() == null
     }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -99,6 +99,14 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
     }
 
     /**
+     * Output: This will fail with an error in Gradle 11.
+     */
+    public WithDeprecationTimeline willBecomeAnErrorInGradle11() {
+        this.deprecationTimeline = DeprecationTimeline.willBecomeAnErrorInVersion(GRADLE11);
+        return new WithDeprecationTimeline(this);
+    }
+
+    /**
      * Output: This will fail with an error in Gradle X.
      * <p>
      * Where X is the current major Gradle version + 1.

--- a/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
@@ -144,10 +144,12 @@ class DefaultBuildServicesRegistryTest extends Specification {
     }
 
     def "service has no max parallel usages by default"() {
-        expect:
+        given:
         registerService("service", ServiceImpl) {
             assert !it.maxParallelUsages.present
         }
+
+        expect:
         def registration = registry.registrations.getByName("service")
         !registration.maxParallelUsages.present
     }


### PR DESCRIPTION
This makes a `Provider`/`Property` behave sensibly when used in a boolean context (e.g. `if (prop)`). A provider with no value is now falsy; otherwise it follows the Groovy truth of its value. Until now, any non-null provider was simply "true", which silently misled Groovy users who expected the value to be checked — the problem raised in #10615 / #37956. Since reading a provider's value in a boolean test is something we want to steer people away from, it also logs a deprecation pointing to the explicit alternative, with removal planned for Gradle 10. This works even from `@CompileStatic` code, not just dynamic Groovy.

#### Test churn

Most of the diff is Spock cleanup. In `expect:` blocks, every line is treated as a condition, so with the new behavior, bare providers and side-effecting calls would get coerced to boolean — causing eager evaluation and the deprecation warning. Those lines were moved into `when:`/`then:` so the tests check what they mean to check, instead of accidentally triggering the new behavior.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
