### PR TITLE
Support editor reports in Isolated Projects Kotlin DSL scripts model

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest.groovy
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
+import org.gradle.kotlin.dsl.tooling.fixtures.FetchKotlinDslScriptsModelForAllBuilds
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkBuildTreeScriptsModels
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkKotlinDslScriptsModel
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkScriptModelEditorReportsArePositioned
+
+class IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest implements KotlinDslTestProjectInitiation {
+
+    def "can fetch KotlinDslScripts model contains editor reports for #scriptError-broken #scriptKind script in lenient mode"() {
+        withSettings("""
+            ${scriptError(scriptKind, ScriptKind.SETTINGS, scriptError)}
+        """)
+        withBuildScript(scriptError(scriptKind, ScriptKind.BUILD, scriptError))
+        if (scriptKind == ScriptKind.INIT) {
+            def initScript = file("init.gradle.kts")
+            initScript.text = scriptError(scriptKind, ScriptKind.INIT, scriptError)
+            // The executer is reset() after each run, which clears its init scripts.
+            // Use beforeExecute so the --init-script arg is re-applied before each fetch.
+            executer.beforeExecute { it.usingInitScript(initScript) }
+        }
+
+        when:
+        def originalModel = fetchScriptsModelLeniently()
+
+        then:
+        fixture.assertNoConfigurationCache()
+        // Sanity check: vintage model actually carries editor reports for the broken script
+        originalModel.scriptModels.values().any { !it.editorReports.isEmpty() }
+
+        when:
+        withIsolatedProjects()
+        def model = fetchScriptsModelLeniently()
+
+        then:
+        checkKotlinDslScriptsModel(model, originalModel)
+
+        where:
+        [scriptKind, scriptError] << [ScriptKind.values() as List, ScriptError.values() as List].combinations()
+        // A settings *compile* error is intentionally excluded: without a compilable settings script the
+        // build can't determine project structure, so no model is produced at all (the fetch throws) —
+        // unlike a settings *runtime* error, which lenient mode tolerates, and unlike build/init compile
+        // errors, which degrade gracefully.
+            .findAll { it != [ScriptKind.SETTINGS, ScriptError.COMPILE] }
+    }
+
+    def "can fetch KotlinDslScripts model honors subproject-local locationAwareEditorHints for runtime-broken script in lenient mode"() {
+        withSettings("""
+            include("a")
+        """)
+        withBuildScript(ScriptError.RUNTIME.snippet)
+        withBuildScriptIn("a", ScriptError.RUNTIME.snippet)
+        file("a/gradle.properties") << "org.gradle.kotlin.dsl.internal.locationAwareEditorHints=true"
+
+        when:
+        def originalModel = fetchScriptsModelLeniently()
+
+        then:
+        fixture.assertNoConfigurationCache()
+        // Sanity check: vintage produces a positioned editor report for :a/build.gradle.kts
+        checkScriptModelEditorReportsArePositioned(originalModel.scriptModels, "a${File.separator}build.gradle.kts")
+
+        when:
+        withIsolatedProjects()
+        def model = fetchScriptsModelLeniently()
+
+        then:
+        checkKotlinDslScriptsModel(model, originalModel)
+    }
+
+    def "can fetch KotlinDslScripts model honors root-level locationAwareEditorHints for runtime-broken #scriptKinds script in lenient mode"() {
+        file("gradle.properties") << "org.gradle.kotlin.dsl.internal.locationAwareEditorHints=true"
+        withSettings("""
+            ${scriptError(scriptKinds, ScriptKind.SETTINGS, ScriptError.RUNTIME)}
+        """)
+        withBuildScript(scriptError(scriptKinds, ScriptKind.BUILD, ScriptError.RUNTIME))
+        if (scriptKinds.contains(ScriptKind.INIT)) {
+            def initScript = file("init.gradle.kts")
+            initScript.text = scriptError(scriptKinds, ScriptKind.INIT, ScriptError.RUNTIME)
+            executer.beforeExecute { it.usingInitScript(initScript) }
+        }
+
+        when:
+        def originalModel = fetchScriptsModelLeniently()
+
+        then:
+        fixture.assertNoConfigurationCache()
+        // Sanity check: vintage produces a positioned editor report for the broken scripts
+        scriptKinds.forEach {
+            checkScriptModelEditorReportsArePositioned(originalModel.scriptModels, it.scriptFileName)
+        }
+
+        when:
+        withIsolatedProjects()
+        def model = fetchScriptsModelLeniently()
+
+        then:
+        checkKotlinDslScriptsModel(model, originalModel)
+
+        where:
+        scriptKinds << (ScriptKind.values() as List).subsequences()
+    }
+
+    def "can fetch KotlinDslScripts model with positioned editor reports for runtime-broken settings and build scripts across composite build in lenient mode"() {
+        file("gradle.properties") << "org.gradle.kotlin.dsl.internal.locationAwareEditorHints=true"
+        file("included/gradle.properties") << "org.gradle.kotlin.dsl.internal.locationAwareEditorHints=true"
+
+        withSettingsIn("included", """
+            include("a")
+            ${ScriptError.RUNTIME.snippet}
+        """)
+        withBuildScriptIn("included")
+        withBuildScriptIn("included/a", ScriptError.RUNTIME.snippet)
+
+        withSettings("""
+            includeBuild("included")
+            rootProject.name = "root"
+            include("a")
+            ${ScriptError.RUNTIME.snippet}
+        """)
+        withBuildScript()
+        withBuildScriptIn("a", ScriptError.RUNTIME.snippet)
+
+        when:
+        def originalModel = fetchBuildTreeScriptsModelsLeniently()
+
+        then:
+        fixture.assertNoConfigurationCache()
+        // Sanity check: vintage produces positioned reports for each broken script in each build.
+        checkScriptModelEditorReportsArePositioned(originalModel[":"].scriptModels, "settings.gradle.kts")
+        checkScriptModelEditorReportsArePositioned(originalModel[":"].scriptModels, "a${File.separator}build.gradle.kts".toString())
+        checkScriptModelEditorReportsArePositioned(originalModel[":included"].scriptModels, "settings.gradle.kts")
+        checkScriptModelEditorReportsArePositioned(originalModel[":included"].scriptModels, "a${File.separator}build.gradle.kts".toString())
+
+        when:
+        withIsolatedProjects()
+        def ipModel = fetchBuildTreeScriptsModelsLeniently()
+
+        then:
+        checkBuildTreeScriptsModels(ipModel, originalModel)
+    }
+
+    def "can fetch KotlinDslScripts model with editor reports for compile-broken build scripts across composite build in lenient mode"() {
+        // Settings scripts are left valid on purpose: a settings *compile* error is a hard failure that
+        // prevents the build from producing any model. Build-script compile errors degrade gracefully in
+        // lenient mode and surface as a ScriptCompilationException whose 'location' embeds the compiler's
+        // temp-copy path (normalized by the model checker so IP and non-IP compare equal).
+        withSettingsIn("included", """
+            include("a")
+        """)
+        withBuildScriptIn("included/a", ScriptError.COMPILE.snippet)
+
+        withSettings("""
+            includeBuild("included")
+        """)
+        withBuildScript(ScriptError.COMPILE.snippet)
+
+        when:
+        def originalModel = fetchBuildTreeScriptsModelsLeniently()
+
+        then:
+        fixture.assertNoConfigurationCache()
+        // Sanity check: vintage carries the compile-error exception for the broken build scripts in each build.
+        originalModel[":"].scriptModels.values().any { !it.exceptions.isEmpty() }
+        originalModel[":included"].scriptModels.values().any { !it.exceptions.isEmpty() }
+
+        when:
+        withIsolatedProjects()
+        def ipModel = fetchBuildTreeScriptsModelsLeniently()
+
+        then:
+        checkBuildTreeScriptsModels(ipModel, originalModel)
+    }
+
+    private KotlinDslScriptsModel fetchScriptsModelLeniently() {
+        toolingApiExecutor.withToolingApiJvmArgs("-Dorg.gradle.kotlin.dsl.provider.mode=classpath")
+        return fetchModel(KotlinDslScriptsModel)
+    }
+
+    private Map<String, KotlinDslScriptsModel> fetchBuildTreeScriptsModelsLeniently() {
+        return runBuildAction(new FetchKotlinDslScriptsModelForAllBuilds()) {
+            addJvmArguments("-Dorg.gradle.kotlin.dsl.provider.mode=classpath")
+        }
+    }
+
+    // Returns the error snippet for 'target' when it is among the broken kinds, otherwise an empty string —
+    // used to inject broken scripts of the requested kinds into an otherwise valid build.
+    private static String scriptError(Collection<ScriptKind> brokenKinds, ScriptKind target, ScriptError error) {
+        target in brokenKinds ? error.snippet : ""
+    }
+
+    private static String scriptError(ScriptKind brokenKind, ScriptKind target, ScriptError error) {
+        scriptError([brokenKind], target, error)
+    }
+
+    private enum ScriptKind {
+        BUILD("build.gradle.kts"),
+        SETTINGS("settings.gradle.kts"),
+        INIT("init.gradle.kts")
+
+        final String scriptFileName
+
+        ScriptKind(String scriptFileName) {
+            this.scriptFileName = scriptFileName
+        }
+    }
+
+    private enum ScriptError {
+        // The script compiles but throws during execution; in lenient (classpath) mode the model builder
+        // continues and surfaces a LocationAwareException pointing at the real script (eligible for a
+        // positioned editor report).
+        RUNTIME('error("fail")'),
+        // The script fails to compile; the failure is a ScriptCompilationException, which is filtered out
+        // of positioned reports and only yields the generic "Build configuration failed" warning. Its
+        // message embeds the compiler's temp copy path (normalized by the model checker).
+        COMPILE('val x: Int = "not an int"')
+
+        final String snippet
+
+        ScriptError(String snippet) {
+            this.snippet = snippet
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.isolated
 import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.kotlin.dsl.tooling.fixtures.FetchKotlinDslScriptsModelForAllBuilds
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+import org.junit.Assume
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkBuildTreeScriptsModels
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkKotlinDslScriptsModel
@@ -27,13 +28,19 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.check
 class IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest implements KotlinDslTestProjectInitiation {
 
     def "can fetch KotlinDslScripts model contains editor reports for #scriptError-broken #scriptKind script in lenient mode"() {
+        // A settings *compile* error is intentionally excluded: without a compilable settings script the
+        // build can't determine project structure, so no model is produced at all (the fetch throws) —
+        // unlike a settings *runtime* error, which lenient mode tolerates, and unlike build/init compile
+        // errors, which degrade gracefully.
+        Assume.assumeFalse(scriptKind == ScriptKind.SETTINGS && scriptError == ScriptError.COMPILE)
+
         withSettings("""
-            ${scriptError(scriptKind, ScriptKind.SETTINGS, scriptError)}
+            ${scriptErrorSnippet(scriptKind, ScriptKind.SETTINGS, scriptError)}
         """)
-        withBuildScript(scriptError(scriptKind, ScriptKind.BUILD, scriptError))
+        withBuildScript(scriptErrorSnippet(scriptKind, ScriptKind.BUILD, scriptError))
         if (scriptKind == ScriptKind.INIT) {
             def initScript = file("init.gradle.kts")
-            initScript.text = scriptError(scriptKind, ScriptKind.INIT, scriptError)
+            initScript.text = scriptErrorSnippet(scriptKind, ScriptKind.INIT, scriptError)
             // The executer is reset() after each run, which clears its init scripts.
             // Use beforeExecute so the --init-script arg is re-applied before each fetch.
             executer.beforeExecute { it.usingInitScript(initScript) }
@@ -55,12 +62,10 @@ class IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest extends Ab
         checkKotlinDslScriptsModel(model, originalModel)
 
         where:
-        [scriptKind, scriptError] << [ScriptKind.values() as List, ScriptError.values() as List].combinations()
-        // A settings *compile* error is intentionally excluded: without a compilable settings script the
-        // build can't determine project structure, so no model is produced at all (the fetch throws) —
-        // unlike a settings *runtime* error, which lenient mode tolerates, and unlike build/init compile
-        // errors, which degrade gracefully.
-            .findAll { it != [ScriptKind.SETTINGS, ScriptError.COMPILE] }
+        scriptKind << ScriptKind.values()
+
+        combined:
+        scriptError << ScriptError.values()
     }
 
     def "can fetch KotlinDslScripts model honors subproject-local locationAwareEditorHints for runtime-broken script in lenient mode"() {
@@ -90,12 +95,12 @@ class IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest extends Ab
     def "can fetch KotlinDslScripts model honors root-level locationAwareEditorHints for runtime-broken #scriptKinds script in lenient mode"() {
         file("gradle.properties") << "org.gradle.kotlin.dsl.internal.locationAwareEditorHints=true"
         withSettings("""
-            ${scriptError(scriptKinds, ScriptKind.SETTINGS, ScriptError.RUNTIME)}
+            ${scriptErrorSnippet(scriptKinds, ScriptKind.SETTINGS, ScriptError.RUNTIME)}
         """)
-        withBuildScript(scriptError(scriptKinds, ScriptKind.BUILD, ScriptError.RUNTIME))
+        withBuildScript(scriptErrorSnippet(scriptKinds, ScriptKind.BUILD, ScriptError.RUNTIME))
         if (scriptKinds.contains(ScriptKind.INIT)) {
             def initScript = file("init.gradle.kts")
-            initScript.text = scriptError(scriptKinds, ScriptKind.INIT, ScriptError.RUNTIME)
+            initScript.text = scriptErrorSnippet(scriptKinds, ScriptKind.INIT, ScriptError.RUNTIME)
             executer.beforeExecute { it.usingInitScript(initScript) }
         }
 
@@ -204,12 +209,12 @@ class IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest extends Ab
 
     // Returns the error snippet for 'target' when it is among the broken kinds, otherwise an empty string —
     // used to inject broken scripts of the requested kinds into an otherwise valid build.
-    private static String scriptError(Collection<ScriptKind> brokenKinds, ScriptKind target, ScriptError error) {
+    private static String scriptErrorSnippet(Collection<ScriptKind> brokenKinds, ScriptKind target, ScriptError error) {
         target in brokenKinds ? error.snippet : ""
     }
 
-    private static String scriptError(ScriptKind brokenKind, ScriptKind target, ScriptError error) {
-        scriptError([brokenKind], target, error)
+    private static String scriptErrorSnippet(ScriptKind brokenKind, ScriptKind target, ScriptError error) {
+        scriptErrorSnippet([brokenKind], target, error)
     }
 
     private enum ScriptKind {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslCompositeBuildIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslCompositeBuildIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.kotlin.dsl.tooling.fixtures.FetchKotlinDslScriptsModelForAllBuilds
+import org.gradle.tooling.BuildActionExecuter
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinDslModelChecker.checkBuildTreeScriptsModels
@@ -232,7 +233,7 @@ class IsolatedProjectsToolingApiKotlinDslCompositeBuildIntegrationTest extends A
         "build-logic"      | """pluginManagement { includeBuild("build-logic") }"""
     }
 
-    Map<String , KotlinDslScriptsModel> fetchBuildTreeScriptModels() {
-        return runBuildAction(new FetchKotlinDslScriptsModelForAllBuilds())
+    private Map<String, KotlinDslScriptsModel> fetchBuildTreeScriptModels(@DelegatesTo(BuildActionExecuter) Closure config = {}) {
+        return runBuildAction(new FetchKotlinDslScriptsModelForAllBuilds(), config)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
@@ -134,5 +134,4 @@ class IsolatedProjectsToolingApiKotlinDslIntegrationTest extends AbstractIsolate
             return controller.getModel(build.rootProject, KotlinDslScriptsModel)
         }
     }
-
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
@@ -134,4 +134,5 @@ class IsolatedProjectsToolingApiKotlinDslIntegrationTest extends AbstractIsolate
             return controller.getModel(build.rootProject, KotlinDslScriptsModel)
         }
     }
+
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -481,7 +481,7 @@ val Project.hierarchy: Sequence<Project>
     }
 
 
-private
+internal
 val Project.isLocationAwareEditorHintsEnabled: Boolean
     get() = findProperty(EditorReports.locationAwareEditorHintsPropertyName) == "true"
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -217,7 +217,7 @@ fun <T : Any> commonPrefixOf(lists: List<List<T>>): List<T> =
     } ?: emptyList()
 
 
-private
+internal
 fun mapEditorReports(internalReports: List<org.gradle.kotlin.dsl.tooling.models.EditorReport>): List<EditorReport> =
     internalReports.map { internalReport ->
         StandardEditorReport(

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
@@ -48,7 +48,11 @@ import org.gradle.kotlin.dsl.tooling.builders.discoverInitScripts
 import org.gradle.kotlin.dsl.tooling.builders.discoverPrecompiledScriptPluginScripts
 import org.gradle.kotlin.dsl.tooling.builders.discoverSettingScript
 import org.gradle.kotlin.dsl.tooling.builders.resolveCorrelationIdParameter
+import org.gradle.kotlin.dsl.tooling.builders.buildEditorReportsFor
+import org.gradle.kotlin.dsl.tooling.builders.mapEditorReports
 import org.gradle.kotlin.dsl.tooling.builders.runtimeFailuresLocatedIn
+import org.gradle.kotlin.dsl.resolver.EditorReports
+import org.gradle.kotlin.dsl.tooling.builders.isLocationAwareEditorHintsEnabled
 import org.gradle.kotlin.dsl.tooling.builders.scriptCompilationClassPath
 import org.gradle.kotlin.dsl.tooling.builders.scriptHandlerFactoryOf
 import org.gradle.kotlin.dsl.tooling.builders.settings
@@ -81,10 +85,37 @@ class IsolatedProjectsSafeKotlinDslScriptsModelBuilder(
     private
     fun buildFor(rootProject: ProjectInternal): StandardKotlinDslScriptsModel {
         val base = ScriptModelBase(rootProject)
-        val nonProjectScriptModels = buildNonProjectScriptModels(rootProject, base)
-        val projectHierarchyScriptModels = buildScriptModelsInHierarchy(rootProject, base, intermediateModelProvider)
+
+        // Phase 1: trigger all script evaluations that may populate the build-scoped exception collector.
+        //   - nonProjectIntermediateModels evaluates init and settings scripts, collecting failures during
+        //     script compilation classpath and accessors classpath computation accordingly.
+        //   - visitProjectHierarchy builds each project's IsolatedScriptsModel, which evaluates project
+        //     build scripts under lenient mode and collects any failures.
+        // Each IsolatedScriptsModel also snapshots its locationAwareEditorHints in the per-project context.
+        val nonProjectIntermediate = nonProjectIntermediateModels(rootProject)
+        val projectHierarchy = visitProjectHierarchy(rootProject, intermediateModelProvider)
+
+        // Phase 2: snapshot the exceptions caught by the collector.
+        val exceptions = rootProject.serviceOf<ClassPathModeExceptionCollector>().exceptions
+
+        // Phase 3: assemble output models. Non-project scripts (init, settings) use the root project's
+        // locationAwareEditorHints; per-project scripts use their owning project's value.
+        val nonProjectScriptModels = buildOutputsForNonProject(nonProjectIntermediate, base, exceptions)
+        val projectHierarchyScriptModels = buildOutputsForHierarchy(projectHierarchy, base, exceptions)
         return createStandardKotlinDslScriptsModel(nonProjectScriptModels + projectHierarchyScriptModels)
     }
+}
+
+
+private fun buildOutputsForNonProject(
+    nonProjectIntermediate: List<NonProjectScriptModel>,
+    base: ScriptModelBase,
+    exceptions: List<Exception>
+): Map<File, StandardKotlinDslScriptModel> = nonProjectIntermediate.associateBy({ it.scriptFile }) {
+    val classPath = base.nonProjectScriptPaths.bin + it.classPath
+    val gradleKotlinDslJar = classPath.filter(::isGradleKotlinDslJar)
+    val sourcePath = gradleKotlinDslJar + base.nonProjectScriptPaths.src + it.sourcePath
+    buildOutputModel(it.scriptFile, classPath, sourcePath, base.implicitImports, exceptions, base.locationAwareEditorHints)
 }
 
 
@@ -108,25 +139,25 @@ class ScriptModelBase(
         rootProject.gradleSourceRoots()
     }
 
-    val classPathModeExceptions: List<Exception> by unsafeLazy {
-        rootProject.serviceOf<ClassPathModeExceptionCollector>().exceptions
-    }
-
     val implicitImports: List<String> by unsafeLazy {
         rootProject.serviceOf<ImplicitImports>().list
     }
 
+    val locationAwareEditorHints: Boolean by unsafeLazy {
+        rootProject.isLocationAwareEditorHintsEnabled
+    }
+
     val nonProjectScriptPaths: ScriptClassPath by unsafeLazy {
         ScriptClassPath(
-            bin = ClassPath.EMPTY, // Non-project script models currently resolve their base classpath themselves
-            src = ClassPath.EMPTY + gradleSourceRoots
+            bin = EMPTY, // Non-project script models currently resolve their base classpath themselves
+            src = EMPTY + gradleSourceRoots
         )
     }
 
     val scriptPaths: ScriptClassPath by unsafeLazy {
         ScriptClassPath(
             bin = scriptClassPath,
-            src = ClassPath.EMPTY + buildSrcSources + gradleSourceRoots
+            src = EMPTY + buildSrcSources + gradleSourceRoots
         )
     }
 }
@@ -137,23 +168,15 @@ data class ScriptClassPath(val bin: ClassPath, val src: ClassPath)
 
 
 private
-fun buildNonProjectScriptModels(
-    rootProject: ProjectInternal,
-    base: ScriptModelBase
-): Map<File, StandardKotlinDslScriptModel> {
-
-    val intermediateModels = buildList {
+fun nonProjectIntermediateModels(rootProject: ProjectInternal): List<NonProjectScriptModel> =
+    buildList {
         addAll(initScriptModels(rootProject))
         addNotNull(settingsScriptModel(rootProject))
     }
 
-    return intermediateModels.associateBy({ it.scriptFile }) {
-        val classPath = base.nonProjectScriptPaths.bin + it.classPath
-        val gradleKotlinDslJar = classPath.filter(::isGradleKotlinDslJar)
-        val sourcePath = gradleKotlinDslJar + base.nonProjectScriptPaths.src + it.sourcePath
-        buildOutputModel(it.scriptFile, classPath, sourcePath, base.implicitImports, base.classPathModeExceptions)
-    }
-}
+
+internal
+data class VisitedProject(val model: IsolatedScriptsModel, val parentSourcePath: ClassPath)
 
 
 /**
@@ -163,13 +186,11 @@ fun buildNonProjectScriptModels(
  * since then IDE can still show code highlighting for at least some parts of Kotlin DSL script, even if project configuration fails.
  */
 private
-fun buildScriptModelsInHierarchy(
+fun visitProjectHierarchy(
     rootProject: ProjectInternal,
-    base: ScriptModelBase,
     intermediateModelProvider: IntermediateToolingModelProvider
-): Map<File, KotlinDslScriptModel> {
-
-    val outputModels = mutableMapOf<File, KotlinDslScriptModel>()
+): List<VisitedProject> {
+    val visited = mutableListOf<VisitedProject>()
     val classPathModeExceptionCollector = rootProject.serviceOf<ClassPathModeExceptionCollector>()
 
     fun prepareForParallelAccess() {
@@ -178,18 +199,6 @@ fun buildScriptModelsInHierarchy(
         // so a broken root build degrades to empty accessors instead of aborting the model build.
         classPathModeExceptionCollector.runCatching {
             rootProject.serviceOf<Stage1BlocksAccessorClassPathGenerator>().prepareForParallelAccess()
-        }
-    }
-
-    fun collect(models: IsolatedScriptsModel, parentSourcePath: ClassPath) {
-        for (childScriptModel in models.models) {
-            val classPath = childScriptModel.localClassPath
-            val gradleKotlinDslJar = classPath.filter(::isGradleKotlinDslJar)
-            val effectiveParentSourcePath = if (childScriptModel.includeParentSourcePath) parentSourcePath else EMPTY
-            val sourcePath = gradleKotlinDslJar + base.scriptPaths.src + effectiveParentSourcePath + childScriptModel.localSourcePath
-            val implicitImports = base.implicitImports + childScriptModel.localImplicitImports
-            val outputModel = buildOutputModel(childScriptModel.scriptFile, classPath, sourcePath, implicitImports, base.classPathModeExceptions)
-            outputModels[childScriptModel.scriptFile] = outputModel
         }
     }
 
@@ -202,7 +211,7 @@ fun buildScriptModelsInHierarchy(
                 classPathModeExceptionCollector.collect(original as? Exception ?: RuntimeException(original))
             }
             result.model?.let {
-                collect(it, parentSourcePath)
+                visited.add(VisitedProject(it, parentSourcePath))
                 visitChildren(child, parentSourcePath + it.buildScriptSourcePath)
             }
         }
@@ -210,9 +219,38 @@ fun buildScriptModelsInHierarchy(
 
     prepareForParallelAccess()
     val rootModel = isolatedScriptsModelFor(rootProject)
-    collect(rootModel, ClassPath.EMPTY)
+    visited.add(VisitedProject(rootModel, EMPTY))
     visitChildren(rootProject.owner, rootModel.buildScriptSourcePath)
+    return visited
+}
 
+
+private
+fun buildOutputsForHierarchy(
+    visitedProjects: List<VisitedProject>,
+    base: ScriptModelBase,
+    exceptions: List<Exception>
+): Map<File, KotlinDslScriptModel> {
+    val outputModels = mutableMapOf<File, KotlinDslScriptModel>()
+    visitedProjects.forEach { (model, parentSourcePath) ->
+        for (childScriptModel in model.models) {
+            val classPath = childScriptModel.localClassPath
+            val gradleKotlinDslJar = classPath.filter(::isGradleKotlinDslJar)
+            val effectiveParentSourcePath = if (childScriptModel.includeParentSourcePath) parentSourcePath else EMPTY
+            val sourcePath = gradleKotlinDslJar + base.scriptPaths.src + effectiveParentSourcePath + childScriptModel.localSourcePath
+            val implicitImports = base.implicitImports + childScriptModel.localImplicitImports
+            // Use the owning project's locationAwareEditorHints — a subproject's gradle.properties
+            // override is only visible inside that project's IsolatedScriptsModel build.
+            outputModels[childScriptModel.scriptFile] = buildOutputModel(
+                childScriptModel.scriptFile,
+                classPath,
+                sourcePath,
+                implicitImports,
+                exceptions,
+                model.locationAwareEditorHints
+            )
+        }
+    }
     return outputModels
 }
 
@@ -303,7 +341,8 @@ data class IntermediateScriptModel(
 internal
 data class IsolatedScriptsModel(
     val models: List<IntermediateScriptModel>,
-    val buildScriptSourcePath: ClassPath
+    val buildScriptSourcePath: ClassPath,
+    val locationAwareEditorHints: Boolean
 )
 
 
@@ -328,8 +367,12 @@ fun isolatedScriptsModelFor(project: ProjectInternal): IsolatedScriptsModel {
     }
     val buildScriptSourcePath =
         if (buildScriptModel != null) sourcePathFor(listOf(project.buildscript))
-        else ClassPath.EMPTY
-    return IsolatedScriptsModel(models, buildScriptSourcePath)
+        else EMPTY
+    // Subproject-local gradle.properties IS honored here on purpose, matching the vintage builder.
+    // Project.findProperty is now safe under IP,so it reads only this project's own properties —
+    // including subproject-local gradle.properties.
+    val locationAwareEditorHints = project.isLocationAwareEditorHintsEnabled
+    return IsolatedScriptsModel(models, buildScriptSourcePath, locationAwareEditorHints)
 }
 
 
@@ -373,7 +416,7 @@ fun precompiledScriptModelsFor(project: ProjectInternal): List<IntermediateScrip
         IntermediateScriptModel(
             scriptFile,
             classPath,
-            ClassPath.EMPTY,
+            EMPTY,
             accessorImports + pluginSpecImports,
             includeParentSourcePath = false
         )
@@ -381,14 +424,20 @@ fun precompiledScriptModelsFor(project: ProjectInternal): List<IntermediateScrip
 }
 
 private
-fun buildOutputModel(scriptFile: File, classPath: ClassPath, sourcePath: ClassPath, implicitImports: List<String>, exceptions: List<Exception>) =
-    StandardKotlinDslScriptModel(
-        classPath.asFiles,
-        sourcePath.asFiles,
-        implicitImports,
-        editorReports = emptyList(), // TODO:isolated support editor reports
-        exceptions = getExceptionsForFile(scriptFile, exceptions)
-    )
+fun buildOutputModel(
+    scriptFile: File,
+    classPath: ClassPath,
+    sourcePath: ClassPath,
+    implicitImports: List<String>,
+    exceptions: List<Exception>,
+    locationAwareEditorHints: Boolean
+) = StandardKotlinDslScriptModel(
+    classPath.asFiles,
+    sourcePath.asFiles,
+    implicitImports,
+    editorReports = mapEditorReports(buildEditorReportsFor(scriptFile, exceptions, locationAwareEditorHints)),
+    exceptions = getExceptionsForFile(scriptFile, exceptions)
+)
 
 
 private

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
@@ -51,7 +51,6 @@ import org.gradle.kotlin.dsl.tooling.builders.resolveCorrelationIdParameter
 import org.gradle.kotlin.dsl.tooling.builders.buildEditorReportsFor
 import org.gradle.kotlin.dsl.tooling.builders.mapEditorReports
 import org.gradle.kotlin.dsl.tooling.builders.runtimeFailuresLocatedIn
-import org.gradle.kotlin.dsl.resolver.EditorReports
 import org.gradle.kotlin.dsl.tooling.builders.isLocationAwareEditorHintsEnabled
 import org.gradle.kotlin.dsl.tooling.builders.scriptCompilationClassPath
 import org.gradle.kotlin.dsl.tooling.builders.scriptHandlerFactoryOf
@@ -86,20 +85,15 @@ class IsolatedProjectsSafeKotlinDslScriptsModelBuilder(
     fun buildFor(rootProject: ProjectInternal): StandardKotlinDslScriptsModel {
         val base = ScriptModelBase(rootProject)
 
-        // Phase 1: trigger all script evaluations that may populate the build-scoped exception collector.
-        //   - nonProjectIntermediateModels evaluates init and settings scripts, collecting failures during
-        //     script compilation classpath and accessors classpath computation accordingly.
-        //   - visitProjectHierarchy builds each project's IsolatedScriptsModel, which evaluates project
-        //     build scripts under lenient mode and collects any failures.
-        // Each IsolatedScriptsModel also snapshots its locationAwareEditorHints in the per-project context.
         val nonProjectIntermediate = nonProjectIntermediateModels(rootProject)
         val projectHierarchy = visitProjectHierarchy(rootProject, intermediateModelProvider)
 
-        // Phase 2: snapshot the exceptions caught by the collector.
+        // Script evaluation failures are reported to a single build-scoped collector rather than travelling
+        // back with each intermediate model, so we read them here once every script (init, settings, and
+        // every project's build script) has been evaluated above.
+        // TODO:isolated reconsider this central-collector approach for the IP-first model builders.
         val exceptions = rootProject.serviceOf<ClassPathModeExceptionCollector>().exceptions
 
-        // Phase 3: assemble output models. Non-project scripts (init, settings) use the root project's
-        // locationAwareEditorHints; per-project scripts use their owning project's value.
         val nonProjectScriptModels = buildOutputsForNonProject(nonProjectIntermediate, base, exceptions)
         val projectHierarchyScriptModels = buildOutputsForHierarchy(projectHierarchy, base, exceptions)
         return createStandardKotlinDslScriptsModel(nonProjectScriptModels + projectHierarchyScriptModels)
@@ -175,8 +169,8 @@ fun nonProjectIntermediateModels(rootProject: ProjectInternal): List<NonProjectS
     }
 
 
-internal
-data class VisitedProject(val model: IsolatedScriptsModel, val parentSourcePath: ClassPath)
+private
+data class ProjectModelWithParentSource(val model: IsolatedScriptsModel, val parentSourcePath: ClassPath)
 
 
 /**
@@ -189,8 +183,8 @@ private
 fun visitProjectHierarchy(
     rootProject: ProjectInternal,
     intermediateModelProvider: IntermediateToolingModelProvider
-): List<VisitedProject> {
-    val visited = mutableListOf<VisitedProject>()
+): List<ProjectModelWithParentSource> {
+    val visited = mutableListOf<ProjectModelWithParentSource>()
     val classPathModeExceptionCollector = rootProject.serviceOf<ClassPathModeExceptionCollector>()
 
     fun prepareForParallelAccess() {
@@ -211,7 +205,7 @@ fun visitProjectHierarchy(
                 classPathModeExceptionCollector.collect(original as? Exception ?: RuntimeException(original))
             }
             result.model?.let {
-                visited.add(VisitedProject(it, parentSourcePath))
+                visited.add(ProjectModelWithParentSource(it, parentSourcePath))
                 visitChildren(child, parentSourcePath + it.buildScriptSourcePath)
             }
         }
@@ -219,7 +213,7 @@ fun visitProjectHierarchy(
 
     prepareForParallelAccess()
     val rootModel = isolatedScriptsModelFor(rootProject)
-    visited.add(VisitedProject(rootModel, EMPTY))
+    visited.add(ProjectModelWithParentSource(rootModel, EMPTY))
     visitChildren(rootProject.owner, rootModel.buildScriptSourcePath)
     return visited
 }
@@ -227,7 +221,7 @@ fun visitProjectHierarchy(
 
 private
 fun buildOutputsForHierarchy(
-    visitedProjects: List<VisitedProject>,
+    visitedProjects: List<ProjectModelWithParentSource>,
     base: ScriptModelBase,
     exceptions: List<Exception>
 ): Map<File, KotlinDslScriptModel> {
@@ -368,9 +362,6 @@ fun isolatedScriptsModelFor(project: ProjectInternal): IsolatedScriptsModel {
     val buildScriptSourcePath =
         if (buildScriptModel != null) sourcePathFor(listOf(project.buildscript))
         else EMPTY
-    // Subproject-local gradle.properties IS honored here on purpose, matching the vintage builder.
-    // Project.findProperty is now safe under IP,so it reads only this project's own properties —
-    // including subproject-local gradle.properties.
     val locationAwareEditorHints = project.isLocationAwareEditorHintsEnabled
     return IsolatedScriptsModel(models, buildScriptSourcePath, locationAwareEditorHints)
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
@@ -26,6 +26,14 @@ import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.check
 
 class KotlinDslModelChecker {
 
+    static void checkScriptModelEditorReportsArePositioned(Map<File, KotlinDslScriptModel> scriptModels, String scriptFileName) {
+        // Anchor the match to a path-segment boundary: a bare endsWith("a/build.gradle.kts") also matches a
+        // root build script under a temp dir that happens to end in 'a' (e.g. ".../todga/build.gradle.kts").
+        def script = scriptModels.keySet().find { it.path == scriptFileName || it.path.endsWith(File.separator + scriptFileName) }
+        assert script != null: "no script model found ending with '$scriptFileName'"
+        assert scriptModels[script].editorReports.any { it.position != null }: "no positioned editor report on '$scriptFileName'"
+    }
+
     static void checkBuildTreeScriptsModels(Map<String, KotlinDslScriptsModel> actual, Map<String, KotlinDslScriptsModel> expected) {
         assert actual.keySet() == expected.keySet()
         actual.each { build, actualModel ->
@@ -44,10 +52,30 @@ class KotlinDslModelChecker {
             { withNormalizedAccessorHash(it.classPath) },
             { withNormalizedAccessorHash(it.sourcePath) },
             { it.implicitImports },
-            // TODO:isolated support editor reports
-//            [{ it.editorReports }, { a, e -> checkEditorReport(a, e) }],
-            { it.exceptions },
+            [{ it.editorReports }, { a, e -> checkEditorReport(a, e) }],
+            // Stack-trace strings legitimately differ between IP and non-IP runs
+            // (different call stacks during script evaluation). Compare only the
+            // exception class + message line, which is stable across the two modes.
+            { it.exceptions.collect { normalizeExceptionSummary(it) } },
         ])
+    }
+
+    private static String normalizeExceptionSummary(String exceptionString) {
+        // Drop stack-frame lines (start with whitespace: "\tat ..." or "\t... N more").
+        // This yields the exception class + message and any "Caused by:" headers,
+        // which are stable across IP and non-IP runs.
+        exceptionString.readLines()
+            .findAll { !it.matches(/\s+.*/) }
+            .collect { normalizeCompilerTempPath(it) }
+            .join("\n")
+    }
+
+    // A compile error's ScriptCompilationException reports its 'location' in a throwaway file, not the real
+    // script: the Kotlin DSL compiles generated "residual program" fragments written to a fresh
+    // "gradle-kotlin-dsl-<random>" temp dir (see TemporaryScriptFiles.withTemporaryScriptFileFor). IP and
+    // non-IP get different <random> values, so scrub it — otherwise it's the one field that breaks parity.
+    private static String normalizeCompilerTempPath(String line) {
+        line.replaceAll(/gradle-kotlin-dsl-\d+\.tmp/, "gradle-kotlin-dsl-<tmp>.tmp")
     }
 
     private static void checkEditorReport(actual, expected) {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.tooling.fixtures
 
 
+import java.nio.file.Paths
 import org.gradle.tooling.model.kotlin.dsl.EditorReport
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
@@ -27,9 +28,8 @@ import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.check
 class KotlinDslModelChecker {
 
     static void checkScriptModelEditorReportsArePositioned(Map<File, KotlinDslScriptModel> scriptModels, String scriptFileName) {
-        // Anchor the match to a path-segment boundary: a bare endsWith("a/build.gradle.kts") also matches a
-        // root build script under a temp dir that happens to end in 'a' (e.g. ".../todga/build.gradle.kts").
-        def script = scriptModels.keySet().find { it.path == scriptFileName || it.path.endsWith(File.separator + scriptFileName) }
+        def expectedPath = Paths.get(scriptFileName)
+        def script = scriptModels.keySet().find { it.toPath().endsWith(expectedPath) }
         assert script != null: "no script model found ending with '$scriptFileName'"
         assert scriptModels[script].editorReports.any { it.position != null }: "no positioned editor report on '$scriptFileName'"
     }


### PR DESCRIPTION
Fixes: #37913 

### Context

The Isolated Projects-safe `KotlinDslScriptsModel` builder did not emit editor
reports, so under Isolated Projects the IDE lost the inline build-script
diagnostics (the "location-aware editor hints") that the vintage builder
provides. This PR closes that gap, bringing the IP builder to parity with the
vintage one — the final step in making the Kotlin DSL scripts model fully
equivalent under Isolated Projects.

What changed:

- **Editor reports under Isolated Projects.** Script failures are read once from
  the build-scoped `ClassPathModeExceptionCollector` after the whole project
  hierarchy is visited, then threaded into each script's output model.
- **Per-project `location-aware-editor-hints`.** The flag is captured while each
  project's intermediate model is built, so a subproject-local
  `gradle.properties` override is honored under Isolated Projects (cross-project
  property lookup is forbidden, so the root cannot read it).
- Reuses the existing report-building helpers (`mapEditorReports`,
  `Project.isLocationAwareEditorHintsEnabled`) by widening them to `internal`.

Testing:

- New `IsolatedProjectsToolingApiKotlinDslBrokenScriptsIntegrationTest`
  consolidates broken-script parity coverage: runtime and compile errors across
  build/settings/init scripts, root-level and subproject-local hints, and
  composite builds. Each case asserts the IP model matches the vintage model.
- `KotlinDslModelChecker` now actually compares editor reports (previously
  skipped). Two fixes were needed for a stable comparison: normalizing the random
  Kotlin DSL compiler temp-script path in compile-error exceptions (it differs
  between IP and vintage runs), and anchoring the positioned-report lookup to a
  path-segment boundary so it can't match a root build script under a temp
  directory whose name ends in the looked-up segment.

Note: compile errors intentionally yield only a whole-file warning, not a
positioned one — the IDE's own Kotlin compiler positions those, so duplicating
them would be noise. This mirrors existing vintage behavior.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
