### PR TITLE
Exclude Gradle 8.8 daemon from CapturingUserInputCrossVersionSpec

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
@@ -22,7 +22,11 @@ import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.ProjectConnection
 import spock.lang.Timeout
 
-@TargetGradleVersion(">=4.3")
+// 8.8 is excluded: it shipped the new client-side prompt protocol (PromptOutputEvent/UserResponse) but
+// still had the daemon greedily consume the client's stdin, so the forwarded answer is swallowed as raw
+// stdin before the prompt response is read and askYesNoQuestion returns null. The greedy consumption was
+// removed in 8.9 (commit 66832d04eff), and 8.7 and earlier use the older protocol that is unaffected.
+@TargetGradleVersion(">=4.3 !8.8")
 @Timeout(120)
 class CapturingUserInputCrossVersionSpec extends ToolingApiSpecification {
 


### PR DESCRIPTION
## What

`CapturingUserInputCrossVersionSpec` fails deterministically for the **TAPI current → Gradle 8.8** direction (`License accepted: null` instead of `true`).

## Root cause (verified by local reproduction + bisection)

Gradle **8.8 is a unique broken window**:

- 8.8 shipped the new **client-side prompt protocol** (`PromptOutputEvent`/`UserResponse`, prompt handling moved daemon→client).
- But the 8.8 daemon still **greedily consumed the client's stdin**. So the forwarded `yes\n` is swallowed as raw stdin before the prompt's response path reads it, and `askYesNoQuestion` returns `null`.
- The greedy consumption was removed in **8.9** (`66832d04eff` — "Do not greedily consume all the client's stdin"). **8.7 and earlier** use the older prompt protocol and are unaffected.

Per-version reproduction (current client, `ByteArrayInputStream`, `--rerun-tasks`):

| Target daemon | Result |
|---|---|
| 8.7 | **PASS** 3/3 |
| 8.8 | **FAIL** 3/3 (deterministic) |
| 8.9 | **PASS** 3/3 |

The 8.8 daemon is released and cannot be fixed retroactively. This is the same class of issue that led the sibling `CapturingMultipleUserInputCrossVersionSpec` to be pinned to `>=8.9` (a8baf400eee).

## Fix

Exclude **only the 8.8 daemon** via `@TargetGradleVersion(">=4.3 !8.8")`. `@TargetGradleVersion` constrains the **daemon** version — which is exactly what's broken — so this:

- drops the broken `TAPI current → Gradle 8.8` direction, and
- preserves all other versions **and** the reverse `TAPI 8.8 → Gradle current` direction (8.8 client → fixed current daemon works fine).

This is more surgical than the sibling's blunt `>=8.9` bump: coverage for 4.3–8.7 and 8.9+ is retained.

## Verification

With the fix applied:
- `current → 8.8` direction: no longer executed (excluded).
- `8.8 → current` direction: runs, passes (2/2).
- `8.7` and `8.9` (both directions): run, pass.

## History of this PR

This PR went through two earlier wrong diagnoses before reproduction pinned the real cause:
1. A `DaemonClientInputForwarder` "race" fix — disproved (the failure is deterministic, not a race).
2. Reverting the test to the `poll`-based input — that's the *original* approach that was `@Flaky` (gradle-private#5166); it would only have restored the intermittent flakiness, which is in fact the 8.8 daemon itself.

The `ByteArrayInputStream` input is kept as-is (it works for every non-8.8 daemon); the only change is the version exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)