### PR TITLE
Add diagnostic `repositories` task to report build repos (IP safe)

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -62,6 +62,14 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
     @Incubating
     public static final String ARTIFACT_TRANSFORMS_TASK = DiagnosticsTaskNames.ARTIFACT_TRANSFORMS_TASK;
 
+    /**
+     * The name of the repositories report task.
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    public static final String REPOSITORIES_TASK = DiagnosticsTaskNames.REPOSITORIES_TASK;
+
     public static final String MODEL_TASK = DiagnosticsTaskNames.MODEL_TASK;
 
 

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/DiagnosticsTaskNames.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/DiagnosticsTaskNames.java
@@ -86,6 +86,14 @@ public interface DiagnosticsTaskNames {
     String ARTIFACT_TRANSFORMS_TASK = "artifactTransforms";
 
     /**
+     * The name of the repositories report task.
+     *
+     * @since 9.5
+     */
+    @Incubating
+    String REPOSITORIES_TASK = "repositories";
+
+    /**
      * The name of the model report task.
      *
      * @since 8.13

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -1004,9 +1004,9 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails("ok", "-DPROP=12")
 
         then:
-        outputContains("Configuration cache entry discarded with 16 problems")
+        outputContains("Configuration cache entry discarded with 17 problems")
         problems.assertFailureHasProblems(failure) {
-            totalProblemsCount = 16
+            totalProblemsCount = 17
             withInput("Script 'script.gradle': system property 'PROP'")
             withProblem("Script 'script.gradle': line 4: registration of listener on 'Gradle.buildFinished' is unsupported")
         }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -342,7 +342,9 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
      * Returns the set of implicit task names expected for any project for the target Gradle version.
      */
     Set<String> getImplicitTasks() {
-        if (targetVersion >= GradleVersion.version("9.0")) {
+        if (targetVersion >= GradleVersion.version("9.6")) {
+            return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'repositories', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
+        } else if (targetVersion >= GradleVersion.version("9.0")) {
             return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
         } else if (targetVersion >= GradleVersion.version("8.13")) {
             return ['artifactTransforms', 'buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants', 'resolvableConfigurations']

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -342,8 +342,10 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
      * Returns the set of implicit task names expected for any project for the target Gradle version.
      */
     Set<String> getImplicitTasks() {
-        if (targetVersion >= GradleVersion.version("9.6")) {
-            return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'repositories', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
+        if (targetVersion >= GradleVersion.version("9.7")) {
+            // 'repositories' is a root-only consumer task (see SoftwareReportingTasksPlugin);
+            // 'generateRepositoriesReportData' is the per-project producer.
+            return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'generateRepositoriesReportData', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
         } else if (targetVersion >= GradleVersion.version("9.0")) {
             return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
         } else if (targetVersion >= GradleVersion.version("8.13")) {
@@ -406,7 +408,10 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
      */
     Set<String> getRootProjectImplicitTasks() {
         final rootOnlyTasks
-        if (targetVersion >= GradleVersion.version("8.8")) {
+        if (targetVersion >= GradleVersion.version("9.7")) {
+            // 'repositories' is a root-only consumer task (see SoftwareReportingTasksPlugin's producer/consumer split).
+            rootOnlyTasks = ['init', 'wrapper', 'updateDaemonJvm', 'repositories']
+        } else if (targetVersion >= GradleVersion.version("8.8")) {
             rootOnlyTasks = ['init', 'wrapper', 'updateDaemonJvm']
         } else {
             rootOnlyTasks = ['init', 'wrapper']

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -49,6 +49,7 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
                     dependencies()
                     dependencyInsight()
                     dependentComponents()
+                    generateRepositoriesReportData()
                     javaToolchains()
                     help()
                     init()
@@ -57,6 +58,7 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
                     prepareKotlinBuildScriptModel()
                     projects()
                     properties()
+                    repositories()
                     resovableVariants()
                     tasks()
                     wrapper()
@@ -344,6 +346,12 @@ model {
           | Creator: \tProject.<init>.tasks.dependentComponents()
           | Rules:
              ⤷ copyToTaskContainer
+    + generateRepositoriesReportData
+          | Type:   \torg.gradle.api.tasks.diagnostics.GenerateRepositoriesReportDataTask
+          | Value:  \ttask ':generateRepositoriesReportData\'
+          | Creator: \tProject.<init>.tasks.generateRepositoriesReportData()
+          | Rules:
+             ⤷ copyToTaskContainer
     + help
           | Type:   \torg.gradle.configuration.Help
           | Value:  \ttask ':help\'
@@ -390,6 +398,12 @@ model {
           | Type:   \torg.gradle.api.tasks.diagnostics.PropertyReportTask
           | Value:  \ttask ':properties\'
           | Creator: \tProject.<init>.tasks.properties()
+          | Rules:
+             ⤷ copyToTaskContainer
+    + repositories
+          | Type:   \torg.gradle.api.tasks.diagnostics.RepositoriesReportTask
+          | Value:  \ttask ':repositories\'
+          | Creator: \tProject.<init>.tasks.repositories()
           | Rules:
              ⤷ copyToTaskContainer
     + resolvableConfigurations

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -36,6 +36,8 @@ import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -186,7 +188,9 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private void addInclude(String group, @Nullable String moduleName, @Nullable String version, MatcherKind matcherKind) {
         assertMutable();
         if (includeSpecs == null) {
-            includeSpecs = new HashSet<>();
+            // LinkedHashSet preserves declaration order so describeIncludeRules() reports
+            // rules in the order the user declared them.
+            includeSpecs = new LinkedHashSet<>();
         }
         includeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, true));
     }
@@ -242,7 +246,9 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private void addExclude(String group, @Nullable String moduleName, @Nullable String version, MatcherKind matcherKind) {
         assertMutable();
         if (excludeSpecs == null) {
-            excludeSpecs = new HashSet<>();
+            // LinkedHashSet preserves declaration order so describeExcludeRules() reports
+            // rules in the order the user declared them.
+            excludeSpecs = new LinkedHashSet<>();
         }
         excludeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, false));
     }
@@ -314,6 +320,27 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         this.excludeSpecs = excludeSpecs;
     }
 
+    @Override
+    public List<String> describeIncludeRules() {
+        return describeSpecs(includeSpecs);
+    }
+
+    @Override
+    public List<String> describeExcludeRules() {
+        return describeSpecs(excludeSpecs);
+    }
+
+    private static List<String> describeSpecs(@Nullable Set<ContentSpec> specs) {
+        if (specs == null || specs.isEmpty()) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<String> out = ImmutableList.builderWithExpectedSize(specs.size());
+        for (ContentSpec spec : specs) {
+            out.add(spec.describe());
+        }
+        return out.build();
+    }
+
     @Nullable
     @Override
     public Map<Attribute<Object>, Set<Object>> getRequiredAttributes() {
@@ -365,6 +392,40 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         @Override
         public int hashCode() {
             return hashCode;
+        }
+
+        String describe() {
+            String prefix = inclusive ? "include" : "exclude";
+            if (module == null && version == null) {
+                // group-only
+                String methodName;
+                switch (matcherKind) {
+                    case SIMPLE:
+                        methodName = prefix + "Group";
+                        break;
+                    case SUB_GROUP:
+                        methodName = prefix + "GroupAndSubgroups";
+                        break;
+                    case REGEX:
+                        methodName = prefix + "GroupByRegex";
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown matcher kind: " + matcherKind);
+                }
+                return methodName + "(\"" + group + "\")";
+            }
+            if (version == null) {
+                // group+module
+                String methodName = matcherKind == MatcherKind.REGEX
+                    ? prefix + "ModuleByRegex"
+                    : prefix + "Module";
+                return methodName + "(\"" + group + "\", \"" + module + "\")";
+            }
+            // group+module+version
+            String versionMethod = matcherKind == MatcherKind.REGEX
+                ? prefix + "VersionByRegex"
+                : prefix + "Version";
+            return versionMethod + "(\"" + group + "\", \"" + module + "\", \"" + version + "\")";
         }
 
         SpecMatcher toMatcher() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.attributes.Attribute;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,4 +45,27 @@ public interface RepositoryContentDescriptorInternal extends RepositoryContentDe
      */
     @Nullable
     Map<Attribute<Object>, Set<Object>> getRequiredAttributes();
+
+    /**
+     * Returns user-facing descriptions of include rules declared on this descriptor,
+     * for use by diagnostic reporting.
+     *
+     * <p>Each entry is a human-readable form such as
+     * {@code includeGroup("com.example")} or
+     * {@code includeVersion("g", "m", "1.0")}. Entries preserve declaration order.
+     *
+     * <p>Note: {@code includeModule(group, module)} and {@code includeModuleByRegex(groupRegex, moduleRegex)}
+     * store identically internally and are both rendered as {@code includeModuleByRegex(...)}.
+     *
+     * @return immutable list of rule descriptions, empty when none
+     */
+    List<String> describeIncludeRules();
+
+    /**
+     * Returns user-facing descriptions of exclude rules declared on this descriptor,
+     * for use by diagnostic reporting.
+     *
+     * @return immutable list of rule descriptions, empty when none
+     */
+    List<String> describeExcludeRules();
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories
+
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import spock.lang.Specification
+
+/** Tests for {@link DefaultRepositoryContentDescriptor} describe rules. */
+class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification {
+    def descriptor = new DefaultRepositoryContentDescriptor({ "test" }, new VersionParser())
+
+    def "describes includeGroup as includeGroup(\"g\")"() {
+        when:
+        descriptor.includeGroup("com.example")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroup("com.example")']
+        descriptor.describeExcludeRules() == []
+    }
+
+    def "describes includeGroupAndSubgroups"() {
+        when:
+        descriptor.includeGroupAndSubgroups("com.example")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroupAndSubgroups("com.example")']
+    }
+
+    def "describes includeGroupByRegex"() {
+        when:
+        descriptor.includeGroupByRegex("com\\\\.example.*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroupByRegex("com\\\\.example.*")']
+    }
+
+    def "describes includeModuleByRegex"() {
+        when:
+        descriptor.includeModuleByRegex("com\\\\.example.*", "lib.*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeModuleByRegex("com\\\\.example.*", "lib.*")']
+    }
+
+    def "describes excludeModuleByRegex distinctly from excludeModule, preserving declaration order"() {
+        when:
+        descriptor.excludeModule("a", "b")
+        descriptor.excludeModuleByRegex("x\\\\..*", "y.*")
+
+        then:
+        descriptor.describeExcludeRules() == [
+            'excludeModule("a", "b")',
+            'excludeModuleByRegex("x\\\\..*", "y.*")'
+        ]
+    }
+
+    def "preserves declaration order for include rules"() {
+        when:
+        descriptor.includeGroup("z.last")
+        descriptor.includeGroup("a.first")
+        descriptor.includeGroup("m.middle")
+
+        then:
+        descriptor.describeIncludeRules() == [
+            'includeGroup("z.last")',
+            'includeGroup("a.first")',
+            'includeGroup("m.middle")'
+        ]
+    }
+
+    def "preserves declaration order for exclude rules"() {
+        when:
+        descriptor.excludeGroup("z.last")
+        descriptor.excludeGroup("a.first")
+        descriptor.excludeGroup("m.middle")
+
+        then:
+        descriptor.describeExcludeRules() == [
+            'excludeGroup("z.last")',
+            'excludeGroup("a.first")',
+            'excludeGroup("m.middle")'
+        ]
+    }
+
+    def "includeModule renders identically to includeModuleByRegex because of internal storage"() {
+        when:
+        descriptor.includeModule("com.example", "lib")
+
+        then:
+        // Known ambiguity: includeModule stores as MatcherKind.REGEX, indistinguishable from includeModuleByRegex
+        descriptor.describeIncludeRules() == ['includeModuleByRegex("com.example", "lib")']
+    }
+
+    def "describes includeVersion"() {
+        when:
+        descriptor.includeVersion("com.example", "lib", "1.0")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeVersion("com.example", "lib", "1.0")']
+    }
+
+    def "describes includeVersionByRegex"() {
+        when:
+        descriptor.includeVersionByRegex("com\\\\.example.*", "lib.*", "1\\\\..*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeVersionByRegex("com\\\\.example.*", "lib.*", "1\\\\..*")']
+    }
+
+    def "describes excludeGroup, excludeModule, excludeVersion in declaration order"() {
+        when:
+        descriptor.excludeGroup("a")
+        descriptor.excludeModule("b", "m")
+        descriptor.excludeVersion("c", "m", "1.0")
+
+        then:
+        descriptor.describeIncludeRules() == []
+        descriptor.describeExcludeRules() == [
+            'excludeGroup("a")',
+            'excludeModule("b", "m")',
+            'excludeVersion("c", "m", "1.0")'
+        ]
+    }
+
+    def "returns empty lists when no rules declared"() {
+        expect:
+        descriptor.describeIncludeRules() == []
+        descriptor.describeExcludeRules() == []
+    }
+}

--- a/platforms/software/software-diagnostics/build.gradle.kts
+++ b/platforms/software/software-diagnostics/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api(libs.jspecify)
     api(libs.inject)
 
+    implementation(projects.credentialsApi)
     implementation(projects.functional)
     implementation(projects.loggingApi)
     implementation(projects.modelCore)
@@ -44,6 +45,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.gson)
     implementation(libs.jatl)
+    implementation(libs.slf4jApi)
 
     implementationResources(variantOf(libs.jquery) { artifactType("js") })
 

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -27,6 +27,20 @@ import spock.lang.Issue
 class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.requireOwnGradleUserHomeDir()
+        // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin so that
+        // tests focused on user-defined configurations are not polluted by the diagnostics machinery.
+        settingsFile << """
+            gradle.lifecycle.beforeProject { p ->
+                p.afterEvaluate {
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = p.configurations.findByName(name)
+                        if (cfg != null) {
+                            p.configurations.remove(cfg)
+                        }
+                    }
+                }
+            }
+        """
     }
 
     def "renders graph"() {

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -32,6 +32,17 @@ class DependencyInsightReportTaskIntegrationTest extends AbstractIntegrationSpec
             rootProject.name = 'insight-test'
             gradle.lifecycle.beforeProject { project ->
                 project.pluginManager.apply('org.gradle.jvm-ecosystem')
+                project.afterEvaluate {
+                    // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin
+                    // so that tests focused on user-defined configurations and variants are not
+                    // polluted by the diagnostics machinery.
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = project.configurations.findByName(name)
+                        if (cfg != null) {
+                            project.configurations.remove(cfg)
+                        }
+                    }
+                }
             }
         """
     }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -35,6 +35,17 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         settingsFile << """
             gradle.lifecycle.beforeProject { project ->
                 project.pluginManager.apply('org.gradle.jvm-ecosystem')
+                project.afterEvaluate {
+                    // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin
+                    // so that tests focused on user-defined configurations and variants are not
+                    // polluted by the diagnostics machinery.
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = project.configurations.findByName(name)
+                        if (cfg != null) {
+                            project.configurations.remove(cfg)
+                        }
+                    }
+                }
             }
         """
     }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -18,6 +18,23 @@ package org.gradle.api.tasks.diagnostics
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class DependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin so that
+        // tests focused on user-defined configurations are not polluted by the diagnostics machinery.
+        settingsFile << """
+            gradle.lifecycle.beforeProject { p ->
+                p.afterEvaluate {
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = p.configurations.findByName(name)
+                        if (cfg != null) {
+                            p.configurations.remove(cfg)
+                        }
+                    }
+                }
+            }
+        """
+    }
+
     def "omits repeated dependencies in case of circular dependencies"() {
         given:
         createDirs("client", "a", "b", "c")

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
@@ -25,6 +25,18 @@ class OutgoingVariantsReportTaskIntegrationTest extends AbstractIntegrationSpec 
     def setup() {
         settingsFile << """
             rootProject.name = "myLib"
+            // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin so that
+            // tests focused on user-defined configurations are not polluted by the diagnostics machinery.
+            gradle.lifecycle.beforeProject { p ->
+                p.afterEvaluate {
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = p.configurations.findByName(name)
+                        if (cfg != null) {
+                            p.configurations.remove(cfg)
+                        }
+                    }
+                }
+            }
         """
     }
 

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -1,0 +1,1941 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics
+
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.handler.AbstractHandler
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.hamcrest.CoreMatchers
+import org.junit.Rule
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for {@link org.gradle.api.tasks.diagnostics.RepositoriesReportTask}.
+ */
+class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    public final HttpServer server = new HttpServer()
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "myLib"
+        """
+    }
+
+    def "task is registered under help group"() {
+        when:
+        succeeds ':tasks', '--all'
+
+        then:
+        outputContains("repositories")
+    }
+
+    def "task reports empty when no repositories declared"() {
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""There are no repositories present.""")
+        outputDoesNotContain('All Repositories')
+        outputDoesNotContain('Repositories by Location')
+        outputDoesNotContain('(none)')
+        outputDoesNotContain('Legend')
+    }
+
+    def "task reports a single mavenCentral repository in All Repositories"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
+    }
+
+    def "task reports settings pluginManagement repo under All Repositories with PLUGINS role"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                }
+            }
+            rootProject.name = "myLib"
+        """
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   ${pluginPortalUrl}
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in:  settings > pluginManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - Gradle Central Plugin Repository (1)
+
+project ':' uses
+    - Gradle Central Plugin Repository (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
+    }
+
+    def "task reports settings.buildscript repo in All Repositories and under settings uses"() {
+        given:
+        settingsFile.text = """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "myLib"
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      SETTINGS_BUILDSCRIPT_DEPENDENCIES
+    Defined in:  settings > buildscript.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - MavenRepo (1)""")
+    }
+
+    def "multi-project: PLUGINS and DRM repos appear under every project's reference list"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories { gradlePluginPortal() }
+            }
+            dependencyResolutionManagement {
+                repositories { mavenCentral() }
+            }
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   ${pluginPortalUrl}
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in:  settings > pluginManagement.repositories
+
+MavenRepo (2)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':app' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':lib' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
+    }
+
+    def "--project filter limits Repositories by Location to the single project"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories { gradlePluginPortal() }
+            }
+            dependencyResolutionManagement {
+                repositories { mavenCentral() }
+            }
+            rootProject.name = "myLib"
+            include ":app"
+            include ":other"
+        """
+        createDirs("app", "other")
+        file('app/build.gradle') << 'repositories { google() }'
+
+        when:
+        succeeds ':repositories', '--project', ':app'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   ${pluginPortalUrl}
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in:  settings > pluginManagement.repositories
+
+MavenRepo (2)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+Google (3)
+    Location:   ${googleUrl} (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+    - Google (3)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+        outputDoesNotContain('settings uses')
+        outputDoesNotContain("project ':other'")
+    }
+
+    def "--project with unknown project path fails with clear error"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+
+        when:
+        fails ':repositories', '--project', ':nope'
+
+        then:
+        failure.assertHasCause("Project ':nope' not found")
+    }
+
+    def "identical declarations in multiple projects mark entries with star and render Legend"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        file('app/build.gradle') << 'repositories { mavenCentral() }'
+        file('lib/build.gradle') << 'repositories { mavenCentral() }'
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+MavenRepo (2) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - MavenRepo (1)
+
+project ':lib' uses
+    - MavenRepo (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html""")
+    }
+
+    def "non-identical declarations do NOT trigger Legend"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        file('app/build.gradle') << '''
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content { includeGroup("com.example") }
+                }
+            }
+        '''
+        file('lib/build.gradle') << '''
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                }
+            }
+        '''
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example")
+    Defined in:  project ':app' > repositories
+
+maven (2)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - maven (1)
+
+project ':lib' uses
+    - maven (2)""")
+        outputDoesNotContain('Legend')
+    }
+
+    def "reports authentication scheme class name"() {
+        given:
+        // Use literal credentials rather than `credentials(PasswordCredentials)` so that
+        // resolving the producer\u2192consumer Configuration does not trigger Gradle's eager
+        // credential evaluation (via `populateAuthenticationCredentials` during repository
+        // descriptor creation, which is fired by `ResolveConfigurationResolutionBuildOperationDetails`).
+        // Test intent: verify the `Auth:` line renders the authentication scheme class name.
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://corp.example.com/")
+                    credentials {
+                        username = "u"
+                        password = "p"
+                    }
+                    authentication {
+                        basic(BasicAuthentication)
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://corp.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Auth:       DefaultBasicAuthentication_Decorated
+    Credentials: PRESENT
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "reports Credentials: PRESENT for repo with declared credentials"() {
+        given:
+        // Use distinctive, non-substring credential values so leak detection is unambiguous —
+        // e.g. "user" would collide with the "/userguide/" links that appear in --warning-mode output.
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://corp.example.com/")
+                    credentials {
+                        username = "cred-username-xyzzy"
+                        password = "cred-password-xyzzy"
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://corp.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Credentials: PRESENT
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+        // ensure the actual credential values never leak
+        outputDoesNotContain('cred-username-xyzzy')
+        outputDoesNotContain('cred-password-xyzzy')
+    }
+
+    def "omits Credentials line when no credentials declared"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://open.example.com/")
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://open.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+        outputDoesNotContain('Credentials:')
+    }
+
+    def "reports Secure: false when allowInsecureProtocol = true"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("http://legacy.example.com/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   http://legacy.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "renders content filter with include and onlyForConfigurations"() {
+        given:
+        buildFile << """
+            configurations.create("compile")
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        includeGroup("com.example")
+                        excludeModule("com.other", "bad")
+                        onlyForConfigurations("compile")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example"), excludeModule("com.other", "bad"), onlyForConfigurations([compile])
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+    }
+
+    def "task is configuration-cache compatible"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
+        postBuildOutputContains('Configuration cache entry stored')
+
+        when:
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        postBuildOutputContains('Configuration cache entry reused')
+    }
+
+    def "reports FlatDir repository with dirs location"() {
+        given:
+        file('libs').mkdirs()
+        buildFile << """
+            repositories {
+                flatDir {
+                    dirs 'libs'
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+flatDir (1)
+    Location:   dirs:[${testDirectory.absolutePath}/libs]
+    Type:       FLAT_DIR
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - flatDir (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
+    }
+
+    def "reports Ivy repository"() {
+        given:
+        buildFile << """
+            repositories {
+                ivy {
+                    url = uri("https://example.com/ivy/")
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+ivy (1)
+    Location:   https://example.com/ivy/ (ur)
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - ivy (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "reports Ivy repository with content filter includeGroup"() {
+        given:
+        buildFile << """
+            repositories {
+                ivy {
+                    url = uri("https://example.com/ivy/")
+                    content {
+                        includeGroup("com.example")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+ivy (1)
+    Location:   https://example.com/ivy/ (ur)
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example")
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - ivy (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "reports mavenLocal repository with MAVEN_LOCAL type"() {
+        given:
+        // MavenLocal under the embedded integ-test harness is redirected to
+        // <testDirectory>/m2-home-should-not-be-filled via -Dmaven.repo.local (see M2Installation),
+        // which the report renders as a file:/ URI (spaces percent-encoded).
+        def mavenLocalUri = "file:" + testDirectory.absolutePath.replace(' ', '%20') + "/m2-home-should-not-be-filled/"
+        buildFile << """
+            repositories {
+                mavenLocal()
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+MavenLocal (1)
+    Location:   ${mavenLocalUri}
+    Type:       MAVEN_LOCAL
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenLocal (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
+    }
+
+    def "project buildscript repo gets PROJECT_BUILDSCRIPT_DEPENDENCIES role"() {
+        given:
+        buildFile.text = """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_BUILDSCRIPT_DEPENDENCIES
+    Defined in:  project ':' > buildscript.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
+    }
+
+    def "does not list repositories from included builds"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            includeBuild 'included'
+        """
+        file('included/settings.gradle') << "rootProject.name = 'included'"
+        file('included/build.gradle') << '''
+            repositories {
+                maven { url = uri("https://included.example.com/") }
+            }
+        '''
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
+        outputDoesNotContain('included.example.com')
+        outputDoesNotContain("project ':included' uses")
+    }
+
+    def "complex example reports properly"() {
+        given:
+        // Settings plugin: adds a repo via settings.dependencyResolutionManagement.
+        file('settings-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                }
+            }
+            buildscript {
+                repositories {
+                    maven { url = uri("https://settings-buildscript.example.com/") }
+                }
+            }
+            apply from: 'settings-plugin.gradle'
+            dependencyResolutionManagement {
+                repositories {
+                    mavenCentral()
+                    google()
+                }
+            }
+            rootProject.name = "myLib"
+            include ':app'
+            include ':lib'
+            includeBuild 'included'
+        """
+        createDirs('app', 'lib')
+        buildFile << '''
+            subprojects {
+                repositories {
+                    maven { url = uri("https://subprojects.example.com/") }
+                }
+            }
+        '''
+        // Project plugin: applied to :app, adds a repo to :app's own repositories container.
+        file('app/project-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            buildscript {
+                repositories {
+                    maven { url = uri("https://app-buildscript.example.com/") }
+                }
+            }
+            apply from: 'project-plugin.gradle'
+            repositories {
+                ivy {
+                    url = uri("https://app-ivy.example.com/")
+                    credentials {
+                        username = "ivyUser"
+                        password = "ivyPass"
+                    }
+                }
+            }
+        '''
+        file('lib/build.gradle') << '''
+            repositories {
+                mavenCentral()
+            }
+            repositories {
+                flatDir { dirs 'libs' }
+            }
+        '''
+        file('included/settings.gradle') << "rootProject.name = 'included'"
+        file('included/build.gradle') << '''
+            repositories {
+                maven { url = uri("https://included.example.com/") }
+            }
+        '''
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://settings-buildscript.example.com/
+    Type:       MAVEN
+    Roles:      SETTINGS_BUILDSCRIPT_DEPENDENCIES
+    Defined in:  settings > buildscript.repositories
+
+Gradle Central Plugin Repository (2)
+    Location:   ${pluginPortalUrl}
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in:  settings > pluginManagement.repositories
+
+maven (3)
+    Location:   https://settings-plugin-drm.example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+MavenRepo (4) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+Google (5)
+    Location:   ${googleUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+maven (6)
+    Location:   https://app-buildscript.example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_BUILDSCRIPT_DEPENDENCIES
+    Defined in:  project ':app' > buildscript.repositories
+
+maven (7) *
+    Location:   https://subprojects.example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+maven2 (8)
+    Location:   https://project-plugin-repo.example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+ivy (9)
+    Location:   https://app-ivy.example.com/
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Credentials: PRESENT
+    Defined in:  project ':app' > repositories
+
+maven (10) *
+    Location:   https://subprojects.example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+MavenRepo (11) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+flatDir (12)
+    Location:   dirs:[${testDirectory.absolutePath}/lib/libs]
+    Type:       FLAT_DIR
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - maven (1)
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+
+project ':' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+
+project ':app' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+    - maven (6)
+    - maven (7)
+    - maven2 (8)
+    - ivy (9)
+
+project ':lib' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+    - maven (10)
+    - MavenRepo (11)
+    - flatDir (12)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
+        // Included build must NOT be descended
+        outputDoesNotContain('included.example.com')
+        outputDoesNotContain("project ':included'")
+        // Credential values must never leak into the output
+        outputDoesNotContain('ivyUser')
+        outputDoesNotContain('ivyPass')
+    }
+
+    def "project plugin adds repositories to its host project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+        // Script plugin acting as a project plugin: when applied to a project,
+        // it adds a repository to that project's `repositories` container.
+        file('app/project-repo-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            apply from: 'project-repo-plugin.gradle'
+        '''
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://project-plugin-repo.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "settings plugin adds repositories via dependencyResolutionManagement"() {
+        given:
+        // Script plugin acting as a settings plugin: when applied to settings,
+        // it adds a repository to settings.dependencyResolutionManagement.repositories.
+        file('settings-drm-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-drm-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://settings-plugin-drm.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - maven (1)
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (1)
+
+project ':lib' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "both project plugin and settings plugin add repositories"() {
+        given:
+        file('settings-drm-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-drm-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+        file('app/project-repo-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            apply from: 'project-repo-plugin.gradle'
+        '''
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://settings-plugin-drm.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  settings > dependencyResolutionManagement.repositories
+
+maven (2)
+    Location:   https://project-plugin-repo.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - maven (1)
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (1)
+    - maven (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "settings plugin adds repositories directly to each project"() {
+        given:
+        // Script plugin acting as a settings plugin that uses gradle.beforeProject
+        // to mutate each project's own `repositories` container.
+        file('settings-per-project-plugin.gradle') << '''
+            gradle.beforeProject { project ->
+                project.repositories {
+                    maven { url = uri("https://settings-plugin-per-project.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-per-project-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+maven (2) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+maven (3) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (2)
+
+project ':lib' uses
+    - maven (3)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+        outputDoesNotContain("Defined in:  settings >")
+    }
+
+    def "reports (ur) marker for unreachable URL"() {
+        given:
+        // Port 1 is a reserved "tcpmux" port that virtually nothing listens on — a connect there
+        // will fail immediately with ECONNREFUSED, giving us a deterministic unreachable URL.
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("http://127.0.0.1:1/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   http://127.0.0.1:1/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "reports (ua) marker for URL requiring authentication"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/ (ua)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ua) Unauthorized \u2014 the URL returned 401/403; credentials were not sent.""")
+        outputDoesNotContain('(ur)')
+    }
+
+    def "reports (o) marker on All Repositories heading in offline mode"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.
+""")
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
+    }
+
+    def "no reachability markers when URL is reachable"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                response.setStatus(HttpServletResponse.SC_OK)
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
+        outputDoesNotContain('(o)')
+        outputDoesNotContain('Legend')
+    }
+
+    def "no reachability markers when server returns 405 on HEAD but 200 on GET (fallback classifies as REACHABLE)"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                if ("HEAD".equalsIgnoreCase(request.method)) {
+                    response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED)
+                } else {
+                    response.setStatus(HttpServletResponse.SC_OK)
+                }
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
+        outputDoesNotContain('(m)')
+    }
+
+    def "reachability probes re-run on CC reuse"() {
+        given:
+        // Dynamically switchable response status — first run returns 200 (reachable),
+        // second run returns 500 (unreachable). This proves the probe runs each task
+        // execution even when the configuration cache entry is reused (no re-configuration).
+        def responseStatus = new AtomicInteger(HttpServletResponse.SC_OK)
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                response.setStatus(responseStatus.get())
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        def repoUrl = "${server.uri}"
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${repoUrl}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        postBuildOutputContains('Configuration cache entry stored')
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${repoUrl}/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('Legend')
+
+        when:
+        // Flip the handler to 500 before the second run — with CC reuse, configuration
+        // is skipped, so the only way (ur) can appear is if the execution-time probe runs again.
+        responseStatus.set(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        postBuildOutputContains('Configuration cache entry reused')
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${repoUrl}/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "renders notForConfigurations content filter branch"() {
+        given:
+        buildFile << """
+            configurations.create("skipMe")
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        notForConfigurations("skipMe")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    notForConfigurations([skipMe])
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+    }
+
+    def "renders onlyForAttribute content filter branch"() {
+        given:
+        buildFile << """
+            import org.gradle.api.attributes.Attribute
+            def attr = Attribute.of("example-attr", String)
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        onlyForAttribute(attr, "one", "two")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    onlyForAttribute(example-attr, [one, two])
+    Defined in:  project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
+    }
+
+    def "repos declared via allprojects and subprojects are shown under each project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        buildFile << '''
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            subprojects {
+                repositories {
+                    maven {
+                        url = uri("https://sub.example.com/")
+                    }
+                }
+            }
+        '''
+
+        when:
+        succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':' > repositories
+
+MavenRepo (2) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+maven (3) *
+    Location:   https://sub.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':app' > repositories
+
+MavenRepo (4) *
+    Location:   ${mavenCentralUrl}
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+maven (5) *
+    Location:   https://sub.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in:  project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)
+
+project ':app' uses
+    - MavenRepo (2)
+    - maven (3)
+
+project ':lib' uses
+    - MavenRepo (4)
+    - maven (5)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(ur) Unreachable \u2014 the URL could not be contacted.""")
+    }
+
+    def "task runs successfully under isolated projects"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        file("app/build.gradle") << "repositories { mavenCentral() }"
+        file("lib/build.gradle") << "repositories { google() }"
+
+        when:
+        succeeds ":repositories", "-Dorg.gradle.unsafe.isolated-projects=true"
+
+        then:
+        outputContains("All Repositories")
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+        // No IP-violation warnings/errors in the build output.
+        !output.contains("Cannot access project")
+        !output.contains("Project ':' cannot dynamically look up")
+    }
+
+    def "task runs successfully under isolated projects with configuration cache"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+        file("app/build.gradle") << "repositories { mavenCentral() }"
+
+        when:
+        succeeds ":repositories", "--configuration-cache", "-Dorg.gradle.unsafe.isolated-projects=true"
+
+        then:
+        postBuildOutputContains("Configuration cache entry stored")
+        outputContains("All Repositories")
+        outputContains("project ':app' uses")
+
+        when:
+        succeeds ":repositories", "--configuration-cache", "-Dorg.gradle.unsafe.isolated-projects=true"
+
+        then:
+        postBuildOutputContains("Configuration cache entry reused")
+        outputContains("project ':app' uses")
+    }
+
+    def "repositories task is only registered on the root project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":sub"
+        """
+        createDirs("sub")
+
+        expect:
+        succeeds ":repositories"
+
+        when:
+        fails ":sub:repositories"
+
+        then:
+        failure.assertThatDescription(CoreMatchers.containsString(
+            "Cannot locate tasks that match ':sub:repositories' as task 'repositories' not found in project ':sub'."))
+    }
+
+    def "generateRepositoriesReportData is registered on every project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":sub"
+        """
+        createDirs("sub")
+        file("sub/build.gradle") << "repositories { mavenCentral() }"
+
+        expect:
+        succeeds ":generateRepositoriesReportData"
+        succeeds ":sub:generateRepositoriesReportData"
+
+        and:
+        file("build/diagnostics/repositories/repositories-report-data.json").exists()
+        file("sub/build/diagnostics/repositories/repositories-report-data.json").exists()
+    }
+
+    def "generateRepositoriesReportData is not invoked by lifecycle tasks"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+        """
+
+        when:
+        succeeds "build", "--dry-run"
+
+        then:
+        !output.contains(":generateRepositoriesReportData")
+    }
+
+    /**
+     * Returns the URL that the repositories report will print for the given canonical
+     * repository factory. On CI the URL is rewritten by {@code mirroring-init-script.gradle}
+     * based on the {@code REPO_MIRROR_URLS} env var; locally the original URL is used.
+     *
+     * @param mirrorKey one of "gradle-prod-plugins", "mavencentral", "google", "jcenter"
+     * @param originalUrl the canonical URL used when no mirror is configured
+     */
+    private static String resolveReportedUrl(String mirrorKey, String originalUrl) {
+        def env = System.getenv("REPO_MIRROR_URLS")
+        if (!env) {
+            return originalUrl
+        }
+        def entries = env.split(',').collectEntries { it.split(':', 2) as List }
+        entries[mirrorKey] ?: originalUrl
+    }
+
+    private pluginPortalUrl = resolveReportedUrl("gradle-prod-plugins", "https://plugins.gradle.org/m2")
+    private mavenCentralUrl = resolveReportedUrl("mavencentral", "https://repo.maven.apache.org/maven2/")
+    private googleUrl = resolveReportedUrl("google", "https://dl.google.com/dl/android/maven2/")
+}

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ResolvableConfigurationsReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ResolvableConfigurationsReportTaskIntegrationTest.groovy
@@ -24,6 +24,18 @@ class ResolvableConfigurationsReportTaskIntegrationTest extends AbstractIntegrat
     def setup() {
         settingsFile << """
             rootProject.name = "myLib"
