### PR TITLE
Expose variant name directly on SourceVariantData

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/metadata/ProjectMetadataController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/metadata/ProjectMetadataController.kt
@@ -142,7 +142,7 @@ class ProjectMetadataController(
     suspend fun WriteContext.writeVariantArtifactSet(variant: VariantResolveMetadata) {
         writeString(variant.name)
         write(variant.identifier)
-        writeNullableString(variant.ownerDisplayName?.displayName)
+        writeNullableString(variant.owner?.displayName)
         write(variant.attributes)
         write(variant.capabilities)
         writeCollection(variant.artifacts)
@@ -254,14 +254,14 @@ class ProjectMetadataController(
         val variantName = readString()
         val identifier = readNonNull<VariantResolveMetadata.Identifier>()
         val displayName = Describables.of(variantName)
-        val ownerDisplayName = readNullableString()?.let { Describables.of(it) }
+        val owner = readNullableString()?.let { Describables.of(it) }
         val attributes = readNonNull<ImmutableAttributes>()
         val capabilities = readNonNull<ImmutableCapabilities>()
         val artifacts = readNonNullList<PublishArtifactLocalArtifactMetadata>()
         val artifactMetadata = factory.create(Describables.of(displayName, "artifacts"), ValueCalculator {
             ImmutableList.copyOf<LocalComponentArtifactMetadata>(artifacts)
         })
-        return LocalVariantMetadata(variantName, identifier, displayName, ownerDisplayName, attributes, capabilities, artifactMetadata)
+        return LocalVariantMetadata(variantName, identifier, displayName, owner, attributes, capabilities, artifactMetadata)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/metadata/ProjectMetadataController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/metadata/ProjectMetadataController.kt
@@ -142,6 +142,7 @@ class ProjectMetadataController(
     suspend fun WriteContext.writeVariantArtifactSet(variant: VariantResolveMetadata) {
         writeString(variant.name)
         write(variant.identifier)
+        writeNullableString(variant.ownerDisplayName?.displayName)
         write(variant.attributes)
         write(variant.capabilities)
         writeCollection(variant.artifacts)
@@ -253,13 +254,14 @@ class ProjectMetadataController(
         val variantName = readString()
         val identifier = readNonNull<VariantResolveMetadata.Identifier>()
         val displayName = Describables.of(variantName)
+        val ownerDisplayName = readNullableString()?.let { Describables.of(it) }
         val attributes = readNonNull<ImmutableAttributes>()
         val capabilities = readNonNull<ImmutableCapabilities>()
         val artifacts = readNonNullList<PublishArtifactLocalArtifactMetadata>()
         val artifactMetadata = factory.create(Describables.of(displayName, "artifacts"), ValueCalculator {
             ImmutableList.copyOf<LocalComponentArtifactMetadata>(artifacts)
         })
-        return LocalVariantMetadata(variantName, identifier, displayName, attributes, capabilities, artifactMetadata)
+        return LocalVariantMetadata(variantName, identifier, displayName, ownerDisplayName, attributes, capabilities, artifactMetadata)
     }
 
     private

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -196,6 +196,10 @@ class RecordingVariantSet(
         return Describables.of(source)
     }
 
+    override fun getVariantName(): String {
+        return asDescribable().displayName
+    }
+
     override fun getProducerSchema(): ImmutableAttributesSchema {
         return ImmutableAttributesSchema.EMPTY
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
@@ -149,13 +149,13 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
             @Override
             public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(displayName, componentId, artifacts, model, calculatedValueContainerFactory);
-                artifactSets.add(new LocalVariantMetadata(configurationName, configurationIdentifier, displayName, attributes, capabilities, variantArtifacts));
+                artifactSets.add(new LocalVariantMetadata(configurationName, configurationIdentifier, displayName, null, attributes, capabilities, variantArtifacts));
             }
 
             @Override
             public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(displayName, componentId, artifacts, model, calculatedValueContainerFactory);
-                artifactSets.add(new LocalVariantMetadata(configurationName + "-" + name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, attributes, capabilities, variantArtifacts));
+                artifactSets.add(new LocalVariantMetadata(name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, configuration.asDescribable(), attributes, capabilities, variantArtifacts));
             }
         });
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
@@ -155,7 +155,7 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
             @Override
             public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(displayName, componentId, artifacts, model, calculatedValueContainerFactory);
-                artifactSets.add(new LocalVariantMetadata(name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, Describables.of(configurationName), attributes, capabilities, variantArtifacts));
+                artifactSets.add(new LocalVariantMetadata(name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, configuration.asDescribable(), attributes, capabilities, variantArtifacts));
             }
         });
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
@@ -155,7 +155,7 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
             @Override
             public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(displayName, componentId, artifacts, model, calculatedValueContainerFactory);
