### PR TITLE
Unpack InvocationTargetException when building the Failure tree

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
@@ -25,6 +25,7 @@ import org.gradle.internal.exceptions.MultiCauseException;
 import org.gradle.util.internal.CollectionUtils;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -86,6 +87,10 @@ public class DefaultFailureFactory implements FailureFactory {
         }
 
         private Failure convertRecursively(Throwable failure) {
+            // InvocationTargetException carries no information of its own beyond the wrapped target.
+            while (failure instanceof InvocationTargetException && failure.getCause() != null && seen.add(failure)) {
+                failure = failure.getCause();
+            }
             if (!seen.add(failure)) {
                 Throwable replacement = new Throwable("[CIRCULAR REFERENCE: " + failure + "]");
                 replacement.setStackTrace(failure.getStackTrace());

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.failure.SimulatedJavaException
 import spock.lang.Specification
 
+import java.lang.reflect.InvocationTargetException
+
 class DefaultFailureFactoryTest extends Specification {
 
     def "creates failure from a throwable with circular references"() {
@@ -60,6 +62,56 @@ class DefaultFailureFactoryTest extends Specification {
 
         secondCause.header == "java.lang.RuntimeException: Simulated exception"
         secondCause.causes.empty
+    }
+
+    def "unwraps InvocationTargetException when it appears as a cause"() {
+        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE)
+        def real = new IllegalStateException("real failure")
+        def outer = new RuntimeException("outer", new InvocationTargetException(real))
+
+        when:
+        def failure = factory.create(outer)
+
+        then:
+        failure.exceptionType == RuntimeException
+        failure.causes.size() == 1
+        failure.causes[0].original.is(real)
+        failure.causes[0].causes.empty
+    }
+
+    def "unwraps InvocationTargetException when it is the top-level throwable"() {
+        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE)
+        def real = new IllegalStateException("real failure")
+
+        when:
+        def failure = factory.create(new InvocationTargetException(real))
+
+        then:
+        failure.original.is(real)
+    }
+
+    def "collapses chained InvocationTargetExceptions"() {
+        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE)
+        def real = new IllegalStateException("real failure")
+        def doubleWrapped = new InvocationTargetException(new InvocationTargetException(real))
+
+        when:
+        def failure = factory.create(doubleWrapped)
+
+        then:
+        failure.original.is(real)
+    }
+
+    def "keeps InvocationTargetException with no target as-is"() {
+        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE)
+        def ite = new InvocationTargetException(null)
+
+        when:
+        def failure = factory.create(ite)
+
+        then:
+        failure.exceptionType == InvocationTargetException
+        failure.causes.empty
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -45,6 +45,7 @@ import org.gradle.util.Path
 import spock.lang.Specification
 
 import java.lang.reflect.Field
+import java.lang.reflect.InvocationTargetException
 
 class BuildExceptionReporterTest extends Specification {
     final TestStyledTextOutput output = new TestStyledTextOutput()
@@ -258,6 +259,55 @@ $MESSAGE
    {info}> {normal}<cause1.2>
 {info}> {normal}<cause2>
    {info}> {normal}<cause2.1>
+
+* Try:
+$STACKTRACE
+$INFO_OR_DEBUG
+$TRY_SCAN
+$GET_HELP
+"""
+    }
+
+    def "unpacks InvocationTargetException so the real cause is shown"() {
+        Throwable exception = new LocationAwareException(
+            new GradleException(MESSAGE, new InvocationTargetException(new RuntimeException(FAILURE))),
+            LOCATION, 42)
+
+        expect:
+        reporter.buildFinished(failure(exception))
+        output.value == """
+{failure}FAILURE: {normal}{failure}Build failed with an exception.{normal}
+
+* Where:
+$LOCATION line: 42
+
+* What went wrong:
+$MESSAGE
+{info}> {normal}$FAILURE
+
+* Try:
+$STACKTRACE
+$INFO_OR_DEBUG
+$TRY_SCAN
+$GET_HELP
+"""
+    }
+
+    def "keeps InvocationTargetException with no target in the output"() {
+        Throwable exception = new LocationAwareException(
+            new GradleException(MESSAGE, new InvocationTargetException(null)), LOCATION, 42)
+
+        expect:
+        reporter.buildFinished(failure(exception))
+        output.value == """
+{failure}FAILURE: {normal}{failure}Build failed with an exception.{normal}
+
+* Where:
+$LOCATION line: 42
+
+* What went wrong:
+$MESSAGE
+{info}> {normal}java.lang.reflect.InvocationTargetException (no error message)
 
 * Try:
 $STACKTRACE


### PR DESCRIPTION
`InvocationTargetException` carries no information of its own beyond the wrapped target, but the console renderer treated it as an opaque node and emitted "InvocationTargetException (no error message)", hiding the real cause.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/11413

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
