### PR TITLE
Emit build operation events to JFR

### DIFF
--- a/platforms/core-runtime/build-operations-trace/build.gradle.kts
+++ b/platforms/core-runtime/build-operations-trace/build.gradle.kts
@@ -20,6 +20,15 @@ plugins {
 
 description = "Produces traces from build operations"
 
+jvmCompile {
+    compilations {
+        named("main") {
+            // We use the JFR APIs that are only available in Java 11 and later.
+            usesFutureStdlib = true
+        }
+    }
+}
+
 dependencies {
     api(projects.buildOperations)
     api(projects.buildOption)

--- a/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
+++ b/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.trace
+
+import jdk.jfr.consumer.RecordedEvent
+import jdk.jfr.consumer.RecordingFile
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+
+/**
+ * Tests that build operations are emitted into an active (user-managed) JFR recording.
+ */
+class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
+
+    def "emits build operation events into an active JFR recording"() {
+        given:
+        def jfr = startJfrRecording()
+        enableBuildOperationEmission()
+
+        when:
+        succeeds("help")
+        stopDaemonAndWait()
+
+        then:
+        def buildOps = buildOperationEvents(jfr)
+        buildOps.any { it.getString("displayName") == "Run build" }
+        buildOps.every { it.getLong("operationId") != 0L }
+        buildOps.every { it.getInstant("gradleStartTime").toEpochMilli() > 0 }
+        buildOps.every { it.getInstant("gradleEndTime").toEpochMilli() > 0 }
+    }
+
+    def "JFR build operation events agree with the BuildOperationTrace"() {
+        given:
+        def operations = newBuildOperationsFixture()
+        def jfr = startJfrRecording()
+        enableBuildOperationEmission()
+
+        when:
+        succeeds("help")
+        stopDaemonAndWait()
+
+        then:
+        def jfrEventsById = buildOperationEvents(jfr).collectEntries { [(it.getLong("operationId")): it] }
+        def recordsById = operations.records.collectEntries { [(it.id): it] }
+        !jfrEventsById.isEmpty()
+
+        and: "JFR never records an operation that the BuildOperationTrace did not"
+        // JFR only captures operations that ran while a recording was active, so it is a subset of the trace.
+        (jfrEventsById.keySet() - recordsById.keySet()).isEmpty()
+
+        and: "JFR and the BuildOperationTrace agree on every shared field of every operation they both recorded"
+        jfrEventsById.each { id, event ->
+            def record = recordsById[id]
+            assert event.getString("displayName") == record.displayName
+            assert event.getLong("parentId") == (record.parentId == null ? 0L : record.parentId)
+            assert event.getInstant("gradleStartTime").toEpochMilli() == record.startTime
+            assert event.getInstant("gradleEndTime").toEpochMilli() == record.endTime
+        }
+    }
+
+    def "emits nothing when the feature is not enabled"() {
+        given:
+        // An active recording, but the emission flag is left off.
+        def jfr = startJfrRecording()
+
+        when:
+        succeeds("help")
+        stopDaemonAndWait()
+
+        then:
+        buildOperationEvents(jfr).isEmpty()
+    }
+
+    private void enableBuildOperationEmission() {
+        executer.withArgument("-D${BuildOperationJfrEmitter.SYSPROP}=true")
+    }
+
+    private File startJfrRecording() {
+        def jfrFile = file("build.jfr")
+        // Ask the daemon JVM to dump the recording to a known path on exit.
+        // withBuildJvmOpts appends to the args already set by GRADLE_OPTS so the
+        // flag actually reaches the daemon JVM (not just the client).
+        executer.withBuildJvmOpts("-XX:StartFlightRecording=filename=${jfrFile.absolutePath},dumponexit=true")
+        jfrFile
+    }
+
+    private static List<RecordedEvent> buildOperationEvents(File jfrFile) {
+        RecordingFile.readAllEvents(jfrFile.toPath()).findAll { RecordedEvent event ->
+            event.eventType.name == "org.gradle.BuildOperation"
+        }
+    }
+}

--- a/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
+++ b/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
@@ -27,7 +27,7 @@ class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
 
     def "emits build operation events into an active JFR recording"() {
         given:
-        def jfr = startJfrRecording()
+        def jfr = withJfrRecording()
         enableBuildOperationEmission()
 
         when:
@@ -45,7 +45,7 @@ class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
     def "JFR build operation events agree with the BuildOperationTrace"() {
         given:
         def operations = newBuildOperationsFixture()
-        def jfr = startJfrRecording()
+        def jfr = withJfrRecording()
         enableBuildOperationEmission()
 
         when:
@@ -74,7 +74,7 @@ class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
     def "emits nothing when the feature is not enabled"() {
         given:
         // An active recording, but the emission flag is left off.
-        def jfr = startJfrRecording()
+        def jfr = withJfrRecording()
 
         when:
         succeeds("help")
@@ -88,7 +88,7 @@ class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
         executer.withArgument("-D${BuildOperationJfrEmitter.SYSPROP}=true")
     }
 
-    private File startJfrRecording() {
+    private File withJfrRecording() {
         def jfrFile = file("build.jfr")
         // Ask the daemon JVM to dump the recording to a known path on exit.
         // withBuildJvmOpts appends to the args already set by GRADLE_OPTS so the

--- a/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
+++ b/platforms/core-runtime/build-operations-trace/src/integTest/groovy/org/gradle/internal/operations/trace/BuildOperationJfrEmitterIntegrationTest.groovy
@@ -99,7 +99,7 @@ class BuildOperationJfrEmitterIntegrationTest extends DaemonIntegrationSpec {
 
     private static List<RecordedEvent> buildOperationEvents(File jfrFile) {
         RecordingFile.readAllEvents(jfrFile.toPath()).findAll { RecordedEvent event ->
-            event.eventType.name == "org.gradle.BuildOperation"
+            event.eventType.name == "org.gradle.internal.operations.BuildOperation"
         }
     }
 }

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.trace;
+
+import org.gradle.internal.buildoption.InternalOption;
+import org.gradle.internal.buildoption.InternalOptions;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Emits a JFR event per Gradle build operation into whatever JFR recording is active.
+ *
+ * <p>Enabled with {@code -Dorg.gradle.internal.operations.jfr=true}, mirroring the file-based
+ * {@link BuildOperationTrace}. This only emits events; it does not start or manage a recording.
+ * The events are picked up by any active recording — e.g. one started by the user with
+ * {@code -XX:StartFlightRecording}. When disabled, no listener is registered and there is no overhead.
+ */
+@ServiceScope(Scope.CrossBuildSession.class)
+public class BuildOperationJfrEmitter implements Closeable {
+
+    public static final String SYSPROP = "org.gradle.internal.operations.jfr";
+
+    static final InternalOption<Boolean> ENABLED_OPTION = InternalOptions.ofBoolean(SYSPROP, false);
+
+    private final BuildOperationListenerManager manager;
+    private final @Nullable BuildOperationListener listener;
+
+    /**
+     * In-flight events keyed by operation id.
+     *
+     * <p>A build operation may start on one thread and finish on another.
+     * The {@link BuildOperationListener} contract only guarantees the two signals are serialized, not that they share a thread.
+     * A per-thread map would silently drop such operations, so we key across threads.
+     */
+    private final Map<Long, BuildOperationJfrEvent> inFlightEvents = new ConcurrentHashMap<>();
+
+    public BuildOperationJfrEmitter(InternalOptions options, BuildOperationListenerManager manager) {
+        Listener listener = null;
+        if (options.getBoolean(ENABLED_OPTION)) {
+            listener = new Listener();
+            manager.addListener(listener);
+        }
+
+        this.manager = manager;
+        this.listener = listener;
+    }
+
+    @Override
+    public void close() {
+        if (listener != null) {
+            manager.removeListener(listener);
+        }
+    }
+
+    private class Listener implements BuildOperationListener {
+
+        @Override
+        public void started(BuildOperationDescriptor descriptor, OperationStartEvent startEvent) {
+            BuildOperationJfrEvent event = new BuildOperationJfrEvent();
+            if (!event.isEnabled()) {
+                return; // JFR not recording — skip entirely
+            }
+            OperationIdentifier id = descriptor.getId();
+            if (id == null) {
+                return;
+            }
+            event.operationId = id.getId();
+            OperationIdentifier parentId = descriptor.getParentId();
+            event.parentId = parentId != null ? parentId.getId() : 0;
+            event.displayName = descriptor.getDisplayName();
+            event.gradleStartTime = startEvent.getStartTime();
+            event.begin();
+            inFlightEvents.put(id.getId(), event);
+        }
+
+        @Override
+        public void progress(OperationIdentifier id, OperationProgressEvent progressEvent) {
+            // Not represented in JFR; ignored.
+        }
+
+        @Override
+        public void finished(BuildOperationDescriptor descriptor, OperationFinishEvent finishEvent) {
+            OperationIdentifier id = descriptor.getId();
+            if (id == null) {
+                return;
+            }
+            BuildOperationJfrEvent event = inFlightEvents.remove(id.getId());
+            if (event == null) {
+                return; // not recorded at start (recording was not yet active)
+            }
+            event.gradleEndTime = finishEvent.getEndTime();
+            Throwable failure = finishEvent.getFailure();
+            if (failure != null) {
+                event.failed = true;
+                event.failureMessage = failure.getMessage();
+                event.failureType = failure.getClass().getName();
+            }
+            event.commit();
+        }
+    }
+}

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
@@ -53,9 +53,7 @@ public class BuildOperationJfrEmitter implements Closeable {
     /**
      * In-flight events keyed by operation id.
      *
-     * <p>A build operation may start on one thread and finish on another.
-     * The {@link BuildOperationListener} contract only guarantees the two signals are serialized, not that they share a thread.
-     * A per-thread map would silently drop such operations, so we key across threads.
+     * <p> A build operation may start on one thread and finish on another, therefore, we need a synchronized map
      */
     private final Map<Long, BuildOperationJfrEvent> inFlightEvents = new ConcurrentHashMap<>();
 

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
@@ -116,7 +116,6 @@ public class BuildOperationJfrEmitter implements Closeable {
             event.gradleEndTime = finishEvent.getEndTime();
             Throwable failure = finishEvent.getFailure();
             if (failure != null) {
-                event.failed = true;
                 event.failureMessage = failure.getMessage();
                 event.failureType = failure.getClass().getName();
             }

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEmitter.java
@@ -55,7 +55,7 @@ public class BuildOperationJfrEmitter implements Closeable {
      *
      * <p> A build operation may start on one thread and finish on another, therefore, we need a synchronized map
      */
-    private final Map<Long, BuildOperationJfrEvent> inFlightEvents = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, BuildOperationJfrEvent> inFlightEvents = new ConcurrentHashMap<>();
 
     public BuildOperationJfrEmitter(InternalOptions options, BuildOperationListenerManager manager) {
         Listener listener = null;

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.trace;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+import jdk.jfr.Timestamp;
+
+/**
+ * JFR event describing a single Gradle build operation.
+ */
+@Name(BuildOperationJfrEvent.NAME)
+@Label("Build Operation")
+@Category({"Gradle", "Build Operations"})
+@StackTrace(false)
+class BuildOperationJfrEvent extends Event {
+
+    /**
+     * The name of the JFR event type.
+     */
+    static final String NAME = "org.gradle.BuildOperation";
+
+    /**
+     * Unique ID of the operation
+     */
+    @Label("Operation ID")
+    long operationId;
+
+    /**
+     * ID of the parent operation, or 0 if this is a root operation
+     */
+    @Label("Parent Operation ID")
+    long parentId; // 0 = root operation
+
+    /**
+     * Human-readable description of the operation, e.g. "Compile Java source 'Main.java'"
+     */
+    @Label("Display Name")
+    String displayName;
+
+    /**
+     * Gradle's own timestamp when the operation started.
+     */
+    @Label("Gradle Start Time")
+    @Timestamp
+    long gradleStartTime;
+
+    /**
+     * Gradle's own timestamp when the operation ended.
+     */
+    @Label("Gradle End Time")
+    @Timestamp
+    long gradleEndTime;
+
+    /**
+     * {@code true} if the operation threw an exception, {@code false} otherwise
+     */
+    @Label("Failed")
+    boolean failed;
+
+    /**
+     * Message from the exception, or null
+     */
+    @Label("Failure Message")
+    String failureMessage;
+
+    /**
+     * FQN of the exception class, or null
+     */
+    @Label("Failure Type")
+    String failureType;
+}

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -86,6 +86,7 @@ class BuildOperationJfrEvent extends Event {
     /**
      * FQN of the exception class, or null
      */
+    @Nullable
     @Label("Failure Type")
     String failureType;
 }

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * JFR event describing a single Gradle build operation.
  */
+// NOTE: Because the project is used in workers (but not specifically this class), it's expected that this class will contain language level-related red squiggles
 @Name(BuildOperationJfrEvent.NAME)
 @Label("Build Operation")
 @Category({"Gradle", "Build Operations"})
@@ -71,16 +72,17 @@ class BuildOperationJfrEvent extends Event {
     long gradleEndTime;
 
     /**
+     * FQN of the exception class, or null
+     */
+    @Nullable
+    @Label("Failure Type")
+    String failureType;
+
+    /**
      * Message from the exception, or null
      */
     @Nullable
     @Label("Failure Message")
     String failureMessage;
 
-    /**
-     * FQN of the exception class, or null
-     */
-    @Nullable
-    @Label("Failure Type")
-    String failureType;
 }

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -71,12 +71,6 @@ class BuildOperationJfrEvent extends Event {
     long gradleEndTime;
 
     /**
-     * {@code true} if the operation threw an exception, {@code false} otherwise
-     */
-    @Label("Failed")
-    boolean failed;
-
-    /**
      * Message from the exception, or null
      */
     @Nullable

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -22,6 +22,7 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 import jdk.jfr.StackTrace;
 import jdk.jfr.Timestamp;
+import org.jspecify.annotations.Nullable;
 
 /**
  * JFR event describing a single Gradle build operation.
@@ -78,6 +79,7 @@ class BuildOperationJfrEvent extends Event {
     /**
      * Message from the exception, or null
      */
+    @Nullable
     @Label("Failure Message")
     String failureMessage;
 

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationJfrEvent.java
@@ -36,7 +36,7 @@ class BuildOperationJfrEvent extends Event {
     /**
      * The name of the JFR event type.
      */
-    static final String NAME = "org.gradle.BuildOperation";
+    static final String NAME = "org.gradle.internal.operations.BuildOperation";
 
     /**
      * Unique ID of the operation

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -22,6 +22,7 @@ import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.operations.BuildOperationsParameters;
 import org.gradle.internal.operations.DefaultBuildOperationsParameters;
+import org.gradle.internal.operations.trace.BuildOperationJfrEmitter;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
@@ -57,8 +58,9 @@ public class CrossBuildSessionState implements Closeable {
             .parent(parent)
             .provider(new Services(startParameter, userActionRootDir))
             .build();
-        // Trigger listener to wire itself in
+        // Trigger listeners to wire themselves in
         services.get(BuildOperationTrace.class);
+        services.get(BuildOperationJfrEmitter.class);
     }
 
     public ServiceRegistry getServices() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -35,6 +35,7 @@ import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
+import org.gradle.internal.operations.trace.BuildOperationJfrEmitter;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -109,6 +110,11 @@ public class CoreCrossBuildSessionServices implements ServiceRegistrationProvide
     @Provides
     BuildOperationTrace createBuildOperationTrace(InternalOptions internalOptions, CrossBuildSessionParameters parameters, BuildOperationListenerManager buildOperationListenerManager) {
         return new BuildOperationTrace(parameters.getUserActionRootDirectory(), internalOptions, buildOperationListenerManager);
+    }
+
+    @Provides
+    BuildOperationJfrEmitter createBuildOperationJfrEmitter(InternalOptions internalOptions, BuildOperationListenerManager buildOperationListenerManager) {
+        return new BuildOperationJfrEmitter(internalOptions, buildOperationListenerManager);
     }
 
     @Provides

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonIntegrationSpec.groovy
@@ -22,6 +22,8 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
+import java.util.concurrent.TimeUnit
+
 @Requires(value = TestExecutionPreconditions.NotEmbeddedExecutor, reason = "explicitly requests a daemon")
 abstract class DaemonIntegrationSpec extends AbstractIntegrationSpec {
     def setup() {
@@ -31,6 +33,27 @@ abstract class DaemonIntegrationSpec extends AbstractIntegrationSpec {
 
     void stopDaemonsNow() {
         result = executer.withArguments("--stop", "--info").run()
+    }
+
+    /**
+     * Stops the daemon and waits for its JVM to actually exit, so that shutdown hooks have run.
+     * Useful when a test relies on side effects that only happen on a graceful JVM shutdown, such
+     * as a JFR recording dumped via {@code -XX:StartFlightRecording=...,dumponexit=true}.
+     */
+    void stopDaemonAndWait() {
+        def daemonPid = daemons.daemon.context.pid
+        stopDaemonsNow()
+        waitForProcessExit(daemonPid)
+    }
+
+    private static void waitForProcessExit(long pid) {
+        def handle = ProcessHandle.of(pid)
+        if (!handle.isPresent()) {
+            // process is already dead, no need to wait
+            return
+        }
+        // waiting with a 10 second timeout
+        handle.get().onExit().get(10, TimeUnit.SECONDS)
     }
 
     void buildSucceeds() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonIntegrationSpec.groovy
@@ -31,6 +31,11 @@ abstract class DaemonIntegrationSpec extends AbstractIntegrationSpec {
         executer.requireIsolatedDaemons()
     }
 
+    /**
+     * Stops the daemon but <b>doesn't</b> wait for its exit.
+     *
+     * @see #stopDaemonAndWait()
+     */
     void stopDaemonsNow() {
         result = executer.withArguments("--stop", "--info").run()
     }
@@ -39,6 +44,8 @@ abstract class DaemonIntegrationSpec extends AbstractIntegrationSpec {
      * Stops the daemon and waits for its JVM to actually exit, so that shutdown hooks have run.
      * Useful when a test relies on side effects that only happen on a graceful JVM shutdown, such
      * as a JFR recording dumped via {@code -XX:StartFlightRecording=...,dumponexit=true}.
+     *
+     * @see #stopDaemonsNow()
      */
     void stopDaemonAndWait() {
         def daemonPid = daemons.daemon.context.pid


### PR DESCRIPTION
### Context

Build operations are Gradle's own unit of "what the build is doing," but there was no first-class way to see them on a JFR timeline. This emits each build operation as a JFR event into whatever recording is active, so you can profile a build with `-XX:StartFlightRecording` and see Gradle's operations in JDK Mission Control (or `jfr print`).

**What it adds**

- `BuildOperationJfrEmitter`, a sibling of `BuildOperationTrace` in `:build-operations-trace`, enabled with `-Dorg.gradle.internal.operations.jfr=true` (mirroring the file-based `org.gradle.internal.operations.trace`). It emits an `org.gradle.BuildOperation` event per build operation while *any* recording is active, with near-zero cost otherwise (no listener is registered when the option is off).
- Each event carries the operation id, parent id, display name, failure info, and **Gradle's own clock** at start and finish. That lets JFR's JVM-clock `startTime`/`duration` be compared against Gradle's clock to diagnose timing drift. An integration test cross-checks every shared field against the `BuildOperationTrace`.
- The emitter is a `CrossBuildSession` (daemon) service, so its JFR code (Java 11+) is never loaded on the Java 8 client or worker, even though `:build-operations-trace` also targets them.

This PR only **emits** events into an existing recording. Gradle starting and managing its own recording (`org.gradle.internal.tracing.jfr.managed`) is a separate, stacked follow-up.
