### PR TITLE
Update Documentation: improve documentation of dependency resolution types with CC

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -78,13 +78,15 @@ Use a less specific type that gives necessary features instead:
 * If referencing a `Configuration` to get resolved files, declare a `FileCollection` input.
 * If referencing a `SourceDirectorySet`, declare a `FileTree` input.
 
-Additionally, referencing resolved dependency results is disallowed (e.g., `ArtifactResolutionQuery`, `ResolvedArtifact`, `ArtifactResult`).
-Instead:
+Additionally, referencing resolved dependency results directly is disallowed (e.g., `ArtifactResolutionQuery`, `ResolvedArtifact`, `ArtifactResult`).
+Instead, use lazy providers that defer resolution to execution time:
 
-* Use a `Provider<ResolvedComponentResult>` from `ResolutionResult.getRootComponent()`.
-* Use `ArtifactCollection.getResolvedArtifacts()`, which returns a `Provider<Set<ResolvedArtifactResult>>`.
+* Use a `Provider<ResolvedComponentResult>` from `ResolutionResult.getRootComponent()` for dependency graph metadata.
+* Use `ArtifactCollection.getResolvedArtifacts()`, which returns a `Provider<Set<ResolvedArtifactResult>>`, for artifact metadata and files.
 
-Tasks should avoid referencing _resolved_ results and instead rely on lazy specifications to defer dependency resolution until execution time.
+IMPORTANT: The `Provider` returned by `getResolvedArtifacts()` is Configuration Cache-compatible, but the `ResolvedArtifactResult` type itself is *not* serializable. You cannot wire the provider directly into a `SetProperty<ResolvedArtifactResult>` task property. Instead, use `Provider.map()` to extract the data you need (artifact identifiers, variant information, files) into serializable types, and wire those into your task's input properties. See <<artifact_resolution.adoc#sec:resolving_artifacts, Resolving artifacts>> for a complete example of this pattern.
+
+NOTE: There is a known edge case (link:{gradle-issues}27582[gradle/gradle#27582]) where `getResolvedArtifacts()` fails Configuration Cache serialization when the resolved configuration contains only external dependencies and no project dependencies. As a workaround, store the `ArtifactCollection` itself as a task field and call `getResolvedArtifacts()` at execution time.
 
 Some types, such as `Publication` or `Dependency`, are not serializable but could be made so in the future.
 Gradle may allow them as task inputs if necessary.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -79,7 +79,7 @@ Use a less specific type that gives necessary features instead:
 * If referencing a `SourceDirectorySet`, declare a `FileTree` input.
 
 Additionally, referencing resolved dependency results directly is disallowed (e.g., `ArtifactResolutionQuery`, `ResolvedArtifact`, `ArtifactResult`).
-Instead, use lazy providers that defer resolution to execution time:
+Instead, use lazy providers that defer resolution:
 
 * Use a `Provider<ResolvedComponentResult>` from `ResolutionResult.getRootComponent()` for dependency graph metadata.
 * Use `ArtifactCollection.getResolvedArtifacts()`, which returns a `Provider<Set<ResolvedArtifactResult>>`, for artifact metadata and files.


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Fix https://github.com/gradle/gradle/issues/25372
- Fix https://github.com/gradle/gradle/issues/27582

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description