### PR TITLE
Drop import layout that matches IDEA defaults

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,16 +2,6 @@
   <code_scheme name="Project" version="173">
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-    <option name="IMPORT_LAYOUT_TABLE">
-      <value>
-        <package name="" withSubpackages="true" static="true" />
-        <emptyLine />
-        <package name="" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="javax" withSubpackages="true" static="false" />
-        <package name="java" withSubpackages="true" static="false" />
-      </value>
-    </option>
     <option name="RIGHT_MARGIN" value="200" />
     <GroovyCodeStyleSettings>
       <option name="ALIGN_NAMED_ARGS_IN_MAP" value="false" />


### PR DESCRIPTION
Since we've migrated to use IDEA 2026.1.1 or later,
it seems that the new defaults for the import layout cover our needs and after sync IDEA removes such values from the `Project.xml`

`Editor > Code Style > Java`
<img width="1159" height="282" alt="image" src="https://github.com/user-attachments/assets/5d384968-1ed4-461f-af9b-1269cf282791" />

---

Otherwise, after every sync, the `Project.xml` is being edited by IDEA to remove those values.
