### PR TITLE
Merge release into master

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-rc-1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "9.6.0-20260527074125+0000",
-    "buildTime": "20260527074125+0000"
+    "version": "9.6.0-20260529023525+0000",
+    "buildTime": "20260529023525+0000"
   },
   "latestRc": {
     "version": "9.6.0-rc-1",


### PR DESCRIPTION
Automated merge of `release` into `master` following the release promotion build.

Conflicts were resolved by analysing branch histories on `origin/master` and `origin/release`.

- `gradle/wrapper/gradle-wrapper.properties` resolved to master's version (`9.6.0-milestone-3`), consistent with prior `Merge release into master` commits.
- Release-tracking files (`version.txt`, release notes + assets, `accepted-public-api-changes.json`, `release-features.txt`) restored from `origin/master` per the promotion build's recovery instructions.
- `released-versions.json` updated via `:updateReleasedVersions` → `Publish version 9.6.0-20260529023525+0000`.