### PR TITLE
Set idea.io.use.nio2 eagerly to avoid CC misses

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslConfigurationCacheIdeaIoIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslConfigurationCacheIdeaIoIntegrationTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.junit.Test
+import spock.lang.Issue
+
+
+class KotlinDslConfigurationCacheIdeaIoIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/30145")
+    @Requires(TestExecutionPreconditions.NotConfigCached::class, reason = "drives configuration cache explicitly")
+    fun `configuration cache is reused across daemons when build logic reads idea_io_use_nio2`() {
+
+        withBuildScript(
+            """
+            // Read it at configuration time (as some plugins do) to make it a cache input
+            println("idea.io.use.nio2 = " + System.getProperty("idea.io.use.nio2"))
+
+            tasks.register("noop")
+            """
+        )
+
+        executer.requireDaemon().requireIsolatedDaemons()
+        build("--configuration-cache", "noop")
+            .assertOutputContains("Calculating task graph as no cached configuration is available")
+
+        // Kill the daemon to clear system properties
+        DaemonLogsAnalyzer(executer.daemonBaseDir).killAll()
+        build("--configuration-cache", "noop")
+            .assertOutputContains("Reusing configuration cache.")
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
@@ -31,6 +31,7 @@ class KotlinScriptServices : AbstractGradleModuleServices() {
 
     override fun registerBuildTreeServices(registration: ServiceRegistration) {
         registration.addProvider(org.gradle.kotlin.dsl.accessors.BuildTreeServices)
+        registration.addProvider(org.gradle.kotlin.dsl.support.BuildTreeServices)
     }
 
     override fun registerGlobalServices(registration: ServiceRegistration) {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/BuildTreeServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/BuildTreeServices.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.internal.service.Provides
+import org.gradle.internal.service.ServiceRegistrationProvider
+
+
+internal object BuildTreeServices : ServiceRegistrationProvider {
+
+    @Provides
+    fun createIdeaIoSystemPropertyInitializer(): IdeaIoSystemPropertyInitializer =
+        IdeaIoSystemPropertyInitializer()
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IdeaIoSystemPropertyInitializer.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IdeaIoSystemPropertyInitializer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.internal.buildtree.BuildTreeLifecycleListener
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+
+
+/**
+ * Sets `idea.io.use.nio2`, which speeds up file I/O in the Kotlin compiler for `.gradle.kts` scripts.
+ *
+ * Done eagerly rather than lazily during compilation, so its value stays stable for the configuration cache across
+ * builds that compile scripts and builds that reuse already-compiled ones.
+ */
+@ServiceScope(Scope.BuildTree::class)
+internal
+class IdeaIoSystemPropertyInitializer : BuildTreeLifecycleListener {
+
+    override fun afterStart() {
+        org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -381,7 +381,6 @@ fun CompilerConfiguration.addScriptingCompilerComponents() {
 @OptIn(K1Deprecation::class)
 private
 fun Disposable.kotlinCoreEnvironmentFor(configuration: CompilerConfiguration): KotlinCoreEnvironment {
-    org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
     return SystemProperties.getInstance().withSystemProperty(
         KOTLIN_COMPILER_ENVIRONMENT_KEEPALIVE_PROPERTY.property,
         "true"


### PR DESCRIPTION
Setting it once per build tree, before the fingerprint is checked, keeps the value consistent across builds.

* Fixes https://github.com/gradle/gradle/issues/30145

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
