### PR TITLE
Update Gradle wrapper to 9.6.0-milestone-3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-3-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Update the wrapper to pick up the thread-safety fix for `ResolutionResult` from gradle/gradle#37928, which is needed to resolve the build failure observed at:

https://ge.gradle.org/s/trbonbdmm4rza/failures?expanded-stacktrace=WyIwLTEiXQ#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)