### PR TITLE
Update build-builder ref and force Swift 6 toolchain for Swift performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ com.gradleup.shadow.enableDevelocityIntegration=false
 androidSmokeTestProjectRef=https://github.com/gradle/nowinandroid.git#4a5becfc8878471c1063a10c558f87e4399d12f2
 
 # Build-builder project repository and commit
-buildBuilderProjectRef=https://github.com/gradle/build-builder.git#76349287aac653e500a4c2581707cae98fe85e79
+buildBuilderProjectRef=https://github.com/gradle/build-builder.git#0ae2c07e619513fca46ba26ce36ca1d073d8b5a2
 
 # Performance test project repositories and commits
 nowInAndroidBuildProjectRef=https://github.com/gradle/nowinandroid.git#6c94ed76c42cc8a45374930059cf241cc134cf15

--- a/testing/internal-performance-testing/build.gradle.kts
+++ b/testing/internal-performance-testing/build.gradle.kts
@@ -52,7 +52,9 @@ dependencies {
     implementation(projects.concurrent)
     implementation(projects.core)
     implementation(projects.internalIntegTesting)
+    implementation(projects.languageNative)
     implementation(projects.projectFeaturesApi)
+    implementation(testFixtures(projects.platformNative))
 
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/SwiftToolchainFixture.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/SwiftToolchainFixture.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.fixture
+
+import org.gradle.language.swift.plugins.SwiftBasePlugin
+import org.gradle.nativeplatform.fixtures.AvailableToolChains
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.nativeplatform.toolchain.Swiftc
+import org.gradle.test.fixtures.file.TestFile
+
+class SwiftToolchainFixture {
+
+    static void configureSwift6Toolchain(CrossVersionPerformanceTestRunner runner, TestFile workDir) {
+        def swiftc = AvailableToolChains.getToolChain(ToolChainRequirement.SWIFTC_6)
+        if (swiftc == null || !swiftc.available) {
+            throw new IllegalStateException("Swift 6 toolchain is required for this performance test but was not found on the agent.")
+        }
+        def pathArgs = ((AvailableToolChains.InstalledSwiftc) swiftc).pathEntries
+            .collect { "'${it.absolutePath}'" }
+            .join(', ')
+        def initScript = workDir.file("swiftc-toolchain.init.gradle")
+        initScript.text = """
+allprojects {
+    plugins.withType(${SwiftBasePlugin.name}).configureEach {
+        toolChains {
+            swiftc(${Swiftc.name}) {
+                path ${pathArgs}
+            }
+        }
+    }
+}
+"""
+        runner.args += ['-I', initScript.absolutePath]
+    }
+}

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.regression.buildcache
 
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
+import org.gradle.performance.fixture.SwiftToolchainFixture
 
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
@@ -27,7 +28,8 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 )
 class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
     def setup() {
-        runner.minimumBaseVersion = "4.5"
+        runner.minimumBaseVersion = "4.9"
+        SwiftToolchainFixture.configureSwift6Toolchain(runner, temporaryFolder.testDirectory)
     }
 
     def "clean assemble with local cache (swift)"() {

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.performance.regression.nativeplatform
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
+import org.gradle.performance.fixture.SwiftToolchainFixture
 import org.gradle.profiler.BuildContext
 import org.gradle.profiler.mutations.AbstractFileChangeMutator
 
@@ -30,7 +31,8 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 )
 class SwiftBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
-        runner.minimumBaseVersion = '4.6'
+        runner.minimumBaseVersion = '4.9'
+        SwiftToolchainFixture.configureSwift6Toolchain(runner, temporaryFolder.testDirectory)
     }
 
     def "up-to-date assemble (swift)"() {

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.performance.regression.nativeplatform
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
+import org.gradle.performance.fixture.SwiftToolchainFixture
 
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
@@ -29,7 +30,8 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.minimumBaseVersion = '4.6'
+        runner.minimumBaseVersion = '4.9'
+        SwiftToolchainFixture.configureSwift6Toolchain(runner, temporaryFolder.testDirectory)
     }
 
     def "clean assemble (swift)"() {


### PR DESCRIPTION
## Summary
- Bump `buildBuilderProjectRef` to a newer build-builder commit for CI validation.
- Add `SwiftToolchainFixture` that generates an init script pinning the toolchain to the Swift 6 install discovered on the agent.
- Wire the fixture into SwiftBuild / SwiftCleanBuild / TaskOutputCachingSwift performance tests and bump `minimumBaseVersion` to 4.9 so the init script's `configureEach` usage is valid.
- Add the dependencies needed by the fixture in `testing/internal-performance-testing`.

## Test plan
- [ ] CI green on performance tests.