### PR TITLE
Enable IP tests for dependency management

### DIFF
--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -180,6 +180,3 @@ tasks.clean {
         }.visit { this.file.setWritable(true) }
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest.groovy
@@ -321,13 +321,13 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
                     inputs.files.files.forEach { println(it) }
                 }
             }
-
-            subprojects {
-                apply plugin: "java-library"
-            }
         """
 
         groovyFile("a/build.gradle", """
+            plugins {
+                id("java-library")
+            }
+
             dependencies {
                 api(project(":a:a1"))
                 api(project(":a:a2"))
@@ -335,6 +335,10 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         """)
 
         groovyFile("b/build.gradle", """
+            plugins {
+                id("java-library")
+            }
+
             dependencies {
                 api(project(":b:b1"))
                 api(project(":b:b2"))
@@ -342,17 +346,22 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         """)
 
         groovyFile("c/build.gradle", """
+            plugins {
+                id("java-library")
+            }
+
             dependencies {
                 api(project(":c:c1"))
                 api(project(":c:c2"))
             }
         """)
 
-        file("a/a1/build.gradle").touch()
-        file("a/a2/build.gradle").touch()
-        file("b/b1/build.gradle").touch()
-        file("b/b2/build.gradle").touch()
-        file("c/c1/build.gradle").touch()
-        file("c/c2/build.gradle").touch()
+        ["a/a1", "a/a2", "b/b1", "b/b2", "c/c1", "c/c2"].each {
+            file("$it/build.gradle") << """
+                plugins {
+                    id("java-library")
+                }
+            """
+        }
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.cache.internal.scopes.DefaultCacheScopeMapping
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.cache.CachingIntegrationFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.hash.Hashing
@@ -71,6 +72,7 @@ task deleteCacheFiles(type: Delete) {
         succeeds('listJars')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Needs further investigation on IP incompatibility: https://github.com/gradle/gradle/issues/38006")
     void "cache entries are segregated between different repositories"() {
         given:
         def repo1 = ivyHttpRepo('ivy-repo-a')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -52,9 +52,7 @@ class MultiProjectProjectDependencyConflictResolutionIntegrationTest extends Abs
 
     @Override
     void moduleDefinition(String name, String definition) {
-        buildFile << "project(':$name') {"
-        buildFile << definition
-        buildFile << "}"
+        file("$name/build.gradle") << definition
     }
 
     @Override
@@ -62,11 +60,4 @@ class MultiProjectProjectDependencyConflictResolutionIntegrationTest extends Abs
         false
     }
 
-    @Override
-    String parentMethodLookupDeprecationFor(String methodName) {
-        // Modules are configured via project(':...') {} blocks in the root build script,
-        // so projectId()/moduleId() (declared by checkHelper() in the same build script)
-        // are looked up by walking up from :ProjectA to root project 'root'.
-        formatParentMethodLookupDeprecation(methodName, ':ProjectA', "root project 'root'")
-    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -618,6 +619,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         file("b/build/copied/a-1.0.zip").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
     def "resolving configuration with project dependency marks dependency's configuration as observed"() {
         settingsFile << """
             include 'api'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -17,10 +17,11 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
 
 @FluidDependenciesResolveTest
@@ -619,7 +620,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         file("b/build/copied/a-1.0.zip").exists()
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
+    @Requires(value = [TestExecutionPreconditions.NotIsolatedProjects], reason = "Explicitly tests IP incompatible behavior")
     def "resolving configuration with project dependency marks dependency's configuration as observed"() {
         settingsFile << """
             include 'api'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
 import org.gradle.test.precondition.Requires
@@ -217,6 +218,7 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
         failure.assertHasCause("Build was configured to prefer settings repositories over project repositories but repository 'maven' was added by build file 'build.gradle'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
     def "can fail the build if repositories are declared in a subproject block"() {
         settingsFile << """
             dependencyResolutionManagement {
@@ -224,10 +226,17 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
             }
 
             include 'lib1'
-            include 'lib2'
         """
 
-        def common = """
+        buildFile << """
+            subprojects {
+                repositories {
+                    maven { url = 'dummy' }
+                }
+            }
+        """
+
+        file("lib1/build.gradle") << """
             configurations {
                 conf
             }
@@ -235,20 +244,13 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
             dependencies {
                 conf 'org:module:1.0'
             }
-
-            repositories {
-                maven { url = 'dummy' }
-            }
         """
-
-        file("lib1/build.gradle") << common
-        file("lib2/build.gradle") << common
 
         when:
         fails ':lib1:checkDeps'
 
         then:
-        failure.assertHasCause("Build was configured to prefer settings repositories over project repositories but repository 'maven' was added by build file 'lib1${File.separator}build.gradle'")
+        failure.assertHasCause("Build was configured to prefer settings repositories over project repositories but repository 'maven' was added by build file 'build.gradle'")
 
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -18,12 +18,11 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
-
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
@@ -218,7 +217,7 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
         failure.assertHasCause("Build was configured to prefer settings repositories over project repositories but repository 'maven' was added by build file 'build.gradle'")
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
+    @Requires(value = [TestExecutionPreconditions.NotIsolatedProjects], reason = "Explicitly tests IP incompatible behavior")
     def "can fail the build if repositories are declared in a subproject block"() {
         settingsFile << """
             dependencyResolutionManagement {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -17,13 +17,15 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.util.GradleVersion
 import org.spockframework.lang.Wildcard
 
 class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDependencyResolutionTest {
-    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
+
+    @Requires(value = [TestExecutionPreconditions.NotIsolatedProjects], reason = "Explicitly tests IP incompatible behavior")
     def "configuration in another project fails when resolved"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.GradleVersion
 import org.spockframework.lang.Wildcard
 
 class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDependencyResolutionTest {
+    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
     def "configuration in another project fails when resolved"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -19,7 +19,8 @@ package org.gradle.integtests.resolve.api
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
 
 class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
@@ -203,7 +204,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         'buildSrc:implementation'   | 'setCanBeDeclared'   | 'Dependency Scope' | false
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
+    @Requires(value = [TestExecutionPreconditions.NotIsolatedProjects], reason = "Explicitly tests IP incompatible behavior")
     def "configurations can not have usage changed from other projects (#configuration - #method(#value)"() {
         given:
         file("projectA/build.gradle") << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.api
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
@@ -202,6 +203,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         'buildSrc:implementation'   | 'setCanBeDeclared'   | 'Dependency Scope' | false
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
     def "configurations can not have usage changed from other projects (#configuration - #method(#value)"() {
         given:
         file("projectA/build.gradle") << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import spock.lang.Issue
 
@@ -178,6 +179,7 @@ task checkResolveParentThenChild {
         succeeds("resolve")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
     def "extending a configuration in another project is not allowed"() {
         given:
         settingsFile """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
@@ -16,8 +16,9 @@
 package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
 
 @FluidDependenciesResolveTest
@@ -179,7 +180,7 @@ task checkResolveParentThenChild {
         succeeds("resolve")
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Explicitly tests IP incompatible behavior")
+    @Requires(value = [TestExecutionPreconditions.NotIsolatedProjects], reason = "Explicitly tests IP incompatible behavior")
     def "extending a configuration in another project is not allowed"() {
         given:
         settingsFile """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -701,13 +701,13 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
             dependencies {
                 compile project(':b')
-                compile rootProject.files('lib.jar')
+                compile files(rootProject.isolated.projectDirectory.file('lib.jar'))
                 compile files('lib.jar')
             }
             artifacts {
                 compile file('one/lib.jar')
                 compile file('two/lib.jar')
-                compile rootProject.file('lib.jar')
+                compile file(rootProject.isolated.projectDirectory.file('lib.jar'))
             }
         """
 
@@ -715,11 +715,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
             $header
 
             dependencies {
-                compile rootProject.files('lib.jar')
+                compile files(rootProject.isolated.projectDirectory.file('lib.jar'))
                 compile files('lib.jar')
             }
             artifacts {
-                compile rootProject.file('lib.jar')
+                compile file(rootProject.isolated.projectDirectory.file('lib.jar'))
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -107,48 +107,44 @@ abstract class AbstractConfigurationAttributesResolveIntegrationTest extends Abs
         def resolve = new ResolveTestFixture(testDirectory)
 
         given:
-        createDirs("a", "b")
         file('settings.gradle') << """
             rootProject.name='test'
             include 'a', 'b'
         """
 
-        buildFile << """
+        file("a/build.gradle") << """
             $typeDefs
+            configurations {
+                compile
+                _compileFreeDebug.attributes { $freeDebug }
+                _compileFreeRelease.attributes { $freeRelease }
+                _compileFreeDebug.extendsFrom compile
+                _compileFreeRelease.extendsFrom compile
+            }
+            dependencies {
+                compile project(':b')
+            }
+            task checkDebug(dependsOn: configurations._compileFreeDebug) {
+                doLast {
+                    assert configurations._compileFreeDebug.collect { it.name } == ['b-foo.jar']
+                }
+            }
+            task checkRelease(dependsOn: configurations._compileFreeRelease) {
+                doLast {
+                    assert configurations._compileFreeRelease.collect { it.name } == ['b-bar.jar']
+                }
+            }
 
-            project(':a') {
-                configurations {
-                    compile
-                    _compileFreeDebug.attributes { $freeDebug }
-                    _compileFreeRelease.attributes { $freeRelease }
-                    _compileFreeDebug.extendsFrom compile
-                    _compileFreeRelease.extendsFrom compile
-                }
-                dependencies {
-                    compile project(':b')
-                }
-                task checkDebug(dependsOn: configurations._compileFreeDebug) {
-                    doLast {
-                        assert configurations._compileFreeDebug.collect { it.name } == ['b-foo.jar']
-                    }
-                }
-                task checkRelease(dependsOn: configurations._compileFreeRelease) {
-                    doLast {
-                        assert configurations._compileFreeRelease.collect { it.name } == ['b-bar.jar']
-                    }
-                }
-            }
-            project(':b') {
-                configurations {
-                    foo.attributes { $freeDebug }
-                    bar.attributes { $freeRelease }
-                }
-                ${fooAndBarJars()}
-            }
+            ${resolve.configureProject("_compileFreeRelease", "_compileFreeDebug")}
         """
 
-        file("a/build.gradle") << """
-            ${resolve.configureProject("_compileFreeRelease", "_compileFreeDebug")}
+        file("b/build.gradle") << """
+            $typeDefs
+            configurations {
+                foo.attributes { $freeDebug }
+                bar.attributes { $freeRelease }
+            }
+            ${fooAndBarJars()}
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectVariantResolutionIntegrationTest.groovy
@@ -22,56 +22,75 @@ import org.gradle.integtests.resolve.VariantAwareDependencyResolutionTestFixture
 
 class ProjectVariantResolutionIntegrationTest extends AbstractIntegrationSpec implements VariantAwareDependencyResolutionTestFixture, TasksWithInputsAndOutputs {
     def "does not realize tasks that produce outgoing artifacts that are not required"() {
-        createDirs("a", "b")
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithColorVariants()
-        taskTypeWithOutputFileProperty()
-        buildFile << """
-            allprojects {
-                def p = tasks.register("producer", FileProducer) {
-                    output = file(project.name + ".txt")
-                }
-                def b = tasks.register("broken", FileProducer) {
-                    throw new RuntimeException("broken task")
-                }
-                tasks.register("resolve", ShowFileCollection) {
-                    def view = configurations.resolver.incoming.artifactView {
-                        attributes.attribute(color, 'green')
-                    }.files
-                    files.from(view)
-                }
 
-                configurations {
-                    broken {
-                        assert canBeConsumed
-                        canBeResolved = false
-                        attributes.attribute(color, 'orange')
-                        outgoing {
-                            artifact(b.flatMap { it.output })
-                            artifact(b.flatMap { throw new RuntimeException("broken outgoing artifact") })
-                            variants {
-                                create("broken") {
-                                    artifact(b.flatMap { it.output })
-                                    artifact(b.flatMap { throw new RuntimeException("broken variant artifact") })
-                                }
+        file("b/build.gradle") << """
+            def color = Attribute.of('color', String)
+            configurations {
+                dependencyScope("implementation")
+                consumable("outgoing") {
+                    attributes.attribute(color, 'blue')
+                    extendsFrom(implementation)
+                }
+            }
+
+            ${fileProducerTask()}
+
+            def p = tasks.register("producer", FileProducer) {
+                output = file(project.name + ".txt")
+            }
+            def b = tasks.register("broken", FileProducer) {
+                throw new RuntimeException("broken task")
+            }
+
+            configurations {
+                broken {
+                    assert canBeConsumed
+                    canBeResolved = false
+                    attributes.attribute(color, 'orange')
+                    outgoing {
+                        artifact(b.flatMap { it.output })
+                        artifact(b.flatMap { throw new RuntimeException("broken outgoing artifact") })
+                        variants {
+                            create("broken") {
+                                artifact(b.flatMap { it.output })
+                                artifact(b.flatMap { throw new RuntimeException("broken variant artifact") })
                             }
                         }
                     }
                 }
+            }
 
-                artifacts {
-                    implementation p.flatMap { it.output }
-                    broken b.flatMap { it.output }
-                    broken b.flatMap { throw new RuntimeException("broken artifact") }
+            artifacts {
+                implementation p.flatMap { it.output }
+                broken b.flatMap { it.output }
+                broken b.flatMap { throw new RuntimeException("broken artifact") }
+            }
+        """
+
+        file("a/build.gradle") << """
+            def color = Attribute.of('color', String)
+            configurations {
+                dependencyScope("implementation")
+                resolvable("resolver") {
+                    attributes.attribute(color, 'blue')
+                    extendsFrom(implementation)
                 }
             }
 
-            project(':a') {
-                dependencies {
-                    implementation project(':b')
-                }
+            dependencies {
+                implementation project(':b')
+            }
+
+            ${showFileCollectionTask()}
+
+            tasks.register("resolve", ShowFileCollection) {
+                def view = configurations.resolver.incoming.artifactView {
+                    attributes.attribute(color, 'green')
+                }.files
+                files.from(view)
             }
         """
 
@@ -83,34 +102,55 @@ class ProjectVariantResolutionIntegrationTest extends AbstractIntegrationSpec im
     }
 
     def "reports failure to realize tasks that produce outgoing artifacts"() {
-        createDirs("a", "b")
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithColorVariants()
-        taskTypeWithOutputFileProperty()
-        buildFile << """
-            allprojects {
-                def p = tasks.register("producer", FileProducer) {
-                    throw new RuntimeException("broken")
+
+        file("b/build.gradle") << """
+            def color = Attribute.of('color', String)
+            configurations {
+                dependencyScope("implementation")
+                consumable("outgoing") {
+                    attributes.attribute(color, 'blue')
+                    extendsFrom(implementation)
                 }
-                tasks.register("resolve", ShowFileCollection) {
-                    def view = configurations.resolver.incoming.artifactView {
-                        attributes.attribute(color, 'green')
-                    }.files
-                    files.from(view)
-                }
-                configurations {
-                    parent { }
-                    implementation { extendsFrom parent }
-                }
-                $registerExpression
             }
 
-            project(':a') {
-                dependencies {
-                    implementation project(':b')
+            configurations {
+                parent { }
+                implementation { extendsFrom parent }
+            }
+
+            ${fileProducerTask()}
+
+            def p = tasks.register("producer", FileProducer) {
+                throw new RuntimeException("broken")
+            }
+
+            $registerExpression
+        """
+
+        file("a/build.gradle") << """
+            def color = Attribute.of('color', String)
+            configurations {
+                dependencyScope("implementation")
+                resolvable("resolver") {
+                    attributes.attribute(color, 'blue')
+                    extendsFrom(implementation)
                 }
+            }
+
+            dependencies {
+                implementation project(':b')
+            }
+
+            ${showFileCollectionTask()}
+
+            tasks.register("resolve", ShowFileCollection) {
+                def view = configurations.resolver.incoming.artifactView {
+                    attributes.attribute(color, 'green')
+                }.files
+                files.from(view)
             }
         """
 
@@ -124,9 +164,9 @@ class ProjectVariantResolutionIntegrationTest extends AbstractIntegrationSpec im
         failure.assertHasCause("broken")
 
         where:
-        registerExpression                                                         | _
-        "artifacts.implementation(p.flatMap { it.output })"                        | _
-        "configurations.outgoing.outgoing.artifact(p.flatMap { it.output })" | _
-        "artifacts.parent(p.flatMap { it.output })"                                | _
+        registerExpression                                                          | _
+        "artifacts.implementation(p.flatMap { it.output })"                         | _
+        "configurations.outgoing.outgoing.artifact(p.flatMap { it.output })"        | _
+        "artifacts.parent(p.flatMap { it.output })"                                 | _
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.resolve.attributes
 
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
+
 /**
  * Variant of the configuration attributes resolution integration test which makes use of the strongly typed attributes notation.
  */
@@ -586,6 +588,7 @@ All of them match the consumer attributes:
         result.assertTasksScheduled(':b:fooJar', ':a:checkDebug')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Compatibility and disambiguation rules require shared Class instance to be discovered.")
     def "producer can apply additional compatibility rules when consumer does not have an opinion for attribute known to both"() {
         given:
         createDirs("a", "b")
@@ -662,6 +665,7 @@ All of them match the consumer attributes:
         result.assertTasksScheduled(':b:barJar', ':a:checkDebug')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Compatibility and disambiguation rules require shared Class instance to be discovered.")
     def "consumer can veto producers view of compatibility"() {
         given:
         createDirs("a", "b")
@@ -737,6 +741,7 @@ All of them match the consumer attributes:
         result.assertTasksScheduled(':b:barJar', ':a:checkDebug')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Compatibility and disambiguation rules require shared Class instance to be discovered.")
     def "producer can apply disambiguation for attribute known to both"() {
         given:
         createDirs("a", "b")
@@ -796,6 +801,7 @@ All of them match the consumer attributes:
         result.assertTasksScheduled(':b:barJar', ':a:check')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Compatibility and disambiguation rules require shared Class instance to be discovered.")
     def "producer can apply disambiguation for attribute not known to consumer"() {
         given:
         createDirs("a", "b")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.caching
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
@@ -550,6 +551,7 @@ Required by:
     }
 
     @Requires(TestExecutionPreconditions.NotParallelExecutor)
+    @ToBeFixedForIsolatedProjects(because = "Needs further investigation on IP incompatibility: https://github.com/gradle/gradle/issues/38006")
     def "hit each remote repo only once per build and missing module"() {
         given:
         def repo1 = mavenHttpRepo("repo1")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheRecreateOption
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.cache.CachingIntegrationFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
@@ -1008,6 +1009,7 @@ group:projectB:2.2;release
         outputContains 'Providing metadata for group:projectA:1.2'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Needs further investigation on IP incompatibility: https://github.com/gradle/gradle/issues/38006")
     def "can cache the result of processing a rule across projects"() {
         settingsFile << """
             include 'b'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 
 class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
-        createDirs("libInclude", "libExclude")
         settingsFile << """
             rootProject.name = 'root'
             include 'libInclude'
@@ -34,26 +33,26 @@ class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest
                 maven { url = "${mavenRepo.uri}" }
             }
 
-            project(':libInclude') {
-                configurations.create('default')
-                task jar {}
-                artifacts {
-                    'default' file('libInclude.jar'), { builtBy tasks.jar }
-                }
-            }
-
-            project(':libExclude') {
-                configurations.create('default')
-                task jar {}
-                artifacts {
-                    'default' file('libExclude.jar'), { builtBy tasks.jar }
-                }
-            }
-
             configurations {
                 compile
             }
-"""
+        """
+
+        buildFile("libInclude/build.gradle", """
+            configurations.create('default')
+            def jar = tasks.register("jar")
+            artifacts {
+                'default' file('libInclude.jar'), { builtBy jar }
+            }
+        """)
+
+        buildFile("libExclude/build.gradle", """
+            configurations.create('default')
+            def jar = tasks.register("jar")
+            artifacts {
+                'default' file('libExclude.jar'), { builtBy jar }
+            }
+        """)
     }
 
     def "can filter artifacts based on component id"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
@@ -46,6 +47,7 @@ import java.util.function.Predicate
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.INSTRUMENTED_ATTRIBUTE
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.NOT_INSTRUMENTED
 
+@ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
 class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegrationSpec implements ArtifactTransformTestFixture, DirectoryBuildCacheFixture {
 
     @EqualsAndHashCode
@@ -661,9 +663,9 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         """
 
         taskTypeWithMultipleOutputFileProperties()
-        setupBuildWithColorVariants()
 
         buildFile << """
+            ${colorVariants()}
             allprojects {
                 task producer(type: OutputFilesTask) {
                     out1.convention(layout.buildDirectory.file("\${project.name}.out1.jar"))
@@ -682,6 +684,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
                     files.from(view)
                 }
             }
+            ${showFileCollectionTask()}
         """
 
         buildFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -21,6 +21,7 @@ import com.google.common.collect.Streams
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.cache.internal.GradleUserHomeCleanupFixture
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
@@ -44,6 +45,7 @@ import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
+@ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
 class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture, ValidationMessageChecker, GradleUserHomeCleanupFixture {
     static final int HALF_DEFAULT_MAX_AGE_IN_DAYS = Math.max(1, DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES / 2 as int)
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformContinuousBuildIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformContinuousBuildIntegrationTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.ProjectDirectoryCreator
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.util.internal.ToBeImplemented
 
+@ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
 class ArtifactTransformContinuousBuildIntegrationTest extends AbstractContinuousIntegrationTest implements ArtifactTransformTestFixture, ProjectDirectoryCreator {
 
     def setup() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ScopeIdsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.operations.dependencies.transforms.ExecuteTransformActionBuildOperationType
@@ -39,6 +40,7 @@ import org.junit.Rule
 
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES
 
+@ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
 class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIntegrationSpec implements ArtifactTransformTestFixture, DirectoryBuildCacheFixture {
 
     def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.INSTRUMENTED_ATTRIBUTE
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.NOT_INSTRUMENTED
@@ -95,6 +96,7 @@ class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyReso
         outputContains("processing [b.jar]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can query incremental changes"() {
         createDirs("a", "b")
         settingsFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 import java.util.regex.Pattern
 
 class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture, DirectoryBuildCacheFixture {
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform does not execute when project artifact cannot be built"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -65,6 +67,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     // Documents existing behaviour. The absolute path of the input artifact is baked into the workspace identity
     // for incremental transforms, and so when the path changes the outputs are invalidated
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can attach #description to input artifact property with incrementally transformed artifact but it has no effect when not caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -198,6 +201,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         "@PathSensitive(PathSensitivity.NONE)"      | "@PathSensitive(PathSensitivity.NONE)"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can attach #normalization to input artifact property with #type transformed artifact directory but it has no effect when not caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -386,6 +390,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         type = (incremental ? "incremental" : "non-incremental")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "re-runs incremental transform when input artifact file changes from file to missing"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -451,6 +456,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "inputs to the build cache key are reported when build cache logging is enabled"() {
         given:
         createDirs("a", "b")
@@ -492,6 +498,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         output.contains("Build cache key for MakeGreen")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors @PathSensitive(NONE) on input artifact property for project artifact file when caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -586,6 +593,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors @PathSensitive(#sensitivity) to input artifact property for incremental artifact directory transforms when caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -701,6 +709,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         sensitivity << [PathSensitivity.NAME_ONLY, PathSensitivity.RELATIVE]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors @PathSensitive(#sensitivity) on input artifact property for project artifact file when caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -797,6 +806,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         sensitivity << [PathSensitivity.RELATIVE, PathSensitivity.NAME_ONLY]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors content changes for @PathSensitive(NONE) on input artifact property for incremental artifact directory transforms when not caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -908,6 +918,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         outputContains("result = [b-dir.green, c-dir.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors @PathSensitive(NONE) on input artifact property for incremental artifact directory transforms when caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -1180,6 +1191,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         sensitivity << [PathSensitivity.RELATIVE, PathSensitivity.NAME_ONLY]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors content changes with @#annotation on input artifact property with incremental artifact transforms file when not caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -1299,6 +1311,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         annotation << ["Classpath", "CompileClasspath"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors @#annotation on input artifact property with project artifact file when caching"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -1416,6 +1429,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         annotation << ["Classpath", "CompileClasspath"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "honors runtime classpath normalization for input artifact for incremental transform"() {
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
@@ -1477,6 +1491,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     @Issue("https://github.com/gradle/gradle/issues/19003")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can transform an empty input artifact"() {
         createDirs("a", "b")
         settingsFile << "include 'a', 'b'"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.transform
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.internal.file.FileType
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
@@ -90,6 +91,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to artifacts for external dependencies matching on implicit format attribute"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -134,6 +136,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can use transformations in build script dependencies"() {
         file("buildSrc/src/main/groovy/FileSizer.groovy") << fileSizer
 
@@ -174,6 +177,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming commons-math3-3.6.1.jar to commons-math3-3.6.1.jar.txt") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to files from file dependencies matching on implicit format attribute"() {
         given:
         buildFile << """
@@ -221,6 +225,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to artifacts from local projects matching on implicit format attribute"() {
         given:
         buildFile << """
@@ -279,6 +284,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can map artifact extension to implicit attributes"() {
         given:
         createDirs("app2")
@@ -380,6 +386,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to artifacts from local projects, files and external dependencies"() {
         def dependency = mavenRepo.module("test", "test-dependency", "1.3").publish()
         dependency.artifactFile.text = "dependency"
@@ -461,6 +468,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 7
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to artifacts from local projects matching on explicit format attribute"() {
         given:
         buildFile << """
@@ -518,6 +526,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "does not apply transform to variants with requested implicit format attribute"() {
         given:
         buildFile << """
@@ -567,6 +576,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "does not apply transforms to artifacts from local projects matching requested format attribute"() {
         given:
         buildFile << """
@@ -617,6 +627,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies transforms to artifacts from local projects matching on some variant attributes"() {
         given:
         buildFile << """
@@ -721,6 +732,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "applies chain of transforms to artifacts from local projects matching on some variant attributes"() {
         given:
         buildFile << """
@@ -853,6 +865,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transforms can be applied to multiple files with the same name"() {
         given:
         buildFile << """
@@ -914,6 +927,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can register the input as an output"() {
         buildFile << """
             def f = file("lib.jar")
@@ -960,6 +974,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
     }
 
     @Issue("https://github.com/gradle/gradle/issues/16962")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transforms registering the input as an output can use normalization"() {
         file("input1.jar").text = "jar"
         file("input2.jar").text = "jar"
@@ -1030,6 +1045,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
     }
 
     @Issue("https://github.com/gradle/gradle/issues/22735")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform selection prioritizes shorter transforms over attribute schema matching"() {
 
         // The lib project defines two variants:
@@ -1141,6 +1157,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         outputContains("files: [lib.jar.txt]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can generate multiple output files for a single input"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -1189,6 +1206,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can generate an empty output"() {
         mavenRepo.module("test", "test", "1.3").publish()
         mavenRepo.module("test", "test2", "2.3").publish()
@@ -1234,6 +1252,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user receives reasonable error message when multiple transforms are available to produce requested variant"() {
         given:
         buildFile << """
@@ -1316,6 +1335,7 @@ Found the following transformation chains:
                       - extra 'baz'"""
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user receives reasonable error message when multiple variants can be transformed to produce requested variant"() {
         given:
         buildFile << """
@@ -1441,6 +1461,7 @@ Found the following transformation chains:
                       - artifactType 'transformed'"""
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "result is applied for all query methods"() {
         def resolve = new ResolveTestFixture(testDirectory)
 
@@ -1488,6 +1509,7 @@ Found the following transformation chains:
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transforms are applied lazily in file collections"() {
         def m1 = mavenHttpRepo.module('org.test', 'test1', '1.0').publish()
         def m2 = mavenHttpRepo.module('org.test', 'test2', '2.0').publish()
@@ -1657,6 +1679,7 @@ Found the following transformation chains:
         outputContains("files: [jar1.jar.txt, jar2.jar.txt]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when a transform throws exception and continues with other inputs"() {
         given:
         buildFile << """
@@ -1795,6 +1818,7 @@ Found the following transformation chains:
         outputContains("files: [thing1.jar.txt, thing2.jar.txt]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when null is registered via outputs.#method"() {
         given:
         buildFile << """
@@ -1827,6 +1851,7 @@ Found the following transformation chains:
         method << ['dir', 'file']
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when transform returns a non-existing file"() {
         given:
         buildFile << """
@@ -1862,6 +1887,7 @@ Found the following transformation chains:
         outputContains(":resolve NO-SOURCE")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when transform registers a #type output via #method"() {
         given:
         buildFile << """
@@ -1932,6 +1958,7 @@ Found the following transformation chains:
         'dir'  | FileType.Missing     | 'output .*this_file_does_not.exist must exist'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "directories are created for outputs in the workspace"() {
         given:
         buildFile << """
@@ -1967,6 +1994,7 @@ Found the following transformation chains:
         succeeds "resolve"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "directories are not created for output #method which is part of the input"() {
         given:
         buildFile << """
@@ -2013,6 +2041,7 @@ Found the following transformation chains:
         method << ["file", "dir"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when transform returns a file that is not part of the input artifact or in the output directory"() {
         given:
         buildFile << """
@@ -2045,6 +2074,7 @@ Found the following transformation chains:
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when transform registers an output that is not part of the input artifact or in the output directory"() {
         given:
         buildFile << """
@@ -2085,6 +2115,7 @@ Found the following transformation chains:
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "user gets a reasonable error message when transform cannot be instantiated"() {
         given:
         buildFile << """
@@ -2193,6 +2224,7 @@ Found the following transformation chains:
         outputContains("files: [a.jar, c.jar, c-2.0.jar]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "provides useful error message when registration action fails"() {
         when:
         buildFile << """
@@ -2210,6 +2242,7 @@ Found the following transformation chains:
         failure.assertHasCause("Bad registration")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "provides useful error message when parameter value cannot be isolated for #type transform"() {
         mavenRepo.module("test", "a", "1.3").publish()
         settingsFile << "include 'lib'"
@@ -2282,6 +2315,7 @@ Found the following transformation chains:
         type = scheduled ? 'scheduled' : 'immediate'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transformation attribute cycles are permitted"() {
         mavenRepo.module("test", "a", "1.0").publish()
 
@@ -2342,6 +2376,7 @@ Found the following transformation chains:
         outputContains("files: [a-1.0.jar.txt.txt.txt]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "artifacts with same component id and extension, but different classifier are uniquely identifiable after transformation"() {
         def module = mavenRepo.module("test", "test", "1.3").publish()
         module.getArtifactFile(classifier: "foo").text = "1234"
@@ -2392,6 +2427,7 @@ Found the following transformation chains:
         succeeds "hasUniqueArtifactIds"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "artifact excludes applied to external dependency on different graphs are honored"() {
         def m1 = ivyRepo.module("test", "test", "1.3")
         m1.artifact(name: "test-one", conf: "*")
@@ -2466,6 +2502,7 @@ Found the following transformation chains:
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "artifacts with the same id but different content are transformed independently"() {
         def repo1 = new MavenFileRepository(testDirectory.file("repo1"))
         def repo2 = new MavenFileRepository(testDirectory.file("repo2"))
@@ -2529,6 +2566,7 @@ Found the following transformation chains:
         output.count("Transforming") == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform runs only once even when variant is consumed from multiple projects"() {
         given:
         createDirs("app2")
@@ -2575,6 +2613,7 @@ Found the following transformation chains:
         output.count("Transforming") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can resolve transformed variant during configuration time"() {
         given:
         buildFile << """
@@ -2623,6 +2662,7 @@ Found the following transformation chains:
         output.count("Transforming") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "notifies transform listeners and build operation listeners on successful execution"() {
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
@@ -2690,6 +2730,7 @@ Found the following transformation chains:
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "notifies transform listeners and build operation listeners on failed execution"() {
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
@@ -2764,6 +2805,7 @@ Found the following transformation chains:
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6156")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "stops resolving dependencies of task when artifact transforms are encountered"() {
         given:
         buildFile << """
@@ -2811,6 +2853,7 @@ Found the following transformation chains:
     }
 
     @Issue("https://github.com/gradle/gradle/issues/33298")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "does not OOM due to exhaustively searching all possible transform paths when many unrelated transforms are registered"() {
         buildFile << """
             @CacheableTransform

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -140,7 +140,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         outputContains("Transforming test3-3.3.jar to test3-3.3.jar.txt")
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
     def "transformations are applied in parallel for project artifacts"() {
         given:
         createDirs("lib1", "lib2", "lib3")
@@ -384,7 +384,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         failure.assertHasCause("Failed to transform bad-c.jar to match attributes {artifactType=size}")
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
     def "only one transformer execution per workspace"() {
 
         createDirs("lib", "app1", "app2")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -139,6 +140,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         outputContains("Transforming test3-3.3.jar to test3-3.3.jar.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
     def "transformations are applied in parallel for project artifacts"() {
         given:
         createDirs("lib1", "lib2", "lib3")
@@ -382,6 +384,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         failure.assertHasCause("Failed to transform bad-c.jar to match attributes {artifactType=size}")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
     def "only one transformer execution per workspace"() {
 
         createDirs("lib", "app1", "app2")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.api.tasks.options.OptionValues
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
 import spock.lang.Issue
@@ -52,6 +53,7 @@ import static org.gradle.util.Matchers.matchesRegexp
 
 class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive parameters, workspace and input artifact via abstract getter"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -106,6 +108,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive parameter of type #type"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -163,6 +166,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
     }
 
     @Issue("https://github.com/gradle/gradle/issues/16982")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can set convention on parameter of type #type"() {
         given:
         createDirs("a", "b", "c")
@@ -211,6 +215,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         "MapProperty<String, Number>" | "[a: 1, b: 2]"   | "[a:1, b:2]"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a build service as a parameter"() {
         createDirs("a", "b")
         settingsFile << """
@@ -266,6 +271,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("result = [out-1.txt]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive Gradle provided service #serviceType via injection"() {
         createDirs("a", "b")
         settingsFile << """
@@ -309,6 +315,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ].collect { it.name }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform cannot receive Gradle provided service #serviceType via injection"() {
         createDirs("a", "b")
         settingsFile << """
@@ -348,6 +355,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ].collect { it.name }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform parameters are validated for input output annotations"() {
         enableProblemsApiCheck()
         createDirs("a", "b")
@@ -586,6 +594,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can query parameters for transform with None parameters"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -612,6 +621,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("Parameters: org.gradle.api.artifacts.transform.TransformParameters\$None@")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform parameters type cannot use caching annotations"() {
         createDirs("a", "b")
         settingsFile << """
@@ -656,6 +666,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasErrorOutput("Type 'MakeGreen.Parameters' is incorrectly annotated with @CacheableTransform")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform parameters type cannot use annotation @#ann.simpleName"() {
         enableProblemsApiCheck()
         createDirs("a", "b")
@@ -717,6 +728,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ann << [OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform parameters type cannot use injection annotation @#annotation.simpleName"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -763,6 +775,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         annotation << [InputArtifact, InputArtifactDependencies]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform action is validated for input output annotations"() {
         enableProblemsApiCheck()
         createDirs("a", "b", "c")
@@ -887,6 +900,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform action type cannot use @#ann.simpleName"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -921,6 +935,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ann << [CacheableTask, UntrackedTask]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform action type cannot use annotation @#ann.simpleName"() {
         enableProblemsApiCheck()
         createDirs("a", "b", "c")
@@ -980,6 +995,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ann << [Input, InputFile, InputDirectory, OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues, Console, Internal]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive dependencies via abstract getter of type #targetType"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -1025,6 +1041,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         targetType << ["FileCollection", "Iterable<File>"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive parameter object via constructor parameter"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -1066,6 +1083,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         succeeds(":a:resolve")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform cannot use @InputArtifact to receive #propertyType"() {
         createDirs("a", "b")
         settingsFile << """
@@ -1108,6 +1126,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform cannot use @InputArtifactDependencies to receive #propertyType"() {
         createDirs("a", "b")
         settingsFile << """
@@ -1146,6 +1165,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         InputArtifactDependencies | String
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform cannot use @Inject to receive input file"() {
         createDirs("a", "b", "c")
         settingsFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -20,14 +20,15 @@ import com.google.common.collect.Comparators
 import com.google.common.collect.ImmutableSortedMultiset
 import com.google.common.collect.Iterables
 import com.google.common.collect.Multiset
-import groovy.test.NotYetImplemented
 import groovy.transform.Canonical
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.gradle.util.internal.ToBeImplemented
 import org.hamcrest.CoreMatchers
 import spock.lang.Issue
 
@@ -35,6 +36,7 @@ import javax.annotation.Nonnull
 import java.util.regex.Pattern
 
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
+@ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
 class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest implements ArtifactTransformTestFixture {
 
     def setup() {
@@ -1243,7 +1245,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         )
     }
 
-    @NotYetImplemented
+    @ToBeImplemented
     def "transform dependencies include multiple artifacts for the same output"() {
         setupBuildWithSingleStep()
         buildFile("""
@@ -1266,8 +1268,8 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
             singleStep('slf4j-api-1.7.25.jar'),
             singleStep('hamcrest-core-1.3.jar'),
             singleStep('junit-4.11.jar', 'hamcrest-core-1.3.jar'),
-            singleStep('common.jar', 'common2.jar'), // Requested behavior: transforming common includes common2 as a dependency
-            singleStep('common2.jar', 'common.jar'), // Requested behavior: transforming common2 includes common as a dependency
+            singleStep('common.jar'),  // Requested behavior: transforming common includes common2 as a dependency
+            singleStep('common2.jar'), // Requested behavior: transforming common2 includes common as a dependency
             singleStep('lib.jar','slf4j-api-1.7.25.jar', 'common.jar', 'common2.jar'),
         )
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesParallelIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.internal.resources.ProjectLeaseRegistry
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
@@ -24,7 +25,9 @@ import spock.lang.Issue
 
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
 class ArtifactTransformWithDependenciesParallelIntegrationTest extends AbstractHttpDependencyResolutionTest implements ArtifactTransformTestFixture {
+
     @Issue("https://github.com/gradle/gradle/issues/20975")
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform is applied to project output when project and external library have conflicting group and module name"() {
         mavenRepo.module("libs", "producer", "1.0").publish()
 
@@ -85,4 +88,5 @@ class ArtifactTransformWithDependenciesParallelIntegrationTest extends AbstractH
         outputContains("processing producer.jar using []")
         outputContains("processing consumer.jar using [producer.jar]")
     }
+
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.transform
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 
 class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
     /**
@@ -51,6 +52,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file collection containing pre-built files via parameter object"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -81,6 +83,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file collection containing external dependencies as parameter"() {
         mavenRepo.module("test", "tool-a", "1.2").publish()
         mavenRepo.module("test", "tool-b", "1.2").publish()
@@ -117,6 +120,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file input from a nested bean on the parameter object"() {
         createDirs("a", "b")
         settingsFile << """
@@ -174,6 +178,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file collection containing task outputs as parameter"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -206,6 +211,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file collection containing transform outputs as parameter"() {
         createDirs("a", "b", "c", "d", "e")
         settingsFile << """
@@ -269,6 +275,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a file collection containing substituted external dependencies as parameter"() {
         createDirs("tools", "tools/tool-a", "tools/tool-b")
         file("tools/settings.gradle") << """
@@ -327,6 +334,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a task output file as parameter"() {
         createDirs("a", "b", "c", "d", "e")
         settingsFile << """
@@ -380,6 +388,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("processing c.jar using tool-a.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform can receive a task output directory as parameter"() {
         createDirs("a", "b", "c", "d", "e")
         settingsFile << """
@@ -433,6 +442,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("processing c.jar using tool-a-dir")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "transform does not execute when file inputs cannot be built"() {
         createDirs("a", "b", "c")
         settingsFile << """
@@ -468,6 +478,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         failure.assertHasCause("broken")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ArtifactTransformTestFixture is not IP compatible")
     def "can use input path sensitivity #pathSensitivity for parameter object"() {
         createDirs("a", "b", "c")
         settingsFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class DisambiguateArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -43,6 +44,7 @@ class DisambiguateArtifactTransformIntegrationTest extends AbstractHttpDependenc
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
     def "disambiguates A -> B -> C and B -> C by selecting the latter"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -135,6 +137,7 @@ ${artifactTransform("FileSizer")}
         output.count("Transforming test-1.3.jar.txt to test-1.3.jar.txt.txt") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
     def "can not disambiguate A -> C and B -> C as both are valid chains"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -409,6 +412,7 @@ task resolve(type: Copy) {
         output.count('Sizing') == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
     def "disambiguation leverages schema rules before doing it size based"() {
         given:
         createDirs("child")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -44,7 +44,7 @@ class DisambiguateArtifactTransformIntegrationTest extends AbstractHttpDependenc
         """
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
     def "disambiguates A -> B -> C and B -> C by selecting the latter"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -137,7 +137,7 @@ ${artifactTransform("FileSizer")}
         output.count("Transforming test-1.3.jar.txt to test-1.3.jar.txt.txt") == 1
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
     def "can not disambiguate A -> C and B -> C as both are valid chains"() {
         def m1 = mavenRepo.module("test", "test", "1.3").publish()
         m1.artifactFile.text = "1234"
@@ -412,7 +412,7 @@ task resolve(type: Copy) {
         output.count('Sizing') == 0
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+    @ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
     def "disambiguation leverages schema rules before doing it size based"() {
         given:
         createDirs("child")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.integtests.resolve.transform
 
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
+@ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
 class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunctionalTest {
     ConsoleOutput consoleType
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.test.fixtures.server.http.BlockingHttpServer
 
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
-@ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project")
+@ToBeFixedForIsolatedProjects(because = "Transforms registered and configured in root project using allprojects. This allows transform tests to use the same artifact transform implementation Class.")
 class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunctionalTest {
     ConsoleOutput consoleType
 

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -56,24 +56,6 @@ abstract class AbstractProjectDependencyConflictResolutionIntegrationSpec extend
      */
     abstract boolean isAutoDependencySubstitution();
 
-    /**
-     * The deprecation warning expected when the {@code check()} task helper calls {@code projectId(...)}
-     * or {@code moduleId(...)} during configuration of {@code ProjectA}. Subclasses whose
-     * {@link #moduleDefinition} configures modules via {@code project(':...') {}} blocks inside a parent
-     * build script will see those calls walk up the project hierarchy and trigger the implicit
-     * parent-method-lookup deprecation added in Gradle 9.6. Subclasses that inline the check helper
-     * into each module's own build script return {@code null}.
-     */
-    abstract String parentMethodLookupDeprecationFor(String methodName);
-
-    protected static String formatParentMethodLookupDeprecation(String methodName, String referrerPath, String resolverDisplayName) {
-        return "Implicitly resolving methods in the project hierarchy has been deprecated. " +
-            "This will fail with an error in Gradle 10. " +
-            "Method '${methodName}' was not declared in project '${referrerPath}' and was resolved from ${resolverDisplayName}. " +
-            "Consult the upgrading guide for further information: " +
-            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_project_hierarchy_lookup"
-    }
-
     def "project (#projectDep) vs external resolves to (#winner), when preferProjectModules=#preferProjectModules and depSubstitution=#depSubstitution"() {
         def transitiveDep = "2.0"
         given:
@@ -114,7 +96,6 @@ $includeMechanism 'ProjectA'
             task check {
                 dependsOn ${dependsOnMechanism('ProjectA', 'checkModuleC_conf')}
             }
-            ${checkHelper(buildId, projectPath)}
 """
         moduleDefinition('ModuleC', """
             group = "myorg"
@@ -125,6 +106,17 @@ $includeMechanism 'ProjectA'
 """)
 
         moduleDefinition('ProjectA', """
+            def moduleId(String group, String name, String version) {
+                def mid = org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId(group, name)
+                return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(mid, version)
+            }
+
+            def projectId(String projectName) {
+                def buildId = $buildId
+                def projectPath = $projectPath
+                return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).projects.getProject(${Path.name}.path(projectPath)).componentIdentifier
+            }
+
             repositories { maven { url = "${mavenRepo.uri}" } }
 
             configurations { conf }
@@ -143,15 +135,6 @@ $includeMechanism 'ProjectA'
 """)
 
         then:
-        def declaredDeprecation = parentMethodLookupDeprecationFor('projectId')
-        if (declaredDeprecation != null) {
-            // Subclass uses project(':ProjectA') {} blocks (or the equivalent nested in a composite),
-            // so check() embeds projectId()/moduleId() calls that walk up the project hierarchy.
-            // Two warnings fire per row: one always for projectId (from $declaredDependencyId) and
-            // one for the method referenced by the winner expression.
-            executer.expectDocumentedDeprecationWarning(declaredDeprecation)
-            executer.expectDocumentedDeprecationWarning(parentMethodLookupDeprecationFor(winnerMethod))
-        }
         succeeds('check')
 
         where:
@@ -187,20 +170,6 @@ $includeMechanism 'ProjectA'
 
                 assert projectDependency && projectDependency.selected.id == expected
             }
-        }
-"""
-    }
-
-    static String checkHelper(String buildId, String projectPath) { """
-        def moduleId(String group, String name, String version) {
-            def mid = org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId(group, name)
-            return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(mid, version)
-        }
-
-        def projectId(String projectName) {
-            def buildId = $buildId
-            def projectPath = $projectPath
-            return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).projects.getProject(${Path.name}.path(projectPath)).componentIdentifier
         }
 """
     }

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/VariantAwareDependencyResolutionTestFixture.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/VariantAwareDependencyResolutionTestFixture.groovy
@@ -22,8 +22,8 @@ import org.gradle.test.fixtures.file.TestFile
 trait VariantAwareDependencyResolutionTestFixture extends TasksWithInputsAndOutputs {
     abstract TestFile getBuildFile()
 
-    def setupBuildWithColorVariants(TestFile buildFile = getBuildFile()) {
-        buildFile << """
+    String colorVariants() {
+        """
             def color = Attribute.of('color', String)
             allprojects {
                 configurations {
@@ -46,7 +46,11 @@ trait VariantAwareDependencyResolutionTestFixture extends TasksWithInputsAndOutp
                     }
                 }
             }
+        """
+    }
 
+    String showFileCollectionTask() {
+        """
             class ShowFileCollection extends DefaultTask {
                 @InputFiles
                 final ConfigurableFileCollection files = project.objects.fileCollection()

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -56,13 +56,12 @@ trait ArtifactTransformTestFixture extends VariantAwareDependencyResolutionTestF
     }
 
     void setupBuildWithColorAttributes(TestFile buildFile = getBuildFile(), Builder builder) {
-        setupBuildWithColorVariants(buildFile)
-
         buildFile << """
 import ${javax.inject.Inject.name}
 // TODO: Default imports should work for of inner classes
 import ${org.gradle.api.artifacts.transform.TransformParameters.name}
 
+${colorVariants()}
 allprojects {
     task producer(type: ${builder.producerTaskClassName}) {
         ${builder.producerConfig}
@@ -117,6 +116,8 @@ class JarProducer extends DefaultTask {
         }
     }
 }
+
+${showFileCollectionTask()}
 """
         taskTypeWithOutputFileProperty(buildFile)
         taskTypeWithOutputDirectoryProperty(buildFile)

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -37,9 +37,7 @@ class CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionInteg
 
     def setup() {
         buildTestFixture.withBuildInSubDir()
-        multiProject = buildTestFixture.populate('multiProject') {
-            buildFile << checkHelper(buildId, projectPath)
-        }
+        multiProject = buildTestFixture.populate('multiProject')
         super.settingsFile << "includeBuild 'multiProject'\n";
     }
 
@@ -80,9 +78,7 @@ class CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionInteg
 
     @Override
     void moduleDefinition(String name, String definition) {
-        multiProject.buildFile << "project(':$name') {"
-        multiProject.buildFile << definition
-        multiProject.buildFile << "}"
+        multiProject.project(name).buildFile(definition)
     }
 
     @Override
@@ -90,11 +86,4 @@ class CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionInteg
         true
     }
 
-    @Override
-    String parentMethodLookupDeprecationFor(String methodName) {
-        // The included 'multiProject' build configures its modules via project(':...') {} blocks,
-        // so projectId()/moduleId() walk up from :multiProject:ProjectA to project :multiProject.
-        // Composite-build messages refer to projects by build path, not by "root project '<name>'".
-        formatParentMethodLookupDeprecation(methodName, ':multiProject:ProjectA', "project ':multiProject'")
-    }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -54,7 +54,6 @@ class CompositeBuildProjectDependencyConflictResolutionIntegrationTest extends A
     void moduleDefinition(String name, String definition) {
         buildTestFixture.populate(name) {
             buildFile << definition
-            buildFile << checkHelper(buildId, projectPath)
         }
     }
 
@@ -63,10 +62,4 @@ class CompositeBuildProjectDependencyConflictResolutionIntegrationTest extends A
         true
     }
 
-    @Override
-    String parentMethodLookupDeprecationFor(String methodName) {
-        // moduleDefinition() inlines checkHelper() into each included build's own build script,
-        // so projectId()/moduleId() resolve locally without walking the project hierarchy.
-        null
-    }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -27,7 +27,11 @@ trait TasksWithInputsAndOutputs {
     abstract TestFile getBuildKotlinFile()
 
     def taskTypeWithOutputFileProperty(TestFile buildFile = getBuildFile()) {
-        buildFile << """
+        buildFile << fileProducerTask()
+    }
+
+    String fileProducerTask() {
+        """
             abstract class FileProducer extends DefaultTask {
                 @OutputFile
                 abstract RegularFileProperty getOutput()

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
@@ -49,7 +49,7 @@ class BuildTestFixture {
         this
     }
 
-    def populate(String projectName, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl) {
+    def populate(String projectName, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         def project = buildInRootDir ? new BuildTestFile(getRootDir(), projectName) : new BuildTestFile(getRootDir().file(projectName), projectName)
         project.settingsFile << """
                     rootProject.name = '${projectName}'

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
@@ -34,17 +34,15 @@ class ResolveFailureTestFixture {
 
     void prepare(String config = this.config) {
         buildFile << """
-            allprojects {
-                tasks.register("checkDeps") {
-                    if (${GradleContextualExecuter.configCache}) {
-                        def files = configurations.${config}
-                        doLast {
-                            files.forEach { }
-                        }
-                    } else {
-                        doLast {
-                            configurations.${config}.resolve()
-                        }
+            tasks.register("checkDeps") {
+                if (${GradleContextualExecuter.configCache}) {
+                    def files = configurations.${config}
+                    doLast {
+                        files.forEach { }
+                    }
+                } else {
+                    doLast {
+                        configurations.${config}.resolve()
                     }
                 }
             }


### PR DESCRIPTION
Some tests require mechnical refactoring for IP compatibility Many artifact transform tests remain disabled due to the way they are written, requiring non-trivial refactorings
- Caching artifact transform tests require different Projects to share the same artifact transform Class instance, meaning we cannot duplicate the class in each project. We can potentially use included builds or buildsrc here, but these cause very slow integ test execution durations and therefore are not ideal from a DX perspective
- Some tests are marked incompatible since they specifically test IP incompatible behavior
- Four attribute compatbility tests are marked incompatible since they need to share a Class instance to detect registered rules. This is 1. a limitation of dependency management and 2. can potentially be solved with included builds, but again these are not ideal for DX
- Three tests fail during IP for unknown reasons. They are tracked by https://github.com/gradle/gradle/issues/38006


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
