### PR TITLE
Validate parent-walk deprecation across community plugins

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.smoketests
 
 import groovy.transform.SelfType
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 
 @SelfType(AbstractSmokeTest)
 abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest implements WithPluginValidation {
@@ -33,6 +35,50 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
 
     String getBuildScriptConfigurationForValidation() {
         ""
+    }
+
+    /**
+     * Override to opt a plugin into the "configures plugin from subproject" smoke test. Return the
+     * DSL snippet that should go into {@code child/build.gradle} — typically a reference to the
+     * plugin's project extension (e.g. {@code spotless { }}). Returning {@code null} (default) makes
+     * the iteration a no-op for that plugin/version combination.
+     *
+     * <p>The purpose is to catch plugins that resolve their DSL extension through the deprecated
+     * implicit parent-project property/method lookup when configured from a subproject — the same
+     * failure mode as the Develocity 3.x case.
+     */
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        null
+    }
+
+    /**
+     * Override to declare deprecation warnings that the "configures plugin from subproject" test
+     * should expect for a given plugin/version. The returned warnings are passed to
+     * {@link SmokeTestGradleRunner#expectLegacyDeprecationWarning(String)} — appropriate for
+     * third-party plugin issues that are out of our control.
+     *
+     * <p>Use {@link #parentMethodInvocationDeprecation(String)} or
+     * {@link #parentPropertyAccessDeprecation(String)} to build the parent-walk deprecation
+     * message for a plugin that resolves its DSL extension from subprojects.
+     */
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        []
+    }
+
+    protected static String parentMethodInvocationDeprecation(String methodName) {
+        "Implicitly resolving methods in the project hierarchy has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Method '$methodName' was not declared in project ':child' and was resolved from root project 'test'. " +
+            "Consult the upgrading guide for further information: " +
+            "${DEPRECATED_PARENT_PROPERTY_ACCESS_URL}"
+    }
+
+    protected static String parentPropertyAccessDeprecation(String propertyName) {
+        "Implicitly resolving properties in the project hierarchy has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Property '$propertyName' was not declared in project ':child' and was resolved from root project 'test'. " +
+            "Consult the upgrading guide for further information: " +
+            "${DEPRECATED_PARENT_PROPERTY_ACCESS_URL}"
     }
 
     private List<List<String>> iterations() {
@@ -67,6 +113,45 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
 
         expect:
         performValidation(version)
+
+        where:
+        iterations << iterations()
+        (id, version) = iterations
+    }
+
+    @Requires(value = TestExecutionPreconditions.NotIsolatedProjects, reason = "Under Isolated Projects the parent walk is disabled, so the plugin's extension is not reachable from a subproject — the scenario this test exercises (firing the parent-walk deprecation) is Vintage-specific")
+    def "configures plugin #id version #version from subproject"(String id, String version) {
+        def childConfig = getSubprojectExtensionAccess(id, version)
+
+        given:
+        def extraPluginsBlock = getExtraPluginsRequiredForValidation(id, version).collect { pluginId, pluginVersion ->
+            "                id '$pluginId'" + (pluginVersion ? "version '$pluginVersion'" : "")
+        }.join('\n')
+        SmokeTestGradleRunner testRunner = null
+        if (childConfig != null) {
+            buildFile << """
+                plugins {
+                    $extraPluginsBlock
+                    id '$id'${version ? " version '$version'" : ""}
+                }
+
+                $buildScriptConfigurationForValidation
+            """
+            settingsFile << """
+                rootProject.name = "test"
+                include("child")
+            """
+            file("child/build.gradle") << childConfig
+            testRunner = runner("help")
+            getSubprojectExtensionDeprecations(id, version).each { testRunner.expectLegacyDeprecationWarning(it) }
+        }
+
+        expect:
+        // When getSubprojectExtensionAccess returns null (the default), this iteration is a no-op
+        // — there's nothing meaningful to verify for plugins that don't opt in. Filtering the
+        // iterations out via where: would be cleaner, but breaks Spock for classes where no
+        // combination opts in (empty data provider).
+        childConfig == null || testRunner.build() != null
 
         where:
         iterations << iterations()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import groovy.transform.SelfType
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.junit.Assume
 
 @SelfType(AbstractSmokeTest)
 abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest implements WithPluginValidation {
@@ -40,8 +41,8 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
     /**
      * Override to opt a plugin into the "configures plugin from subproject" smoke test. Return the
      * DSL snippet that should go into {@code child/build.gradle} — typically a reference to the
-     * plugin's project extension (e.g. {@code spotless { }}). Returning {@code null} (default) makes
-     * the iteration a no-op for that plugin/version combination.
+     * plugin's project extension (e.g. {@code spotless { }}). Returning {@code null} (default) causes
+     * the iteration to be skipped (reported as skipped, not passed) for that plugin/version combination.
      *
      * <p>The purpose is to catch plugins that resolve their DSL extension through the deprecated
      * implicit parent-project property/method lookup when configured from a subproject — the same
@@ -66,7 +67,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
     }
 
     protected static String parentMethodInvocationDeprecation(String methodName) {
-        "Implicitly resolving methods in the project hierarchy has been deprecated. " +
+        "Implicit lookup of methods in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Method '$methodName' was not declared in project ':child' and was resolved from root project 'test'. " +
             "Consult the upgrading guide for further information: " +
@@ -74,7 +75,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
     }
 
     protected static String parentPropertyAccessDeprecation(String propertyName) {
-        "Implicitly resolving properties in the project hierarchy has been deprecated. " +
+        "Implicit lookup of properties in parent projects has been deprecated. " +
             "This will fail with an error in Gradle 10. " +
             "Property '$propertyName' was not declared in project ':child' and was resolved from root project 'test'. " +
             "Consult the upgrading guide for further information: " +
@@ -122,36 +123,30 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
     @Requires(value = TestExecutionPreconditions.NotIsolatedProjects, reason = "Under Isolated Projects the parent walk is disabled, so the plugin's extension is not reachable from a subproject — the scenario this test exercises (firing the parent-walk deprecation) is Vintage-specific")
     def "configures plugin #id version #version from subproject"(String id, String version) {
         def childConfig = getSubprojectExtensionAccess(id, version)
+        Assume.assumeTrue("Plugin $id:$version does not opt into subproject extension access", childConfig != null)
 
         given:
         def extraPluginsBlock = getExtraPluginsRequiredForValidation(id, version).collect { pluginId, pluginVersion ->
             "                id '$pluginId'" + (pluginVersion ? "version '$pluginVersion'" : "")
         }.join('\n')
-        SmokeTestGradleRunner testRunner = null
-        if (childConfig != null) {
-            buildFile << """
-                plugins {
-                    $extraPluginsBlock
-                    id '$id'${version ? " version '$version'" : ""}
-                }
+        buildFile << """
+            plugins {
+                $extraPluginsBlock
+                id '$id'${version ? " version '$version'" : ""}
+            }
 
-                $buildScriptConfigurationForValidation
-            """
-            settingsFile << """
-                rootProject.name = "test"
-                include("child")
-            """
-            file("child/build.gradle") << childConfig
-            testRunner = runner("help")
-            getSubprojectExtensionDeprecations(id, version).each { testRunner.expectLegacyDeprecationWarning(it) }
-        }
+            $buildScriptConfigurationForValidation
+        """
+        settingsFile << """
+            rootProject.name = "test"
+            include("child")
+        """
+        file("child/build.gradle") << childConfig
+        SmokeTestGradleRunner testRunner = runner("help")
+        getSubprojectExtensionDeprecations(id, version).each { testRunner.expectLegacyDeprecationWarning(it) }
 
         expect:
-        // When getSubprojectExtensionAccess returns null (the default), this iteration is a no-op
-        // — there's nothing meaningful to verify for plugins that don't opt in. Filtering the
-        // iterations out via where: would be cleaner, but breaks Spock for classes where no
-        // combination opts in (empty data provider).
-        childConfig == null || testRunner.build() != null
+        testRunner.build() != null
 
         where:
         iterations << iterations()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import org.apache.commons.io.FileUtils
 import org.gradle.api.JavaVersion
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
@@ -42,6 +43,9 @@ import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
 
 abstract class AbstractSmokeTest extends Specification {
+
+    protected static final DocumentationRegistry DOCS = new DocumentationRegistry()
+    protected static final String DEPRECATED_PARENT_PROPERTY_ACCESS_URL = DOCS.getDocumentationFor("upgrading_version_9", "deprecated_implicit_project_hierarchy_lookup")
 
     protected static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -45,7 +45,7 @@ import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLU
 abstract class AbstractSmokeTest extends Specification {
 
     protected static final DocumentationRegistry DOCS = new DocumentationRegistry()
-    protected static final String DEPRECATED_PARENT_PROPERTY_ACCESS_URL = DOCS.getDocumentationFor("upgrading_version_9", "deprecated_implicit_project_hierarchy_lookup")
+    protected static final String DEPRECATED_PARENT_PROPERTY_ACCESS_URL = DOCS.getDocumentationFor("upgrading_version_9", "deprecated_implicit_lookup_in_parent_projects")
 
     protected static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
@@ -76,6 +76,27 @@ class AsciidoctorPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         }
     }
 
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        testedPluginId.startsWith("org.asciidoctor.jvm.") ? "asciidoctorj {}" : null
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        if (!testedPluginId.startsWith("org.asciidoctor.jvm.")) {
+            return []
+        }
+        def versionNumber = VersionNumber.parse(version)
+        def deprecations = [parentMethodInvocationDeprecation('asciidoctorj')]
+        if (versionNumber.major >= 4) {
+            deprecations << ("The StartParameter.isConfigurationCacheRequested property has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Please use 'configurationCache.requested' property on 'BuildFeatures' service instead. " +
+                "Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_8.html#deprecated_startparameter_is_configuration_cache_requested").toString()
+        }
+        return deprecations
+    }
+
     static class AsciidocDeprecations extends BaseDeprecations {
         AsciidocDeprecations(SmokeTestGradleRunner runner) {
             super(runner)

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AvroPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AvroPluginSmokeTest.groovy
@@ -23,4 +23,14 @@ class AvroPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'com.github.davidmc24.gradle.plugin.avro': TestedVersions.avro,
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "avro {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('avro')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DetektPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DetektPluginSmokeTest.groovy
@@ -23,4 +23,17 @@ class DetektPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'io.gitlab.arturbosch.detekt': TestedVersions.detekt
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "detekt {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [
+            parentMethodInvocationDeprecation('detekt'),
+            "The ReportingExtension.file(String) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getBaseDirectory().file(String) or getBaseDirectory().dir(String) method instead. Consult the upgrading guide for further information: ${DOCS.getDocumentationFor("upgrading_version_9", "reporting_extension_file")}".toString()
+        ]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FlywayPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FlywayPluginSmokeTest.groovy
@@ -28,4 +28,14 @@ class FlywayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'org.flywaydb.flyway': TestedVersions.flyway
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "flyway {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('flyway')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleGitPropertiesSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleGitPropertiesSmokeTest.groovy
@@ -28,4 +28,14 @@ class GradleGitPropertiesSmokeTest extends AbstractPluginValidatingSmokeTest {
             'com.gorylenko.gradle-git-properties': TestedVersions.gradleGitProperties
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "gitProperties {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('gitProperties')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -85,6 +85,16 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
         ]
     }
 
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "gretty {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('gretty')]
+    }
+
     static def grettyConfigForCurrentJavaVersion() {
         TestedVersions.gretty.findAll {
             JavaVersion.current().isCompatibleWith(it.javaMinVersion as JavaVersion) &&

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
@@ -28,4 +28,14 @@ class JenkinsJpiPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'org.jenkins-ci.jpi': TestedVersions.jenkinsJpi,
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "jenkinsPlugin {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('jenkinsPlugin')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JibPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JibPluginSmokeTest.groovy
@@ -28,4 +28,14 @@ class JibPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     Map<String, String> getExtraPluginsRequiredForValidation() {
         ['java': '']
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "jib {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('jib')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinCompilerPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinCompilerPluginsSmokeTest.groovy
@@ -24,4 +24,14 @@ class KotlinCompilerPluginsSmokeTest extends AbstractPluginValidatingSmokeTest {
             'org.jetbrains.kotlin.plugin.spring': TestedVersions.kotlin
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "allOpen {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('allOpen')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -213,6 +213,21 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         ]
     }
 
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "kotlin {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        def kotlinVersionNumber = VersionNumber.parse(version)
+        def deprecations = [parentMethodInvocationDeprecation('kotlin')]
+        if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_21) {
+            deprecations << "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration".toString()
+        }
+        return deprecations
+    }
+
     private void replaceCssSupportBlocksInBuildFile() {
         Map<String, String> replacementMap = [:]
         replacementMap['enableCssSupportNew'] = """

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -238,4 +238,23 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         }
         return [:]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        testedPluginId == 'org.jetbrains.kotlin.native.cocoapods' ? null : "kotlin {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        if (testedPluginId == 'org.jetbrains.kotlin.native.cocoapods') {
+            return []
+        }
+        def kotlinVersionNumber = VersionNumber.parse(version)
+        def deprecations = [parentMethodInvocationDeprecation('kotlin')]
+        if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_20) {
+            deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-api-jars'. Declare a Usage attribute with value 'java-api' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()
+            deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-runtime-jars'. Declare a Usage attribute with value 'java-runtime' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()
+        }
+        return deprecations
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KtLintPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KtLintPluginSmokeTest.groovy
@@ -24,4 +24,14 @@ class KtLintPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'org.jlleitschuh.gradle.ktlint-idea': TestedVersions.ktlintIdea,
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        testedPluginId == 'org.jlleitschuh.gradle.ktlint' ? "ktlint {}" : null
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        testedPluginId == 'org.jlleitschuh.gradle.ktlint' ? [parentMethodInvocationDeprecation('ktlint')] : []
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/LombokPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/LombokPluginSmokeTest.groovy
@@ -23,4 +23,14 @@ class LombokPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'io.freefair.lombok': TestedVersions.lombok
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "lombok {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('lombok')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/MicronautPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/MicronautPluginsSmokeTest.groovy
@@ -57,7 +57,8 @@ class MicronautPluginsSmokeTest extends AbstractPluginValidatingSmokeTest {
     List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
         [
             parentMethodInvocationDeprecation('micronaut'),
-            "Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: ${DOCS.getDocumentationFor("upgrading_version_9", "dependency_project_notation")}".toString()
+            "Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: ${DOCS.getDocumentationFor("upgrading_version_9", "dependency_project_notation")}".toString(),
+            "Using types related to file generation tasks of IDE plugins (org.gradle.plugins.ide.eclipse.model.EclipseJdt.file). This behavior has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: ${DOCS.getDocumentationFor("upgrading_version_9", "ide_task_deprecation")}".toString()
         ]
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/MicronautPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/MicronautPluginsSmokeTest.groovy
@@ -47,4 +47,17 @@ class MicronautPluginsSmokeTest extends AbstractPluginValidatingSmokeTest {
             "io.micronaut.application": Versions.of(TestedVersions.micronaut),
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "micronaut {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [
+            parentMethodInvocationDeprecation('micronaut'),
+            "Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: ${DOCS.getDocumentationFor("upgrading_version_9", "dependency_project_notation")}".toString()
+        ]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -245,6 +245,30 @@ testImplementation('junit:junit:4.7')""")
             'com.netflix.nebula.resolution-rules': Versions.of(TestedVersions.nebulaResolutionRules)
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        switch (testedPluginId) {
+            case 'com.netflix.nebula.dependency-recommender':
+                return "dependencyRecommendations {}"
+            case 'com.netflix.nebula.lint':
+                return "gradleLint.rules = []"
+            default:
+                return null
+        }
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        switch (testedPluginId) {
+            case 'com.netflix.nebula.dependency-recommender':
+                return [parentMethodInvocationDeprecation('dependencyRecommendations')]
+            case 'com.netflix.nebula.lint':
+                return [parentPropertyAccessDeprecation('gradleLint')]
+            default:
+                return []
+        }
+    }
 }
 
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -31,6 +31,16 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
     }
 
     @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "node {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('node')]
+    }
+
+    @Override
     void configureValidation(String testedPluginId, String version) {
         validatePlugins {
             if (testedPluginId == 'com.moowork.node') {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -77,4 +77,14 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'org.gradle.playframework': Versions.of(TestedVersions.playframework)
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "play {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('play')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
@@ -108,4 +108,14 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     Map<String, String> getExtraPluginsRequiredForValidation() {
         ['java': '']
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "protobuf {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('protobuf')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PublishingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PublishingSmokeTest.groovy
@@ -24,6 +24,16 @@ class PublishingSmokeTest extends AbstractPluginValidatingSmokeTest {
         ]
     }
 
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "mavenPublishing {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('mavenPublishing')]
+    }
+
     def "can publish with vanniktech maven publish plugin"() {
         given:
         settingsFile << """

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
@@ -60,4 +60,14 @@ class SpotBugsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'com.github.spotbugs': Versions.of(TestedVersions.spotbugs)
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "spotbugs {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('spotbugs')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotlessPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotlessPluginSmokeTest.groovy
@@ -28,4 +28,14 @@ class SpotlessPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             'com.diffplug.spotless': TestedVersions.spotless,
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "spotless {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('spotless')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -106,4 +106,14 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
             'org.springframework.boot': Versions.of(TestedVersions.springBoot)
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "springBoot {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('springBoot')]
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringDependencyManagementPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringDependencyManagementPluginSmokeTest.groovy
@@ -56,4 +56,14 @@ class SpringDependencyManagementPluginSmokeTest extends AbstractPluginValidating
             'io.spring.dependency-management' : Versions.of(TestedVersions.springDependencyManagement)
         ]
     }
+
+    @Override
+    String getSubprojectExtensionAccess(String testedPluginId, String version) {
+        "dependencyManagement {}"
+    }
+
+    @Override
+    List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
+        [parentMethodInvocationDeprecation('dependencyManagement')]
+    }
 }


### PR DESCRIPTION
## Summary

Validates the parent-property-lookup deprecation merged in #37830 across the community-plugin ecosystem.

Extends `AbstractPluginValidatingSmokeTest` with a new `configures plugin ... from subproject` iteration that applies each smoke-tested plugin at the root project and references its DSL extension from a child subproject. The child reference walks the parent chain, which triggers the deprecation. Per-plugin opt-in via two new hooks:

- `getSubprojectExtensionAccess(testedPluginId, version)` — the DSL snippet placed in `child/build.gradle` (typically a reference to the plugin's project extension, e.g. `spotless { }`). Returning `null` (the default) skips the iteration for that plugin/version.
- `getSubprojectExtensionDeprecations(testedPluginId, version)` — deprecation messages the iteration expects, built with the `parentMethodInvocationDeprecation` / `parentPropertyAccessDeprecation` helpers.

Plugins that don't opt in return `null`, and the iteration is reported as **skipped** (via `Assume`, so the data provider stays non-empty for classes where nothing opts in) rather than passing as a no-op. The interesting subset (Asciidoctor, Develocity 3.x, Kotlin, Kotlin Multiplatform, Detekt, Micronaut, etc.) opts in and declares expected deprecations, documenting which plugin ecosystems trip the deprecation through normal usage.

## Isolated Projects

The subproject test is guarded with `@Requires(TestExecutionPreconditions.NotIsolatedProjects)`: under Isolated Projects #37830 disables the parent walk entirely, so the plugin's extension is not reachable from a subproject and the scenario this test exercises is Vintage-specific.

## Deprecation message alignment

The expected parent-walk warning text and upgrade-guide anchor were realigned with the message as reworded on `master` (`Implicit lookup of methods/properties in parent projects` / `deprecated_implicit_lookup_in_parent_projects`), so the opted-in iterations match the actual runtime output.

## Stack

Independent of the open PRs in the parent-property-lookup series. Builds directly on #37830 (merged). Not in the stack with #37831 (caller-context detail) or #37832 (feature preview).

## Test plan

- [x] `./gradlew :smoke-test:smokeTest --tests "*configures plugin*from subproject*"` (Vintage) — verified opt-in (Spotless) passes and non-opt-in (Nohttp) is skipped
- [ ] `./gradlew :smoke-test:isolatedProjectsSmokeTest --tests "*configures plugin*from subproject*"` — iterations excluded via `@Requires`
- [ ] `./gradlew :smoke-test:configCacheSmokeTest --tests "*configures plugin*from subproject*"`
- [ ] `./gradlew sanityCheck`
