### PR TITLE
Update Documentation: clarify JavaForkOptions.getJvmArgs() wording

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -124,7 +124,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
 
     /**
      * Returns the extra arguments to use to launch the JVM for the process. Does not include system properties and the
-     * minimum/maximum heap size.
+     * minimum/maximum heap size settings, which are managed separately and included in {@link #getAllJvmArgs()}.
      *
      * @return The immutable list of arguments. Returns an empty list if there are no arguments.
      */


### PR DESCRIPTION
Fixes #35904

### Context

The current `JavaForkOptions.getJvmArgs()` documentation states that it "does not include system properties and the minimum/maximum heap size", which can be interpreted as those arguments being ignored when supplied via `jvmArgs()`.

In practice, system properties and heap size settings are processed separately and are included in `getAllJvmArgs()`.

This change clarifies that these arguments are managed separately and are included in `getAllJvmArgs()`, making the relationship between `getJvmArgs()` and `getAllJvmArgs()` clearer.
