### PR TITLE
Unmark CapturingUserInputCrossVersionSpec as flaky

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
@@ -18,14 +18,12 @@ package org.gradle.integtests.tooling.r43
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
-import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.ProjectConnection
 import spock.lang.Timeout
 
 @TargetGradleVersion(">=4.3")
 @Timeout(120)
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/5166")
 class CapturingUserInputCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {


### PR DESCRIPTION
The underlying race was fixed in 48c844c05c8 by switching to a preloaded ByteArrayInputStream. Since then the spec has had no genuine failures, so move it out of the Flaky Quarantine back into the normal test suite.

* Fixes https://github.com/gradle/gradle-private/issues/5166

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
