### PR TITLE
Include target project directory in tooling model cache key

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiTargetProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiTargetProjectIntegrationTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
+
+class IsolatedProjectsToolingApiTargetProjectIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+
+    def "model cache key differentiates between target subproject directories"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            rootProject.name = 'root'
+            include('a')
+            include('b')
+        """
+        file("a/build.gradle") << "plugins.apply(my.MyPlugin)"
+        file("b/build.gradle") << "plugins.apply(my.MyPlugin)"
+
+        when:
+        withIsolatedProjects()
+        executer.inDirectory(file("a"))
+        def modelA = fetchModel(SomeToolingModel)
+
+        then:
+        modelA.message == "It works from project :a"
+
+        when:
+        withIsolatedProjects()
+        executer.inDirectory(file("b"))
+        def modelB = fetchModel(SomeToolingModel)
+
+        then:
+        modelB.message == "It works from project :b"
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiTargetProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiTargetProjectIntegrationTest.groovy
@@ -20,10 +20,10 @@ import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 
 class IsolatedProjectsToolingApiTargetProjectIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
-    def "model cache key differentiates between target subproject directories"() {
+    def "caches model per target project directory"() {
         given:
         withSomeToolingModelBuilderPluginInBuildSrc()
-        settingsFile << """
+        settingsFile """
             rootProject.name = 'root'
             include('a')
             include('b')
@@ -31,20 +31,46 @@ class IsolatedProjectsToolingApiTargetProjectIntegrationTest extends AbstractIso
         file("a/build.gradle") << "plugins.apply(my.MyPlugin)"
         file("b/build.gradle") << "plugins.apply(my.MyPlugin)"
 
-        when:
+        when: "first query targets subproject 'a' — stores a new cache entry"
         withIsolatedProjects()
         executer.inDirectory(file("a"))
-        def modelA = fetchModel(SomeToolingModel)
+        def modelA1 = fetchModel(SomeToolingModel)
 
         then:
-        modelA.message == "It works from project :a"
+        modelA1.message == "It works from project :a"
+        fixture.assertModelStored {
+            projectsConfigured(":buildSrc", ":")
+            modelsCreated(":a")
+        }
 
-        when:
+        when: "query targets subproject 'b' — must miss :a's cache and store its own"
         withIsolatedProjects()
         executer.inDirectory(file("b"))
-        def modelB = fetchModel(SomeToolingModel)
+        def modelB1 = fetchModel(SomeToolingModel)
 
         then:
-        modelB.message == "It works from project :b"
+        modelB1.message == "It works from project :b"
+        fixture.assertModelStored {
+            projectsConfigured(":buildSrc", ":")
+            modelsCreated(":b")
+        }
+
+        when: "repeat query against 'a' — loads from :a's cache"
+        withIsolatedProjects()
+        executer.inDirectory(file("a"))
+        def modelA2 = fetchModel(SomeToolingModel)
+
+        then:
+        modelA2.message == "It works from project :a"
+        fixture.assertModelLoaded()
+
+        when: "repeat query against 'b' — loads from :b's cache"
+        withIsolatedProjects()
+        executer.inDirectory(file("b"))
+        def modelB2 = fetchModel(SomeToolingModel)
+
+        then:
+        modelB2.message == "It works from project :b"
+        fixture.assertModelLoaded()
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -66,6 +66,14 @@ class ConfigurationCacheKey(
         if (buildActionRequirements.isRunsTasks) {
             appendRequestedTasks()
         }
+        if (buildActionRequirements.isCreatesModel) {
+            // Tooling model queries target a specific project directory
+            // (via `ProjectConnection.forProjectDirectory(...)`), and different
+            // subprojects of the same root build can produce different models.
+            // Include the project directory in the key so that consecutive model
+            // queries against different subprojects do not collide.
+            appendTargetProjectDirectory()
+        }
 
         putBoolean(startParameter.isOffline)
         putBoolean(startParameter.isIsolatedProjects)
@@ -123,21 +131,26 @@ class ConfigurationCacheKey(
             // Because unqualified task names are resolved relative to the selected
             // sub-project according to either `projectDirectory` or `currentDirectory`,
             // the relative directory information must be part of the key.
-            val projectDir = startParameter.projectDirectory
-            if (projectDir != null) {
-                relativePathOf(
-                    projectDir,
-                    startParameter.buildTreeRootDirectory
-                ).let { relativeProjectDir ->
-                    putString(relativeProjectDir)
-                }
-            } else {
-                relativeChildPathOrNull(
-                    startParameter.currentDirectory,
-                    startParameter.buildTreeRootDirectory
-                )?.let { relativeSubDir ->
-                    putString(relativeSubDir)
-                }
+            appendTargetProjectDirectory()
+        }
+    }
+
+    private
+    fun Hasher.appendTargetProjectDirectory() {
+        val projectDir = startParameter.projectDirectory
+        if (projectDir != null) {
+            relativePathOf(
+                projectDir,
+                startParameter.buildTreeRootDirectory
+            ).let { relativeProjectDir ->
+                putString(relativeProjectDir)
+            }
+        } else {
+            relativeChildPathOrNull(
+                startParameter.currentDirectory,
+                startParameter.buildTreeRootDirectory
+            )?.let { relativeSubDir ->
+                putString(relativeSubDir)
             }
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -61,21 +61,27 @@ class ConfigurationCacheKey(
 
         buildActionRequirements.appendKeyTo(this)
 
-        var trackingTargetDirectory = false
-        if (buildActionRequirements.isCreatesModel) {
+        val hasRelativeTaskNames = sequenceOf(startParameter.requestedTaskNames, startParameter.excludedTaskNames).flatten()
+            .any { !it.startsWith(':') }
+        if (buildActionRequirements.isCreatesModel || (buildActionRequirements.isRunsTasks && hasRelativeTaskNames)) {
+            // (1)
             // Tooling model queries target a specific project directory
             // (via `ProjectConnection.forProjectDirectory(...)`), and different
             // subprojects of the same root build can produce different models.
             // Include the project directory in the key so that consecutive model
             // queries against different subprojects do not collide.
+            // (2)
+            // Because unqualified task names are resolved relative to the selected
+            // sub-project according to either `projectDirectory` or `currentDirectory`,
+            // the relative directory information must be part of the key.
             appendTargetProjectDirectory()
-            trackingTargetDirectory = true
         }
 
         // TODO:bamboo review with Adam
 //        require(buildActionRequirements.isRunsTasks || startParameter.requestedTaskNames.isEmpty())
         if (buildActionRequirements.isRunsTasks) {
-            appendRequestedTasks(trackingTargetDirectory)
+            putAll(startParameter.requestedTaskNames)
+            putAll(startParameter.excludedTaskNames)
         }
 
         putBoolean(startParameter.isOffline)
@@ -102,24 +108,6 @@ class ConfigurationCacheKey(
                 }
             }
         )
-    }
-
-    private
-    fun Hasher.appendRequestedTasks(appendedTargetProjectDirectory: Boolean) {
-        val requestedTaskNames = startParameter.requestedTaskNames
-        putAll(requestedTaskNames)
-
-        val excludedTaskNames = startParameter.excludedTaskNames
-        putAll(excludedTaskNames)
-
-        val taskNames = requestedTaskNames.asSequence() + excludedTaskNames.asSequence()
-        val hasRelativeTaskName = taskNames.any { !it.startsWith(':') }
-        if (hasRelativeTaskName && !appendedTargetProjectDirectory) {
-            // Because unqualified task names are resolved relative to the selected
-            // sub-project according to either `projectDirectory` or `currentDirectory`,
-            // the relative directory information must be part of the key.
-            appendTargetProjectDirectory()
-        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -61,11 +61,7 @@ class ConfigurationCacheKey(
 
         buildActionRequirements.appendKeyTo(this)
 
-        // TODO:bamboo review with Adam
-//        require(buildActionRequirements.isRunsTasks || startParameter.requestedTaskNames.isEmpty())
-        if (buildActionRequirements.isRunsTasks) {
-            appendRequestedTasks()
-        }
+        var trackingTargetDirectory = false
         if (buildActionRequirements.isCreatesModel) {
             // Tooling model queries target a specific project directory
             // (via `ProjectConnection.forProjectDirectory(...)`), and different
@@ -73,6 +69,13 @@ class ConfigurationCacheKey(
             // Include the project directory in the key so that consecutive model
             // queries against different subprojects do not collide.
             appendTargetProjectDirectory()
+            trackingTargetDirectory = true
+        }
+
+        // TODO:bamboo review with Adam
+//        require(buildActionRequirements.isRunsTasks || startParameter.requestedTaskNames.isEmpty())
+        if (buildActionRequirements.isRunsTasks) {
+            appendRequestedTasks(trackingTargetDirectory)
         }
 
         putBoolean(startParameter.isOffline)
@@ -118,7 +121,7 @@ class ConfigurationCacheKey(
     }
 
     private
-    fun Hasher.appendRequestedTasks() {
+    fun Hasher.appendRequestedTasks(appendedTargetProjectDirectory: Boolean) {
         val requestedTaskNames = startParameter.requestedTaskNames
         putAll(requestedTaskNames)
 
@@ -127,7 +130,7 @@ class ConfigurationCacheKey(
 
         val taskNames = requestedTaskNames.asSequence() + excludedTaskNames.asSequence()
         val hasRelativeTaskName = taskNames.any { !it.startsWith(':') }
-        if (hasRelativeTaskName) {
+        if (hasRelativeTaskName && !appendedTargetProjectDirectory) {
             // Because unqualified task names are resolved relative to the selected
             // sub-project according to either `projectDirectory` or `currentDirectory`,
             // the relative directory information must be part of the key.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -81,8 +81,8 @@ class ConfigurationCacheKey(
         putBoolean(startParameter.isOffline)
         putBoolean(startParameter.isIsolatedProjects)
         putBuildScan()
-        putDevelocityUrl()
-        putDevelocityPluginVersion()
+        putStringIfNotNull(startParameter.develocityUrl)
+        putStringIfNotNull(startParameter.develocityPluginVersion)
         putBoolean(encryptionConfiguration.isEncrypting)
         putHash(encryptionConfiguration.encryptionKeyHashCode)
         putBoolean(startParameter.isDeduplicatingStrings)
@@ -105,22 +105,6 @@ class ConfigurationCacheKey(
     }
 
     private
-    fun Hasher.putDevelocityUrl() {
-        val develocityUrl = startParameter.develocityUrl
-        if (develocityUrl != null) {
-            putString(develocityUrl)
-        }
-    }
-
-    private
-    fun Hasher.putDevelocityPluginVersion() {
-        val develocityPluginVersion = startParameter.develocityPluginVersion
-        if (develocityPluginVersion != null) {
-            putString(develocityPluginVersion)
-        }
-    }
-
-    private
     fun Hasher.appendRequestedTasks(appendedTargetProjectDirectory: Boolean) {
         val requestedTaskNames = startParameter.requestedTaskNames
         putAll(requestedTaskNames)
@@ -140,28 +124,27 @@ class ConfigurationCacheKey(
 
     private
     fun Hasher.appendTargetProjectDirectory() {
+        val buildTreeRoot = startParameter.buildTreeRootDirectory
         val projectDir = startParameter.projectDirectory
-        if (projectDir != null) {
-            relativePathOf(
-                projectDir,
-                startParameter.buildTreeRootDirectory
-            ).let { relativeProjectDir ->
-                putString(relativeProjectDir)
-            }
+        val relativeDir = if (projectDir != null) {
+            relativePathOf(projectDir, buildTreeRoot)
         } else {
-            relativeChildPathOrNull(
-                startParameter.currentDirectory,
-                startParameter.buildTreeRootDirectory
-            )?.let { relativeSubDir ->
-                putString(relativeSubDir)
-            }
+            relativeChildPathOrNull(startParameter.currentDirectory, buildTreeRoot)
         }
+        putStringIfNotNull(relativeDir)
     }
 
     private
     fun Hasher.putAll(list: Collection<String>) {
         putInt(list.size)
         list.forEach(::putString)
+    }
+
+    private
+    fun Hasher.putStringIfNotNull(value: String?) {
+        if (value != null) {
+            putString(value)
+        }
     }
 
     /**

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
@@ -18,13 +18,17 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.initialization.layout.BuildLayout
+import org.gradle.internal.Describables
+import org.gradle.internal.DisplayName
 import org.gradle.internal.buildoption.DefaultInternalOptions
 import org.gradle.internal.buildoption.Option
+import org.gradle.internal.buildtree.BuildActionModelRequirements
 import org.gradle.internal.buildtree.RunTasksRequirements
 import org.gradle.internal.buildtree.control.BuildModelParametersProvider
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.encryption.EncryptionConfiguration
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.Hasher
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.initialization.layout.BuildTreeLocations
 import org.gradle.internal.scripts.DefaultScriptFileResolver
@@ -132,8 +136,35 @@ class ConfigurationCacheKeyTest {
         )
     }
 
+    @Test
+    fun `model query cache key differs by project directory`() {
+        val rootDir = file("root").apply { mkdirs() }
+        val subA = rootDir.createDir("a")
+        val subB = rootDir.createDir("b")
+
+        assertThat(
+            modelCacheKeyStringFromStartParameter { projectDir = subA },
+            equalTo(modelCacheKeyStringFromStartParameter { projectDir = subA })
+        )
+        assertThat(
+            modelCacheKeyStringFromStartParameter { projectDir = subA },
+            not(equalTo(modelCacheKeyStringFromStartParameter { projectDir = subB }))
+        )
+    }
+
     private
-    fun cacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String {
+    fun cacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String =
+        cacheKeyString(configure) { RunTasksRequirements(it) }
+
+    private
+    fun modelCacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String =
+        cacheKeyString(configure) { ModelOnlyRequirements(it) }
+
+    private
+    fun cacheKeyString(
+        configure: StartParameterInternal.() -> Unit,
+        requirements: (StartParameterInternal) -> BuildActionModelRequirements
+    ): String {
         val startParameter = StartParameterInternal().apply(configure)
         val internalOptions = DefaultInternalOptions(mapOf())
         return ConfigurationCacheKey(
@@ -143,7 +174,7 @@ class ConfigurationCacheKeyTest {
                 internalOptions,
                 BuildModelParametersProvider.parameters(RunTasksRequirements(startParameter), internalOptions),
             ),
-            RunTasksRequirements(startParameter),
+            requirements(startParameter),
             object : EncryptionConfiguration {
                 override val encryptionKeyHashCode: HashCode
                     get() = Hashing.newHasher().hash()
@@ -153,6 +184,20 @@ class ConfigurationCacheKeyTest {
                     get() = SupportedEncryptionAlgorithm.getDefault()
             }
         ).string
+    }
+
+    private
+    class ModelOnlyRequirements(
+        private val startParameter: StartParameterInternal
+    ) : BuildActionModelRequirements {
+        override fun isRunsTasks(): Boolean = false
+        override fun isCreatesModel(): Boolean = true
+        override fun getStartParameter(): StartParameterInternal = startParameter
+        override fun getActionDisplayName(): DisplayName = Describables.of("creating tooling model")
+        override fun getConfigurationCacheKeyDisplayName(): DisplayName = Describables.of("the requested model")
+        override fun appendKeyTo(hasher: Hasher) {
+            hasher.putByte(2)
+        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
@@ -152,6 +152,58 @@ class ConfigurationCacheKeyTest {
         )
     }
 
+    @Test
+    fun `model query cache key differs by current directory when project directory is not set`() {
+        val rootDir = file("root").apply { mkdirs() }
+        val subA = rootDir.createDir("a")
+        val subB = rootDir.createDir("b")
+
+        assertThat(
+            modelCacheKeyStringFromStartParameter { setCurrentDir(subA) },
+            equalTo(modelCacheKeyStringFromStartParameter { setCurrentDir(subA) })
+        )
+        assertThat(
+            modelCacheKeyStringFromStartParameter { setCurrentDir(subA) },
+            not(equalTo(modelCacheKeyStringFromStartParameter { setCurrentDir(subB) }))
+        )
+    }
+
+    @Test
+    fun `model query cache key includes project directory even when an action also runs tasks`() {
+        val rootDir = file("root").apply { mkdirs() }
+        val subA = rootDir.createDir("a")
+        val subB = rootDir.createDir("b")
+
+        assertThat(
+            cacheKeyString({ projectDir = subA }) { ModelOnlyRequirements(it, runsTasks = true) },
+            not(
+                equalTo(
+                    cacheKeyString({ projectDir = subB }) { ModelOnlyRequirements(it, runsTasks = true) }
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `task-only cache key is unaffected by project directory when no unqualified task name is present`() {
+        val rootDir = file("root").apply { mkdirs() }
+        val subA = rootDir.createDir("a")
+        val subB = rootDir.createDir("b")
+
+        assertThat(
+            cacheKeyStringFromStartParameter {
+                projectDir = subA
+                setTaskNames(listOf(":help"))
+            },
+            equalTo(
+                cacheKeyStringFromStartParameter {
+                    projectDir = subB
+                    setTaskNames(listOf(":help"))
+                }
+            )
+        )
+    }
+
     private
     fun cacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String =
         cacheKeyString(configure) { RunTasksRequirements(it) }
@@ -188,9 +240,10 @@ class ConfigurationCacheKeyTest {
 
     private
     class ModelOnlyRequirements(
-        private val startParameter: StartParameterInternal
+        private val startParameter: StartParameterInternal,
+        private val runsTasks: Boolean = false
     ) : BuildActionModelRequirements {
-        override fun isRunsTasks(): Boolean = false
+        override fun isRunsTasks(): Boolean = runsTasks
         override fun isCreatesModel(): Boolean = true
         override fun getStartParameter(): StartParameterInternal = startParameter
         override fun getActionDisplayName(): DisplayName = Describables.of("creating tooling model")


### PR DESCRIPTION
Model-only requests were hashing the same cache key for different `forProjectDirectory()` targets in the same root build, causing the wrong subproject's model to be returned on subsequent queries.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
Found this while finishing up the Sqldelight support for isolated projects, it was breaking the integration tests. https://github.com/sqldelight/sqldelight/pull/6259

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
