### PR TITLE
Fix ConcurrentModificationException during dependency graph teardown of pending modules

### DIFF
--- a/platforms/software/dependency-management/README.md
+++ b/platforms/software/dependency-management/README.md
@@ -219,11 +219,11 @@ continues. Only one conflict is resolved at a time before returning to queue pro
 
 ### Module Conflicts
 
-Users may declare that two or more modules are mutually exclusive (e.g. `log4j` vs
-`logback`). When the engine detects that both modules are present in the graph, it
-marks them as being in a module conflict. Nodes belonging to conflicting modules have
-their outgoing edges removed and are skipped during traversal, similar to capability
-conflicts.
+Users may declare that two or more modules are mutually exclusive (e.g. `hamcrest-all`
+is replaced by `hamcrest`). When the engine detects that both modules are present in 
+the graph, it marks them as being in a module conflict. Nodes belonging to conflicting
+modules have their outgoing edges removed and are skipped during traversal, similar to
+capability conflicts.
 
 Module conflict resolution is deferred until the queue is empty, following the same
 pattern as capability conflicts. When resolved, the nodes of the winning module are
@@ -232,8 +232,8 @@ winning module's selected component.
 
 ## Features
 
-The dependency resolution engine includes a number of supplementary features users 
-can leverage. 
+The dependency resolution engine includes a number of supplementary features users
+can leverage.
 
 ### Virtual Platforms
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -467,4 +467,52 @@ org:a:1 -> org:b:1""")
         true   | "A replaced with B"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/38049")
+    def "does not fail when module replacement causes constraints to be removed from a pending module"() {
+        def lifecycleCommonJvm = mavenRepo.module("androidx.lifecycle", "lifecycle-common-jvm", "2.10.0")
+            .dependencyConstraint(mavenRepo.module("androidx.lifecycle", "lifecycle-livedata", "2.10.0").publish())
+            .dependencyConstraint(mavenRepo.module("androidx.lifecycle", "lifecycle-livedata-core", "2.10.0").publish())
+            .withModuleMetadata()
+            .publish()
+
+        def lifecycleCoreKtx = mavenRepo.module("androidx.lifecycle", "lifecycle-livedata-core-ktx", "2.6.1").publish()
+
+        def livedataCore262 = mavenRepo.module("androidx.lifecycle", "lifecycle-livedata-core", "2.6.2").publish()
+
+        def livedata262 = mavenRepo.module("androidx.lifecycle", "lifecycle-livedata", "2.6.2")
+            .dependsOn(lifecycleCommonJvm)
+            .dependsOn(lifecycleCoreKtx)
+            .dependsOn(livedataCore262)
+            .dependencyConstraint(livedataCore262)
+            .withModuleMetadata()
+            .publish()
+        ResolveTestFixture resolve = new ResolveTestFixture(testDirectory)
+
+        buildFile << """
+            dependencies {
+                modules {
+                    module("androidx.lifecycle:lifecycle-livedata-core-ktx") {
+                        replacedBy("androidx.lifecycle:lifecycle-livedata-core", "reason")
+                    }
+                }
+
+                conf(${livedata262})
+            }
+
+            ${resolve.configureProject("conf")}
+        """
+
+        when:
+        succeeds("checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("androidx.lifecycle:lifecycle-livedata:2.6.2", "androidx.lifecycle:lifecycle-livedata:2.10.0") {
+                    byConflictResolution("between versions 2.10.0 and 2.6.2")
+                }
+            }
+        }
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -178,7 +178,7 @@ public class DependencyGraphBuilder {
             if (resolveState.peek() != null) {
                 final NodeState node = resolveState.pop();
 
-                if (node.contributesToGraph()) {
+                if (!node.shouldBuildSubgraph()) {
                     node.removeOutgoingEdges();
                     continue;
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -113,11 +113,13 @@ class EdgeState implements DependencyGraphEdge {
         return false;
     }
 
-    public void clearSelector() {
+    public boolean clearSelector() {
         if (this.selector != null) {
-            this.selector.release();
+            SelectorState currentSelector = this.selector;
             this.selector = null;
+            return currentSelector.release();
         }
+        return false;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -325,13 +325,9 @@ public class ModuleResolveState implements CandidateModule {
 
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
-        boolean alreadyReused = selector.markForReuse();
         mergedConstraintAttributes = ImmutableAttributes.EMPTY;
         for (SelectorState selectorState : selectors) {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
-        }
-        if (!alreadyReused && selectors.size() != 0 && selected != null) {
-            maybeUpdateSelection();
         }
     }
 
@@ -390,7 +386,8 @@ public class ModuleResolveState implements CandidateModule {
     void disconnectIncomingEdge(NodeState removalSource, EdgeState incomingEdge) {
         // Remove the unattached edge first, as clearing the selector may trigger re-selection and mutate the unattached edge
         removeUnattachedEdge(incomingEdge);
-        incomingEdge.clearSelector();
+        boolean needsSelection = incomingEdge.clearSelector();
+        boolean isPending = false;
         if (!incomingEdge.isConstraint()) {
             pendingDependencies.decreaseHardEdgeCount();
             if (pendingDependencies.isPending()) {
@@ -398,7 +395,13 @@ public class ModuleResolveState implements CandidateModule {
                 // All incoming constraint edges must now be removed, as we are no longer part of the graph.
                 clearIncomingAttachedConstraints(removalSource);
                 clearIncomingUnattachedConstraints(removalSource);
+                isPending = true;
             }
+        }
+        // We removed an edge targeting this module, which dropped an existing selector, requiring this
+        // module to select a new target component.
+        if (needsSelection && !isPending && getSelectors().size() != 0 && getSelected() != null) {
+            maybeUpdateSelection();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -740,15 +740,19 @@ public class NodeState implements DependencyGraphNode {
     }
 
     /**
-     * Determine if this node should be processed when it is dequeued during traversal, or if it
-     * instead be removed from the graph.
+     * Determine if this node should be processed when it is dequeued during traversal, or if its
+     * subgraph should be removed from the graph.
      * <p>
-     * False if this node has no incoming edges, or is in conflict and should temporarily not
-     * contribute to the graph. We need special handling for root since it does not yet have
-     * its own module, but should never be considered a conflict participant.
+     * True if this node has incoming edges and is not in a conflict. We temporarily delay building
+     * subgraphs of nodes in conflict while the conflict has not yet been resolved to avoid subgraphs
+     * of losing nodes from affecting the graph shape.
      */
-    boolean contributesToGraph() {
-        return !isSelected() || isInCapabilityConflict() || (getComponent().getModule().isInModuleConflict() && !isRoot());
+    boolean shouldBuildSubgraph() {
+        return isSelected() &&
+            !isInCapabilityConflict() &&
+            // We need special handling for root since it does not yet have
+            // its own module, but should never be considered a conflict participant.
+            !(getComponent().getModule().isInModuleConflict() && !isRoot());
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -120,17 +120,22 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         }
     }
 
-    public void release() {
+    /**
+     * Decrease the count of edges using this selector, updating state on the target module if
+     * this selector is no longer used by any edges.
+     *
+     * @return True if releasing this selector requires the target module to be reselected.
+     */
+    public boolean release() {
         outgoingEdgeCount--;
         assert outgoingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': outgoing edge count cannot be negative";
         if (outgoingEdgeCount == 0) {
-            removeAndMarkSelectorForReuse();
+            targetModule.removeSelector(this);
+            boolean needsSelection = markForReuse();
+            resolved = false;
+            return needsSelection;
         }
-    }
-
-    private void removeAndMarkSelectorForReuse() {
-        targetModule.removeSelector(this);
-        resolved = false;
+        return false;
     }
 
     @Override
@@ -234,22 +239,22 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
      * Marks a selector for reuse,
      * indicating it could be used again for resolution
      *
-     * @return {@code true} if that selector has been marked for reuse before, {@code false} otherwise
+     * @return true if marking this selector for reuse requires the target module to be reselected
      */
     boolean markForReuse() {
         if (!resolved) {
             // Selector was marked for deferred selection - let's not trigger selection now
-            return true;
+            return false;
         }
         this.reusable = true;
         if (markedReusableAlready) {
             // TODO: We have hit an unstable graph. This selector has already added, removed, added again,
             // and we are removing it once again. We should fail the resolution here and ask the user
             // to fix the graph -- likely by adding a version constraint.
-            return true;
+            return false;
         } else {
             markedReusableAlready = true;
-            return false;
+            return true;
         }
     }
 

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -825,4 +825,9 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         super.withSignature(signer)
         this
     }
+
+    @Override
+    String toString() {
+        return "\"$groupId:$artifactId:$version\""
+    }
 }


### PR DESCRIPTION
When a module loses all hard incoming edges during graph traversal, it becomes "pending" and all remaining constraint edges targeting it are removed in `clearIncomingAttachedConstraints` and
`clearIncomingUnattachedConstraints`. Previously, removing each constraint edge called `clearSelector`, which called `SelectorState.release()`, which called
`ModuleResolveState.removeSelector()`. `removeSelector` eagerly called `maybeUpdateSelection()` if the module still had remaining selectors and a selected component.

This eager reselection was problematic during the pending teardown. When iterating over unattached constraint edges to remove them, clearing the selector of one constraint could trigger `maybeUpdateSelection` using selectors from a *subsequent* unattached constraint that had not yet been removed. This reselection could call `changeSelection`, which calls `attachUnattachedEdges`, which on attach failure adds edges back to the `unattachedEdges` list — the same list currently being iterated — causing a ConcurrentModificationException.

This reentrant behavior has always existed but was latent. It became a regression after 5e020e42d01 (PR #37330), which added an early return in `EdgeState.getTargetComponent()` for modules in conflict:

```
    if (targetModule.isInModuleConflict()) {
        return null;
    }
```

Previously, edges would still attach to modules in conflict. After this change, `attachToTargetNodes` returns early for modules in conflict, leaving the edge unattached and adding it back to `unattachedEdges`, which triggers the CME during the pending teardown iteration.

The root cause is that `maybeUpdateSelection` should never run on a module that is being deconstructed because it has lost all hard edges. The module is leaving the graph — reselecting based on selectors from constraint edges that are about to be removed is both wasteful and dangerous.

The fix lifts the `maybeUpdateSelection` call out of `removeSelector` and into the caller (`disconnectIncomingEdge`), where we have the context to know whether the module is going back to pending. The key changes:

- `SelectorState.release()` now returns a boolean indicating whether the target module needs reselection, instead of triggering it immediately.
- `ModuleResolveState.removeSelector()` no longer calls `maybeUpdateSelection`. It only updates selector bookkeeping.
- `EdgeState.clearSelector()` returns the boolean from `release()`.
- `ModuleResolveState.disconnectIncomingEdge()` captures the return value and only calls `maybeUpdateSelection` if the module is not going back to pending.

This is safe for all other `clearSelector` call sites:
- `EdgeState.computeSelector`: the edge is unconditionally added to `discoveredEdges`, which triggers selection via `performSelectionSerially`.
- `NodeState.removeOutgoingEdge` (via `disconnectIncomingConstraint`): only called when the module is pending, so selection is unnecessary.

Fixes https://github.com/gradle/gradle/issues/38049

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
