### PR TITLE
Fix close-linked-issue workflow by pinning gha-mjolnir to v1.5.0

### DIFF
--- a/.github/workflows/close-linked-issue-when-merged-into-release.yml
+++ b/.github/workflows/close-linked-issue-when-merged-into-release.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Closes issues related to a merged pull request.
-        uses: ldez/gha-mjolnir@7572d92f300beade60bc2f8bbbb2cddc38d35cd3
+        uses: ldez/gha-mjolnir@v1.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The `Close linked issues when PR merged into release` workflow has been failing on every PR close for weeks (e.g. [run 26380122902](https://github.com/gradle/gradle/actions/runs/26380122902)).
- Root cause: dependabot commit 3880d8527f8 bumped `ldez/gha-mjolnir` to untagged commit `7572d92...` (2026-04-28). That upstream commit bumped `go.mod` to require Go ≥ 1.25 but kept the Dockerfile's `golang:alpine3.20` base image (Go 1.24.3), so the action fails to build:
  ```
  go: go.mod requires go >= 1.25.0 (running go 1.24.3; GOTOOLCHAIN=local)
  make: *** [Makefile:15: build] Error 1
  ```
- Pin to tag `v1.5.0` (last stable release, Dec 2024) — matches the `@v…` convention every other action in this repo already uses, and avoids future dependabot bumps to untagged upstream commits.

## Test plan

Test run passed on https://github.com/gradle/gradle/actions/runs/26388806174