+            // Remove the diagnostic configurations registered by SoftwareReportingTasksPlugin so that
+            // tests focused on user-defined configurations are not polluted by the diagnostics machinery.
+            gradle.lifecycle.beforeProject { p ->
+                p.afterEvaluate {
+                    ['repositoriesReportElements', 'repositoriesData', 'repositoriesDataDependencies'].each { name ->
+                        def cfg = p.configurations.findByName(name)
+                        if (cfg != null) {
+                            p.configurations.remove(cfg)
+                        }
+                    }
+                }
+            }
         """
     }
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
@@ -16,19 +16,33 @@
 
 package org.gradle.api.plugins;
 
-import org.apache.groovy.lang.annotation.Incubating;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.initialization.ProjectDescriptor;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.diagnostics.ArtifactTransformsReportTask;
 import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
+import org.gradle.api.tasks.diagnostics.GenerateRepositoriesReportDataTask;
 import org.gradle.api.tasks.diagnostics.OutgoingVariantsReportTask;
+import org.gradle.api.tasks.diagnostics.RepositoriesReportTask;
 import org.gradle.api.tasks.diagnostics.ResolvableConfigurationsReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
+import org.gradle.api.tasks.diagnostics.internal.repositories.attributes.DiagnosticAttributes;
+import org.gradle.api.tasks.diagnostics.internal.repositories.attributes.DiagnosticType;
 import org.jspecify.annotations.NullMarked;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Adds various reporting tasks that provide information about a software project, such as information about
@@ -40,6 +54,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
     @Override
+    @SuppressWarnings("deprecation") // Configuration.setVisible(boolean) is deprecated; we use it to hide diagnostic configs from standard reports.
     public void apply(Project project) {
         final TaskContainer tasks = project.getTasks();
 
@@ -68,10 +83,87 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
             task.setImpliesSubProjects(true);
         });
+        // Producer half: registered on every project.
+        TaskProvider<GenerateRepositoriesReportDataTask> generateTask =
+            tasks.register("generateRepositoriesReportData", GenerateRepositoriesReportDataTask.class, task -> {
+                task.setDescription("Captures this project's repository declarations as JSON for consumption by the repositories report.");
+                // Intentionally no group — keep this internal-feeling task out of the help group.
+                task.getOutputFile().convention(
+                    project.getLayout().getBuildDirectory().file("diagnostics/repositories/repositories-report-data.json"));
+            });
+
+        ObjectFactory objectFactory = project.getObjects();
+        project.getConfigurations().consumable("repositoriesReportElements", config -> {
+            config.setDescription("Repository data published for the repositories report.");
+            config.setVisible(false);
+            config.attributes(attrs -> {
+                attrs.attribute(Category.CATEGORY_ATTRIBUTE,
+                    objectFactory.named(Category.class, DiagnosticAttributes.DIAGNOSTICS_CATEGORY));
+                attrs.attribute(DiagnosticType.DIAGNOSTIC_TYPE_ATTRIBUTE,
+                    objectFactory.named(DiagnosticType.class, DiagnosticType.REPOSITORIES));
+            });
+            config.getOutgoing().artifact(generateTask.flatMap(GenerateRepositoriesReportDataTask::getOutputFile));
+        });
+
+        // Consumer half: only on the root project.
+        if (project == project.getRootProject()) {
+            // Dependency-scope configuration holds the project dependencies (resolvable role disallows direct declarations).
+            project.getConfigurations().dependencyScope("repositoriesDataDependencies", config -> {
+                config.setDescription("Holds per-project dependencies whose `repositoriesReportElements` outputs feed the repositories report.");
+                config.setVisible(false);
+            });
+            project.getConfigurations().resolvable("repositoriesData", config -> {
+                config.setDescription("Resolves per-project repository data for the repositories report.");
+                config.setVisible(false);
+                config.extendsFrom(project.getConfigurations().getByName("repositoriesDataDependencies"));
+                config.attributes(attrs -> {
+                    attrs.attribute(Category.CATEGORY_ATTRIBUTE,
+                        objectFactory.named(Category.class, DiagnosticAttributes.DIAGNOSTICS_CATEGORY));
+                    attrs.attribute(DiagnosticType.DIAGNOSTIC_TYPE_ATTRIBUTE,
+                        objectFactory.named(DiagnosticType.class, DiagnosticType.REPOSITORIES));
+                });
+            });
+
+            // Enumerate every project from Settings (build-wide, IP-safe) and add a project dependency.
+            // Settings may be unavailable in unit-test contexts (e.g. `ProjectBuilder`) where the build
+            // lifecycle hasn't reached the point of having a Settings object. In that case the resolvable
+            // Configuration simply has no dependencies and the report would be empty — graceful degradation
+            // is acceptable since real builds always have Settings available when plugins are applied.
+            try {
+                SettingsInternal settings = ((ProjectInternal) project).getGradle().getSettings();
+                DependencyHandler dependencies = project.getDependencies();
+                addAllProjectsAsDependencies(settings.getRootProject(), dependencies);
+            } catch (IllegalStateException ignored) {
+                // Settings unavailable; skip project enumeration.
+            }
+
+            tasks.register(HelpTasksPlugin.REPOSITORIES_TASK, RepositoriesReportTask.class, task -> {
+                task.setDescription("Displays the repositories available for dependency resolution.");
+                task.setGroup(HelpTasksPlugin.HELP_GROUP);
+                task.setImpliesSubProjects(true);
+                // Wire the resolvable Configuration's resolved files as the data source.
+                // Note: `getRepositoriesData()` is `@Internal` (not `@InputFiles`) — see RepositoriesReportTask
+                // Javadoc for why. Task ordering is established via `dependsOn(configuration)` so the
+                // producer tasks still run before this consumer task.
+                task.dependsOn(project.getConfigurations().named("repositoriesData"));
+                task.getRepositoriesData().from(
+                    project.getConfigurations().named("repositoriesData")
+                        .map(c -> c.getIncoming().getFiles()));
+            });
+        }
         tasks.withType(TaskReportTask.class).configureEach(task -> {
             task.getShowTypes().convention(false);
             task.getShowProvenance().convention(false);
         });
+    }
+
+    private static void addAllProjectsAsDependencies(ProjectDescriptor descriptor, DependencyHandler dependencies) {
+        Map<String, String> notation = new LinkedHashMap<>();
+        notation.put("path", descriptor.getPath());
+        dependencies.add("repositoriesDataDependencies", dependencies.project(notation));
+        for (ProjectDescriptor child : descriptor.getChildren()) {
+            addAllProjectsAsDependencies(child, dependencies);
+        }
     }
 
     private static class DependencyInsightReportTaskAction implements Action<DependencyInsightReportTask> {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/GenerateRepositoriesReportDataTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/GenerateRepositoriesReportDataTask.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ArtifactRepositoryContainer;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.diagnostics.internal.repositories.json.RepositoryReportDataJsonWriter;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportModelFactory;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole;
+import org.gradle.internal.serialization.Cached;
+import org.gradle.work.DisableCachingByDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT;
+
+/**
+ * Produces a JSON file describing the repositories declared in this project's build script
+ * (both `project.buildscript.repositories` and `project.repositories`).
+ *
+ * <p>This task is registered on every project by `SoftwareReportingTasksPlugin` and is
+ * the producer half of the `repositories` report's variant-aware data exchange. The task
+ * is invoked transitively when `:repositories` runs on the root project; it has no
+ * `dependsOn` relationship to any lifecycle task.
+ *
+ * @since 9.7.0
+ */
+@Incubating
+@DisableCachingByDefault(because = "Inputs are the project model, not file properties — task should run whenever invoked")
+public abstract class GenerateRepositoriesReportDataTask extends DefaultTask {
+
+    private final Cached<RepositoryReportProjectModel> capturedModel = Cached.of(this::capture);
+
+    /**
+     * The file to which the JSON-serialized repository data is written.
+     *
+     * @return property holding the output file
+     * @since 9.7.0
+     */
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    @TaskAction
+    void generate() {
+        RepositoryReportDataJsonWriter.write(capturedModel.get(), getOutputFile().get().getAsFile());
+    }
+
+    private RepositoryReportProjectModel capture() {
+        ProjectInternal pi = (ProjectInternal) getProject();
+        String projectDisplayName = pi.getDisplayName();
+        RepositoryReportModelFactory factory = new RepositoryReportModelFactory();
+        RepositoryDeclarationSite buildscriptSite = new RepositoryDeclarationSite(
+            PROJECT, pi.getProjectPath(), "buildscript.repositories");
+        RepositoryDeclarationSite repositoriesSite = new RepositoryDeclarationSite(
+            PROJECT, pi.getProjectPath(), "repositories");
+
+        List<ReportRepository> buildscriptRepos = convertRepos(
+            pi.getBuildscript().getRepositories(),
+            factory,
+            buildscriptSite,
+            Set.of(RepositoryRole.PROJECT_BUILDSCRIPT_DEPENDENCIES),
+            projectDisplayName
+        );
+        List<ReportRepository> projectRepos = convertRepos(
+            pi.getRepositories(),
+            factory,
+            repositoriesSite,
+            Set.of(RepositoryRole.PROJECT_DEPENDENCIES),
+            projectDisplayName
+        );
+        return new RepositoryReportProjectModel(
+            pi.getProjectPath(),
+            pi.getName(),
+            buildscriptRepos,
+            projectRepos
+        );
+    }
+
+    private List<ReportRepository> convertRepos(
+        ArtifactRepositoryContainer container,
+        RepositoryReportModelFactory factory,
+        RepositoryDeclarationSite site,
+        Set<RepositoryRole> roles,
+        String projectDisplayName
+    ) {
+        List<ReportRepository> out = new ArrayList<>(container.size());
+        for (ArtifactRepository repo : container) {
+            if (!(repo instanceof AbstractArtifactRepository)) {
+                getLogger().warn(
+                    "Skipping repository '{}' in project {} > {}: not an AbstractArtifactRepository (class={})",
+                    repo.getName(), projectDisplayName, site.getBlock(), repo.getClass().getName());
+                continue;
+            }
+            out.add(factory.buildReportRepository((AbstractArtifactRepository) repo, roles, site));
+        }
+        return ImmutableList.copyOf(out);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ArtifactRepositoryContainer;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.diagnostics.internal.TextReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.repositories.json.RepositoryReportDataJsonReader;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportModelFactory;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportSettingsModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.RepositoryReachabilityChecker;
+import org.gradle.api.tasks.diagnostics.internal.repositories.renderer.ConsoleRepositoriesReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.serialization.Cached;
+import org.gradle.util.Path;
+import org.gradle.work.DisableCachingByDefault;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS;
+
+/**
+ * Displays a unified view of every repository used by the build, across settings-level
+ * and project-level declaration sites, annotated with the kinds of dependencies each is allowed to serve.
+ *
+ * <p><strong>Task placement invariants</strong>:
+ * <ul>
+ *   <li>This task is registered ONLY on the root project. {@code :sub:repositories} does not exist.</li>
+ *   <li>Per-project repository data is gathered via variant-aware dependency resolution: each
+ *       project's {@code generateRepositoriesReportData} task produces a JSON file consumed via
+ *       this task's {@code repositoriesData} resolvable Configuration. No cross-project state
+ *       access at configuration time — Isolated Projects compatible.</li>
+ *   <li>The resolvable Configuration always depends on every project, regardless of the
+ *       {@code --project} filter value. Filtering happens render-only on the aggregated model.
+ *       This keeps the Configuration's identity stable and allows configuration cache reuse
+ *       across filter changes.</li>
+ * </ul>
+ *
+ * @since 9.7.0
+ */
+@Incubating
+@DisableCachingByDefault(because = "Produces only non-cacheable console output")
+public abstract class RepositoriesReportTask extends ConventionReportTask {
+    private final Cached<RepositoryReportSettingsModel> settingsModel = Cached.of(this::buildSettingsModel);
+    private final Cached<Boolean> offline = Cached.of(this::detectOffline);
+
+    @Inject
+    @Override
+    protected abstract StyledTextOutputFactory getTextOutputFactory();
+
+    private final TextReportRenderer textRenderer = new TextReportRenderer();
+
+    @Override
+    protected TextReportRenderer getRenderer() {
+        return textRenderer;
+    }
+
+    /**
+     * Resolved per-project repository data files, supplied by the {@code repositoriesData}
+     * resolvable Configuration. Wired by {@code SoftwareReportingTasksPlugin}.
+     *
+     * <p>Marked {@code @Internal} on purpose: declaring this as {@code @InputFiles} would
+     * force Gradle to fingerprint the configuration's resolved files at task-execution time,
+     * which fires {@code ResolveConfigurationResolutionBuildOperationDetails} and eagerly
+     * materializes every repository descriptor for the resolving project. That descriptor
+     * pass calls {@code DefaultMavenArtifactRepository.createDescriptor()} which calls
+     * {@code populateAuthenticationCredentials()} — and that triggers a {@code .getOrNull()}
+     * on any {@code credentials(SomeCredentialsType)} provider, failing with
+     * {@code MissingValueException} when the corresponding {@code mavenUsername} /
+     * {@code mavenPassword} Gradle properties are absent. Treating the data as an internal
+     * collection (with execution ordering established by {@code dependsOn(configuration)})
+     * keeps the producer→consumer wiring without forcing eager credential evaluation.
+     *
+     * @return file collection of JSON data files, one per project
+     * @since 9.7.0
+     */
+    @Internal
+    public abstract ConfigurableFileCollection getRepositoriesData();
+
+    /**
+     * Limits the report to a single project path.
+     *
+     * @return property holding the project path to filter to
+     * @since 9.7.0
+     */
+    @Input
+    @Optional
+    @Option(option = "project", description = "Limits the report to a single project path")
+    public abstract Property<String> getProjectFilter();
+
+    @TaskAction
+    void report() {
+        RepositoryReportFullModel model = assembleFullModel();
+        Map<String, ReachabilityStatus> reachability;
+        if (model.isOffline()) {
+            reachability = Collections.emptyMap();
+        } else {
+            List<ReportRepository> all = collectAllRepos(model);
+            int probeCount = countProbeableLocations(all);
+            if (probeCount > 0) {
+                getLogger().lifecycle("Probing {} repository URL{}...", probeCount, probeCount == 1 ? "" : "s");
+            }
+            reachability = RepositoryReachabilityChecker.withDefaultTimeout().check(all, false);
+            if (probeCount > 0) {
+                getLogger().lifecycle("done.");
+            }
+        }
+        RepositoriesReportSpec spec = new RepositoriesReportSpec(
+            getProjectFilter().getOrNull(),
+            reachability
+        );
+        ConsoleRepositoriesReportRenderer renderer = new ConsoleRepositoriesReportRenderer(spec);
+        StyledTextOutput out = getTextOutputFactory().create(getClass());
+        renderer.render(model, out);
+    }
+
+    private RepositoryReportFullModel assembleFullModel() {
+        TreeMap<Path, RepositoryReportProjectModel> projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator());
+        for (File f : getRepositoriesData()) {
+            RepositoryReportProjectModel projectModel = RepositoryReportDataJsonReader.read(f);
+            projects.put(projectModel.getProjectPath(), projectModel);
+        }
+        return new RepositoryReportFullModel(offline.get(), settingsModel.get(), projects);
+    }
+
+    private RepositoryReportSettingsModel buildSettingsModel() {
+        ProjectInternal root = (ProjectInternal) getProject().getRootProject();
+        SettingsInternal settings = root.getGradle().getSettings();
+        RepositoryReportModelFactory factory = new RepositoryReportModelFactory();
+
+        return new RepositoryReportSettingsModel(
+            convertSettingsRepos(settings.getBuildscript().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories"),
+                Set.of(RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES)),
+            convertSettingsRepos(settings.getPluginManagement().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"),
+                Set.of(RepositoryRole.PLUGINS)),
+            convertSettingsRepos(settings.getDependencyResolutionManagement().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"),
+                Set.of(RepositoryRole.PROJECT_DEPENDENCIES))
+        );
+    }
+
+    private boolean detectOffline() {
+        ProjectInternal pi = (ProjectInternal) getProject();
+        return pi.getGradle().getStartParameter().isOffline();
+    }
+
+    private static int countProbeableLocations(List<ReportRepository> all) {
+        Set<String> uniqueProbeable = new LinkedHashSet<>();
+        for (ReportRepository r : all) {
+            if (r.getType() == org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType.MAVEN_LOCAL
+                || r.getType() == org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType.FLAT_DIR) {
+                continue;
+            }
+            String loc = r.getLocation();
+            if (loc.startsWith("http://") || loc.startsWith("https://")) {
+                uniqueProbeable.add(loc);
+            }
+        }
+        return uniqueProbeable.size();
+    }
+
+    private static List<ReportRepository> collectAllRepos(RepositoryReportFullModel model) {
+        List<ReportRepository> all = new ArrayList<>();
+        all.addAll(model.getSettings().getSettingsBuildscriptRepositories());
+        all.addAll(model.getSettings().getPluginManagementRepositories());
+        all.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+            all.addAll(p.getBuildscriptRepositories());
+            all.addAll(p.getProjectRepositories());
+        }
+        return all;
+    }
+
+    private List<ReportRepository> convertSettingsRepos(
+        ArtifactRepositoryContainer container,
+        RepositoryReportModelFactory factory,
+        RepositoryDeclarationSite site,
+        Set<RepositoryRole> roles
+    ) {
+        List<ReportRepository> out = new ArrayList<>(container.size());
+        for (ArtifactRepository repo : container) {
+            if (!(repo instanceof AbstractArtifactRepository)) {
+                getLogger().warn("Skipping repository '{}' in settings > {}: not an AbstractArtifactRepository (class={})",
+                    repo.getName(), site.getBlock(), repo.getClass().getName());
+                continue;
+            }
+            out.add(factory.buildReportRepository((AbstractArtifactRepository) repo, roles, site));
+        }
+        return ImmutableList.copyOf(out);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/DiagnosticAttributes.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/DiagnosticAttributes.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.attributes;
+
+/**
+ * Constants for diagnostic-variant attributes that augment Gradle's existing public attributes.
+ * <p>
+ * Internal-only. The {@code "diagnostics"} value is NOT added to the public {@code Category} constants.
+ */
+public final class DiagnosticAttributes {
+    /** {@link org.gradle.api.attributes.Category} value used by the repositories report's variant exchange. */
+    public static final String DIAGNOSTICS_CATEGORY = "diagnostics";
+
+    private DiagnosticAttributes() {}
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/DiagnosticType.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/DiagnosticType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.attributes;
+
+import org.gradle.api.Named;
+import org.gradle.api.attributes.Attribute;
+
+/**
+ * Attribute identifying which kind of diagnostic data a variant carries.
+ * <p>
+ * Internal-only — not part of the public API contract during incubation.
+ */
+public interface DiagnosticType extends Named {
+    /**
+     * The attribute key identifying which kind of diagnostic data a variant carries.
+     */
+    Attribute<DiagnosticType> DIAGNOSTIC_TYPE_ATTRIBUTE =
+        Attribute.of("org.gradle.diagnostics.type", DiagnosticType.class);
+
+    /**
+     * Identifies a variant carrying repositories-report data published by every project
+     * for consumption by the {@code repositories} report task.
+     */
+    String REPOSITORIES = "repositories";
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/attributes/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.attributes;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/PathTypeAdapter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/PathTypeAdapter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.json;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import org.gradle.util.Path;
+
+import java.io.IOException;
+
+/**
+ * Gson type adapter for {@link Path}, serializing as the path's string form.
+ */
+final class PathTypeAdapter extends TypeAdapter<Path> {
+    static final PathTypeAdapter INSTANCE = new PathTypeAdapter();
+
+    private PathTypeAdapter() {}
+
+    @Override
+    public void write(JsonWriter out, Path value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+        } else {
+            out.value(value.asString());
+        }
+    }
+
+    @Override
+    public Path read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+        }
+        return Path.path(in.nextString());
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonReader.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonReader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.json;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Reads a {@link RepositoryReportProjectModel} from a JSON file produced by
+ * {@link RepositoryReportDataJsonWriter}.
+ * <p>
+ * Registers {@link PathTypeAdapter} so {@link Path} is reconstructed via its
+ * canonical {@link Path#path(String)} factory rather than reflectively populating
+ * private fields.
+ */
+@NullMarked
+public final class RepositoryReportDataJsonReader {
+    private static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapter(Path.class, PathTypeAdapter.INSTANCE)
+        .create();
+
+    private RepositoryReportDataJsonReader() {}
+
+    public static RepositoryReportProjectModel read(File inputFile) {
+        try (BufferedReader reader = Files.newBufferedReader(inputFile.toPath(), StandardCharsets.UTF_8)) {
+            return GSON.fromJson(reader, RepositoryReportProjectModel.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read " + inputFile, e);
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonWriter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.json;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Writes a {@link RepositoryReportProjectModel} to a JSON file using Gson default reflection.
+ * <p>
+ * Registers {@link PathTypeAdapter} for {@link Path} so the path is serialized as its
+ * string representation rather than reflectively descending into its private fields.
+ */
+@NullMarked
+public final class RepositoryReportDataJsonWriter {
+    private static final Gson GSON = new GsonBuilder()
+        .setPrettyPrinting()
+        .serializeNulls()
+        .registerTypeAdapter(Path.class, PathTypeAdapter.INSTANCE)
+        .create();
+
+    private RepositoryReportDataJsonWriter() {}
+
+    public static void write(RepositoryReportProjectModel model, File outputFile) {
+        try {
+            Files.createDirectories(outputFile.getParentFile().toPath());
+            try (BufferedWriter writer = Files.newBufferedWriter(outputFile.toPath(), StandardCharsets.UTF_8)) {
+                GSON.toJson(model, writer);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write " + outputFile, e);
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/json/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.json;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Snapshot of a repository's content-filtering rules (include/exclude rules, configuration
+ * targeting, and attribute targeting) as resolved from
+ * {@code RepositoryContentDescriptorInternal} at model build time.
+ */
+@NullMarked
+public final class ReportContentFilter {
+    public static final ReportContentFilter EMPTY = new ReportContentFilter(
+        ImmutableList.of(), ImmutableList.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableMap.of()
+    );
+
+    private final List<String> includeRules;
+    private final List<String> excludeRules;
+    private final Set<String> onlyForConfigurations;
+    private final Set<String> notForConfigurations;
+    private final Map<String, Set<String>> onlyForAttributes;
+
+    public ReportContentFilter(
+        List<String> includeRules,
+        List<String> excludeRules,
+        Set<String> onlyForConfigurations,
+        Set<String> notForConfigurations,
+        Map<String, Set<String>> onlyForAttributes
+    ) {
+        this.includeRules = ImmutableList.copyOf(includeRules);
+        this.excludeRules = ImmutableList.copyOf(excludeRules);
+        this.onlyForConfigurations = ImmutableSet.copyOf(onlyForConfigurations);
+        this.notForConfigurations = ImmutableSet.copyOf(notForConfigurations);
+        ImmutableMap.Builder<String, Set<String>> b = ImmutableMap.builder();
+        for (Map.Entry<String, Set<String>> e : onlyForAttributes.entrySet()) {
+            b.put(e.getKey(), ImmutableSet.copyOf(e.getValue()));
+        }
+        this.onlyForAttributes = b.build();
+    }
+
+    public boolean isEmpty() {
+        return includeRules.isEmpty()
+            && excludeRules.isEmpty()
+            && onlyForConfigurations.isEmpty()
+            && notForConfigurations.isEmpty()
+            && onlyForAttributes.isEmpty();
+    }
+
+    public List<String> getIncludeRules() {
+        return includeRules;
+    }
+
+    public List<String> getExcludeRules() {
+        return excludeRules;
+    }
+
+    public Set<String> getOnlyForConfigurations() {
+        return onlyForConfigurations;
+    }
+
+    public Set<String> getNotForConfigurations() {
+        return notForConfigurations;
+    }
+
+    public Map<String, Set<String>> getOnlyForAttributes() {
+        return onlyForAttributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ReportContentFilter)) {
+            return false;
+        }
+        ReportContentFilter that = (ReportContentFilter) o;
+        return includeRules.equals(that.includeRules)
+            && excludeRules.equals(that.excludeRules)
+            && onlyForConfigurations.equals(that.onlyForConfigurations)
+            && notForConfigurations.equals(that.notForConfigurations)
+            && onlyForAttributes.equals(that.onlyForAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(includeRules, excludeRules, onlyForConfigurations, notForConfigurations, onlyForAttributes);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Immutable value object representing a single repository as it appears on the report.
+ *
+ * <p>Captures identity-forming attributes (name, type, location, auth/content) plus the
+ * role(s) the repository plays and where it was declared. See {@link #getIdentityKey()} for
+ * the structural key used by the renderer to detect duplicate declarations.
+ */
+@NullMarked
+public final class ReportRepository {
+    private final String name;
+    private final RepositoryType type;
+    private final String location;
+    private final boolean secure;
+    private final List<String> authSchemes;
+    private final boolean hasCredentials;
+    private final ReportContentFilter contentFilter;
+    private final Set<RepositoryRole> roles;
+    private final RepositoryDeclarationSite declarationSite;
+    private transient IdentityKey identityKey;
+
+    public ReportRepository(
+        String name,
+        RepositoryType type,
+        String location,
+        boolean secure,
+        List<String> authSchemes,
+        boolean hasCredentials,
+        ReportContentFilter contentFilter,
+        Set<RepositoryRole> roles,
+        RepositoryDeclarationSite declarationSite
+    ) {
+        this.name = Objects.requireNonNull(name);
+        this.type = Objects.requireNonNull(type);
+        this.location = Objects.requireNonNull(location);
+        this.secure = secure;
+        this.authSchemes = ImmutableList.copyOf(authSchemes);
+        this.hasCredentials = hasCredentials;
+        this.contentFilter = Objects.requireNonNull(contentFilter);
+        this.roles = ImmutableSet.copyOf(roles);
+        this.declarationSite = Objects.requireNonNull(declarationSite);
+        this.identityKey = new IdentityKey(name, type, location, secure, this.authSchemes, hasCredentials, contentFilter);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RepositoryType getType() {
+        return type;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public List<String> getAuthSchemes() {
+        return authSchemes;
+    }
+
+    public boolean hasCredentials() {
+        return hasCredentials;
+    }
+
+    public ReportContentFilter getContentFilter() {
+        return contentFilter;
+    }
+
+    public Set<RepositoryRole> getRoles() {
+        return roles;
+    }
+
+    public RepositoryDeclarationSite getDeclarationSite() {
+        return declarationSite;
+    }
+
+    /**
+     * Returns the identity key used to detect duplicate repository declarations.
+     */
+    public IdentityKey getIdentityKey() {
+        if (identityKey == null) {
+            identityKey = new IdentityKey(name, type, location, secure, authSchemes, hasCredentials, contentFilter);
+        }
+        return identityKey;
+    }
+
+    /**
+     * Structural key for identifying "identical" repositories. Excludes roles
+     * and declarationSite — two entries with the same configuration but
+     * declared in different places compare equal by this key.
+     */
+    public static final class IdentityKey {
+        private final String name;
+        private final RepositoryType type;
+        private final String location;
+        private final boolean secure;
+        private final List<String> authSchemes;
+        private final boolean hasCredentials;
+        private final ReportContentFilter contentFilter;
+
+        IdentityKey(String name, RepositoryType type, String location, boolean secure, List<String> authSchemes, boolean hasCredentials, ReportContentFilter contentFilter) {
+            this.name = name;
+            this.type = type;
+            this.location = location;
+            this.secure = secure;
+            this.authSchemes = authSchemes;
+            this.hasCredentials = hasCredentials;
+            this.contentFilter = contentFilter;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof IdentityKey)) {
+                return false;
+            }
+            IdentityKey that = (IdentityKey) o;
+            return secure == that.secure
+                && hasCredentials == that.hasCredentials
+                && name.equals(that.name)
+                && type == that.type
+                && location.equals(that.location)
+                && authSchemes.equals(that.authSchemes)
+                && contentFilter.equals(that.contentFilter);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, type, location, secure, authSchemes, hasCredentials, contentFilter);
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Identifies where a repository was declared: either in a settings script block or in a
+ * specific project's buildscript/repositories block. The {@link #render()} method produces
+ * the human-readable "Defined in:" line shown on the report.
+ */
+@NullMarked
+public final class RepositoryDeclarationSite {
+    /** Scope of a declaration site. */
+    public enum Scope { SETTINGS, PROJECT }
+
+    private final Scope scope;
+    private final @Nullable Path projectPath;
+    private final String block;
+
+    public RepositoryDeclarationSite(Scope scope, @Nullable Path projectPath, String block) {
+        this.scope = Objects.requireNonNull(scope);
+        this.projectPath = projectPath;
+        this.block = Objects.requireNonNull(block);
+        if (scope == Scope.PROJECT && projectPath == null) {
+            throw new IllegalArgumentException("PROJECT scope requires a non-null projectPath");
+        }
+        if (scope == Scope.SETTINGS && projectPath != null) {
+            throw new IllegalArgumentException("SETTINGS scope requires a null projectPath");
+        }
+    }
+
+    public Scope getScope() {
+        return scope;
+    }
+
+    public @Nullable Path getProjectPath() {
+        return projectPath;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public String render() {
+        if (scope == Scope.SETTINGS) {
+            return "settings > " + block;
+        }
+        return "project '" + projectPath + "' > " + block;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RepositoryDeclarationSite)) {
+            return false;
+        }
+        RepositoryDeclarationSite that = (RepositoryDeclarationSite) o;
+        return scope == that.scope
+            && Objects.equals(projectPath, that.projectPath)
+            && block.equals(that.block);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scope, projectPath, block);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Aggregates the settings-level model and the per-project models into a single
+ * configuration-cache-serializable payload consumed by
+ * {@link org.gradle.api.tasks.diagnostics.internal.repositories.renderer.ConsoleRepositoriesReportRenderer}.
+ */
+@NullMarked
+public final class RepositoryReportFullModel {
+    private static final PathComparator PATH_COMPARATOR = new PathComparator();
+
+    private final boolean offline;
+    private final RepositoryReportSettingsModel settings;
+    private final SortedMap<Path, RepositoryReportProjectModel> projectsByPath;
+
+    public static Comparator<Path> getPathComparator() {
+        return PATH_COMPARATOR;
+    }
+
+    public RepositoryReportFullModel(
+        boolean offline,
+        RepositoryReportSettingsModel settings,
+        SortedMap<Path, RepositoryReportProjectModel> projectsByPath
+    ) {
+        this.offline = offline;
+        this.settings = settings;
+        // Use a plain TreeMap with a named Serializable Comparator rather than Guava's
+        // ImmutableSortedMap so the configuration-cache serializer can round-trip this field.
+        // TreeMap has a dedicated CC codec; a lambda-based Comparator would not survive CC
+        // because the synthetic lambda class is not resolvable from the Gradle runtime class loader
+        // during cache reuse.
+        TreeMap<Path, RepositoryReportProjectModel> copy = new TreeMap<>(PATH_COMPARATOR);
+        copy.putAll(projectsByPath);
+        this.projectsByPath = copy;
+    }
+
+    /**
+     * Whether the build was invoked with {@code --offline}. Captured into the model so the
+     * single {@code Cached<RepositoryReportFullModel>} snapshot already contains everything the
+     * renderer needs, and the task action does not need to access
+     * {@link org.gradle.api.invocation.Gradle Gradle} or {@code StartParameter} at execution time
+     * (which would be CC-incompatible). Configuration cache re-validates this flag via
+     * {@code StartParameter} being a tracked CC input.
+     */
+    public boolean isOffline() {
+        return offline;
+    }
+
+    public RepositoryReportSettingsModel getSettings() {
+        return settings;
+    }
+
+    public SortedMap<Path, RepositoryReportProjectModel> getProjectsByPath() {
+        return projectsByPath;
+    }
+
+    private static final class PathComparator implements Comparator<Path>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int compare(Path a, Path b) {
+            return a.asString().compareTo(b.asString());
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.AuthenticationSupported;
+import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.repositories.UrlArtifactRepository;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.authentication.Authentication;
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenLocalArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal;
+import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the {@link ReportRepository} model for a single {@link AbstractArtifactRepository}.
+ *
+ * <p>All inspection is read-only: the factory never mutates the source repository, and it
+ * explicitly avoids reading credential values (only their presence is recorded).
+ */
+@NullMarked
+public final class RepositoryReportModelFactory {
+    /** Sentinel emitted by {@link #resolveLocation} when a URL-based repository has no URL set. */
+    private static final String NO_URL_SENTINEL = "<NO_URL>";
+
+    /**
+     * Builds a {@link ReportRepository} by inspecting the given Gradle repository.
+     *
+     * @param repo the Gradle repository being reported on
+     * @param roles the role(s) this repository plays in the build
+     * @param site where this repository was declared
+     * @return the immutable report model for this repository
+     */
+    public ReportRepository buildReportRepository(
+        AbstractArtifactRepository repo,
+        Set<RepositoryRole> roles,
+        RepositoryDeclarationSite site
+    ) {
+        RepositoryType type = resolveType(repo);
+        String location = resolveLocation(repo, type);
+        boolean secure;
+        if (type == RepositoryType.FLAT_DIR || type == RepositoryType.CUSTOM) {
+            // FLAT_DIR has no URL and no insecure-protocol concept; CUSTOM repos have unknown
+            // semantics — treat both as secure inline so resolveSecure() can enforce its
+            // URL-based-only contract.
+            secure = true;
+        } else {
+            secure = resolveSecure(repo, type);
+        }
+        List<String> authSchemes = resolveAuthSchemes(repo);
+        boolean hasCredentials = resolveHasCredentials(repo);
+        ReportContentFilter contentFilter = resolveContentFilter(repo);
+
+        return new ReportRepository(
+            repo.getName(),
+            type,
+            location,
+            secure,
+            authSchemes,
+            hasCredentials,
+            contentFilter,
+            roles,
+            site
+        );
+    }
+
+    /**
+     * Detects whether credentials were declared on the repository without ever reading their values.
+     * Uses the internal `AuthenticationSupportedInternal.getConfiguredCredentials()` `Property`
+     * and checks `isPresent()`: the property is only set when `credentials { ... }`,
+     * `credentials(SomeCredentials)`, or `setConfiguredCredentials(...)` has been invoked.
+     */
+    private boolean resolveHasCredentials(ArtifactRepository repo) {
+        if (!(repo instanceof AuthenticationSupportedInternal)) {
+            return false;
+        }
+        return ((AuthenticationSupportedInternal) repo).getConfiguredCredentials().isPresent();
+    }
+
+    private RepositoryType resolveType(ArtifactRepository repo) {
+        if (repo instanceof DefaultMavenLocalArtifactRepository) {
+            return RepositoryType.MAVEN_LOCAL;
+        } else if (repo instanceof MavenArtifactRepository) {
+            return RepositoryType.MAVEN;
+        } else if (repo instanceof IvyArtifactRepository) {
+            return RepositoryType.IVY;
+        } else if (repo instanceof FlatDirectoryArtifactRepository) {
+            return RepositoryType.FLAT_DIR;
+        } else {
+            return RepositoryType.CUSTOM;
+        }
+    }
+
+    private String resolveLocation(ArtifactRepository repo, RepositoryType type) {
+        if (type == RepositoryType.MAVEN || type == RepositoryType.MAVEN_LOCAL) {
+            return mavenUrl((MavenArtifactRepository) repo);
+        } else if (type == RepositoryType.IVY) {
+            return ivyUrl((IvyArtifactRepository) repo);
+        } else if (type == RepositoryType.FLAT_DIR) {
+            Set<File> dirs = ((FlatDirectoryArtifactRepository) repo).getDirs();
+            String joined = dirs.stream()
+                .map(File::getAbsolutePath)
+                .sorted()
+                .collect(Collectors.joining(", "));
+            return "dirs:[" + joined + "]";
+        } else {
+            // CUSTOM — no URL-based accessor; surface the concrete subclass name so users
+            // can identify which third-party repository produced the entry.
+            return repo.getClass().getName();
+        }
+    }
+
+    private static String mavenUrl(MavenArtifactRepository repo) {
+        Object url = repo.getUrl();
+        return url == null ? NO_URL_SENTINEL : url.toString();
+    }
+
+    private static String ivyUrl(IvyArtifactRepository repo) {
+        Object url = repo.getUrl();
+        return url == null ? NO_URL_SENTINEL : url.toString();
+    }
+
+    /**
+     * Resolves the {@code secure} attribute for URL-based repositories.
+     *
+     * <p>This method must only be called with URL-based types ({@link RepositoryType#MAVEN},
+     * {@link RepositoryType#MAVEN_LOCAL}, or {@link RepositoryType#IVY}). Callers are
+     * responsible for setting {@code secure} inline for {@link RepositoryType#FLAT_DIR} and
+     * {@link RepositoryType#CUSTOM}, which have no URL to inspect.
+     *
+     * @param repo the repository being inspected
+     * @param type the previously resolved type
+     * @return {@code true} if the repository does not allow insecure protocols (or is not a
+     *     {@code UrlArtifactRepository}), {@code false} otherwise
+     * @throws IllegalArgumentException if called with a non-URL-based type
+     */
+    private boolean resolveSecure(ArtifactRepository repo, RepositoryType type) {
+        if (type != RepositoryType.MAVEN && type != RepositoryType.MAVEN_LOCAL && type != RepositoryType.IVY) {
+            throw new IllegalArgumentException("resolveSecure must only be called for URL-based repository types; got: " + type);
+        }
+        if (repo instanceof UrlArtifactRepository) {
+            return !((UrlArtifactRepository) repo).isAllowInsecureProtocol();
+        }
+        return true;
+    }
+
+    private List<String> resolveAuthSchemes(ArtifactRepository repo) {
+        if (!(repo instanceof AuthenticationSupported)) {
+            return ImmutableList.of();
+        }
+        Collection<Authentication> auths = ((AuthenticationSupported) repo).getAuthentication();
+        if (auths == null || auths.isEmpty()) {
+            return ImmutableList.of();
+        }
+        List<String> names = new ArrayList<>(auths.size());
+        for (Authentication a : auths) {
+            names.add(a.getClass().getSimpleName());
+        }
+        Collections.sort(names);
+        return ImmutableList.copyOf(names);
+    }
+
+    private ReportContentFilter resolveContentFilter(AbstractArtifactRepository repo) {
+        RepositoryContentDescriptorInternal desc = repo.getRepositoryDescriptorCopy();
+        List<String> includes = desc.describeIncludeRules();
+        List<String> excludes = desc.describeExcludeRules();
+        Set<String> onlyForConfigs = desc.getIncludedConfigurations() == null
+            ? ImmutableSet.of() : ImmutableSet.copyOf(desc.getIncludedConfigurations());
+        Set<String> notForConfigs = desc.getExcludedConfigurations() == null
+            ? ImmutableSet.of() : ImmutableSet.copyOf(desc.getExcludedConfigurations());
+        Map<String, Set<String>> attrs;
+        Map<Attribute<Object>, Set<Object>> raw = desc.getRequiredAttributes();
+        if (raw == null || raw.isEmpty()) {
+            attrs = ImmutableMap.of();
+        } else {
+            Map<String, Set<String>> stringified = new TreeMap<>();
+            for (Map.Entry<Attribute<Object>, Set<Object>> e : raw.entrySet()) {
+                Set<String> values = e.getValue().stream()
+                    .map(String::valueOf).collect(Collectors.toCollection(java.util.TreeSet::new));
+                stringified.put(e.getKey().getName(), values);
+            }
+            attrs = stringified;
+        }
+        return new ReportContentFilter(includes, excludes, onlyForConfigs, notForConfigs, attrs);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Per-project slice of the repositories report: separate lists for buildscript repositories
+ * and project-level repositories, keyed by the project's {@link Path}.
+ */
+@NullMarked
+public final class RepositoryReportProjectModel {
+    private final Path projectPath;
+    private final String projectName;
+    private final List<ReportRepository> buildscriptRepositories;
+    private final List<ReportRepository> projectRepositories;
+
+    public RepositoryReportProjectModel(
+        Path projectPath,
+        String projectName,
+        List<ReportRepository> buildscriptRepositories,
+        List<ReportRepository> projectRepositories
+    ) {
+        this.projectPath = Objects.requireNonNull(projectPath);
+        this.projectName = Objects.requireNonNull(projectName);
+        this.buildscriptRepositories = ImmutableList.copyOf(buildscriptRepositories);
+        this.projectRepositories = ImmutableList.copyOf(projectRepositories);
+    }
+
+    public Path getProjectPath() {
+        return projectPath;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public List<ReportRepository> getBuildscriptRepositories() {
+        return buildscriptRepositories;
+    }
+
+    public List<ReportRepository> getProjectRepositories() {
+        return projectRepositories;
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+/**
+ * Settings-level slice of the repositories report: holds the three settings-scoped
+ * repository buckets in the same order that Gradle actually resolves them during a build
+ * (settings.buildscript, pluginManagement, dependencyResolutionManagement).
+ */
+@NullMarked
+public final class RepositoryReportSettingsModel {
+    private final List<ReportRepository> settingsBuildscriptRepositories;
+    private final List<ReportRepository> pluginManagementRepositories;
+    private final List<ReportRepository> dependencyResolutionManagementRepositories;
+
+    public RepositoryReportSettingsModel(
+        List<ReportRepository> settingsBuildscriptRepositories,
+        List<ReportRepository> pluginManagementRepositories,
+        List<ReportRepository> dependencyResolutionManagementRepositories
+    ) {
+        this.settingsBuildscriptRepositories = ImmutableList.copyOf(settingsBuildscriptRepositories);
+        this.pluginManagementRepositories = ImmutableList.copyOf(pluginManagementRepositories);
+        this.dependencyResolutionManagementRepositories = ImmutableList.copyOf(dependencyResolutionManagementRepositories);
+    }
+
+    public List<ReportRepository> getSettingsBuildscriptRepositories() {
+        return settingsBuildscriptRepositories;
+    }
+
+    public List<ReportRepository> getPluginManagementRepositories() {
+        return pluginManagementRepositories;
+    }
+
+    public List<ReportRepository> getDependencyResolutionManagementRepositories() {
+        return dependencyResolutionManagementRepositories;
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.api.Incubating;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Role a repository plays in a Gradle build, as surfaced by the {@code repositories} report.
+ *
+ * @since 9.5
+ */
+@Incubating
+@NullMarked
+public enum RepositoryRole {
+    /** Used by every project to load plugins — from {@code settings.pluginManagement.repositories}. */
+    PLUGINS,
+    /** Used by the settings script buildscript classpath — from {@code settings.buildscript.repositories}. */
+    SETTINGS_BUILDSCRIPT_DEPENDENCIES,
+    /** Used by buildscript classpath dependencies (including legacy plugin loading) — from {@code project.buildscript.repositories}. */
+    PROJECT_BUILDSCRIPT_DEPENDENCIES,
+    /** Used by project dependency resolution — from {@code project.repositories} and {@code settings.dependencyResolutionManagement.repositories}. */
+    PROJECT_DEPENDENCIES
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Categorization of a reported repository by its underlying Gradle implementation class.
+ *
+ * <p>The four standard types — {@link #MAVEN}, {@link #MAVEN_LOCAL}, {@link #IVY},
+ * {@link #FLAT_DIR} — cover every repository produced by Gradle's built-in repository
+ * factories. Third-party subclasses of {@code AbstractArtifactRepository} that do not
+ * implement any of those interfaces are classified as {@link #CUSTOM}.
+ */
+@NullMarked
+public enum RepositoryType {
+    /** Any {@code MavenArtifactRepository} that is not a local Maven repository. */
+    MAVEN,
+    /** The {@code mavenLocal()} repository. */
+    MAVEN_LOCAL,
+    /** Any {@code IvyArtifactRepository}. */
+    IVY,
+    /** Any {@code FlatDirectoryArtifactRepository}. */
+    FLAT_DIR,
+    /** A third-party {@code AbstractArtifactRepository} subclass that matches none of the above. */
+    CUSTOM
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Model classes for the repositories report, representing repository declarations,
+ * content filters, and report structure.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Result of a lightweight reachability probe for a repository URL.
+ *
+ * <p>The probe is executed at task-execution time for unique remote repository URLs.
+ * Local repositories (e.g. {@code mavenLocal()}, {@code flatDir}) are never probed
+ * and consequently never carry a reachability status.
+ */
+@NullMarked
+public enum ReachabilityStatus {
+    /** URL returned 2xx or 3xx — no marker. */
+    REACHABLE,
+    /** URL could not be contacted (DNS, connect refused, timeout, 4xx other than auth, 5xx). */
+    UNREACHABLE,
+    /** URL returned 401 or 403. */
+    UNAUTHORIZED,
+    /** URL could not be parsed as a URI. */
+    MALFORMED_URL,
+    /** Build was run with {@code --offline} — no probes were performed. */
+    OFFLINE_SKIPPED
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Issues lightweight HEAD (or GET fallback) probes to unique remote repository URLs to classify
+ * their current reachability. Intended for diagnostic purposes only — not for build resolution.
+ *
+ * <p>Credentials are not sent; any URL gated behind HTTP authentication will be reported as
+ * {@link ReachabilityStatus#UNAUTHORIZED}.
+ *
+ * <p>Probes run in parallel across a small fixed thread pool. Each probe respects a per-URL
+ * timeout (default 5 seconds) that bounds total wall time for a single URL regardless of
+ * fallback retries.
+ */
+@NullMarked
+public final class RepositoryReachabilityChecker {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryReachabilityChecker.class);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+    private static final int PROBE_THREAD_POOL_SIZE = 8;
+    private final Duration timeout;
+
+    public RepositoryReachabilityChecker(Duration timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * Convenience constructor using the default 5-second per-URL timeout.
+     */
+    public static RepositoryReachabilityChecker withDefaultTimeout() {
+        return new RepositoryReachabilityChecker(DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Probes each unique remote URL among the given repositories and returns a map from
+     * repository {@code location} to {@link ReachabilityStatus}.
+     *
+     * <p>If {@code offline} is {@code true}, no probes are issued and an empty map is returned —
+     * callers should render the "offline" indicator on the report header instead.
+     *
+     * <p>Repositories whose {@link RepositoryType} is {@link RepositoryType#MAVEN_LOCAL} or
+     * {@link RepositoryType#FLAT_DIR} are skipped entirely; their locations never appear in the
+     * result map. Non-http(s) schemes are likewise skipped.
+     *
+     * <p>Probes run in parallel on a dedicated thread pool; results remain keyed by the
+     * original {@code location} string regardless of completion order.
+     *
+     * @param repos all repositories being reported (may contain duplicates by location)
+     * @param offline whether the build is in offline mode — when true, no probes run
+     * @return map of location to status; empty when offline or no probeable URLs exist
+     */
+    public Map<String, ReachabilityStatus> check(Collection<ReportRepository> repos, boolean offline) {
+        if (offline) {
+            return ImmutableMap.of();
+        }
+        Set<String> uniqueLocations = new LinkedHashSet<>();
+        for (ReportRepository r : repos) {
+            if (isProbeable(r)) {
+                uniqueLocations.add(r.getLocation());
+            }
+        }
+        if (uniqueLocations.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        // HttpClient is not AutoCloseable on Java 17 (this module's release target); rely on GC.
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(timeout)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+        int poolSize = Math.min(PROBE_THREAD_POOL_SIZE, uniqueLocations.size());
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize, r -> {
+            Thread t = new Thread(r, "repo-reachability-probe");
+            t.setDaemon(true);
+            return t;
+        });
+        try {
+            Map<String, Future<ReachabilityStatus>> futures = new LinkedHashMap<>();
+            for (String location : uniqueLocations) {
+                futures.put(location, executor.submit(() -> probe(client, location)));
+            }
+            ImmutableMap.Builder<String, ReachabilityStatus> result = ImmutableMap.builder();
+            // Wall-clock cap per future: timeout + small grace so an individual probe cannot
+            // block the entire report indefinitely on a pathological runtime.
+            long perFutureCapMs = timeout.toMillis() + 1_000L;
+            for (Map.Entry<String, Future<ReachabilityStatus>> e : futures.entrySet()) {
+                ReachabilityStatus status;
+                try {
+                    status = e.getValue().get(perFutureCapMs, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), ie.getClass().getName(), ie.getMessage(), ie);
+                    status = ReachabilityStatus.UNREACHABLE;
+                } catch (ExecutionException ee) {
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), ee.getClass().getName(), ee.getMessage(), ee);
+                    status = ReachabilityStatus.UNREACHABLE;
+                } catch (TimeoutException te) {
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), te.getClass().getName(), te.getMessage(), te);
+                    e.getValue().cancel(true);
+                    status = ReachabilityStatus.UNREACHABLE;
+                }
+                result.put(e.getKey(), status);
+            }
+            return result.build();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static boolean isProbeable(ReportRepository r) {
+        RepositoryType type = r.getType();
+        if (type == RepositoryType.MAVEN_LOCAL || type == RepositoryType.FLAT_DIR) {
+            return false;
+        }
+        String location = r.getLocation();
+        return location.startsWith("http://") || location.startsWith("https://");
+    }
+
+    /**
+     * Probes a single URL. Issues HEAD first; on any 4xx/5xx response, retries with GET and
+     * classifies based on the GET response. Returns {@link ReachabilityStatus#MALFORMED_URL}
+     * if the location fails URI parsing, and {@link ReachabilityStatus#UNREACHABLE} when no
+     * response can be obtained at all.
+     *
+     * @param client shared HttpClient configured with this instance's timeout
+     * @param location the literal repository location string
+     * @return the classified {@link ReachabilityStatus}
+     */
+    private ReachabilityStatus probe(HttpClient client, String location) {
+        URI uri;
+        try {
+            uri = new URI(location);
+        } catch (URISyntaxException e) {
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return ReachabilityStatus.MALFORMED_URL;
+        }
+        Optional<Integer> headStatus = issue(client, uri, location, "HEAD");
+        if (!headStatus.isPresent()) {
+            // Network-level failure on HEAD; no point retrying with GET.
+            return ReachabilityStatus.UNREACHABLE;
+        }
+        int head = headStatus.get();
+        if (head >= 400 && head < 600) {
+            // Server rejected HEAD — fall back to GET and classify on that response.
+            Optional<Integer> getStatus = issue(client, uri, location, "GET");
+            if (!getStatus.isPresent()) {
+                return ReachabilityStatus.UNREACHABLE;
+            }
+            return classify(getStatus.get());
+        }
+        return classify(head);
+    }
+
+    private static ReachabilityStatus classify(int status) {
+        if (status == 401 || status == 403) {
+            return ReachabilityStatus.UNAUTHORIZED;
+        }
+        if (status >= 200 && status < 400) {
+            return ReachabilityStatus.REACHABLE;
+        }
+        return ReachabilityStatus.UNREACHABLE;
+    }
+
+    /**
+     * Issues one HTTP request. Returns {@link Optional#empty()} on any failure (network,
+     * malformed request, interruption); the resulting status — if any — is returned wrapped.
+     *
+     * <p>All caught exceptions are logged at {@code info} level on this class's logger so
+     * diagnostic details surface without polluting default output. {@code InterruptedException}
+     * re-interrupts the current thread.
+     */
+    private Optional<Integer> issue(HttpClient client, URI uri, String location, String method) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(timeout)
+                .method(method, HttpRequest.BodyPublishers.noBody())
+                .build();
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            return Optional.of(response.statusCode());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return Optional.empty();
+        } catch (Exception e) {
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * URL reachability checking for remote repository endpoints.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Failure;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
+
+/**
+ * Text renderer for the repositories report. Produces the "All Repositories" and
+ * "Repositories by Location" sections plus an optional Legend, honoring the filter
+ * and offline state carried in the supplied {@link RepositoriesReportSpec}.
+ */
+@NullMarked
+public final class ConsoleRepositoriesReportRenderer {
+    private static final String DIVIDER = "--------------------------------------------------------";
+    private static final String LEGEND_URL = "https://docs.gradle.org/current/userguide/centralizing_repositories.html";
+
+    private final RepositoriesReportSpec spec;
+
+    public ConsoleRepositoriesReportRenderer(RepositoriesReportSpec spec) {
+        this.spec = spec;
+    }
+
+    public void render(RepositoryReportFullModel model, StyledTextOutput out) {
+        if (spec.isFiltered()) {
+            validateFilter(model);
+        }
+        if (isModelEmpty(model)) {
+            if (spec.isFiltered()) {
+                out.println("There are no repositories present in project '" + spec.getProjectFilter() + "'.");
+            } else {
+                out.println("There are no repositories present.");
+            }
+            return;
+        }
+        if (spec.isFiltered()) {
+            renderFiltered(model, out);
+        } else {
+            renderFull(model, out);
+        }
+    }
+
+    private void validateFilter(RepositoryReportFullModel model) {
+        String filter = spec.getProjectFilter();
+        Path filterPath = Path.path(filter);
+        if (!model.getProjectsByPath().containsKey(filterPath)) {
+            throw new IllegalArgumentException(
+                "Project '" + filter + "' not found. Available projects: "
+                    + model.getProjectsByPath().keySet());
+        }
+    }
+
+    private boolean isModelEmpty(RepositoryReportFullModel model) {
+        var settings = model.getSettings();
+        if (!settings.getPluginManagementRepositories().isEmpty()) {
+            return false;
+        }
+        if (!settings.getSettingsBuildscriptRepositories().isEmpty()) {
+            return false;
+        }
+        if (!settings.getDependencyResolutionManagementRepositories().isEmpty()) {
+            return false;
+        }
+        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+            if (!p.getBuildscriptRepositories().isEmpty() || !p.getProjectRepositories().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void renderFull(RepositoryReportFullModel model, StyledTextOutput out) {
+        var settings = model.getSettings();
+        var projectsByPath = model.getProjectsByPath();
+        boolean offline = model.isOffline();
+        List<ReportRepository> pluginMgmt = settings.getPluginManagementRepositories();
+        List<ReportRepository> settingsBuildscript = settings.getSettingsBuildscriptRepositories();
+        List<ReportRepository> drm = settings.getDependencyResolutionManagementRepositories();
+
+        // Section 1: All Repositories — flat, globally numbered in the following order:
+        //   SETTINGS_BUILDSCRIPT_DEPENDENCIES, PLUGINS, settings DRM,
+        //   then (alphabetical by project) buildscript repos + project.repositories.
+        List<ReportRepository> allRepos = new ArrayList<>();
+        allRepos.addAll(settingsBuildscript);
+        allRepos.addAll(pluginMgmt);
+        allRepos.addAll(drm);
+        for (RepositoryReportProjectModel p : projectsByPath.values()) {
+            allRepos.addAll(p.getBuildscriptRepositories());
+            allRepos.addAll(p.getProjectRepositories());
+        }
+
+        Map<ReportRepository, Integer> numbers = assignNumbers(allRepos);
+        Set<ReportRepository> starred = computeStarred(allRepos);
+        MarkerSet markers = new MarkerSet();
+
+        renderSection("All Repositories", allRepos, numbers, starred, out, true, markers, offline);
+
+        // Section 2: Repositories by Location — settings block (all three buckets, in section-1 order) first,
+        // then per-project blocks in alphabetical order.
+        List<ReportRepository> settingsRefs = new ArrayList<>();
+        settingsRefs.addAll(settingsBuildscript);
+        settingsRefs.addAll(pluginMgmt);
+        settingsRefs.addAll(drm);
+
+        Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
+        for (Map.Entry<Path, RepositoryReportProjectModel> e : projectsByPath.entrySet()) {
+            List<ReportRepository> refs = new ArrayList<>();
+            // Settings-inherited buckets are listed in Gradle's actual repo-search order
+            // (pluginManagement precedes DRM — settings.buildscript is not inherited per-project).
+            refs.addAll(pluginMgmt);
+            refs.addAll(drm);
+            refs.addAll(e.getValue().getBuildscriptRepositories());
+            refs.addAll(e.getValue().getProjectRepositories());
+            projectRefs.put(e.getKey(), refs);
+        }
+
+        renderByLocationSection(settingsRefs, projectRefs, numbers, out);
+
+        if (!starred.isEmpty()) {
+            markers.starUsed = true;
+        }
+        renderLegendIfNeeded(markers, out);
+    }
+
+    private void renderFiltered(RepositoryReportFullModel model, StyledTextOutput out) {
+        String filter = spec.getProjectFilter();
+        Path filterPath = Path.path(filter);
+        RepositoryReportProjectModel target = model.getProjectsByPath().get(filterPath);
+        assert target != null : "validateFilter() should have rejected unknown project '" + filter + "'";
+
+        var settings = model.getSettings();
+        boolean offline = model.isOffline();
+        List<ReportRepository> filtered = new ArrayList<>();
+        filtered.addAll(settings.getPluginManagementRepositories());
+        filtered.addAll(settings.getDependencyResolutionManagementRepositories());
+        filtered.addAll(target.getBuildscriptRepositories());
+        filtered.addAll(target.getProjectRepositories());
+
+        Map<ReportRepository, Integer> numbers = assignNumbers(filtered);
+        Set<ReportRepository> starred = computeStarred(filtered);
+        MarkerSet markers = new MarkerSet();
+
+        renderSection("All Repositories", filtered, numbers, starred, out, true, markers, offline);
+
+        // Section 2 in filtered mode: ONLY the target project's block, no settings block.
+        Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
+        projectRefs.put(filterPath, filtered);
+        renderByLocationSection(null, projectRefs, numbers, out);
+
+        if (!starred.isEmpty()) {
+            markers.starUsed = true;
+        }
+        renderLegendIfNeeded(markers, out);
+    }
+
+    private void renderByLocationSection(
+        @Nullable List<ReportRepository> settingsRefs,
+        Map<Path, List<ReportRepository>> projectRefs,
+        Map<ReportRepository, Integer> numbers,
+        StyledTextOutput out
+    ) {
+        boolean hasSettingsBlock = settingsRefs != null && !settingsRefs.isEmpty();
+        Map<Path, List<ReportRepository>> nonEmptyProjectRefs = new LinkedHashMap<>();
+        for (Map.Entry<Path, List<ReportRepository>> e : projectRefs.entrySet()) {
+            if (!e.getValue().isEmpty()) {
+                nonEmptyProjectRefs.put(e.getKey(), e.getValue());
+            }
+        }
+        if (!hasSettingsBlock && nonEmptyProjectRefs.isEmpty()) {
+            return;
+        }
+
+        out.println();
+        out.println(DIVIDER);
+        out.withStyle(Header).println("Repositories by Location");
+        out.println(DIVIDER);
+        out.println();
+
+        boolean first = true;
+        if (hasSettingsBlock) {
+            renderLocationBlock("settings uses", settingsRefs, numbers, out);
+            first = false;
+        }
+        for (Map.Entry<Path, List<ReportRepository>> e : nonEmptyProjectRefs.entrySet()) {
+            if (!first) {
+                out.println();
+            }
+            first = false;
+            renderLocationBlock("project '" + e.getKey() + "' uses", e.getValue(), numbers, out);
+        }
+    }
+
+    private void renderLocationBlock(
+        String header,
+        List<ReportRepository> refs,
+        Map<ReportRepository, Integer> numbers,
+        StyledTextOutput out
+    ) {
+        out.println(header);
+        for (ReportRepository r : refs) {
+            out.println("    - " + r.getName() + " (" + numbers.get(r) + ")");
+        }
+    }
+
+    private static Map<ReportRepository, Integer> assignNumbers(List<ReportRepository> repos) {
+        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
+        int n = 1;
+        for (ReportRepository r : repos) {
+            numbers.put(r, n++);
+        }
+        return numbers;
+    }
+
+    private Set<ReportRepository> computeStarred(List<ReportRepository> all) {
+        Map<ReportRepository.IdentityKey, Integer> counts = new HashMap<>();
+        for (ReportRepository r : all) {
+            counts.merge(r.getIdentityKey(), 1, Integer::sum);
+        }
+        Set<ReportRepository> starred = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ReportRepository r : all) {
+            if (counts.get(r.getIdentityKey()) > 1) {
+                starred.add(r);
+            }
+        }
+        return starred;
+    }
+
+    private void renderSection(
+        String heading,
+        List<ReportRepository> repos,
+        Map<ReportRepository, Integer> numbers,
+        Set<ReportRepository> starred,
+        StyledTextOutput out,
+        boolean allowEmpty,
+        MarkerSet markers,
+        boolean offline
+    ) {
+        out.println();
+        out.println(DIVIDER);
+        String renderedHeading = heading;
+        if ("All Repositories".equals(heading) && offline) {
+            renderedHeading = heading + " (o)";
+            markers.offlineUsed = true;
+        }
+        out.withStyle(Header).println(renderedHeading);
+        out.println(DIVIDER);
+        out.println();
+        if (repos.isEmpty()) {
+            if (allowEmpty) {
+                out.withStyle(Info).println("(none)");
+            }
+            return;
+        }
+        boolean first = true;
+        for (ReportRepository r : repos) {
+            if (!first) {
+                out.println();
+            }
+            first = false;
+            renderRepoEntry(r, numbers.get(r), starred.contains(r), out, markers, offline);
+        }
+    }
+
+    private void renderRepoEntry(ReportRepository r, int number, boolean star, StyledTextOutput out, MarkerSet markers, boolean offline) {
+        StringBuilder header = new StringBuilder(r.getName()).append(" (").append(number).append(")");
+        if (star) {
+            header.append(" *");
+        }
+        // Reachability markers are suppressed in offline mode; the (o) on the All Repositories
+        // heading already communicates that no probes were performed.
+        String locationMarker = "";
+        if (!offline) {
+            ReachabilityStatus status = spec.getReachabilityByLocation().get(r.getLocation());
+            if (status == ReachabilityStatus.UNREACHABLE) {
+                locationMarker = " (ur)";
+                markers.unreachableUsed = true;
+            } else if (status == ReachabilityStatus.UNAUTHORIZED) {
+                locationMarker = " (ua)";
+                markers.unauthorizedUsed = true;
+            } else if (status == ReachabilityStatus.MALFORMED_URL) {
+                locationMarker = " (m)";
+                markers.malformedUsed = true;
+            }
+        }
+        out.withStyle(Identifier).text(header.toString());
+        out.println();
+        out.println("    Location:   " + r.getLocation() + locationMarker);
+        out.println("    Type:       " + r.getType());
+        out.println("    Roles:      " + r.getRoles().stream()
+            .sorted()
+            .map(RepositoryRole::name)
+            .collect(Collectors.joining(", ")));
+        if (!r.isSecure()) {
+            out.withStyle(Failure).println("    Secure:     false");
+        }
+        if (!r.getAuthSchemes().isEmpty()) {
+            out.println("    Auth:       " + String.join(", ", r.getAuthSchemes()));
+        }
+        if (r.hasCredentials()) {
+            out.println("    Credentials: PRESENT");
+        }
+        if (!r.getContentFilter().isEmpty()) {
+            out.println("    Content:    " + renderContent(r.getContentFilter()));
+        }
+        out.println("    Defined in:  " + r.getDeclarationSite().render());
+    }
+
+    private String renderContent(ReportContentFilter f) {
+        List<String> parts = new ArrayList<>();
+        parts.addAll(f.getIncludeRules());
+        parts.addAll(f.getExcludeRules());
+        if (!f.getOnlyForConfigurations().isEmpty()) {
+            parts.add("onlyForConfigurations(" + f.getOnlyForConfigurations() + ")");
+        }
+        if (!f.getNotForConfigurations().isEmpty()) {
+            parts.add("notForConfigurations(" + f.getNotForConfigurations() + ")");
+        }
+        for (Map.Entry<String, Set<String>> a : f.getOnlyForAttributes().entrySet()) {
+            parts.add("onlyForAttribute(" + a.getKey() + ", " + a.getValue() + ")");
+        }
+        return String.join(", ", parts);
+    }
+
+    private void renderLegendIfNeeded(MarkerSet markers, StyledTextOutput out) {
+        if (!markers.any()) {
+            return;
+        }
+        out.println();
+        out.println(DIVIDER);
+        out.withStyle(Header).println("Legend");
+        out.println(DIVIDER);
+        out.println();
+        StyledTextOutput info = out.withStyle(Info);
+        if (markers.starUsed) {
+            info.println("(*) Identical repository declaration found in multiple locations.");
+            info.println("    Consider consolidating to settings.dependencyResolutionManagement.repositories");
+            info.println("    or settings.pluginManagement.repositories.");
+            info.println("    See " + LEGEND_URL);
+        }
+        if (markers.unreachableUsed) {
+            info.println("(ur) Unreachable \u2014 the URL could not be contacted.");
+        }
+        if (markers.unauthorizedUsed) {
+            info.println("(ua) Unauthorized \u2014 the URL returned 401/403; credentials were not sent.");
+        }
+        if (markers.malformedUsed) {
+            info.println("(m)  Malformed URL \u2014 the URL could not be parsed.");
+        }
+        if (markers.offlineUsed) {
+            info.println("(o)  Running in offline mode \u2014 no reachability checks were performed.");
+        }
+    }
+
+    /**
+     * Tracks which legend-worthy markers were actually emitted by the renderer so the Legend
+     * section only surfaces entries that correspond to visible markers.
+     */
+    private static final class MarkerSet {
+        boolean starUsed;
+        boolean unreachableUsed;
+        boolean unauthorizedUsed;
+        boolean malformedUsed;
+        boolean offlineUsed;
+
+        boolean any() {
+            return starUsed || unreachableUsed || unauthorizedUsed || malformedUsed || offlineUsed;
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Console text renderer for the repositories report.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Read-only parameter object passed to {@code ConsoleRepositoriesReportRenderer} describing
+ * how the report should be rendered: the optional project filter and the per-location
+ * reachability results (empty when offline). The offline flag itself lives on
+ * {@link org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel}
+ * so it travels with the cached configuration-cache snapshot.
+ */
+@NullMarked
+public final class RepositoriesReportSpec {
+    private final @Nullable String projectFilter;
+    private final Map<String, ReachabilityStatus> reachabilityByLocation;
+
+    public RepositoriesReportSpec(@Nullable String projectFilter) {
+        this(projectFilter, ImmutableMap.of());
+    }
+
+    public RepositoriesReportSpec(
+        @Nullable String projectFilter,
+        Map<String, ReachabilityStatus> reachabilityByLocation
+    ) {
+        this.projectFilter = projectFilter;
+        // Defensive copy — the spec is shared with the renderer and must not observe
+        // mutations from the caller after construction.
+        this.reachabilityByLocation = ImmutableMap.copyOf(reachabilityByLocation);
+    }
+
+    public @Nullable String getProjectFilter() {
+        return projectFilter;
+    }
+
+    public boolean isFiltered() {
+        return projectFilter != null;
+    }
+
+    /**
+     * Per-location reachability status for remote HTTP(S) repositories. Keys are the literal
+     * {@code location} strings of {@code ReportRepository} entries. Repositories whose locations
+     * are not in this map carry no reachability marker (e.g. local repos, or when offline).
+     */
+    public Map<String, ReachabilityStatus> getReachabilityByLocation() {
+        return reachabilityByLocation;
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Report specification and filter options for the repositories report.
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/GenerateRepositoriesReportDataTaskTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/GenerateRepositoriesReportDataTaskTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.json.RepositoryReportDataJsonReader
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.Path
+
+class GenerateRepositoriesReportDataTaskTest extends AbstractProjectBuilderSpec {
+
+    def "task captures own project's repositories and writes JSON"() {
+        given:
+        project.with {
+            repositories {
+                mavenCentral()
+                google()
+            }
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+        }
+
+        def task = project.tasks.register("generateRepoData", GenerateRepositoriesReportDataTask) {
+            outputFile = project.layout.buildDirectory.file("test-out.json")
+        }.get()
+
+        when:
+        task.generate()
+
+        then:
+        def model = RepositoryReportDataJsonReader.read(task.outputFile.get().asFile)
+        model.projectPath == Path.path(":")
+        model.projectName == project.name
+        model.projectRepositories.size() == 2
+        model.projectRepositories*.name == ["MavenRepo", "Google"]
+        model.projectRepositories*.roles.every { it == [RepositoryRole.PROJECT_DEPENDENCIES] as Set }
+        model.buildscriptRepositories.size() == 1
+        model.buildscriptRepositories[0].roles == [RepositoryRole.PROJECT_BUILDSCRIPT_DEPENDENCIES] as Set
+    }
+
+    def "task captures empty repositories when none declared"() {
+        given:
+        def task = project.tasks.register("generateRepoData", GenerateRepositoriesReportDataTask) {
+            outputFile = project.layout.buildDirectory.file("empty.json")
+        }.get()
+
+        when:
+        task.generate()
+
+        then:
+        def model = RepositoryReportDataJsonReader.read(task.outputFile.get().asFile)
+        model.projectRepositories.isEmpty()
+        model.buildscriptRepositories.isEmpty()
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonRoundTripTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/json/RepositoryReportDataJsonRoundTripTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.json
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType
+import org.gradle.util.Path
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
+
+class RepositoryReportDataJsonRoundTripTest extends Specification {
+    @Rule
+    TemporaryFolder tempDir = new TemporaryFolder()
+
+    def "round-trips an empty project model"() {
+        given:
+        def model = new RepositoryReportProjectModel(Path.path(":empty"), "empty", [], [])
+        def file = tempDir.newFile("data.json")
+
+        when:
+        RepositoryReportDataJsonWriter.write(model, file)
+        def readBack = RepositoryReportDataJsonReader.read(file)
+
+        then:
+        readBack.projectPath == Path.path(":empty")
+        readBack.projectName == "empty"
+        readBack.buildscriptRepositories.isEmpty()
+        readBack.projectRepositories.isEmpty()
+    }
+
+    def "round-trips a Maven repo with full content filter"() {
+        given:
+        def filter = new ReportContentFilter(
+            ['includeGroup("com.example")'],
+            ['excludeModuleByRegex("a", "b")'],
+            ['compile'] as Set,
+            [] as Set,
+            ['org.gradle.usage': ['java-api'] as Set]
+        )
+        def repo = new ReportRepository(
+            "MavenRepo",
+            RepositoryType.MAVEN,
+            "https://repo.maven.apache.org/maven2/",
+            true,
+            ['BasicAuthentication'],
+            true,
+            filter,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        )
+        def model = new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo])
+        def file = tempDir.newFile("data.json")
+
+        when:
+        RepositoryReportDataJsonWriter.write(model, file)
+        def readBack = RepositoryReportDataJsonReader.read(file)
+
+        then:
+        readBack.projectRepositories.size() == 1
+        def r = readBack.projectRepositories[0]
+        r.name == "MavenRepo"
+        r.type == RepositoryType.MAVEN
+        r.location == "https://repo.maven.apache.org/maven2/"
+        r.secure
+        r.authSchemes == ['BasicAuthentication']
+        r.hasCredentials
+        r.contentFilter.includeRules == ['includeGroup("com.example")']
+        r.contentFilter.excludeRules == ['excludeModuleByRegex("a", "b")']
+        r.contentFilter.onlyForConfigurations == ['compile'] as Set
+        r.contentFilter.notForConfigurations == [] as Set
+        r.contentFilter.onlyForAttributes == ['org.gradle.usage': ['java-api'] as Set]
+        r.roles == [RepositoryRole.PROJECT_DEPENDENCIES] as Set
+        r.declarationSite.scope == PROJECT
+        r.declarationSite.projectPath == Path.path(":app")
+        r.declarationSite.block == "repositories"
+    }
+
+    def "round-trips all repository types"() {
+        given:
+        def repos = [
+            buildRepo(RepositoryType.MAVEN_LOCAL, "file:///home/user/.m2/repository"),
+            buildRepo(RepositoryType.IVY, "https://example.com/ivy/"),
+            buildRepo(RepositoryType.FLAT_DIR, "dirs:[/tmp/libs]"),
+            buildRepo(RepositoryType.CUSTOM, "com.example.MyRepository"),
+        ]
+        def model = new RepositoryReportProjectModel(Path.path(":multi"), "multi", [], repos)
+        def file = tempDir.newFile("data.json")
+
+        when:
+        RepositoryReportDataJsonWriter.write(model, file)
+        def readBack = RepositoryReportDataJsonReader.read(file)
+
+        then:
+        readBack.projectRepositories*.type == [RepositoryType.MAVEN_LOCAL, RepositoryType.IVY, RepositoryType.FLAT_DIR, RepositoryType.CUSTOM]
+        readBack.projectRepositories*.location == ["file:///home/user/.m2/repository", "https://example.com/ivy/", "dirs:[/tmp/libs]", "com.example.MyRepository"]
+    }
+
+    def "round-trips <NO_URL> location"() {
+        given:
+        def repo = buildRepo(RepositoryType.MAVEN, "<NO_URL>")
+        def model = new RepositoryReportProjectModel(Path.path(":nul"), "nul", [], [repo])
+        def file = tempDir.newFile("data.json")
+
+        when:
+        RepositoryReportDataJsonWriter.write(model, file)
+        def readBack = RepositoryReportDataJsonReader.read(file)
+
+        then:
+        readBack.projectRepositories[0].location == "<NO_URL>"
+    }
+
+    def "round-trips secure=false and hasCredentials=false flags"() {
+        given:
+        def insecureRepo = new ReportRepository(
+            "insecure",
+            RepositoryType.MAVEN,
+            "http://example.com/legacy",
+            false,                           // secure = false
+            [],
+            false,                           // hasCredentials = false
+            ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":x"), "repositories")
+        )
+        def model = new RepositoryReportProjectModel(Path.path(":x"), "x", [], [insecureRepo])
+        def file = tempDir.newFile("data.json")
+
+        when:
+        RepositoryReportDataJsonWriter.write(model, file)
+        def readBack = RepositoryReportDataJsonReader.read(file)
+
+        then:
+        def r = readBack.projectRepositories[0]
+        !r.secure
+        !r.hasCredentials
+        r.location == "http://example.com/legacy"
+    }
+
+    private static ReportRepository buildRepo(RepositoryType type, String location) {
+        new ReportRepository(
+            "name", type, location, true, [], false,
+            ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":x"), "repositories")
+        )
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model
+
+import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal
+import org.gradle.api.provider.Property
+import org.gradle.authentication.Authentication
+import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal
+import spock.lang.Specification
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
+
+/** Tests for {@link RepositoryReportModelFactory}. */
+class RepositoryReportModelFactoryTest extends Specification {
+    def factory = new RepositoryReportModelFactory()
+
+    def "converts MavenArtifactRepository"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "MavenRepo"
+            getUrl() >> URI.create("https://repo.maven.apache.org/maven2/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set, site)
+
+        then:
+        result.name == "MavenRepo"
+        result.type == RepositoryType.MAVEN
+        result.location == "https://repo.maven.apache.org/maven2/"
+        result.secure
+        result.authSchemes == []
+        !result.hasCredentials()
+        result.contentFilter.isEmpty()
+        result.roles == [RepositoryRole.PLUGINS] as Set
+        result.declarationSite == site
+    }
+
+    def "converts FlatDirectoryArtifactRepository to dirs location"() {
+        given:
+        def descriptor = Stub(RepositoryContentDescriptorInternal) {
+            describeIncludeRules() >> []
+            describeExcludeRules() >> []
+            getIncludedConfigurations() >> null
+            getExcludedConfigurations() >> null
+            getRequiredAttributes() >> null
+        }
+        def repo = Stub(TestFlatDirRepo) {
+            getName() >> "flat"
+            getDirs() >> ([new File("/tmp/a"), new File("/tmp/b")] as Set)
+            getRepositoryDescriptorCopy() >> descriptor
+        }
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "repositories")
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+
+        then:
+        result.type == RepositoryType.FLAT_DIR
+        result.location.startsWith("dirs:[")
+        result.location.contains("/tmp/a")
+        result.location.contains("/tmp/b")
+        result.secure // FlatDir always reported as secure
+    }
+
+    def "marks repo as insecure when allowInsecureProtocol=true"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "corp"
+            getUrl() >> URI.create("http://corp.example.com/maven/")
+            isAllowInsecureProtocol() >> true
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
+
+        then:
+        !result.secure
+    }
+
+    def "captures content filter rules"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "filtered"
+            getUrl() >> URI.create("https://example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> ['includeGroup("com.example")']
+                describeExcludeRules() >> ['excludeModule("a", "b")']
+                getIncludedConfigurations() >> (["compile"] as Set)
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"))
+
+        then:
+        result.contentFilter.includeRules == ['includeGroup("com.example")']
+        result.contentFilter.excludeRules == ['excludeModule("a", "b")']
+        result.contentFilter.onlyForConfigurations == ["compile"] as Set
+    }
+
+    def "extracts authentication scheme class names sorted alphabetically"() {
+        given:
+        // Use concrete implementations named exactly 'BasicAuthentication'/'DigestAuthentication'
+        // so getClass().getSimpleName() returns those strings. Interface mocks/proxies would yield
+        // generated names like '$Proxy12'.
+        def basic = new BasicAuthentication()
+        def digest = new DigestAuthentication()
+        def auths = [basic, digest] as List<Authentication>
+        def authContainer = Stub(AuthenticationContainer) {
+            isEmpty() >> false
+            size() >> auths.size()
+            iterator() >> { auths.iterator() }
+        }
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "secured"
+            getUrl() >> URI.create("https://secure.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> authContainer
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.authSchemes == ['BasicAuthentication', 'DigestAuthentication']
+    }
+
+    def "detects credentials when configured credentials Property is present"() {
+        given:
+        def credentialsProperty = Stub(Property) {
+            isPresent() >> true
+        }
+        def repo = Stub(TestAuthMavenRepo) {
+            getName() >> "secured"
+            getUrl() >> URI.create("https://secure.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getConfiguredCredentials() >> credentialsProperty
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.hasCredentials()
+    }
+
+    def "reports no credentials when configured credentials Property is empty"() {
+        given:
+        def credentialsProperty = Stub(Property) {
+            isPresent() >> false
+        }
+        def repo = Stub(TestAuthMavenRepo) {
+            getName() >> "open"
+            getUrl() >> URI.create("https://open.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getConfiguredCredentials() >> credentialsProperty
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        !result.hasCredentials()
+    }
+
+    def "classifies unknown AbstractArtifactRepository subclass as CUSTOM and surfaces its class name as the location"() {
+        given:
+        def repo = Stub(TestCustomRepo) {
+            getName() >> "mystery"
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.type == RepositoryType.CUSTOM
+        result.location.contains("TestCustomRepo")
+        result.secure // CUSTOM is reported as secure by default — no URL to inspect
+    }
+
+    def "uses <NO_URL> sentinel when MavenArtifactRepository.getUrl() returns null"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "noUrl"
+            getUrl() >> null
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
+
+        then:
+        result.location == "<NO_URL>"
+    }
+
+    def "uses <NO_URL> sentinel when IvyArtifactRepository.getUrl() returns null"() {
+        given:
+        def repo = Stub(TestIvyRepo) {
+            getName() >> "noUrl"
+            getUrl() >> null
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.type == RepositoryType.IVY
+        result.location == "<NO_URL>"
+    }
+
+    // These abstract classes merge AbstractArtifactRepository with the per-type API so Spock can stub both.
+    // (AbstractArtifactRepository is an abstract class, not an interface, so we use 'extends' + 'implements'.)
+    static abstract class TestMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository {
+        TestMavenRepo() { super(null, null) }
+    }
+    static abstract class TestIvyRepo extends AbstractArtifactRepository implements org.gradle.api.artifacts.repositories.IvyArtifactRepository {
+        TestIvyRepo() { super(null, null) }
+    }
+    static abstract class TestFlatDirRepo extends AbstractArtifactRepository implements FlatDirectoryArtifactRepository {
+        TestFlatDirRepo() { super(null, null) }
+    }
+    // Adds AuthenticationSupportedInternal so the factory's instanceof check for credential
+    // detection via getConfiguredCredentials() applies to this stub.
+    static abstract class TestAuthMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository, AuthenticationSupportedInternal {
+        TestAuthMavenRepo() { super(null, null) }
+    }
+    // A minimal AbstractArtifactRepository subclass that does NOT implement any of the
+    // Maven/Ivy/FlatDir/MavenLocal marker interfaces — must fall through to CUSTOM classification.
+    static abstract class TestCustomRepo extends AbstractArtifactRepository {
+        TestCustomRepo() { super(null, null) }
+    }
+
+    // Concrete classes named identically to the SPI interfaces so the factory's
+    // `getClass().getSimpleName()` lookup yields 'BasicAuthentication' / 'DigestAuthentication'.
+    static class BasicAuthentication implements org.gradle.authentication.http.BasicAuthentication {
+        @Override String getName() { "basic" }
+    }
+    static class DigestAuthentication implements org.gradle.authentication.http.DigestAuthentication {
+        @Override String getName() { "digest" }
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType
+import org.gradle.util.Path
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
+
+class RepositoryReachabilityCheckerTest extends Specification {
+    @AutoCleanup("stop")
+    LightweightHttpServer server = new LightweightHttpServer()
+
+    def checker = new RepositoryReachabilityChecker(Duration.ofSeconds(5))
+
+    def "REACHABLE for 200 response on HEAD"() {
+        given:
+        server.start({ exchange -> respond(exchange, 200) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "REACHABLE for 3xx redirect"() {
+        given:
+        // HttpClient follows redirects (NORMAL) by default but only for absolute targets.
+        // We just return a 302 with a location pointing at the same server so the follow yields 200.
+        server.start({ exchange ->
+            if (exchange.requestURI.path == "/redirected") {
+                respond(exchange, 200)
+            } else {
+                exchange.responseHeaders.add("Location", server.uri() + "redirected")
+                respond(exchange, 302)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "UNAUTHORIZED for #status"(int status) {
+        given:
+        server.start({ exchange -> respond(exchange, status) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNAUTHORIZED
+
+        where:
+        status << [401, 403]
+    }
+
+    def "UNREACHABLE for #status after GET fallback also fails with 4xx/5xx"(int status) {
+        given:
+        server.start({ exchange -> respond(exchange, status) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNREACHABLE
+
+        where:
+        status << [404, 500, 501]
+    }
+
+    def "REACHABLE via 405-on-HEAD, 200-on-GET fallback"() {
+        given:
+        server.start({ exchange ->
+            if (exchange.requestMethod == "HEAD") {
+                respond(exchange, 405)
+            } else {
+                respond(exchange, 200)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "REACHABLE via widened 4xx/5xx-on-HEAD, 200-on-GET fallback for status #headStatus"(int headStatus) {
+        given:
+        server.start({ exchange ->
+            if (exchange.requestMethod == "HEAD") {
+                respond(exchange, headStatus)
+            } else {
+                respond(exchange, 200)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+
+        where:
+        headStatus << [400, 501]
+    }
+
+    def "UNREACHABLE when HEAD returns 500 and GET also returns 500"() {
+        given:
+        server.start({ exchange -> respond(exchange, 500) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNREACHABLE
+    }
+
+    def "MALFORMED_URL when location fails URI parsing"() {
+        given:
+        // Force probeable (http scheme) prefix then invalid [bracket to fail URI parsing at probe time.
+        def bad = "http://[not-a-url/"
+        def repo = makeRepo(bad)
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[bad] == ReachabilityStatus.MALFORMED_URL
+    }
+
+    def "MAVEN_LOCAL repositories are skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "local", RepositoryType.MAVEN_LOCAL, "file:///tmp/mvn",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "FLAT_DIR repositories are skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "flat", RepositoryType.FLAT_DIR, "dirs:[/tmp/libs]",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "non-http scheme is skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "file", RepositoryType.MAVEN, "file:///tmp/x",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "offline mode returns empty map regardless of inputs"() {
+        given:
+        def repo = makeRepo("http://anywhere.example.com/")
+
+        when:
+        def result = checker.check([repo], true)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "deduplicates: two repos with same location produce only one probe"() {
+        given:
+        def counter = new AtomicInteger(0)
+        server.start({ exchange ->
+            counter.incrementAndGet()
+            respond(exchange, 200)
+        })
+        def r1 = makeRepo(server.uri())
+        def r2 = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([r1, r2], false)
+
+        then:
+        result.size() == 1
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+        counter.get() == 1
+    }
+
+    private static ReportRepository makeRepo(String location) {
+        return new ReportRepository(
+            "r", RepositoryType.MAVEN, location,
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+    }
+
+    private static void respond(HttpExchange exchange, int status) {
+        exchange.sendResponseHeaders(status, -1)
+        exchange.close()
+    }
+
+    /**
+     * Minimal HTTP server fixture so these unit tests do not depend on Jetty or on the
+     * integration-test HttpServer fixture (which lives in testFixtures we don't consume here).
+     */
+    static class LightweightHttpServer {
+        HttpServer underlying
+        int port
+
+        void start(HttpHandler handler) {
+            underlying = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+            underlying.createContext("/", handler)
+            underlying.start()
+            port = underlying.address.port
+        }
+
+        String uri() {
+            return "http://127.0.0.1:${port}/"
+        }
+
+        void stop() {
+            if (underlying != null) {
+                underlying.stop(0)
+            }
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -1,0 +1,582 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportSettingsModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec
+import org.gradle.internal.logging.text.TestStyledTextOutput
+import org.gradle.util.Path
+import spock.lang.Specification
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
+
+/** Tests for {@link ConsoleRepositoriesReportRenderer}. */
+class ConsoleRepositoriesReportRendererTest extends Specification {
+    def output = new TestStyledTextOutput()
+
+    def "renders completely empty model with top-level empty message"() {
+        given:
+        def model = new RepositoryReportFullModel(
+            false,
+            new RepositoryReportSettingsModel([], [], []),
+            new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        )
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("There are no repositories present.")
+        !text.contains("All Repositories")
+        !text.contains("Repositories by Location")
+        !text.contains("(none)")
+        !text.contains("Legend")
+    }
+
+    def "renders filtered empty model with project-specific empty message"() {
+        given:
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        def model = new RepositoryReportFullModel(
+            false,
+            new RepositoryReportSettingsModel([], [], []),
+            projects
+        )
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("There are no repositories present in project ':app'.")
+        !text.contains("All Repositories")
+        !text.contains("Repositories by Location")
+        !text.contains("(none)")
+    }
+
+    def "renders single PLUGINS repo in All Repositories section with correct numbering"() {
+        given:
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def repo = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, ReportContentFilter.EMPTY, [RepositoryRole.PLUGINS] as Set, site
+        )
+        def settings = new RepositoryReportSettingsModel([], [repo], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("MavenRepo (1)")
+        text.contains("Location:")
+        text.contains("https://repo.maven.apache.org/maven2/")
+        text.contains("Roles:")
+        text.contains("PLUGINS")
+        text.contains("Defined in:")
+        text.contains("settings > pluginManagement.repositories")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("project ':app' uses")
+        text.contains("- MavenRepo (1)")
+        !text.contains("(none)")
+        !text.contains("Legend")
+    }
+
+    def "renders Legend when identical declarations present"() {
+        given:
+        def content = ReportContentFilter.EMPTY
+        def site1 = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def site2 = new RepositoryDeclarationSite(PROJECT, Path.path(":lib"), "repositories")
+        def repo1 = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, content, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site1)
+        def repo2 = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, content, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site2)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo1]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], [repo2]))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("MavenRepo (1) *")
+        text.contains("MavenRepo (2) *")
+        text.contains("Legend")
+        text.contains("Identical repository declaration")
+    }
+
+    def "--project filter suppresses settings block and limits Repositories by Location to the filtered project"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "RepoA", RepositoryType.MAVEN, "https://a.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("RepoA (1)")
+        text.contains("Repositories by Location")
+        text.contains("project ':app' uses")
+        text.contains("- RepoA (1)")
+        !text.contains("settings uses")
+        !text.contains(":lib")
+    }
+
+    def "renders settings-declared buildscript repo in All Repositories and under settings uses"() {
+        given:
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def repo = new ReportRepository(
+            "BuildRepo", RepositoryType.MAVEN, "https://corp.example.com/buildscript/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, site
+        )
+        def settings = new RepositoryReportSettingsModel([repo], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("BuildRepo (1)")
+        text.contains("SETTINGS_BUILDSCRIPT_DEPENDENCIES")
+        text.contains("settings > buildscript.repositories")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("- BuildRepo (1)")
+    }
+
+    def "--project filter includes PLUGINS and DRM repos from settings but no settings uses block"() {
+        given:
+        def pluginSite = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def drmSite = new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories")
+        def projSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def pluginRepo = new ReportRepository(
+            "PluginPortal", RepositoryType.MAVEN, "https://plugins.gradle.org/m2/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PLUGINS] as Set, pluginSite
+        )
+        def drmRepo = new ReportRepository(
+            "DrmRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, drmSite
+        )
+        def appRepo = new ReportRepository(
+            "AppRepo", RepositoryType.MAVEN, "https://app.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [pluginRepo], [drmRepo])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("PluginPortal (1)")
+        text.contains("DrmRepo (2)")
+        text.contains("AppRepo (3)")
+        text.contains("project ':app' uses")
+        !text.contains("settings uses")
+    }
+
+    def "omits project blocks in Repositories by Location when their reference lists are empty"() {
+        given:
+        def projSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def appRepo = new ReportRepository(
+            "AppRepo", RepositoryType.MAVEN, "https://app.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("Repositories by Location")
+        text.contains("project ':app' uses")
+        text.contains("- AppRepo (1)")
+        // settings has no declared repos — block is suppressed
+        !text.contains("settings uses")
+        // :lib has no refs — block is suppressed
+        !text.contains("project ':lib' uses")
+        !text.contains("(none)")
+    }
+
+    def "omits empty project blocks but keeps settings uses when only settings.buildscript present"() {
+        given:
+        // A settings.buildscript repo — goes into All Repositories and under "settings uses" as a bucket.
+        // Projects have no refs (no PLUGINS, no DRM, no project repos).
+        def settingsSite = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def settingsBuildscriptRepo = new ReportRepository(
+            "BuildRepo", RepositoryType.MAVEN, "https://corp.example.com/buildscript/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, settingsSite
+        )
+        def settings = new RepositoryReportSettingsModel([settingsBuildscriptRepo], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("BuildRepo (1)")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("- BuildRepo (1)")
+        // Per-project blocks are suppressed because they inherit no PLUGINS/DRM and declare nothing
+        !text.contains("project ':app' uses")
+        !text.contains("project ':lib' uses")
+        !text.contains("(none)")
+    }
+
+    def "suppresses Repositories by Location heading entirely when --project target has empty reference list"() {
+        given:
+        // Some repo exists in another project so the top-level empty-model short-circuit does not trigger.
+        def otherSite = new RepositoryDeclarationSite(PROJECT, Path.path(":other"), "repositories")
+        def otherRepo = new ReportRepository(
+            "OtherRepo", RepositoryType.MAVEN, "https://other.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, otherSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":foo"),
+            new RepositoryReportProjectModel(Path.path(":foo"), "foo", [], []))
+        projects.put(Path.path(":other"),
+            new RepositoryReportProjectModel(Path.path(":other"), "other", [], [otherRepo]))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":foo"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        // The filtered "All Repositories" section still renders (with (none) content since :foo has no repos).
+        text.contains("All Repositories")
+        // Repositories by Location section is suppressed entirely because :foo has no refs.
+        !text.contains("Repositories by Location")
+        !text.contains("settings uses")
+        !text.contains("project ':foo' uses")
+        !text.contains("project ':other' uses")
+    }
+
+    def "renders (ur) marker and legend entry when a repo is UNREACHABLE"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "DeadRepo", RepositoryType.MAVEN, "http://127.0.0.1:1/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(false, new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null,
+            ["http://127.0.0.1:1/": ReachabilityStatus.UNREACHABLE])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("DeadRepo (1)")
+        text.contains("Location:   http://127.0.0.1:1/ (ur)")
+        !text.contains("DeadRepo (1) (ur)")
+        text.contains("Legend")
+        text.contains("(ur) Unreachable")
+        !text.contains("(ua) Unauthorized")
+        !text.contains("(o)  Running in offline")
+    }
+
+    def "renders (ua) marker and legend entry when a repo is UNAUTHORIZED"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "AuthRepo", RepositoryType.MAVEN, "https://auth.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(false, new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null,
+            ["https://auth.example/": ReachabilityStatus.UNAUTHORIZED])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("AuthRepo (1)")
+        text.contains("Location:   https://auth.example/ (ua)")
+        !text.contains("AuthRepo (1) (ua)")
+        text.contains("Legend")
+        text.contains("(ua) Unauthorized")
+        !text.contains("(ur) Unreachable")
+    }
+
+    def "renders (m) marker and legend entry when a repo has a MALFORMED_URL"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "BadRepo", RepositoryType.MAVEN, "http://[not-a-url/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(false, new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null,
+            ["http://[not-a-url/": ReachabilityStatus.MALFORMED_URL])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("BadRepo (1)")
+        text.contains("Location:   http://[not-a-url/ (m)")
+        !text.contains("BadRepo (1) (m)")
+        text.contains("Legend")
+        text.contains("(m)  Malformed URL")
+        !text.contains("(ur) Unreachable")
+        !text.contains("(ua) Unauthorized")
+    }
+
+    def "renders (o) marker on All Repositories heading and legend when offline"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "AnyRepo", RepositoryType.MAVEN, "https://any.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(true, new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, [:])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories (o)")
+        text.contains("Legend")
+        text.contains("(o)  Running in offline mode")
+        // No per-repo reachability markers in offline mode.
+        !text.contains("(ur)")
+        !text.contains("(ua)")
+        // Sanity: the repo itself still renders.
+        text.contains("AnyRepo (1)")
+    }
+
+    def "legend is suppressed when no marker was emitted even if reachability map is provided"() {
+        given:
+        // A REACHABLE status must not trigger any marker — and therefore no legend.
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "LiveRepo", RepositoryType.MAVEN, "https://live.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(false, new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null,
+            ["https://live.example/": ReachabilityStatus.REACHABLE])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("LiveRepo (1)")
+        !text.contains("(ur)")
+        !text.contains("(ua)")
+        !text.contains("(o)")
+        !text.contains("Legend")
+    }
+
+    def "renders Credentials: PRESENT line when hasCredentials is true and omits it otherwise"() {
+        given:
+        def siteWithCreds = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def siteWithoutCreds = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repoWithCreds = new ReportRepository(
+            "SecuredRepo", RepositoryType.MAVEN, "https://corp.example.com/",
+            true, [], true, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, siteWithCreds
+        )
+        def repoWithoutCreds = new ReportRepository(
+            "OpenRepo", RepositoryType.MAVEN, "https://open.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, siteWithoutCreds
+        )
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repoWithCreds, repoWithoutCreds]))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("SecuredRepo (1)")
+        text.contains("OpenRepo (2)")
+        // Credentials line renders for the repo that has them
+        text.contains("Credentials: PRESENT")
+        // Exactly once — not for the other repo
+        text.count("Credentials: PRESENT") == 1
+    }
+
+    def "getIdentityKey differs when hasCredentials differs"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def withCreds = new ReportRepository(
+            "Repo", RepositoryType.MAVEN, "https://example.com/",
+            true, [], true, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def withoutCreds = new ReportRepository(
+            "Repo", RepositoryType.MAVEN, "https://example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+
+        expect:
+        withCreds.getIdentityKey() != withoutCreds.getIdentityKey()
+        withCreds.getIdentityKey().hashCode() != withoutCreds.getIdentityKey().hashCode()
+    }
+
+    def "All Repositories numbers settings buckets before per-project entries"() {
+        given:
+        def bsSite = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def plSite = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def drmSite = new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories")
+        def appSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def bsRepo = new ReportRepository(
+            "SBD", RepositoryType.MAVEN, "https://sbd.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, bsSite
+        )
+        def plRepo = new ReportRepository(
+            "PL", RepositoryType.MAVEN, "https://pl.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PLUGINS] as Set, plSite
+        )
+        def drmRepo = new ReportRepository(
+            "DRM", RepositoryType.MAVEN, "https://drm.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, drmSite
+        )
+        def appRepo = new ReportRepository(
+            "APP", RepositoryType.MAVEN, "https://app.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, appSite
+        )
+        def settings = new RepositoryReportSettingsModel([bsRepo], [plRepo], [drmRepo])
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        def model = new RepositoryReportFullModel(false, settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        // Ordering: SBD(1) -> PL(2) -> DRM(3) -> APP(4)
+        text.contains("SBD (1)")
+        text.contains("PL (2)")
+        text.contains("DRM (3)")
+        text.contains("APP (4)")
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
@@ -33,11 +33,11 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 2
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
-        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides all tasks non-recursively"() {
@@ -51,10 +51,10 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 1
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides task by name recursively"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
@@ -33,11 +33,11 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 2
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
-        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":generateRepositoriesReportData", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:generateRepositoriesReportData", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:generateRepositoriesReportData", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides all tasks non-recursively"() {
@@ -51,10 +51,10 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 1
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":generateRepositoriesReportData", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:generateRepositoriesReportData", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides task by name recursively"() {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,16 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.diagnostics.GenerateRepositoriesReportDataTask",
+            "member": "Constructor org.gradle.api.tasks.diagnostics.GenerateRepositoriesReportDataTask()",
+            "acceptation": "Class has no explicit constructor; @since is on the class itself",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.tasks.diagnostics.RepositoriesReportTask",
+            "member": "Constructor org.gradle.api.tasks.diagnostics.RepositoriesReportTask()",
+            "acceptation": "Abstract class has no explicit constructor; @since is on the class itself",
+            "changes": []
+        }
+    ]
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/api/tasks/diagnostics/FullTaskListingTaskReportTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/api/tasks/diagnostics/FullTaskListingTaskReportTaskIntegrationTest.groovy
@@ -49,6 +49,7 @@ javaToolchains - Displays the detected java toolchains.
 outgoingVariants - Displays the outgoing variants of root project '$projectName'.
 projects - Displays the sub-projects of root project '$projectName'.
 properties - Displays the properties of root project '$projectName'.
+repositories - Displays the repositories available for dependency resolution.
 resolvableConfigurations - Displays the configurations that can be resolved in root project '$projectName'.
 tasks - Displays the tasks runnable from root project '$projectName'.""")
 
