### PR TITLE
Report actionable error for removed Problems API

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -157,6 +157,12 @@ public class IsolationScheme<INTERFACE, PARAMS> implements TypeParameterInspecti
                         return allServices.find(allowedService);
                     }
                 }
+                // Route the removed InternalProblems type to the service that fails with an actionable error.
+                @SuppressWarnings("deprecation")
+                Class<?> removedInternalProblems = org.gradle.api.problems.internal.InternalProblems.class;
+                if (serviceClass.isAssignableFrom(removedInternalProblems)) {
+                    return allServices.find(removedInternalProblems);
+                }
             }
             return null;
         }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -43,12 +43,14 @@ The previous step will help you identify potential problems by issuing deprecati
 === Potential breaking changes
 
 [[agp_8x_incompatible]]
-==== Android Gradle Plugin 8.x is no longer compatible with Gradle 9.6
+==== Plugins relying on removed Problems API internals are no longer compatible with Gradle 9.6
 
-Several internal classes used by Android Gradle Plugin (AGP) 8.x have been changed.
-Since AGP 8.x relied on these internal classes directly, it is no longer compatible with Gradle 9.6 and later.
+Several internal classes of the Problems API, such as `org.gradle.api.problems.internal.InternalProblems`, have been removed in Gradle 9.6.
+Plugins that bound to these internal classes directly fail at build time with an error mentioning the removed type.
 
+The most common case is Android Gradle Plugin (AGP) 8.x, which relied on these internal classes.
 To resolve this, upgrade to AGP 9.x, which only uses the public Gradle API and fully supports Gradle 9.6.
+If the failure comes from another plugin, update it to a version that no longer uses Gradle internal APIs, or stay on Gradle 9.5 until such a version is available.
 
 [[concurrency_primitives_prohibited_by_cc]]
 ==== Concurrency primitives can no longer be serialized by the Configuration Cache

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+/**
+ * Reintroduced as a tombstone so plugins still binding to this removed internal type fail with an actionable error instead of an obscure class loading failure.
+ *
+ * @deprecated Will be removed in Gradle 10.0
+ */
+@Deprecated
+@ServiceScope(Scope.BuildTree.class)
+public interface InternalProblems {
+}

