### PR TITLE
Allow hits for project default task request in Configuration Cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDefaultTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDefaultTaskIntegrationTest.groovy
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+class ConfigurationCacheDefaultTaskIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def "running build twice with no task arguments hits the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("echo executed")
+    }
+
+    def "running build with no arguments then explicit default task name hits the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+
+        when:
+        configurationCacheRun("echo")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("echo executed")
+    }
+
+    def "running build with explicit default task name then no arguments hits the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun("echo")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("echo executed")
+    }
+
+    def "running unrelated explicit task after no-args does not hit the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            tasks.register("build") {
+                doLast { println("build executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+
+        when:
+        configurationCacheRun("build")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("build executed")
+    }
+
+    def "running no-args after unrelated explicit task does not hit the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            tasks.register("build") {
+                doLast { println("build executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun("build")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("build executed")
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+    }
+
+    def "running multiple default tasks then by explicit names hits the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("first") {
+                doLast { println("first executed") }
+            }
+            tasks.register("second") {
+                doLast { println("second executed") }
+            }
+            defaultTasks "first", "second"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("first executed")
+        outputContains("second executed")
+
+        when:
+        configurationCacheRun("first", "second")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("first executed")
+        outputContains("second executed")
+    }
+
+    def "explicit subset of default tasks does not hit the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("first") {
+                doLast { println("first executed") }
+            }
+            tasks.register("second") {
+                doLast { println("second executed") }
+            }
+            defaultTasks "first", "second"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("first")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("first executed")
+    }
+
+    def "explicit default tasks in reordered order does not hit the configuration cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("first") {
+                doLast { println("first executed") }
+            }
+            tasks.register("second") {
+                doLast { println("second executed") }
+            }
+            defaultTasks "first", "second"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("second", "first")
+
+        then:
+        configurationCache.assertStateStored()
+    }
+
+    def "alias-shared cache entry is invalidated when a build input changes"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("ci=" + System.getProperty("ci", "false")) }
+            }
+            // Make the system property a build-logic input by reading at config time
+            println("config-time ci=" + providers.systemProperty("ci").getOrElse("false"))
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun("-Dci=true")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("config-time ci=true")
+        outputContains("ci=true")
+
+        when:
+        configurationCacheRun("-Dci=false", "echo")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("config-time ci=false")
+        outputContains("ci=false")
+    }
+
+    def "no-args and explicit help do not alias when no defaultTasks are declared"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("// no default tasks")
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("help")
+
+        then:
+        configurationCache.assertStateStored()
+    }
+
+    def "aliasing respects the excluded tasks list"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            tasks.register("other") {
+                doLast { println("other executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun("-x", "other")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("echo", "-x", "other")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("echo executed")
+    }
+
+    def "default tasks on a subproject with -p alias correctly"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        createDirs("sub")
+        settingsFile("include 'sub'")
+        file("sub/build.gradle") << """
+            tasks.register("subEcho") {
+                doLast { println("subEcho executed") }
+            }
+            defaultTasks "subEcho"
+        """
+
+        when:
+        configurationCacheRun("-p", "sub")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("subEcho executed")
+
+        when:
+        configurationCacheRun("-p", "sub", "subEcho")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("subEcho executed")
+    }
+
+    def "qualified task path does not alias to unqualified default task name"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            tasks.register("echo") {
+                doLast { println("echo executed") }
+            }
+            defaultTasks "echo"
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun(":echo")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("echo executed")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDefaultTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDefaultTaskIntegrationTest.groovy
@@ -16,6 +16,16 @@
 
 package org.gradle.internal.cc.impl
 
+/**
+ * Verifies that the configuration cache treats a no-argument invocation and an
+ * explicit invocation of the project's {@code defaultTasks} as interchangeable:
+ * either form on a subsequent build hits the cache entry stored by the other.
+ *
+ * Negative tests pin down that unrelated tasks, partial subsets, reordered task
+ * names, qualified paths, and {@code -x} exclusions are <em>not</em> incorrectly
+ * aliased; an additional test confirms that a shared entry is still invalidated
+ * by the normal fingerprint check when a build input changes between runs.
+ */
 class ConfigurationCacheDefaultTaskIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     def "running build twice with no task arguments hits the configuration cache"() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -38,10 +38,23 @@ class ConfigurationCacheKey(
 ) {
 
     val string: String by unsafeLazy {
-        Hashing.md5().newHasher().apply {
-            putCacheKeyComponents()
-        }.hash().toCompactString()
+        computeKeyString(startParameter.requestedTaskNames)
     }
+
+    /**
+     * Computes the key string as if the given task names had been requested.
+     *
+     * Used to write alias index entries on store so that `gradle` and
+     * `gradle <defaultTaskName>` resolve to the same cache entry.
+     */
+    fun stringForRequestedTaskNames(taskNames: List<String>): String =
+        computeKeyString(taskNames)
+
+    private
+    fun computeKeyString(requestedTaskNames: List<String>): String =
+        Hashing.md5().newHasher().apply {
+            putCacheKeyComponents(requestedTaskNames)
+        }.hash().toCompactString()
 
     override fun toString() = string
 
@@ -50,7 +63,7 @@ class ConfigurationCacheKey(
     override fun equals(other: Any?): Boolean = (other as? ConfigurationCacheKey)?.string == string
 
     private
-    fun Hasher.putCacheKeyComponents() {
+    fun Hasher.putCacheKeyComponents(requestedTaskNames: List<String>) {
         putString(GradleVersion.current().version)
 
         putAll(
@@ -61,10 +74,8 @@ class ConfigurationCacheKey(
 
         buildActionRequirements.appendKeyTo(this)
 
-        // TODO:bamboo review with Adam
-//        require(buildActionRequirements.isRunsTasks || startParameter.requestedTaskNames.isEmpty())
         if (buildActionRequirements.isRunsTasks) {
-            appendRequestedTasks()
+            appendRequestedTasks(requestedTaskNames)
         }
 
         putBoolean(startParameter.isOffline)
@@ -110,8 +121,7 @@ class ConfigurationCacheKey(
     }
 
     private
-    fun Hasher.appendRequestedTasks() {
-        val requestedTaskNames = startParameter.requestedTaskNames
+    fun Hasher.appendRequestedTasks(requestedTaskNames: List<String>) {
         putAll(requestedTaskNames)
 
         val excludedTaskNames = startParameter.excludedTaskNames

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -42,10 +42,10 @@ class ConfigurationCacheKey(
     }
 
     /**
-     * Computes the key string as if the given task names had been requested.
-     *
-     * Used to write alias index entries on store so that `gradle` and
-     * `gradle <defaultTaskName>` resolve to the same cache entry.
+     * Computes the key as if [taskNames] had been requested instead of
+     * [ConfigurationCacheStartParameter.requestedTaskNames]. Used when storing
+     * an alias index entry so that `gradle` and `gradle <defaultTaskName>`
+     * resolve to the same cache entry.
      */
     fun stringForRequestedTaskNames(taskNames: List<String>): String =
         computeKeyString(taskNames)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
@@ -409,7 +410,71 @@ class DefaultConfigurationCache internal constructor(
             classLoaderScopes.commit(fileFor(StateType.ClassLoaderScopes))
         }
         updateMostRecentEntry(entryId)
+        try {
+            writeDefaultTaskAlias()
+        } catch (e: Exception) {
+            // The primary entry was committed successfully above. A failure to write the
+            // secondary alias index is non-fatal: the cache remains correct, only less effective.
+            logger.warn("Failed to write default-task configuration cache alias", e)
+        }
     }
+
+    /**
+     * Writes a secondary `candidates.bin` index pointing at the just-committed cache
+     * entry from the "opposite-form" key's directory, so a follow-up `gradle` and
+     * `gradle <defaultTaskName>` resolve to the same entry. Skipped for non-task-running
+     * invocations and when the effective task names don't match the project's resolved
+     * default tasks (see [computeAliasTaskNames]).
+     */
+    private
+    fun writeDefaultTaskAlias() {
+        if (!buildActionModelRequirements.isRunsTasks) return
+        val aliasTaskNames = computeAliasTaskNames() ?: return
+        val aliasKey = cacheKey.stringForRequestedTaskNames(aliasTaskNames)
+        if (aliasKey == cacheKey.string) return
+        val aliasStore = cacheRepository.forKey(aliasKey)
+        aliasStore.useForStore {
+            applyCandidateEntriesUpdate {
+                withMostRecentEntry(
+                    CandidateEntry(entryId),
+                    startParameter.entriesPerKey
+                )
+            }
+        }
+    }
+
+    /**
+     * Returns the task-names list to use for the alias key, or null if no alias
+     * should be written. The list is the "opposite" view of this invocation:
+     * empty when invocation was explicit-default; the resolved defaults when
+     * invocation was no-args.
+     */
+    private
+    fun computeAliasTaskNames(): List<String>? {
+        val resolvedDefaults = resolvedDefaultTasks()
+        if (resolvedDefaults.isEmpty()) return null
+        val primaryTaskNames = if (startParameter.wasDefaultTaskRequest) {
+            emptyList()
+        } else {
+            startParameter.requestedTaskNames
+        }
+        return when {
+            primaryTaskNames.isEmpty() -> resolvedDefaults
+            primaryTaskNames == resolvedDefaults -> emptyList()
+            else -> null
+        }
+    }
+
+    /**
+     * Resolved default tasks for the build's default project (possibly empty).
+     *
+     * Safe to call from [commitCacheEntry] because the default project must be
+     * attached for configuration to have succeeded.
+     */
+    private
+    fun resolvedDefaultTasks(): List<String> =
+        deferredRootBuildGradle.gradle.defaultProjectState
+            .fromMutableState(ProjectInternal::getDefaultTasks)
 
     private
     fun determineCacheAction(): DescribedAction {
@@ -575,6 +640,18 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun updateCandidateEntries(update: List<CandidateEntry>.() -> List<CandidateEntry>) = store.useForStore {
+        applyCandidateEntriesUpdate(update)
+    }
+
+    /**
+     * Shared read/update/write/schedule-eviction body for candidate-entry index updates.
+     * Reads the current index, applies [update], and if the result differs writes the
+     * new index and schedules now-evicted entries for collection.
+     */
+    private
+    fun ConfigurationCacheRepository.Layout.applyCandidateEntriesUpdate(
+        update: List<CandidateEntry>.() -> List<CandidateEntry>
+    ) {
         val existingEntries = readCandidateEntries()
         val newEntries = update(existingEntries)
         if (existingEntries != newEntries) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -410,36 +410,49 @@ class DefaultConfigurationCache internal constructor(
             classLoaderScopes.commit(fileFor(StateType.ClassLoaderScopes))
         }
         updateMostRecentEntry(entryId)
-        try {
+        if (needToWriteSecondaryEntry()) {
             writeDefaultTaskAlias()
-        } catch (e: Exception) {
-            // The primary entry was committed successfully above. A failure to write the
-            // secondary alias index is non-fatal: the cache remains correct, only less effective.
-            logger.warn("Failed to write default-task configuration cache alias", e)
         }
     }
 
     /**
-     * Writes a secondary `candidates.bin` index pointing at the just-committed cache
-     * entry from the "opposite-form" key's directory, so a follow-up `gradle` and
-     * `gradle <defaultTaskName>` resolve to the same entry. Skipped for non-task-running
-     * invocations and when the effective task names don't match the project's resolved
-     * default tasks (see [computeAliasTaskNames]).
+     * True when the invocation's effective tasks match the project's resolved
+     * default tasks, so an alias index would make the just-committed entry
+     * reachable via the "other form" of the invocation (e.g. `gradle` vs
+     * `gradle <defaultTaskName>`) on a future build.
+     */
+    private
+    fun needToWriteSecondaryEntry(): Boolean {
+        if (!buildActionModelRequirements.isRunsTasks) return false
+        val aliasTaskNames = computeAliasTaskNames() ?: return false
+        return cacheKey.stringForRequestedTaskNames(aliasTaskNames) != cacheKey.string
+    }
+
+    /**
+     * Writes a `candidates.bin` pointer under the alias key so the just-committed
+     * entry is also reachable via the "other form" invocation (e.g. `gradle` vs
+     * `gradle <defaultTaskName>`).
+     *
+     * A write failure is non-fatal: the primary entry was already committed, so
+     * the cache stays correct (only less effective).
+     *
+     * @implSpec Caller must have confirmed [needToWriteSecondaryEntry] first.
      */
     private
     fun writeDefaultTaskAlias() {
-        if (!buildActionModelRequirements.isRunsTasks) return
-        val aliasTaskNames = computeAliasTaskNames() ?: return
+        val aliasTaskNames = checkNotNull(computeAliasTaskNames())
         val aliasKey = cacheKey.stringForRequestedTaskNames(aliasTaskNames)
-        if (aliasKey == cacheKey.string) return
-        val aliasStore = cacheRepository.forKey(aliasKey)
-        aliasStore.useForStore {
-            applyCandidateEntriesUpdate {
-                withMostRecentEntry(
-                    CandidateEntry(entryId),
-                    startParameter.entriesPerKey
-                )
+        try {
+            cacheRepository.forKey(aliasKey).useForStore {
+                applyCandidateEntriesUpdate {
+                    withMostRecentEntry(
+                        CandidateEntry(entryId),
+                        startParameter.entriesPerKey
+                    )
+                }
             }
+        } catch (e: Exception) {
+            logger.warn("Failed to write default-task configuration cache alias", e)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -19,7 +19,10 @@ package org.gradle.internal.cc.impl.initialization
 import org.gradle.StartParameter
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.logging.LogLevel
+import org.gradle.execution.DefaultTasksBuildTaskScheduler
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
+import org.gradle.internal.DefaultTaskExecutionRequest
+import org.gradle.internal.RunDefaultTasksExecutionRequest
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.impl.Workarounds
@@ -146,6 +149,16 @@ class ConfigurationCacheStartParameter internal constructor(
     val requestedTaskNames: List<String> by unsafeLazy {
         startParameter.taskNames
     }
+
+    /**
+     * Whether this build was invoked without explicit task names (i.e. with [RunDefaultTasksExecutionRequest]).
+     *
+     * Captured eagerly at construction time because [DefaultTasksBuildTaskScheduler] replaces
+     * [StartParameter.taskRequests] with a [DefaultTaskExecutionRequest] once it resolves the
+     * default tasks, after which the original signal is unrecoverable.
+     */
+    val wasDefaultTaskRequest: Boolean =
+        startParameter.taskRequests.singleOrNull() is RunDefaultTasksExecutionRequest
 
     val excludedTaskNames: Set<String>
         get() = startParameter.excludedTaskNames


### PR DESCRIPTION
Store configuration cache entries when a project's default task is invoked implicitly (e.g., `gradle`) and allow matching against explicit invocations (e.g., `gradle build`), and vice-versa.

This improves cache hit rates for default task invocations at the small cost of storing additional index data when the default task is invoked (implicitly or explicitly).
