### PR TITLE
Disable regressing AndroidIncrementalExecutionPerformanceTest CC scenario

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -53,14 +53,6 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.abi change with configuration caching",
-    "groups" : [ {
-      "testProject" : "nowInAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux", "windows", "macOs" ]
-      }
-    } ]
-  }, {
     "testId" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.non-abi change",
     "groups" : [ {
       "testProject" : "nowInAndroidBuild",

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -48,6 +48,12 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
         applyDevelocityPlugin()
     }
 
+    // Method-level @RunFor overrides the class-level one to disable the regressing "abi change with configuration caching" iteration.
+    // The iterationMatcher only keeps the "abi change" (no configuration caching) iteration.
+    // See https://github.com/gradle/gradle-private/issues/5247
+    @RunFor(
+        @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = ["nowInAndroidBuild"], iterationMatcher = "abi change")
+    )
     def "abi change#configurationCaching"() {
         given:
         testProject.configureForAbiChange(runner)


### PR DESCRIPTION
The `AndroidIncrementalExecutionPerformanceTest.abi change with configuration caching` iteration regresses badly (see gradle/gradle-private#5247).

This PR disables that single iteration while the regression is investigated:

- Adds a method-level `@RunFor` to `"abi change#configurationCaching"`. A method-level `@RunFor` overrides the class-level one, and the `iterationMatcher = "abi change"` keeps only the no-configuration-caching iteration (`String.matches` requires a full-string match, so `"abi change with configuration caching"` is excluded).
- Removes the matching `abi change with configuration caching` entry from `.teamcity/performance-tests-ci.json` so the scenario definitions stay exactly in sync with the annotations (enforced by `performance:verifyPerformanceScenarioDefinitions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)