### PR TITLE
Update Documentation: improve documentation of CC warn mode

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_debugging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_debugging.adoc
@@ -196,8 +196,9 @@ org.gradle.configuration-cache.problems=warn
 ====
 The warning mode is a migration and troubleshooting aid and not intended as a persistent way of ignoring incompatibilities.
 It will also not prevent new incompatibilities being accidentally added to your build later.
+With warning mode enabled, Gradle stores cache entries even when problems are present, which can lead to silently incorrect builds on a cache hit.
 
-Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>>.
+Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>> and keeping the default `problems=fail`.
 ====
 
 By default, Gradle allows up to 512 warnings before failing the build.
@@ -221,7 +222,9 @@ include::sample[dir="snippets/optimizing-builds/configuration-cache/dependencyLo
 When a task is marked as incompatible:
 
 - Configuration Cache problems *in that task* will no longer cause the build to fail.
-- Gradle discards the configuration state at the end of the build if an incompatible task is executed.
+- With the default `problems=fail`, Gradle discards the cache entry at the end of the build if an incompatible task is executed. This ensures the broken state is never reused on a subsequent run.
+
+IMPORTANT: With `problems=warn`, the cache entry is *not* discarded. On a subsequent cache hit, the incompatible task runs against deserialized state that may be incomplete, producing silently incorrect results (such as missing dependency information or empty task inputs). For this reason, prefer the default `problems=fail` when using `notCompatibleWithConfigurationCache()`.
 
 This mechanism can be useful during migration, allowing you to temporarily opt out tasks that require more extensive changes to become Configuration Cache-compatible.
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_debugging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_debugging.adoc
@@ -178,7 +178,7 @@ With these fixes in place, this task is fully compatible with the Configuration 
 [[sec:enable_warning_mode]]
 == Enable Warning Mode
 
-To ease migration, you can treat configuration cache problems as warnings instead of failures:
+If you want to see more problems at once, including those at execution time, you can treat configuration cache problems as warnings instead of failures:
 
 [source,bash]
 ----
@@ -197,6 +197,7 @@ org.gradle.configuration-cache.problems=warn
 The warning mode is a migration and troubleshooting aid and not intended as a persistent way of ignoring incompatibilities.
 It will also not prevent new incompatibilities being accidentally added to your build later.
 With warning mode enabled, Gradle stores cache entries even when problems are present, which can lead to silently incorrect builds on a cache hit.
+It can also cause confusing errors at execution time when tasks encounter incomplete or missing deserialized state.
 
 Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>> and keeping the default `problems=fail`.
 ====
@@ -224,9 +225,7 @@ When a task is marked as incompatible:
 - Configuration Cache problems *in that task* will no longer cause the build to fail.
 - With the default `problems=fail`, Gradle discards the cache entry at the end of the build if an incompatible task is executed. This ensures the broken state is never reused on a subsequent run.
 
-IMPORTANT: With `problems=warn`, the cache entry is *not* discarded. On a subsequent cache hit, the incompatible task runs against deserialized state that may be incomplete, producing silently incorrect results (such as missing dependency information or empty task inputs). For this reason, prefer the default `problems=fail` when using `notCompatibleWithConfigurationCache()`.
-
-This mechanism can be useful during migration, allowing you to temporarily opt out tasks that require more extensive changes to become Configuration Cache-compatible.
+This mechanism can be useful when adopting the Configuration Cache, allowing you to temporarily opt out tasks that require more extensive changes to become compatible.
 
 For more details, refer to the link:{javadocPath}/org/gradle/api/Task.html#notCompatibleWithConfigurationCache-java.lang.String-[method] documentation.
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
@@ -47,7 +47,8 @@ $ ./gradlew --no-configuration-cache
 === Ignoring Configuration Cache Problems
 
 By default, Gradle fails the build if Configuration Cache problems occur.
-However, when gradually updating plugins or build logic to support the Configuration Cache, it can be useful to temporarily turn problems into warnings by enabling _warning mode_.
+However, when working on adopting the Configuration Cache in the build, it can be useful to temporarily turn problems into warnings by enabling _warning mode_.
+For example, if you want to see execution time problems without fixing the whole configuration phase.
 
 To change this behavior at build time, use the following flag:
 
@@ -72,8 +73,7 @@ Warning mode is a migration and troubleshooting aid and not intended as a persis
 It will also not prevent new incompatibilities being accidentally added to your build later.
 
 With warning mode enabled, Gradle stores cache entries even when problems are present.
-On a cache hit, tasks run against deserialized state that may be incomplete or incorrect, which can produce silently wrong results — such as missing dependency information or empty inputs.
-This also changes the behavior of tasks marked with link:{javadocPath}/org/gradle/api/Task.html#notCompatibleWithConfigurationCache-java.lang.String-[`notCompatibleWithConfigurationCache()`]: with the default `problems=fail`, Gradle discards the cache entry when an incompatible task runs; with `problems=warn`, the entry is kept, and the incompatible task may fail or produce incorrect output on a cache hit.
+On a cache hit, tasks run against deserialized state that may be incomplete or incorrect, which can produce silently wrong results or confusing errors — such as missing dependency information or empty inputs.
 
 Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>> and keeping the default `problems=fail`.
 ====

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
@@ -71,7 +71,11 @@ org.gradle.configuration-cache.problems=warn
 Warning mode is a migration and troubleshooting aid and not intended as a persistent way of ignoring incompatibilities.
 It will also not prevent new incompatibilities being accidentally added to your build later.
 
-Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>>.
+With warning mode enabled, Gradle stores cache entries even when problems are present.
+On a cache hit, tasks run against deserialized state that may be incomplete or incorrect, which can produce silently wrong results — such as missing dependency information or empty inputs.
+This also changes the behavior of tasks marked with link:{javadocPath}/org/gradle/api/Task.html#notCompatibleWithConfigurationCache-java.lang.String-[`notCompatibleWithConfigurationCache()`]: with the default `problems=fail`, Gradle discards the cache entry when an incompatible task runs; with `problems=warn`, the entry is kept, and the incompatible task may fail or produce incorrect output on a cache hit.
+
+Instead, we recommend explicitly marking problematic tasks as <<configuration_cache_debugging.adoc#config_cache:task_opt_out,incompatible>> and keeping the default `problems=fail`.
 ====
 
 [[config_cache:usage:max_problems]]


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Fix https://github.com/gradle/gradle/issues/24636

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description