### PR TITLE
Aggregate performance report when some buckets fail or are cancelled

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -19,6 +19,7 @@ package configurations
 import common.Os
 import common.applyDefaultSettings
 import common.setArtifactRules
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.ReuseBuilds
 import model.CIBuildModel
@@ -51,6 +52,13 @@ class PerformanceTestsPass(
                 param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
                 param("performance.db.username", "tcagent")
                 param("env.PERFORMANCE_CHANNEL", performanceTestSpec.channel())
+                text(
+                    "performance.baselines",
+                    type.defaultBaselines,
+                    display = ParameterDisplay.PROMPT,
+                    allowEmpty = true,
+                    description = "Baselines passed to the aggregate report. Defaults to the type's default baselines.",
+                )
             }
 
             features {
@@ -72,28 +80,22 @@ class PerformanceTestsPass(
 testing/$performanceProjectName/build/performance-test-results.zip
 """,
             )
-            if (performanceTestProject.performanceTests.any { it.testProjects.isNotEmpty() }) {
-                val dependencyBuildIds =
-                    performanceTestProject.performanceTests
-                        .filter { it.testProjects.isNotEmpty() }
-                        .joinToString(",") { "%dep.${it.id}.env.BUILD_ID%" }
-
-                val dependencyBaselines =
-                    performanceTestProject.performanceTests
-                        .first {
-                            it.testProjects.isNotEmpty()
-                        }.let { "%dep.${it.id}.performance.baselines%" }
-
+            val bucketedPerformanceTests = performanceTestProject.performanceTests.filter { it.testProjects.isNotEmpty() }
+            if (bucketedPerformanceTests.isNotEmpty()) {
+                // Baselines come from this build's own parameter; per-bucket TeamCity build IDs are derived inside the
+                // report task from the surviving perf-results-*.json files. The expected bucket count is passed so the
+                // verify task can fail the Trigger when fewer buckets reported than configured.
+                val verifyTaskName = "verify${taskName.replaceFirstChar { it.titlecase() }}Buckets"
                 gradleRunnerStep(
                     model,
-                    ":$performanceProjectName:$taskName",
+                    ":$performanceProjectName:$taskName :$performanceProjectName:$verifyTaskName",
                     extraParameters =
                         listOf(
                             "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
                             "-Porg.gradle.performance.db.url" to "%performance.db.url%",
                             "-Porg.gradle.performance.db.username" to "%performance.db.username%",
-                            "-Porg.gradle.performance.dependencyBuildIds" to dependencyBuildIds,
-                            "-PperformanceBaselines" to dependencyBaselines,
+                            "-Porg.gradle.performance.expectedBuckets" to bucketedPerformanceTests.size.toString(),
+                            "-PperformanceBaselines" to "%performance.baselines%",
                         ).joinToString(" ") { (key, value) -> os.escapeKeyValuePair(key, value) },
                 )
             }
@@ -103,21 +105,25 @@ testing/$performanceProjectName/build/performance-test-results.zip
                     if (type == PerformanceTestType.FLAKINESS_DETECTION) {
                         reuseBuilds = ReuseBuilds.NO
                     }
+                    // Allow the Trigger to run when an upstream bucket is cancelled so the aggregate report is still produced.
+                    onDependencyCancel = FailureAction.ADD_PROBLEM
                 }
                 performanceTestProject.performanceTests.forEachIndexed { index, performanceTest ->
                     if (performanceTest.testProjects.isNotEmpty()) {
                         artifacts(performanceTest.id!!) {
                             id = "ARTIFACT_DEPENDENCY_${performanceTest.id!!}"
                             cleanDestination = true
+                            // `?:` marks the rule as optional (TeamCity 2024.03+) so a bucket with no test-results-*.zip
+                            // only logs a warning instead of blocking the Trigger from starting.
                             val perfResultArtifactRule =
-                                "results/performance/build/test-results-*.zip!performance-tests/perf-results*.json => " +
+                                "?:results/performance/build/test-results-*.zip!performance-tests/perf-results*.json => " +
                                     "$performanceResultsDir/${performanceTest.bucketIndex}/"
                             artifactRules =
                                 if (index == 0) {
                                     // The artifact rule report/css/*.css => performanceResultsDir is there to clean up the target directory.
                                     // If we don't clean that up there might be leftover json files from other report builds running on the same machine.
                                     """
-                                    results/performance/build/test-results-*.zip!performance-tests/report/css/*.css => $performanceResultsDir/
+                                    ?:results/performance/build/test-results-*.zip!performance-tests/report/css/*.css => $performanceResultsDir/
                                     $perfResultArtifactRule
                                     """.trimIndent()
                                 } else {

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -49,7 +49,6 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_URL
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_USERNAME
-import gradlebuild.basics.BuildParams.PERFORMANCE_DEPENDENCY_BUILD_IDS
 import gradlebuild.basics.BuildParams.PERFORMANCE_MAX_PROJECTS
 import gradlebuild.basics.BuildParams.PERFORMANCE_STAGE_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
@@ -122,7 +121,6 @@ object BuildParams {
     const val PERFORMANCE_CHANNEL_ENV = "PERFORMANCE_CHANNEL"
     const val PERFORMANCE_DB_URL = "org.gradle.performance.db.url"
     const val PERFORMANCE_DB_USERNAME = "org.gradle.performance.db.username"
-    const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val PERFORMANCE_STAGE_ENV = "PERFORMANCE_STAGE"
     const val RERUN_ALL_TESTS = "rerunAllTests"
@@ -296,10 +294,6 @@ val Project.flakyTestStrategy: FlakyTestStrategy
 
 val Project.ignoreIncomingBuildReceipt: Provider<Boolean>
     get() = gradleProperty(BUILD_IGNORE_INCOMING_BUILD_RECEIPT).presence()
-
-val Project.performanceDependencyBuildIds: Provider<String>
-    get() = gradleProperty(PERFORMANCE_DEPENDENCY_BUILD_IDS).orElse("")
-
 
 val Project.performanceBaselines: String?
     get() = stringPropertyOrNull(PERFORMANCE_BASELINES)

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -28,7 +28,6 @@ import gradlebuild.basics.includePerformanceTestScenarios
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.performanceBaselines
 import gradlebuild.basics.performanceChannel
-import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
 import gradlebuild.basics.performanceStage
 import gradlebuild.basics.performanceTestBuildOperationTrace
@@ -52,6 +51,7 @@ import gradlebuild.performance.tasks.DefaultCommandExecutor
 import gradlebuild.performance.tasks.DetermineBaselines
 import gradlebuild.performance.tasks.PerformanceTest
 import gradlebuild.performance.tasks.PerformanceTestReport
+import gradlebuild.performance.tasks.VerifyPerformanceBuckets
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -266,11 +266,22 @@ class PerformanceTestPlugin : Plugin<Project> {
     fun Project.createPerformanceTestReportTask(name: String, reportGeneratorClass: String): TaskProvider<PerformanceTestReport> {
         val performanceTestReport = tasks.register<PerformanceTestReport>(name) {
             this.reportGeneratorClass = reportGeneratorClass
-            this.dependencyBuildIds = project.performanceDependencyBuildIds
         }
         val performanceTestReportZipTask = performanceReportZipTaskFor(performanceTestReport)
         performanceTestReport {
             finalizedBy(performanceTestReportZipTask)
+        }
+        // Standalone verifier the Trigger build invokes alongside the report task. It only runs when
+        // `org.gradle.performance.expectedBuckets` is set (i.e. from TeamCity), and fails the build if fewer
+        // bucket subdirectories under perf-results/ contain JSONs than were expected. The aggregate report and zip
+        // are produced first via mustRunAfter ordering, so the artifact still publishes on a partial run.
+        val expectedBucketsProperty = project.providers.gradleProperty("org.gradle.performance.expectedBuckets").map(String::toInt)
+        tasks.register<VerifyPerformanceBuckets>("verify${name.replaceFirstChar { it.titlecase() }}Buckets") {
+            performanceResultsDirectory.set(repoRoot().dir("perf-results"))
+            expectedBuckets.set(expectedBucketsProperty)
+            mustRunAfter(performanceTestReport)
+            mustRunAfter(performanceTestReportZipTask)
+            onlyIf("org.gradle.performance.expectedBuckets is set") { expectedBucketsProperty.isPresent }
         }
         tasks.withType<Delete>().configureEach {
             if (name == "clean${name.capitalize()}") {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
@@ -16,6 +16,8 @@
 
 package gradlebuild.performance.tasks
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonParser
 import gradlebuild.performance.reporter.PerformanceReporter
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -25,6 +27,7 @@ import org.gradle.api.file.FileTree
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
@@ -87,8 +90,35 @@ abstract class PerformanceTestReport : DefaultTask() {
     @get:Input
     abstract val projectName: Property<String>
 
-    @get:Input
-    abstract val dependencyBuildIds: Property<String>
+    /**
+     * Comma-separated TeamCity build IDs of the upstream performance test buckets whose results
+     * are included in this report. Derived at execution time from the `teamCityBuildId` field of
+     * each `perf-results-*.json` so the report stays consistent with whichever buckets actually
+     * produced output. Failed or missing buckets are simply absent from the set.
+     */
+    @get:Internal
+    val dependencyBuildIds: Provider<String>
+        get() = providers.provider {
+            performanceResults.files.asSequence()
+                .flatMap { file ->
+                    runCatching {
+                        val root = file.bufferedReader().use { JsonParser.parseReader(it) }
+                        if (root is JsonArray) {
+                            root.asSequence().mapNotNull { element ->
+                                element.takeIf { it.isJsonObject }
+                                    ?.asJsonObject?.get("teamCityBuildId")
+                                    ?.takeIf { !it.isJsonNull }
+                                    ?.asString
+                            }
+                        } else {
+                            emptySequence()
+                        }
+                    }.getOrElse { emptySequence() }
+                }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .joinToString(",")
+        }
 
     @get:Option(option = "debug-jvm", description = "Debug the JVM started for report generation.")
     @get:Input
@@ -99,6 +129,9 @@ abstract class PerformanceTestReport : DefaultTask() {
 
     @get:Inject
     abstract val execOperations: ExecOperations
+
+    @get:Inject
+    abstract val providers: ProviderFactory
 
     init {
         debugReportGeneration.convention(false)

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/VerifyPerformanceBuckets.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/VerifyPerformanceBuckets.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.performance.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Fails the build when fewer upstream performance test buckets reported results than expected.
+ *
+ * A dedicated task — not a check inside [PerformanceTestReport] — so the build outcome is decided
+ * by a step independent of the report task's input-tracking and skip semantics. It runs after the
+ * report and its zip finalizer so a partial run still publishes `performance-test-results.zip`.
+ */
+@DisableCachingByDefault(because = "Fast filesystem check; output is the build outcome, not a file")
+abstract class VerifyPerformanceBuckets : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val performanceResultsDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val expectedBuckets: Property<Int>
+
+    @TaskAction
+    fun verify() {
+        val expected = expectedBuckets.get()
+        val resultsDir = performanceResultsDirectory.get().asFile
+        val reported =
+            (resultsDir.listFiles()?.filter { it.isDirectory && it.listFiles { _, name -> name.endsWith(".json") }?.isNotEmpty() == true } ?: emptyList())
+                .map { it.name }
+                .toSet()
+        if (reported.size < expected) {
+            throw GradleException(
+                "Only ${reported.size} of $expected expected performance test buckets reported results in $resultsDir. " +
+                    "The aggregate report has been generated from the available data; failing the build so the missing buckets are not silently ignored."
+            )
+        }
+    }
+}


### PR DESCRIPTION
- `PerformanceTestsPass` Trigger used `%dep.<bucket>.env.BUILD_ID%` and `%dep.<bucket>.performance.baselines%` references; a single cancelled bucket left them unresolved and the aggregate report never ran.
- Source baselines from the Trigger's own `performance.baselines` parameter and derive dependency TeamCity build IDs from the `teamCityBuildId` field of each surviving `perf-results-*.json` inside `:performance:performanceTestReport`.
- Override `onDependencyCancel` to `FailureAction.ADD_PROBLEM` so a cancelled bucket still lets the Trigger run, the report still publishes, and the Trigger ends red.
- Drop the now-unused `org.gradle.performance.dependencyBuildIds` Gradle property plumbing.