### PR TITLE
Require DV plugin 4.0+ with IP

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -51,6 +51,7 @@ While the feature is experimental, notable changes are documented here rather th
 ** The `Project.getProperties()` API is now treated as incompatible, while being <<upgrading_version_9.adoc#deprecated_get_properties,generally deprecated>>.
 ** The new <<sec:diagnostics_mode,Diagnostics mode>> runs without parallelism and deterministically reports constraint violations.
 ** Editor support for Kotlin build scripts and precompiled plugins in IDEA-based IDEs has been fixed.
+** The minimum supported version of the link:https://scans.gradle.com/plugin/[Develocity plugin] is 4.0.
 
 * Gradle 9.4.0
 ** Isolated Projects violations are now deduplicated, making the Configuration Cache HTML reports significantly smaller.

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
@@ -230,7 +230,6 @@ abstract class BaseBuildScanPluginCheckInFixture {
         executer.expectDocumentedDeprecationWarning(
             "Usage of the Develocity plugin ${pluginVersion} has been deprecated. " +
                 "This will fail with an error in Gradle 10. " +
-                "The plugin application will be ignored. " +
                 "Upgrade to version ${FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP} or later of the Develocity plugin. " +
                 "Consult the upgrading guide for further information: " +
                 "${new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "deprecated_develocity_plugin_pre_4_0")}"

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInIntegrationTest.groovy
@@ -100,9 +100,6 @@ class DevelocityPluginCheckInIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << """
             println "present: " + services.get($GradleEnterprisePluginManager.name).present
         """
-        if (supported) {
-            plugin.expectParentPropertyLookupDeprecation(executer, pluginVersion)
-        }
 
         when:
         succeeds("t", "-Dorg.gradle.unsafe.isolated-projects=true")
@@ -114,13 +111,14 @@ class DevelocityPluginCheckInIntegrationTest extends AbstractIntegrationSpec {
         if (supported) {
             assert output.contains("develocityPlugin.checkIn.supported")
         } else {
-            assert output.contains("develocityPlugin.checkIn.unsupported.reasonMessage = Gradle Enterprise plugin 3.13.1 has been disabled as it is incompatible with Isolated Projects. Upgrade to Gradle Enterprise plugin 3.15 or newer to restore functionality.")
+            assert output.contains("develocityPlugin.checkIn.unsupported.reasonMessage = Gradle Enterprise plugin ${pluginVersion} has been disabled as it is incompatible with Isolated Projects. Upgrade to Gradle Enterprise plugin 4.0 or newer to restore functionality.")
         }
 
         where:
         pluginVersion                    | supported
         MINIMUM_SUPPORTED_PLUGIN_VERSION | false
-        '3.15'                           | true
+        '3.15'                           | false
+        '4.0'                            | true
     }
 
     def "emits deprecation when Develocity plugin version #pluginVersion relies on parent-property lookup"() {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
@@ -83,7 +83,6 @@ public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterp
 
         if (isAffectedByParentPropertyLookup(pluginBaseVersion)) {
             DeprecationLogger.deprecateIndirectUsage("Usage of the Develocity plugin " + pluginVersion)
-                .withContext("The plugin application will be ignored.")
                 .withAdvice("Upgrade to version " + FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP + " or later of the Develocity plugin.")
                 .willBecomeAnErrorInGradle10()
                 .withUpgradeGuideSection(9, "deprecated_develocity_plugin_pre_4_0")

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DevelocityPluginCompatibility.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DevelocityPluginCompatibility.java
@@ -36,7 +36,12 @@ public class DevelocityPluginCompatibility {
     @VisibleForTesting
     public static final VersionNumber MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER = VersionNumber.parse(MINIMUM_SUPPORTED_PLUGIN_VERSION);
 
-    private static final String ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION = "3.15";
+    /**
+     * Gradle 9.6.0 changes IP behavior by removing the properties lookup in parent projects.
+     * This has the same effects on the plugin as described in {@link #FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP}.
+     * That's why we require 4.0+ when running with IP already starting with 9.6.0.
+     */
+    private static final String ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION = "4.0";
     private static final VersionNumber ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION_NUMBER = VersionNumber.parse(ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION);
 
     /**

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
+import org.junit.Assume
 import spock.lang.Issue
 
 import java.nio.charset.StandardCharsets
@@ -173,8 +174,7 @@ class DevelocityPluginSmokeTest extends AbstractSmokeTest {
     private static final List<String> SUPPORTED_BY_CI_INJECTION = SUPPORTED
         .findAll { VersionNumber.parse("3.6.4") <= VersionNumber.parse(it) }
 
-    private static final VersionNumber FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS = VersionNumber.parse("3.15")
-    private static final VersionNumber FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS_FOR_TEST_ACCELERATION = VersionNumber.parse("3.17")
+    private static final VersionNumber FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS = VersionNumber.parse("4.0")
     private static final VersionNumber FIRST_VERSION_SUPPORTING_SAFE_MODE = VersionNumber.parse("3.15")
     private static final VersionNumber FIRST_VERSION_UNDER_DEVELOCITY_BRAND = VersionNumber.parse("3.17")
     private static final VersionNumber FIRST_VERSION_WITH_IMPORT_JUNIT_XML_REPORTS = VersionNumber.parse("3.17")
@@ -206,6 +206,10 @@ class DevelocityPluginSmokeTest extends AbstractSmokeTest {
 
     @Issue("https://github.com/gradle/gradle/issues/34252")
     def "does not fail when using TD #version"() {
+        Assume.assumeTrue(
+            GradleContextualExecuter.notIsolatedProjects || VersionNumber.parse(version) >= FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS
+        )
+
         when:
         usePluginVersion version
 
@@ -334,7 +338,7 @@ public class MyFlakyTest {
 
         where:
         version << SUPPORTED
-            .findAll { VersionNumber.parse(it) >= FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS_FOR_TEST_ACCELERATION }
+            .findAll { VersionNumber.parse(it) >= FIRST_VERSION_SUPPORTING_ISOLATED_PROJECTS }
     }
 
     @Requires(value = TestExecutionPreconditions.NotConfigCached, reason = "Isolated projects implies config cache")
@@ -347,7 +351,7 @@ public class MyFlakyTest {
             .build().output
 
         then:
-        output.contains("Gradle Enterprise plugin $version has been disabled as it is incompatible with Isolated Projects. Upgrade to Gradle Enterprise plugin 3.15 or newer to restore functionality.")
+        output.contains("Gradle Enterprise plugin $version has been disabled as it is incompatible with Isolated Projects. Upgrade to Gradle Enterprise plugin 4.0 or newer to restore functionality.")
         !output.contains("Build scan written to")
 
         where:
@@ -635,7 +639,7 @@ public class MyFlakyTest {
     }
 
     void createTest(TestFile projectDir, String testName) {
-        projectDir.file("src/test/java/${testName}.java").java"""
+        projectDir.file("src/test/java/${testName}.java").java """
             import org.junit.jupiter.api.*;
             import static org.junit.jupiter.api.Assertions.*;
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
@@ -556,7 +556,6 @@ public class MyFlakyTest {
             runner.maybeExpectLegacyDeprecationWarning(
                 "Usage of the Develocity plugin ${currentPluginVersion} has been deprecated. " +
                     "This will fail with an error in Gradle 10. " +
-                    "The plugin application will be ignored. " +
                     "Upgrade to version 4.0 or later of the Develocity plugin. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecated_develocity_plugin_pre_4_0"
             )


### PR DESCRIPTION
Gradle 9.6.0 changes Isolated Projects behavior by removing the implicit parent-project property lookup. This produces the same effect on the Develocity plugin as upgrading past `FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP`: plugin versions older than 4.0 silently miss properties they used to inherit from parent projects, leading to potentially incomplete build scans under IP.

That's why we are raising the plugin version requirement to `4.0` for IP in the same Gradle release.

---

Additionally, this PR also removes a misleading part of the deprecation message for implicit lookup in parent projects: it was saying that the plugin application will be ignored, while in reality the plugin was still applied and just a deprecation was issued.

---

Related:
- https://github.com/gradle/gradle/issues/37922
- https://github.com/gradle/gradle/pull/37742