-                artifactSets.add(new LocalVariantMetadata(name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, configuration.asDescribable(), attributes, capabilities, variantArtifacts));
+                artifactSets.add(new LocalVariantMetadata(name, new NonImplicitArtifactVariantIdentifier(configurationIdentifier, name), displayName, Describables.of(configurationName), attributes, capabilities, variantArtifacts));
             }
         });
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -23,6 +23,7 @@ import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.Describable;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -46,7 +47,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final VariantIdentifier sourceVariantId;
     private final DisplayName displayName;
     private final String variantName;
-    private final DisplayName ownerDisplayName;
+    private final Describable owner;
     private final ImmutableAttributes attributes;
     private final ImmutableCapabilities capabilities;
     private final List<? extends ComponentArtifactMetadata> artifacts;
@@ -57,7 +58,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         VariantIdentifier sourceVariantId,
         DisplayName displayName,
         String variantName,
-        @Nullable DisplayName ownerDisplayName,
+        @Nullable Describable owner,
         ImmutableAttributes attributes,
         ImmutableCapabilities capabilities,
         List<? extends ComponentArtifactMetadata> artifacts,
@@ -67,7 +68,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         this.sourceVariantId = sourceVariantId;
         this.displayName = displayName;
         this.variantName = variantName;
-        this.ownerDisplayName = ownerDisplayName;
+        this.owner = owner;
         this.attributes = attributes;
         this.capabilities = capabilities;
         this.artifacts = artifacts;
@@ -123,8 +124,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
     @Override
     @Nullable
