### PR TITLE
Update Documentation: document APPLICATION_NAME_OPTS environment variable

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/application_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/application_plugin.adoc
@@ -120,6 +120,20 @@ The application plugin can generate Unix (suitable for Linux, macOS etc.) and Wi
 The start scripts launch a JVM with the specified settings defined as part of the original build and runtime environment (e.g. `JAVA_OPTS` env var).
 The default script templates are based on the same scripts used to launch Gradle itself, that ship as part of a Gradle distribution.
 
+The generated start scripts also support the `<APPLICATION_NAME>_OPTS` environment variable for specifying additional JVM arguments at runtime.
+
+The application name is converted to uppercase with non-alphanumeric characters replaced by underscores.
+
+For example, an application named `my-app` or `myApp` both use `MY_APP_OPTS`:
+
+[source,bash]
+----
+export MY_APP_OPTS="-Xmx512m -Dmy.property=value"
+./bin/my-app
+----
+
+This environment variable is applied in addition to any JVM arguments configured via `applicationDefaultJvmArgs`.
+
 The start scripts are completely customizable.
 Please refer to the documentation of link:{groovyDslPath}/org.gradle.jvm.application.tasks.CreateStartScripts.html[CreateStartScripts] for more details and customization examples.
 


### PR DESCRIPTION
### Context

Document support for the `<APPLICATION_NAME>_OPTS` environment variable in generated application start scripts.

This environment variable is supported by the generated scripts but was not documented in the Application Plugin user guide.

Fixes #36597

### Contributor Checklist

* [x] Review Contribution Guidelines.
* [x] Make sure all contributed code can be distributed under the Apache License 2.0.
* [x] Check "Allow edits from maintainers" option.
* [x] Update User Guide for public-facing changes.