@@ -83,6 +84,7 @@ javaToolchains (org.gradle.jvm.toolchain.internal.task.ShowToolchainsTask) - Dis
 outgoingVariants (org.gradle.api.tasks.diagnostics.OutgoingVariantsReportTask) - Displays the outgoing variants of root project '$projectName'.
 projects (org.gradle.api.tasks.diagnostics.ProjectReportTask) - Displays the sub-projects of root project '$projectName'.
 properties (org.gradle.api.tasks.diagnostics.PropertyReportTask) - Displays the properties of root project '$projectName'.
+repositories (org.gradle.api.tasks.diagnostics.RepositoriesReportTask) - Displays the repositories available for dependency resolution.
 resolvableConfigurations (org.gradle.api.tasks.diagnostics.ResolvableConfigurationsReportTask) - Displays the configurations that can be resolved in root project '$projectName'.
 tasks (org.gradle.api.tasks.diagnostics.TaskReportTask) - Displays the tasks runnable from root project '$projectName'.""")
     }


### PR DESCRIPTION
This new task provides a comprehensive overview of all artifact repositories configured in a build, encompassing settings, pluginManagement, dependencyResolutionManagement, and project-level declarations. It helps developers understand repository roles, authentication, and content filters, aiding in debugging dependency resolution issues.

The task is implemented using a variant-aware data exchange model, ensuring compatibility with the Configuration Cache and Isolated Projects. It reports details such as repository location, type, authentication mechanisms, content filtering rules, and declaration sites. Additionally, it performs URL reachability checks for remote repositories and highlights identical repository declarations across multiple locations for consolidation.

This supercedes:
- https://github.com/gradle/gradle/pull/37603
**SEE COMMENTS ON THAT TO ADDRESS HERE**