### PR TITLE
Name the declaring project in the parent-walk deprecation message

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -177,16 +177,25 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
     }
 
     private DynamicObject snapshotInheritable() {
+        return snapshotInheritable(true);
+    }
+
+    private DynamicObject snapshotInheritable(boolean includeParent) {
         List<DynamicObject> delegates = new ArrayList<>(4);
         delegates.add(extraPropertiesDynamicObject);
         if (beforeConvention != null) {
             delegates.add(beforeConvention);
         }
         delegates.add(extensionContainer.getExtensionsAsDynamicObject());
-        if (parent != null) {
+        if (includeParent && parent != null) {
             delegates.add(parent);
         }
         return new CompositeDynamicObject(delegates, dynamicDelegate::getDisplayName);
+    }
+
+    @Override
+    public DynamicObject withoutParent() {
+        return delegateObjects;
     }
 
     @Override
@@ -196,7 +205,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         }
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
-            if (parent.hasProperty(name)) {
+            if (parent.withoutParent().hasProperty(name)) {
                 failOnParentAccessIfNeeded("property", name, parent);
                 return true;
             }
@@ -213,7 +222,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         }
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
-            result = parent.tryGetProperty(name);
+            result = parent.withoutParent().tryGetProperty(name);
             if (result.isFound()) {
                 failOnParentAccessIfNeeded("property", name, parent);
                 return result;
@@ -262,7 +271,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         }
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
-            if (parent.hasMethod(name, arguments)) {
+            if (parent.withoutParent().hasMethod(name, arguments)) {
                 failOnParentAccessIfNeeded("method", name, parent);
                 return true;
             }
@@ -278,7 +287,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         }
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
-            result = parent.tryInvokeMethod(name, arguments);
+            result = parent.withoutParent().tryInvokeMethod(name, arguments);
             if (result.isFound()) {
                 failOnParentAccessIfNeeded("method", name, parent);
                 return result;
@@ -358,6 +367,11 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         @Override
         public @Nullable HierarchicalDynamicObject getParent() {
             return parent;
+        }
+
+        @Override
+        public DynamicObject withoutParent() {
+            return snapshotInheritable(false);
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensibleDynamicObjectTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensibleDynamicObjectTest.java
@@ -21,6 +21,8 @@ import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
 import org.gradle.api.internal.DynamicObjectAware;
+import org.gradle.internal.Factory;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.metaobject.DynamicObjectUtil;
@@ -190,7 +192,8 @@ public class ExtensibleDynamicObjectTest {
         assertFalse(bean.hasProperty("parentProperty"));
 
         bean.setParent(parent.getInheritable());
-        assertTrue(bean.hasProperty("parentProperty"));
+        // Resolving from the parent is deprecated, but remains the behavior under test here.
+        assertTrue(DeprecationLogger.whileDisabled((Factory<Boolean>) () -> bean.hasProperty("parentProperty")));
     }
 
     @Test
@@ -201,7 +204,8 @@ public class ExtensibleDynamicObjectTest {
         Bean bean = new Bean();
         bean.setParent(parent.getInheritable());
 
-        assertThat(bean.getProperty("parentProperty"), equalTo((Object) "value"));
+        // Resolving from the parent is deprecated, but remains the behavior under test here.
+        assertThat(DeprecationLogger.whileDisabled((Factory<Object>) () -> bean.getProperty("parentProperty")), equalTo((Object) "value"));
     }
 
     @Test
@@ -413,8 +417,9 @@ public class ExtensibleDynamicObjectTest {
 
         bean.setParent(parent.asHierarchicalDynamicObject());
 
-        assertTrue(bean.hasMethod("parentMethod", "a", "b"));
-        assertThat(bean.getAsDynamicObject().invokeMethod("parentMethod", "a", "b"), equalTo((Object) "parent:a.b"));
+        // Resolving from the parent is deprecated, but remains the behavior under test here.
+        assertTrue(DeprecationLogger.whileDisabled((Factory<Boolean>) () -> bean.hasMethod("parentMethod", "a", "b")));
+        assertThat(DeprecationLogger.whileDisabled((Factory<Object>) () -> bean.getAsDynamicObject().invokeMethod("parentMethod", "a", "b")), equalTo((Object) "parent:a.b"));
     }
 
     @Test

--- a/subprojects/core-api/src/main/java/org/gradle/internal/metaobject/HierarchicalDynamicObject.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/metaobject/HierarchicalDynamicObject.java
@@ -31,4 +31,11 @@ public interface HierarchicalDynamicObject extends DynamicObject {
      */
     @Nullable HierarchicalDynamicObject getParent();
 
+    /**
+     * Returns a view of this object that contains only its own members, excluding any members
+     * contributed by its {@link #getParent() parent}. Allows the hierarchy to be walked one
+     * level at a time, attributing a match to the exact object that declares the member.
+     */
+    DynamicObject withoutParent();
+
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ExtraPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ExtraPropertiesIntegrationTest.groovy
@@ -29,7 +29,8 @@ class ExtraPropertiesIntegrationTest extends AbstractIntegrationSpec {
         extraPropertiesMultiBuild()
         expectParentPropertyAccessDeprecation('testProp', ':a', "root project 'extra-properties'")
         expectParentPropertyAccessDeprecation('testProp', ':b', "root project 'extra-properties'")
-        expectParentPropertyAccessDeprecation('testProp', ':a:a1', "project ':a'")
+        // The property is declared on the root project only, so the grandchild's lookup is attributed to the root
+        expectParentPropertyAccessDeprecation('testProp', ':a:a1', "root project 'extra-properties'")
 
         expect:
         succeeds checkTestPropTasks()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -24,17 +24,25 @@ import org.gradle.test.preconditions.TestExecutionPreconditions
 @Requires(value = TestExecutionPreconditions.NotIsolatedProjects, reason = "Under Isolated Projects, parent-project lookup is disabled entirely (see IsolatedProjectsAccessFromGroovyDslIntegrationTest); no deprecation fires")
 class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final String PROPERTY_DEPRECATION = "Implicitly resolving properties in the project hierarchy has been deprecated. " +
-        "This will fail with an error in Gradle 10. " +
-        "Property 'foo' was not declared in project ':a' and was resolved from root project 'root'. " +
-        "Consult the upgrading guide for further information: " +
-        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_project_hierarchy_lookup"
+    private static final String DEPRECATION_DOC_URL = "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_project_hierarchy_lookup"
 
-    private static final String METHOD_DEPRECATION = "Implicitly resolving methods in the project hierarchy has been deprecated. " +
-        "This will fail with an error in Gradle 10. " +
-        "Method 'someMethod' was not declared in project ':a' and was resolved from root project 'root'. " +
-        "Consult the upgrading guide for further information: " +
-        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_implicit_project_hierarchy_lookup"
+    private static final String PROPERTY_DEPRECATION = propertyDeprecation("foo", "project ':a'", "root project 'root'")
+
+    private static final String METHOD_DEPRECATION = methodDeprecation("someMethod", "project ':a'", "root project 'root'")
+
+    private static String propertyDeprecation(String name, String lookupProject, String declaringProject) {
+        "Implicitly resolving properties in the project hierarchy has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Property '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
+            "Consult the upgrading guide for further information: $DEPRECATION_DOC_URL"
+    }
+
+    private static String methodDeprecation(String name, String lookupProject, String declaringProject) {
+        "Implicitly resolving methods in the project hierarchy has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Method '$name' was not declared in $lookupProject and was resolved from $declaringProject. " +
+            "Consult the upgrading guide for further information: $DEPRECATION_DOC_URL"
+    }
 
     def setup() {
         settingsFile << """
@@ -143,6 +151,71 @@ class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec
         then:
         succeeds("help")
         outputContains("result: hello")
+    }
+
+    def "deprecation names the ancestor project that actually declares the property"() {
+        given:
+        settingsFile << """
+            include("a:b")
+        """
+        buildFile << """
+            ext.foo = "from-root"
+        """
+        file("a/build.gradle") << ""
+        file("a/b/build.gradle") << """
+            println("foo: " + foo)
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning(propertyDeprecation("foo", "project ':a:b'", "root project 'root'"))
+
+        then:
+        succeeds("help")
+        outputContains("foo: from-root")
+    }
+
+    def "deprecation names the closest ancestor when several ancestors declare the property"() {
+        given:
+        settingsFile << """
+            include("a:b")
+        """
+        buildFile << """
+            ext.foo = "from-root"
+        """
+        file("a/build.gradle") << """
+            ext.foo = "from-middle"
+        """
+        file("a/b/build.gradle") << """
+            println("foo: " + foo)
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning(propertyDeprecation("foo", "project ':a:b'", "project ':a'"))
+
+        then:
+        succeeds("help")
+        outputContains("foo: from-middle")
+    }
+
+    def "deprecation names the ancestor project that actually declares the method"() {
+        given:
+        settingsFile << """
+            include("a:b")
+        """
+        buildFile << """
+            def someMethod() { "from-root" }
+        """
+        file("a/build.gradle") << ""
+        file("a/b/build.gradle") << """
+            println("result: " + someMethod())
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning(methodDeprecation("someMethod", "project ':a:b'", "root project 'root'"))
+
+        then:
+        succeeds("help")
+        outputContains("result: from-root")
     }
 
     def "no deprecation when the property is defined locally in the child project"() {


### PR DESCRIPTION
### Context

The parent-hierarchy lookup deprecation says `Property 'foo' was not declared in project ':a:b' and was resolved from <project>` — but the named project was always the **immediate parent**, not the project that actually declares the member.

The walk queried each ancestor through its inherited view (`snapshotInheritable()`), which embeds that ancestor's own parent as its last composite delegate. The first level therefore transitively searched the entire ancestor chain: the loop always matched on its first iteration and attributed the member to the immediate parent, even when it is declared further up (e.g. on the root project).

### Change

- Add `HierarchicalDynamicObject.withoutParent()`, exposing a single level's own members (for `InheritedDynamicObject`: extra properties, script members, extensions — without the parent delegate).
- Walk the hierarchy one level at a time via `withoutParent()` + `getParent()`, so the loop's position on a match identifies the exact declaring project, which the deprecation (and the strict `fail-on-parent-property-lookup` error) message then names.

Resolution semantics are unchanged: the recursive composite search linearizes to exactly the level-by-level sequence the loop now walks explicitly (closest ancestor wins; per-level order extras → script members → extensions). The message format is also unchanged — only the attribution becomes precise — so existing two-level test expectations and the Develocity deprecation type are unaffected.

### Verification

New integration tests in `ParentProjectPropertyLookupIntegrationTest` using a three-level hierarchy (`root` → `:a` → `:a:b`):
- property declared only on root → message names `root project 'root'` (previously `project ':a'`)
- property declared on both root and `:a` → names `project ':a'` and resolves the closer value (precedence preserved)
- method declared only on root → names `root project 'root'`

Full `ParentProjectPropertyLookupIntegrationTest` suite passes (23/23). `ExtensibleDynamicObjectTest` shows the same 3 pre-existing failures as vanilla `release` (deprecation nag in uninitialized unit-test environment) and no new ones.