--- a/platforms/ide/problems/src/integTest/groovy/org/gradle/api/problems/LegacyInternalProblemsApiIntegrationTest.groovy
+++ b/platforms/ide/problems/src/integTest/groovy/org/gradle/api/problems/LegacyInternalProblemsApiIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.plugin.PluginBuilder
+import org.gradle.util.GradleVersion
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/38073")
+class LegacyInternalProblemsApiIntegrationTest extends AbstractIntegrationSpec {
+
+    def "a plugin injecting the removed internal Problems API fails with an actionable error"() {
+        given:
+        def pluginBuilder = new PluginBuilder(file("buildSrc"))
+        pluginBuilder.java("LegacyService.java") << """
+            package org.gradle.test;
+
+            import ${BuildService.name};
+            import ${BuildServiceParameters.name};
+            import javax.inject.Inject;
+
+            public abstract class LegacyService implements BuildService<BuildServiceParameters.None> {
+                @Inject
+                public LegacyService(org.gradle.api.problems.internal.InternalProblems problems) {
+                }
+            }
+        """
+        pluginBuilder.addPlugin("""
+            project.gradle.sharedServices.registerIfAbsent("legacy", org.gradle.test.LegacyService) {}.get()
+        """)
+        pluginBuilder.generateForBuildSrc()
+
+        buildFile << """
+            plugins {
+                id 'test-plugin'
+            }
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failureCauseContains(
+            "Plugin 'test-plugin' relies on 'org.gradle.api.problems.internal.InternalProblems', " +
+                "a Gradle internal API that was removed in Gradle 9.6.0. " +
+                "Update the plugin to a version that no longer uses Gradle internal APIs, or use Gradle 9.5. " +
+                "For more information, please refer to " +
+                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#agp_8x_incompatible " +
+                "in the Gradle documentation."
+        )
+    }
+}

--- a/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
+++ b/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
@@ -17,6 +17,8 @@
 package org.gradle.problems.internal.services;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.problems.internal.DefaultProblems;
@@ -30,6 +32,7 @@ import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.problems.internal.TaskIdentity;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.buildoption.InternalOptions;
+import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.exception.ExceptionAnalyser;
@@ -122,5 +125,28 @@ public class ProblemsBuildTreeServices implements ServiceRegistrationProvider {
             return new DefaultProblemsReportCreator(executorFactory, temporaryFileProvider, internalOptions, startParameter, failureFactory, buildStateRegistry);
         }
         return new NoOpProblemReportCreator();
+    }
+
+    /**
+     * Fails with an actionable error when a plugin requests the removed {@code InternalProblems} internal type.
+     *
+     * @deprecated Will be removed in Gradle 10.0
+     */
+    @Deprecated
+    @Provides
+    org.gradle.api.problems.internal.InternalProblems createInternalProblems(UserCodeApplicationContext userCodeContext) {
+        UserCodeApplicationContext.Application current = userCodeContext.current();
+        String culprit;
+        if (current == null) {
+            culprit = "A plugin you are using";
+        } else {
+            String displayName = current.getSource().getDisplayName().getDisplayName();
+            culprit = Character.toUpperCase(displayName.charAt(0)) + displayName.substring(1);
+        }
+        throw new GradleException(
+            culprit + " relies on 'org.gradle.api.problems.internal.InternalProblems', " +
+                "a Gradle internal API that was removed in Gradle 9.6.0. " +
+                "Update the plugin to a version that no longer uses Gradle internal APIs, or use Gradle 9.5. " +
+                new DocumentationRegistry().getDocumentationRecommendationFor("information", "upgrading_version_9", "agp_8x_incompatible"));
     }
 }

--- a/testing/architecture-test/src/changes/archunit-store/internal-classes-internal-suffix.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-classes-internal-suffix.txt
@@ -6,6 +6,8 @@ Class <org.gradle.api.internal.file.copy.FileCopyAction$FileCopyDetailsInternalA
 Class <org.gradle.api.internal.options.InternalOptionsFactory> does not have simple name ending with 'Internal' in (InternalOptionsFactory.java:0)
 Class <org.gradle.api.internal.options.InternalOptionsFactory> has simple name starting with 'Internal' in (InternalOptionsFactory.java:0)
 Class <org.gradle.api.java.archives.internal.CustomManifestInternalWrapper> does not have simple name ending with 'Internal' in (CustomManifestInternalWrapper.java:0)
+Class <org.gradle.api.problems.internal.InternalProblems> does not have simple name ending with 'Internal' in (InternalProblems.java:0)
+Class <org.gradle.api.problems.internal.InternalProblems> has simple name starting with 'Internal' in (InternalProblems.java:0)
 Class <org.gradle.api.tasks.util.internal.DefaultPatternSetFactory$InternalPatternSet> does not have simple name ending with 'Internal' in (DefaultPatternSetFactory.java:0)
 Class <org.gradle.api.tasks.util.internal.DefaultPatternSetFactory$InternalPatternSet> has simple name starting with 'Internal' in (DefaultPatternSetFactory.java:0)
 Class <org.gradle.external.javadoc.internal.JavadocOptionFileOptionInternalAdapter> does not have simple name ending with 'Internal' in (JavadocOptionFileOptionInternalAdapter.java:0)


### PR DESCRIPTION
The internal type org.gradle.api.problems.internal.InternalProblems was removed in 9.6.0. Plugins that bound to it directly, most notably AGP 8.x, then fail with an opaque class loading error that explains neither the cause nor the remedy. Surface a clear failure instead: name the plugin at fault and point to the upgrade guide so users know to update the plugin or remain on Gradle 9.5.

* Fixes https://github.com/gradle/gradle/issues/38073

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