-    public DisplayName getOwnerDisplayName() {
-        return ownerDisplayName;
+    public Describable getOwner() {
+        return owner;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -45,6 +45,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final VariantResolveMetadata.Identifier identifier;
     private final VariantIdentifier sourceVariantId;
     private final DisplayName displayName;
+    private final String variantName;
+    private final DisplayName ownerDisplayName;
     private final ImmutableAttributes attributes;
     private final ImmutableCapabilities capabilities;
     private final List<? extends ComponentArtifactMetadata> artifacts;
@@ -54,6 +56,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         VariantResolveMetadata.@Nullable Identifier identifier,
         VariantIdentifier sourceVariantId,
         DisplayName displayName,
+        String variantName,
+        @Nullable DisplayName ownerDisplayName,
         ImmutableAttributes attributes,
         ImmutableCapabilities capabilities,
         List<? extends ComponentArtifactMetadata> artifacts,
@@ -62,6 +66,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         this.identifier = identifier;
         this.sourceVariantId = sourceVariantId;
         this.displayName = displayName;
+        this.variantName = variantName;
+        this.ownerDisplayName = ownerDisplayName;
         this.attributes = attributes;
         this.capabilities = capabilities;
         this.artifacts = artifacts;
@@ -108,6 +114,17 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     @Override
     public DisplayName asDescribable() {
         return displayName;
+    }
+
+    @Override
+    public String getVariantName() {
+        return variantName;
+    }
+
+    @Override
+    @Nullable
+    public DisplayName getOwnerDisplayName() {
+        return ownerDisplayName;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -240,6 +240,11 @@ public abstract class LocalFileDependencyBackedArtifactSet implements Transforme
         }
 
         @Override
+        public String getVariantName() {
+            return asDescribable().getDisplayName();
+        }
+
+        @Override
         public List<ResolvedVariant> getCandidates() {
             return Collections.singletonList(this);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.matching.AttributeMatchingCandidate;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -41,16 +42,21 @@ public interface ResolvedVariant extends AttributeMatchingCandidate {
     String getVariantName();
 
     /**
-     * Owner display name (e.g. the parent component or configuration). Paired with {@link #getVariantName()}
-     * so consumers can compose formatted displays without parsing {@link #asDescribable()}.
+     * The owner of this variant (e.g. the parent component or configuration). Paired with
+     * {@link #getVariantName()} so consumers can compose formatted displays without parsing
+     * {@link #asDescribable()}.
+     * <p>
+     * Typed as the common public-API supertype {@link Describable} so producers can pass any concrete
+     * owner and consumers stay decoupled from the concrete type. Read
+     * {@link Describable#getDisplayName()} to render the owner in messages.
      * <p>
      * Defaults to {@code null} (no owner separation); implementations whose variant has a meaningful
      * parent — e.g. {@code <componentId> variant <name>} — must override to expose it.
      *
-     * @return the owner display name, or {@code null} when this variant has no meaningful owner separation
+     * @return the owner, or {@code null} when this variant has no meaningful owner separation
      */
     @Nullable
-    default DisplayName getOwnerDisplayName() {
+    default Describable getOwner() {
         return null;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -33,6 +33,28 @@ public interface ResolvedVariant extends AttributeMatchingCandidate {
     DisplayName asDescribable();
 
     /**
+     * The bare variant-name token, suitable for composing user-facing displays such as
+     * {@code "<owner> variant '<variantName>'"}.
+     *
+     * @return the variant name; never {@code null}
+     */
+    String getVariantName();
+
+    /**
+     * Owner display name (e.g. the parent component or configuration). Paired with {@link #getVariantName()}
+     * so consumers can compose formatted displays without parsing {@link #asDescribable()}.
+     * <p>
+     * Defaults to {@code null} (no owner separation); implementations whose variant has a meaningful
+     * parent — e.g. {@code <componentId> variant <name>} — must override to expose it.
+     *
+     * @return the owner display name, or {@code null} when this variant has no meaningful owner separation
+     */
+    @Nullable
+    default DisplayName getOwnerDisplayName() {
+        return null;
+    }
+
+    /**
      * An identifier for this variant, if available. A variant may not have an identifier when it represents some ad hoc set of artifacts, for example artifacts declared on a dependency
      * using {@link org.gradle.api.artifacts.ModuleDependency#artifact(Action)} or where individual artifacts have been excluded from the variant.
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
@@ -367,6 +367,7 @@ public class LenientPlatformGraphResolveState extends AbstractComponentGraphReso
                 name,
                 new ComponentConfigurationIdentifier(componentId, name),
                 Describables.of(componentId, "variant", variant.getDisplayName()),
+                Describables.of(componentId),
                 variant.getAttributes(),
                 ImmutableList.of(),
                 variant.getCapabilities()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -45,7 +45,6 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -212,20 +211,21 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         return component.getCandidatesForGraphVariantSelection()
             .getVariantsForAttributeMatching()
             .stream()
-            .flatMap(variant -> variant.prepareForArtifactResolution().getArtifactVariants().stream())
-            .map(artifactSet -> new DefaultResolvedVariantResult(
-                component.getId(),
-                Describables.of(composeVariantDisplayName(artifactSet)),
-                attributeDesugaring.desugar(artifactSet.getAttributes().asImmutable()),
-                capabilitiesFor(artifactSet.getCapabilities(), component),
-                null
-            ))
+            .flatMap(variant -> variant.prepareForArtifactResolution().getArtifactVariants().stream()
+                .map(artifactSet -> new DefaultResolvedVariantResult(
+                    component.getId(),
+                    Describables.of(composeArtifactVariantName(variant, artifactSet)),
+                    attributeDesugaring.desugar(artifactSet.getAttributes().asImmutable()),
+                    capabilitiesFor(artifactSet.getCapabilities(), component),
+                    null
+                )))
             .collect(Collectors.toList());
     }
 
-    private static String composeVariantDisplayName(VariantResolveMetadata artifactSet) {
-        DisplayName owner = artifactSet.getOwnerDisplayName();
-        return owner != null ? owner.getDisplayName() + "-" + artifactSet.getName() : artifactSet.getName();
+    private static String composeArtifactVariantName(VariantGraphResolveState parent, VariantResolveMetadata artifactSet) {
+        return artifactSet.getOwnerDisplayName() == null
+            ? artifactSet.getName()
+            : parent.getMetadata().getName() + "-" + artifactSet.getName();
     }
 
     // TODO: Would probably be better if a node already knew its real capabilities instead of

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -223,7 +223,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     }
 
     private static String composeArtifactVariantName(VariantGraphResolveState parent, VariantResolveMetadata artifactSet) {
-        return artifactSet.getOwnerDisplayName() == null
+        return artifactSet.getOwner() == null
             ? artifactSet.getName()
             : parent.getMetadata().getName() + "-" + artifactSet.getName();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -45,11 +45,13 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializer;
 import org.gradle.internal.serialize.Decoder;
@@ -213,12 +215,17 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
             .flatMap(variant -> variant.prepareForArtifactResolution().getArtifactVariants().stream())
             .map(artifactSet -> new DefaultResolvedVariantResult(
                 component.getId(),
-                Describables.of(artifactSet.getName()),
+                Describables.of(composeVariantDisplayName(artifactSet)),
                 attributeDesugaring.desugar(artifactSet.getAttributes().asImmutable()),
                 capabilitiesFor(artifactSet.getCapabilities(), component),
                 null
             ))
             .collect(Collectors.toList());
+    }
+
+    private static String composeVariantDisplayName(VariantResolveMetadata artifactSet) {
+        DisplayName owner = artifactSet.getOwnerDisplayName();
+        return owner != null ? owner.getDisplayName() + "-" + artifactSet.getName() : artifactSet.getName();
     }
 
     // TODO: Would probably be better if a node already knew its real capabilities instead of

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -176,7 +176,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
 
     @Override
     public Set<? extends VariantResolveMetadata> getArtifactVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(name, getIdentifier(), asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, getIdentifier(), asDescribable(), null, getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -637,6 +637,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
+        public DisplayName getOwnerDisplayName() {
+            return Describables.of(componentId);
+        }
+
+        @Override
         public ImmutableAttributes getAttributes() {
             return attributes;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
@@ -637,7 +638,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
-        public DisplayName getOwnerDisplayName() {
+        public Describable getOwner() {
             return Describables.of(componentId);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
@@ -121,7 +122,7 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
-        public DisplayName getOwnerDisplayName() {
+        public Describable getOwner() {
             throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
         }
 
@@ -191,7 +192,7 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
-        public DisplayName getOwnerDisplayName() {
+        public Describable getOwner() {
             return Describables.of(componentId);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -121,6 +121,11 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
+        public DisplayName getOwnerDisplayName() {
+            throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
+        }
+
+        @Override
         public ImmutableAttributes getAttributes() {
             throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
         }
@@ -183,6 +188,11 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         @Override
         public DisplayName asDescribable() {
             return Describables.of(componentId, "variant", name);
+        }
+
+        @Override
+        public DisplayName getOwnerDisplayName() {
+            return Describables.of(componentId);
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.NamedVariantIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
+import org.gradle.api.Describable;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -115,7 +116,7 @@ class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
-    public DisplayName getOwnerDisplayName() {
+    public Describable getOwner() {
         return Describables.of(id.getComponentId());
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -115,6 +115,11 @@ class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
+    public DisplayName getOwnerDisplayName() {
+        return Describables.of(id.getComponentId());
+    }
+
+    @Override
     public ImmutableAttributes getAttributes() {
         return variant.getAttributes().asImmutable();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -128,7 +128,7 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
 
     @Override
     public Set<? extends VariantResolveMetadata> getArtifactVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(name, null, asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+        return ImmutableSet.of(new DefaultVariantMetadata(name, null, asDescribable(), null, getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -85,6 +86,12 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         @Override
         public DisplayName asDescribable() {
             return delegate.asDescribable();
+        }
+
+        @Override
+        @Nullable
+        public DisplayName getOwnerDisplayName() {
+            return delegate.getOwnerDisplayName();
         }
 
         /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.AttributesFactory;
+import org.gradle.api.Describable;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -90,8 +91,8 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
 
         @Override
         @Nullable
-        public DisplayName getOwnerDisplayName() {
-            return delegate.getOwnerDisplayName();
+        public Describable getOwner() {
+            return delegate.getOwner();
         }
 
         /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.jspecify.annotations.Nullable;
 
 public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantBackedConfigurationMetadata {
 
@@ -61,6 +62,12 @@ public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantB
         @Override
         public DisplayName asDescribable() {
             return delegate.asDescribable();
+        }
+
+        @Override
+        @Nullable
+        public DisplayName getOwnerDisplayName() {
+            return delegate.getOwnerDisplayName();
         }
 
         /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.AttributesFactory;
+import org.gradle.api.Describable;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.jspecify.annotations.Nullable;
@@ -66,8 +67,8 @@ public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantB
 
         @Override
         @Nullable
-        public DisplayName getOwnerDisplayName() {
-            return delegate.getOwnerDisplayName();
+        public Describable getOwner() {
+            return delegate.getOwner();
         }
 
         /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -32,8 +33,8 @@ import org.jspecify.annotations.Nullable;
 public final class LocalVariantMetadata extends DefaultVariantMetadata {
     private final CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts;
 
-    public LocalVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable DisplayName ownerDisplayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
-        super(name, identifier, displayName, ownerDisplayName, attributes, ImmutableList.of(), capabilities);
+    public LocalVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable Describable owner, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
+        super(name, identifier, displayName, owner, attributes, ImmutableList.of(), capabilities);
         this.artifacts = artifacts;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
@@ -32,8 +32,8 @@ import org.jspecify.annotations.Nullable;
 public final class LocalVariantMetadata extends DefaultVariantMetadata {
     private final CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts;
 
-    public LocalVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
-        super(name, identifier, displayName, attributes, ImmutableList.of(), capabilities);
+    public LocalVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable DisplayName ownerDisplayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
+        super(name, identifier, displayName, ownerDisplayName, attributes, ImmutableList.of(), capabilities);
         this.artifacts = artifacts;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -27,16 +28,16 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     private final Identifier identifier;
     private final DisplayName displayName;
     @Nullable
-    private final DisplayName ownerDisplayName;
+    private final Describable owner;
     private final ImmutableAttributes attributes;
     private final ImmutableList<? extends ComponentArtifactMetadata> artifacts;
     private final ImmutableCapabilities capabilitiesMetadata;
 
-    public DefaultVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable DisplayName ownerDisplayName, ImmutableAttributes attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ImmutableCapabilities capabilitiesMetadata) {
+    public DefaultVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable Describable owner, ImmutableAttributes attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ImmutableCapabilities capabilitiesMetadata) {
         this.name = name;
         this.identifier = identifier;
         this.displayName = displayName;
-        this.ownerDisplayName = ownerDisplayName;
+        this.owner = owner;
         this.attributes = attributes;
         this.artifacts = artifacts;
         this.capabilitiesMetadata = capabilitiesMetadata;
@@ -59,8 +60,8 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
 
     @Override
     @Nullable
-    public DisplayName getOwnerDisplayName() {
-        return ownerDisplayName;
+    public Describable getOwner() {
+        return owner;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -26,14 +26,17 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     private final String name;
     private final Identifier identifier;
     private final DisplayName displayName;
+    @Nullable
+    private final DisplayName ownerDisplayName;
     private final ImmutableAttributes attributes;
     private final ImmutableList<? extends ComponentArtifactMetadata> artifacts;
     private final ImmutableCapabilities capabilitiesMetadata;
 
-    public DefaultVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ImmutableCapabilities capabilitiesMetadata) {
+    public DefaultVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, @Nullable DisplayName ownerDisplayName, ImmutableAttributes attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ImmutableCapabilities capabilitiesMetadata) {
         this.name = name;
         this.identifier = identifier;
         this.displayName = displayName;
+        this.ownerDisplayName = ownerDisplayName;
         this.attributes = attributes;
         this.artifacts = artifacts;
         this.capabilitiesMetadata = capabilitiesMetadata;
@@ -52,6 +55,12 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     @Override
     public DisplayName asDescribable() {
         return displayName;
+    }
+
+    @Override
+    @Nullable
+    public DisplayName getOwnerDisplayName() {
+        return ownerDisplayName;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -43,18 +44,24 @@ public interface VariantResolveMetadata {
     DisplayName asDescribable();
 
     /**
-     * Owner display name (e.g. the parent component or configuration), used to compose user-facing variant displays.
+     * The owner of this variant — typically the parent component or configuration — used to compose
+     * user-facing variant displays.
      * <p>
-     * May be {@code null} when this variant has no meaningful owner separation (e.g. adhoc artifact sets or
-     * configurations that present themselves without a distinct variant suffix).
+     * Typed as the common public-API supertype {@link Describable} so producers can pass any concrete
+     * owner (a {@link DisplayName}, a {@code Configuration}'s describable, an identifier describable)
+     * and consumers stay decoupled from the concrete type. Read {@link Describable#getDisplayName()}
+     * to render the owner in messages.
      * <p>
-     * Defaults to {@code null} (no owner); implementations that have a meaningful
-     * parent must override to expose it.
+     * May be {@code null} when this variant has no meaningful owner separation (e.g. adhoc artifact
+     * sets or configurations that present themselves without a distinct variant suffix).
+     * <p>
+     * Defaults to {@code null} (no owner); implementations that have a meaningful parent must override
+     * to expose it.
      *
-     * @return the owner display name, or {@code null} when no separation exists
+     * @return the owner, or {@code null} when no separation exists
      */
     @Nullable
-    default DisplayName getOwnerDisplayName() {
+    default Describable getOwner() {
         return null;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -42,6 +42,22 @@ public interface VariantResolveMetadata {
 
     DisplayName asDescribable();
 
+    /**
+     * Owner display name (e.g. the parent component or configuration), used to compose user-facing variant displays.
+     * <p>
+     * May be {@code null} when this variant has no meaningful owner separation (e.g. adhoc artifact sets or
+     * configurations that present themselves without a distinct variant suffix).
+     * <p>
+     * Defaults to {@code null} (no owner); implementations that have a meaningful
+     * parent must override to expose it.
+     *
+     * @return the owner display name, or {@code null} when no separation exists
+     */
+    @Nullable
+    default DisplayName getOwnerDisplayName() {
+        return null;
+    }
+
     ImmutableAttributes getAttributes();
 
     ImmutableList<? extends ComponentArtifactMetadata> getArtifacts();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -17,6 +17,8 @@
 package org.gradle.internal.component.resolution.failure.transform;
 
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.DisplayName;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -30,10 +32,12 @@ import java.util.Objects;
  * properly implement {@link #equals(Object)} and {@link #hashCode()}.
  */
 public final class SourceVariantData {
+    private final @Nullable DisplayName ownerDisplayName;
     private final String variantName;
     private final ImmutableAttributes attributes;
 
-    public SourceVariantData(String variantName, ImmutableAttributes attributes) {
+    public SourceVariantData(@Nullable DisplayName ownerDisplayName, String variantName, ImmutableAttributes attributes) {
+        this.ownerDisplayName = ownerDisplayName;
         this.variantName = variantName;
         this.attributes = attributes;
     }
@@ -47,12 +51,10 @@ public final class SourceVariantData {
     }
 
     public String getFormattedVariantName() {
-        int variantIdx = variantName.indexOf(" variant ");
-        if (variantIdx == -1) {
+        if (ownerDisplayName == null) {
             return variantName;
-        } else {
-            return variantName.substring(0, variantIdx + 9) + "'" + variantName.substring(variantIdx + 9) + "'";
         }
+        return ownerDisplayName.getDisplayName() + " variant '" + variantName + "'";
     }
 
     @Override
@@ -65,12 +67,15 @@ public final class SourceVariantData {
         }
 
         SourceVariantData that = (SourceVariantData) o;
-        return Objects.equals(variantName, that.variantName) && Objects.equals(attributes, that.attributes);
+        return Objects.equals(ownerDisplayName, that.ownerDisplayName)
+            && Objects.equals(variantName, that.variantName)
+            && Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hashCode(variantName);
+        int result = Objects.hashCode(ownerDisplayName);
+        result = 31 * result + Objects.hashCode(variantName);
         result = 31 * result + Objects.hashCode(attributes);
         return result;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.transform;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.DisplayName;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
@@ -32,12 +32,12 @@ import java.util.Objects;
  * properly implement {@link #equals(Object)} and {@link #hashCode()}.
  */
 public final class SourceVariantData {
-    private final @Nullable DisplayName ownerDisplayName;
+    private final @Nullable Describable owner;
     private final String variantName;
     private final ImmutableAttributes attributes;
 
-    public SourceVariantData(@Nullable DisplayName ownerDisplayName, String variantName, ImmutableAttributes attributes) {
-        this.ownerDisplayName = ownerDisplayName;
+    public SourceVariantData(@Nullable Describable owner, String variantName, ImmutableAttributes attributes) {
+        this.owner = owner;
         this.variantName = variantName;
         this.attributes = attributes;
     }
@@ -51,10 +51,10 @@ public final class SourceVariantData {
     }
 
     public String getFormattedVariantName() {
-        if (ownerDisplayName == null) {
+        if (owner == null) {
             return variantName;
         }
-        return ownerDisplayName.getDisplayName() + " variant '" + variantName + "'";
+        return owner.getDisplayName() + " variant '" + variantName + "'";
     }
 
     @Override
@@ -67,14 +67,14 @@ public final class SourceVariantData {
         }
 
         SourceVariantData that = (SourceVariantData) o;
-        return Objects.equals(ownerDisplayName, that.ownerDisplayName)
+        return Objects.equals(owner, that.owner)
             && Objects.equals(variantName, that.variantName)
             && Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hashCode(ownerDisplayName);
+        int result = Objects.hashCode(owner);
         result = 31 * result + Objects.hashCode(variantName);
         result = 31 * result + Objects.hashCode(attributes);
         return result;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.resolution.failure.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.transform.Transform;
 import org.gradle.api.internal.artifacts.transform.TransformStep;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
@@ -43,7 +44,8 @@ public final class TransformedVariantConverter {
     public TransformationChainData convert(TransformedVariant transformedVariant) {
         TransformDataRecordingVisitor visitor = new TransformDataRecordingVisitor();
         transformedVariant.getTransformChain().visitTransformSteps(visitor);
-        SourceVariantData source = new SourceVariantData(transformedVariant.getRoot().asDescribable().getDisplayName(), transformedVariant.getRoot().getAttributes());
+        ResolvedVariant root = transformedVariant.getRoot();
+        SourceVariantData source = new SourceVariantData(root.getOwnerDisplayName(), root.getVariantName(), root.getAttributes());
         return new TransformationChainData(source, visitor.getSteps(), transformedVariant.getAttributes());
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -45,7 +45,7 @@ public final class TransformedVariantConverter {
         TransformDataRecordingVisitor visitor = new TransformDataRecordingVisitor();
         transformedVariant.getTransformChain().visitTransformSteps(visitor);
         ResolvedVariant root = transformedVariant.getRoot();
-        SourceVariantData source = new SourceVariantData(root.getOwnerDisplayName(), root.getVariantName(), root.getAttributes());
+        SourceVariantData source = new SourceVariantData(root.getOwner(), root.getVariantName(), root.getAttributes());
         return new TransformationChainData(source, visitor.getSteps(), transformedVariant.getAttributes());
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -23,8 +23,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
+import org.gradle.api.Describable;
 import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -124,9 +124,9 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         // the same one that resolves its artifacts. This would benefit greatly from "repository deduplication", where we could
         // consider repositories from multiple projects as equivalent as long as they are configured the same (same url, cache policy,
         // component metadata rules, metadata sources, etc.). We should probably leverage ComponentArtifactResolveMetadata#getSources() for this.
-        DisplayName ownerDisplayName = artifactVariant.getOwnerDisplayName();
+        Describable owner = artifactVariant.getOwner();
         // When there is no owner separation, the variant has no meaningful "bare name" distinct from its full display
-        String variantName = ownerDisplayName == null
+        String variantName = owner == null
             ? artifactVariant.asDescribable().getDisplayName()
             : artifactVariant.getName();
         return new ArtifactBackedResolvedVariant(
@@ -134,7 +134,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
             sourceVariantId,
             artifactVariant.asDescribable(),
             variantName,
-            ownerDisplayName,
+            owner,
             attributes,
             capabilities,
             artifacts,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
 import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -57,6 +58,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
             "adhoc",
             identifier,
             Describables.of("adhoc variant for", component.getId()),
+            null,
             component.getAttributes(),
             artifacts,
             ImmutableCapabilities.EMPTY
@@ -122,10 +124,17 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         // the same one that resolves its artifacts. This would benefit greatly from "repository deduplication", where we could
         // consider repositories from multiple projects as equivalent as long as they are configured the same (same url, cache policy,
         // component metadata rules, metadata sources, etc.). We should probably leverage ComponentArtifactResolveMetadata#getSources() for this.
+        DisplayName ownerDisplayName = artifactVariant.getOwnerDisplayName();
+        // When there is no owner separation, the variant has no meaningful "bare name" distinct from its full display
+        String variantName = ownerDisplayName == null
+            ? artifactVariant.asDescribable().getDisplayName()
+            : artifactVariant.getName();
         return new ArtifactBackedResolvedVariant(
             identifier,
             sourceVariantId,
             artifactVariant.asDescribable(),
+            variantName,
+            ownerDisplayName,
             attributes,
             capabilities,
             artifacts,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
@@ -56,6 +56,17 @@ public class ExcludingVariantArtifactSet implements ResolvedVariant, VariantReso
     }
 
     @Override
+    public String getVariantName() {
+        return delegate.getVariantName();
+    }
+
+    @Override
+    @Nullable
+    public DisplayName getOwnerDisplayName() {
+        return delegate.getOwnerDisplayName();
+    }
+
+    @Override
     public VariantResolveMetadata.@Nullable Identifier getIdentifier() {
         return id;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.resolve.resolver;
 
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -62,8 +63,8 @@ public class ExcludingVariantArtifactSet implements ResolvedVariant, VariantReso
 
     @Override
     @Nullable
-    public DisplayName getOwnerDisplayName() {
-        return delegate.getOwnerDisplayName();
+    public Describable getOwner() {
+        return delegate.getOwner();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1115,6 +1115,7 @@ class DependencyGraphBuilderTest extends Specification {
                 name,
                 new ComponentConfigurationIdentifier(componentId, name),
                 Describables.of(name),
+                null,
                 attributes,
                 ImmutableCapabilities.EMPTY,
                 artifactMetadata

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -211,7 +211,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
     }
 
     ResolvedVariant of(List<ResolvableArtifact> artifacts) {
-        return new ArtifactBackedResolvedVariant(id, sourceVariantId, variantDisplayName, ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, [], { artifacts as Set })
+        return new ArtifactBackedResolvedVariant(id, sourceVariantId, variantDisplayName, "test-variant", null, ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, [], { artifacts as Set })
     }
 
     interface TestArtifact extends ResolvableArtifact, Buildable {}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorTest.groovy
@@ -110,8 +110,12 @@ class DefaultArtifactVariantSelectorTest extends Specification {
         set.asDescribable() >> Describables.of('<component>')
         variant1.attributes >> typeAttributes("jar")
         variant1.asDescribable() >> Describables.of('<variant1>')
+        variant1.variantName >> '<variant1>'
+        variant1.ownerDisplayName >> null
         variant2.attributes >> typeAttributes("classes")
         variant2.asDescribable() >> Describables.of('<variant2>')
+        variant2.variantName >> '<variant2>'
+        variant2.ownerDisplayName >> null
 
         attributeMatcher.matchMultipleCandidates(ImmutableList.copyOf(variants), _) >> []
         attributeMatcher.matchMultipleCandidates(transformedVariants, _) >> transformedVariants

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorTest.groovy
@@ -111,11 +111,11 @@ class DefaultArtifactVariantSelectorTest extends Specification {
         variant1.attributes >> typeAttributes("jar")
         variant1.asDescribable() >> Describables.of('<variant1>')
         variant1.variantName >> '<variant1>'
-        variant1.ownerDisplayName >> null
+        variant1.owner >> null
         variant2.attributes >> typeAttributes("classes")
         variant2.asDescribable() >> Describables.of('<variant2>')
         variant2.variantName >> '<variant2>'
-        variant2.ownerDisplayName >> null
+        variant2.owner >> null
 
         attributeMatcher.matchMultipleCandidates(ImmutableList.copyOf(variants), _) >> []
         attributeMatcher.matchMultipleCandidates(transformedVariants, _) >> transformedVariants

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
@@ -266,15 +266,15 @@ class LocalComponentGraphResolveStateFactoryTest extends AbstractProjectBuilderS
         def config2 = state.candidatesForGraphVariantSelection.getVariantByConfigurationName("conf2")
 
         then:
-        config1.prepareForArtifactResolution().artifactVariants*.name as List == ["conf1", "conf1-variant1"]
-        config1.prepareForArtifactResolution().artifactVariants.find { it.name == "conf1-variant1" }.attributes == AttributeTestUtil.attributes(["foo1": "bar1"])
+        config1.prepareForArtifactResolution().artifactVariants*.name as List == ["conf1", "variant1"]
+        config1.prepareForArtifactResolution().artifactVariants.find { it.name == "variant1" }.attributes == AttributeTestUtil.attributes(["foo1": "bar1"])
 
-        config2.prepareForArtifactResolution().artifactVariants*.name as List == ["conf2", "conf2-variant2"]
-        config2.prepareForArtifactResolution().artifactVariants.find { it.name == "conf2-variant2" }.attributes == AttributeTestUtil.attributes(["foo2": "bar2"])
+        config2.prepareForArtifactResolution().artifactVariants*.name as List == ["conf2", "variant2"]
+        config2.prepareForArtifactResolution().artifactVariants.find { it.name == "variant2" }.attributes == AttributeTestUtil.attributes(["foo2": "bar2"])
 
         and:
-        config1.prepareForArtifactResolution().artifactVariants.find { it.name == "conf1-variant1" }.artifacts.size() == 1
-        config2.prepareForArtifactResolution().artifactVariants.find { it.name == "conf2-variant2" }.artifacts.size() == 2
+        config1.prepareForArtifactResolution().artifactVariants.find { it.name == "variant1" }.artifacts.size() == 1
+        config2.prepareForArtifactResolution().artifactVariants.find { it.name == "variant2" }.artifacts.size() == 2
     }
 
     def "builds and caches exclude rules for a configuration"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/resolution/failure/transform/SourceVariantDataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/resolution/failure/transform/SourceVariantDataTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.resolution.failure.transform
+
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.Describables
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue("https://github.com/gradle/gradle/issues/31503")
+class SourceVariantDataTest extends Specification {
+
+    def "formats with an owner display name by composing the parts"() {
+        given:
+        def owner = Describables.of("configuration ':lib:compile'")
+        def data = new SourceVariantData(owner, "variant1", ImmutableAttributes.EMPTY)
+
+        expect:
+        data.formattedVariantName == "configuration ':lib:compile' variant 'variant1'"
+    }
+
+    def "falls back to the bare variant name when owner display is null"() {
+        given:
+        def data = new SourceVariantData(null, "variant 'red'", ImmutableAttributes.EMPTY)
+
+        expect:
+        data.formattedVariantName == "variant 'red'"
+    }
+
+    def "exposes constructor inputs via accessors"() {
+        given:
+        def data = new SourceVariantData(Describables.of("owner"), "variant1", ImmutableAttributes.EMPTY)
+
+        expect:
+        data.variantName == "variant1"
+        data.attributes == ImmutableAttributes.EMPTY
+    }
+
+    def "two source variants sharing a bare name across different owners remain distinct identities"() {
+        given:
+        def fromComponentA = new SourceVariantData(Describables.of("component A"), "runtime", ImmutableAttributes.EMPTY)
+        def fromComponentB = new SourceVariantData(Describables.of("component B"), "runtime", ImmutableAttributes.EMPTY)
+
+        expect:
+        fromComponentA != fromComponentB
+        fromComponentA.hashCode() != fromComponentB.hashCode()
+    }
+
+    def "equality covers owner, variant name, and attributes"() {
+        given:
+        def a = new SourceVariantData(Describables.of("owner-1"), "variant1", ImmutableAttributes.EMPTY)
+        def aPrime = new SourceVariantData(Describables.of("owner-1"), "variant1", ImmutableAttributes.EMPTY)
+        def differentOwner = new SourceVariantData(Describables.of("owner-2"), "variant1", ImmutableAttributes.EMPTY)
+        def differentName = new SourceVariantData(Describables.of("owner-1"), "variant2", ImmutableAttributes.EMPTY)
+        def nullOwner = new SourceVariantData(null, "variant1", ImmutableAttributes.EMPTY)
+        def nullOwnerPrime = new SourceVariantData(null, "variant1", ImmutableAttributes.EMPTY)
+
+        expect:
+        a == aPrime
+        a.hashCode() == aPrime.hashCode()
+        a != differentOwner
+        a != differentName
+        a != nullOwner
+        nullOwner == nullOwnerPrime
+        nullOwner.hashCode() == nullOwnerPrime.hashCode()
+    }
+}


### PR DESCRIPTION
SourceVariantData used to receive a single composed display name and
reverse-parse the variant-name token out of it via indexOf(" variant ").
That made the class brittle and dependent on the structure of an upstream
DisplayName.

Pass the variant name and its owner display separately so the formatter
can compose the user-facing string locally with no string surgery:

`ownerDisplay == null ? variantName : ownerDisplay + " variant '" + variantName + "'"`

Fixes: 
- #31503