### PR TITLE
Restore :properties task under Isolated Projects

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/PropertyReportTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/PropertyReportTaskIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.api.tasks.diagnostics
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import spock.lang.Issue
 
-@ToBeFixedForIsolatedProjects(because = "The `properties` task calls Project.getProperties() internally, which is a hard violation under Isolated Projects")
 class PropertyReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
@@ -52,5 +53,27 @@ class PropertyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         run "properties", "-q", "--property=nonexistent"
         then:
         outputContains 'nonexistent: null'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/35797")
+    @Requires(value = TestExecutionPreconditions.IsolatedProjects, reason = "Under Isolated Projects the parent walk is disabled, so parent-only properties must not appear in a child's properties report")
+    def "subproject properties report does not include parent-only properties under Isolated Projects"() {
+        given:
+        settingsFile << """
+            include 'sub'
+        """
+        buildFile << """
+            ext.parentOnly = 'from-root'
+        """
+        file("sub/build.gradle") << """
+            ext.childOnly = 'from-sub'
+        """
+
+        when:
+        run ":sub:properties", "-q"
+
+        then:
+        outputContains 'childOnly: from-sub'
+        outputDoesNotContain 'parentOnly'
     }
 }

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/PropertyReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/PropertyReportTask.java
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.diagnostics;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -26,7 +27,6 @@ import org.gradle.api.tasks.diagnostics.internal.PropertyReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.ReportRenderer;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.Pair;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.work.DisableCachingByDefault;
@@ -74,10 +74,9 @@ public abstract class PropertyReportTask extends AbstractProjectBasedReportTask<
         return computePropertyReportModel(project);
     }
 
-    @SuppressWarnings("deprecation")
     private PropertyReportTask.PropertyReportModel computePropertyReportModel(Project project) {
         PropertyReportModel model = new PropertyReportModel();
-        Map<String, ?> projectProperties = DeprecationLogger.whileDisabled(project::getProperties);
+        Map<String, ?> projectProperties = ((ProjectInternal) project).collectPropertiesInternal();
         if (getProperty().isPresent()) {
             String propertyName = getProperty().get();
             if ("properties".equals(propertyName)) {

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -440,6 +440,17 @@ It is recommended to enable this flag in builds that are migrating to or already
 enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
 ----
 
+[[sec:properties_report_no_inherited]]
+=== Properties report does not include properties inherited from parent projects
+
+Under Isolated Projects, the <<command_line_interface.adoc#sec:listing_properties,properties report>>
+of a child project lists only the properties defined on that project itself.
+Properties inherited from parent projects are not present in the report.
+This is a consequence of the <<sec:no_implicit_parents_lookup,no implicit parent lookup>> behavior.
+
+Direct uses of link:{javadocPath}/org/gradle/api/Project.html#getProperties--[`Project.getProperties()`]
+continue to be reported as an Isolated Projects violation, as that API is being phased out.
+
 [[sec:migration]]
 == Migration
 

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.BuildScriptBuilder
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.TextUtil
 import org.hamcrest.Matcher
@@ -85,7 +84,6 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         outputContains "init - Initializes a new Gradle build."
     }
 
-    @ToBeFixedForIsolatedProjects(because = "The `properties` task calls Project.getProperties() internally, which is a hard violation under Isolated Projects")
     def "creates a simple project with #scriptDsl build scripts when no pom file present and no type specified"() {
         given:
         useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
@@ -112,7 +110,6 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @ToBeFixedForIsolatedProjects(because = "The `properties` task calls Project.getProperties() internally, which is a hard violation under Isolated Projects")
     def "creates a simple project with #scriptDsl build scripts when no pom file present and no type specified which uses @Incubating APIs"() {
         given:
         useTestDirectoryThatIsNotEmbeddedInAnotherBuild()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1226,6 +1226,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         );
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public Map<String, ? extends @Nullable Object> collectPropertiesInternal() {
+        return extensibleDynamicObject.getProperties();
+    }
+
     @Override
     public WorkResult copy(Closure closure) {
         return copy(configureUsing(closure));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -471,6 +471,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.getProperties();
     }
 
+    @Override
+    public Map<String, ? extends @Nullable Object> collectPropertiesInternal() {
+        return delegate.collectPropertiesInternal();
+    }
+
     @Nullable
     @Override
     public Object property(String propertyName) throws MissingPropertyException {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -232,6 +232,20 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     Object getLifecycleActionsState();
 
     /**
+     * Returns the project's properties without firing the deprecation of {@link Project#getProperties()}
+     * or the Isolated Projects violation it triggers.
+     *
+     * <p>Intended for internal callers (e.g., diagnostic tasks) that have a legitimate need to enumerate
+     * the project's properties and accept responsibility for the call.
+     *
+     * @apiNote <p><b>Deliberately named {@code collect..}</b>, a {@code get*} name would make
+     * this a Groovy bean property on {@code Project}. {@code BeanDynamicObject.getProperties()}
+     * enumerates bean properties by invoking each getter — which would recurse straight back into
+     * this method via {@code extensibleDynamicObject.getProperties()}.
+     */
+    Map<String, ? extends @Nullable Object> collectPropertiesInternal();
+
+    /**
      * Two {@link ProjectInternal} instances are considered equal if their {@link #getProjectIdentity() identity} is equal.
      *
      * @param obj the object to compare with this project


### PR DESCRIPTION
## Summary

Closes #35797.

`:properties` fails under Isolated Projects with *use of `Project.getProperties()` is not allowed with Isolated Projects* (regression from #37782). The violation was justified when `Project.getProperties()` walked the parent projects properties, but #37830 disabled that walk under IP, making the violation superficial for internal callers like `PropertyReportTask`.

## Approach

Introduce internal-only `ProjectInternal.collectProperties()` that returns the same map without firing the deprecation or the IP violation. `PropertyReportTask` switches to it. The user-facing `Project.getProperties()` keeps the Vintage deprecation **and** the IP violation — calling `project.properties` from a build script still fails under IP exactly as before.

The method is named `collectProperties()` rather than `getPropertiesInternal()` so it isn't treated as a Groovy bean property — otherwise `BeanDynamicObject.getProperties()` would enumerate the getter and recurse into itself.

## Test plan

- [x] `:base-diagnostics:isolatedProjectsIntegTest --tests PropertyReportTaskIntegrationTest` — class-level `@ToBeFixedForIsolatedProjects` removed; new IP-only test verifies parent-only properties do **not** leak into a child's `:properties` report.
- [x] `:build-init:isolatedProjectsIntegTest --tests "BuildInitPluginIntegrationTest.creates a simple project*"` — stale `@ToBeFixedForIsolatedProjects` annotations removed (these tests also call `:properties`).
- [x] `:configuration-cache:forkingIntegTest --tests "IsolatedProjectsAccessFromGroovyDslIntegrationTest.reports problem when build script uses *"` — user-code regression guard unchanged; `println(properties)` and `println(project.properties)` still fire the violation.

Targeting `release` for RC2 per [Slack discussion](https://gradle.slack.com/archives/C05Q92AUM8D/p1779956515867689?thread_ts=1778161808.514089&cid=C05Q92AUM8D).