### PR TITLE
Embed a public API ABI jar in all integ-testing distributions

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/model/GradleDistribution.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/model/GradleDistribution.kt
@@ -75,6 +75,12 @@ abstract class GradleDistribution {
             include("lib/plugins/*.jar")
         }
 
+    @get:Classpath
+    val apiJars: FileCollection
+        get() = homeDir.asFileTree.matching {
+            include("lib/api/*.jar")
+        }
+
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val moduleProperties: FileCollection
@@ -82,6 +88,7 @@ abstract class GradleDistribution {
             include("lib/*.properties")
             include("lib/agents/*.properties")
             include("lib/plugins/*.properties")
+            include("lib/api/*.properties")
         }
 
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -233,19 +233,32 @@ tasks.register<GenerateClasspathModuleProperties>("generateAgentsRuntimeModulePr
     outputDir = layout.buildDirectory.dir("classpathProperties/$name")
 }
 
-// Distributions that don't include an API variant jar (anything other than :distributions-full)
-// get an empty output directory — the task tolerates an empty resolved configuration.
+// The jar's file name is read from the resolved ABI classpath; :distributions-full resolves it from
+// :public-api, the smaller distros from their own locally produced jar (see the block below).
 val generatePublicAbiModuleProperties = tasks.register<GenerateSingleModuleProperties>("generatePublicAbiModuleProperties") {
     moduleName = PublicApiVariants.LEGACY_MODULE_NAME
     artifactFileName = gradlePublicAbiClasspath.incoming.artifacts.resolvedArtifacts.map { artifacts ->
         when (artifacts.size) {
-            0 -> null // No API variant jar in this distribution (anything other than :distributions-full)
             1 -> artifacts.single().file.name
-            else -> error("Expected at most one public API ABI jar, but resolved ${artifacts.size}: ${artifacts.map { it.file.name }}")
+            else -> error("Expected a single public API ABI jar, but resolved ${artifacts.size}: ${artifacts.map { it.file.name }}")
         }
     }
     configureDependenciesFrom(gradlePublicAbiRuntimeClasspath, excludingProjectName = "public-api")
     outputDir = layout.buildDirectory.dir("classpathProperties/$name")
+}
+
+// A distribution applying gradlebuild.public-api-jar produces its own ABI jar scoped to its own
+// runtime modules, instead of consuming :public-api's full-surface jar. Feeding the jar through
+// publicAbiOnly keeps the lib/api packaging and file-name wiring identical to :distributions-full;
+// only the recorded module dependencies differ, coming from this distribution's runtime classpath.
+pluginManager.withPlugin("gradlebuild.public-api-jar") {
+    configurations.named("distribution") {
+        extendsFrom(coreRuntimeOnly, pluginsRuntimeOnly)
+    }
+    publicAbiOnly.dependencies.add(dependencies.create(files(tasks.named("jarGradleApiLegacy"))))
+    generatePublicAbiModuleProperties.configure {
+        configureDependenciesFrom(runtimeClasspath)
+    }
 }
 
 // Generate the component license section for the distribution LICENSE file.

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
@@ -15,182 +15,33 @@
  */
 
 import gradlebuild.basics.PublicApiVariants
-import gradlebuild.configureAsApiElements
 import gradlebuild.configureAsRuntimeJarClasspath
-import gradlebuild.packaging.support.ArtifactViewHelper.lenientProjectArtifactReselection
-import gradlebuild.packaging.support.FileLinesValueSource
-import gradlebuild.packaging.tasks.PathPrefixLister
-import org.gradle.kotlin.dsl.support.serviceOf
+import gradlebuild.packaging.support.includePublicApiAbiStubs
+import gradlebuild.packaging.support.publicApiAbiStubs
 
 plugins {
     id("gradlebuild.dependency-modules")
     id("gradlebuild.repositories")
     id("gradlebuild.reproducible-archives")
     id("gradlebuild.module-identity")
-    id("maven-publish")
-    id("signing")
 }
 
-description = "Generates a public API jar and corresponding component to publish it"
+description = "Produces the public API ABI jar (signature stubs) of the Gradle distribution it is applied to"
 
-// Defines configurations used to resolve external dependencies
-// that the public API depends on.
-// TODO: We should be able to derive these dependencies automatically.
-//       In fact, our public API should have no external dependencies.
-val externalApi = configurations.dependencyScope("externalApi") {
-    description = "External dependencies that the public Gradle API depends on"
-}
-val externalRuntimeOnly = configurations.dependencyScope("externalRuntimeOnly") {
-    dependencies.add(project.dependencies.create(project.dependencies.platform(project(":distributions-dependencies"))))
-}
-val externalRuntimeClasspath = configurations.resolvable("externalRuntimeClasspath") {
-    extendsFrom(externalApi.get())
-    extendsFrom(externalRuntimeOnly.get())
-    configureAsRuntimeJarClasspath(objects)
-}
-
-// Defines configurations used to resolve external dependencies that the legacy public API depends on.
-// The legacy variant inherits everything in the public API, minus the relocated impldeps qdox and javaparser-core.
-val legacyExternalApi = configurations.dependencyScope("legacyExternalApi") {
-    description = "External dependencies that the legacy public Gradle API depends on"
-    extendsFrom(externalApi.get())
-    exclude(module = "qdox")
-    exclude(module = "javaparser-core")
-}
-val legacyExternalRuntimeOnly = configurations.dependencyScope("legacyExternalRuntimeOnly") {
-    dependencies.add(project.dependencies.create(project.dependencies.platform(project(":distributions-dependencies"))))
-}
-val legacyExternalRuntimeClasspath = configurations.resolvable("legacyExternalRuntimeClasspath") {
-    extendsFrom(legacyExternalApi.get())
-    extendsFrom(legacyExternalRuntimeOnly.get())
-    configureAsRuntimeJarClasspath(objects)
-}
-
-// Defines configurations used to resolve the public Gradle API.
+// The source of API stubs to assemble into the ABI jar. Consumers populate it differently:
+// `:public-api` adds a dependency on the distribution to extract the full API surface from;
+// each distribution extends it from its own runtime buckets to extract only its own surface.
 val distribution = configurations.dependencyScope("distribution") {
     description = "Dependencies to extract the public Gradle API from"
 }
-
-// Resolvable configuration to get all projects having a runtime JAR
 val distributionClasspath = configurations.resolvable("distributionClasspath") {
     extendsFrom(distribution.get())
     configureAsRuntimeJarClasspath(objects)
 }
 
-fun Jar.commonPublicApiJarConfiguration() {
-    // We use the resolvable configuration, but leverage withVariantReselection to obtain the subset of api stubs artifacts
-    // Some projects simply don't have one, which excludes them
-    from(lenientProjectArtifactReselection<FileCollection>(
-        distributionClasspath,
-        {
-                attribute(Category.CATEGORY_ATTRIBUTE, objects.named("api-stubs"))
-            }
-    )) {
-        // TODO Use better filtering
-        include("**/*.class")
-        include("META-INF/*.kotlin_module")
-    }
-    // This is needed because of the duplicate package-info.class files, it is safe thanks to PackageInfoTest
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
-// Both jars carry the ABI of internals; the suffix marks the variant. The -legacy jar mirrors the
-// historical gradleApi() classpath and ships in lib/api/, pending an internals-free public API.
-val internalBaseName = gradleModule.identity.baseName.map { "$it${PublicApiVariants.INTERNAL_SUFFIX}" }
-val legacyBaseName = gradleModule.identity.baseName.map { "$it${PublicApiVariants.LEGACY_SUFFIX}" }
-
-val apiJarTask = tasks.register<Jar>("jarGradleApi") {
-    commonPublicApiJarConfiguration()
-    archiveBaseName = internalBaseName
-    destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api")
-}
-
-val legacyApiJarTask = tasks.register<Jar>("jarGradleApiLegacy") {
-    commonPublicApiJarConfiguration()
-    archiveBaseName = legacyBaseName
+// Named after the runtime module so the module registry finds it as `gradle-public-api-legacy` in every distribution.
+tasks.register<Jar>("jarGradleApiLegacy") {
+    includePublicApiAbiStubs(publicApiAbiStubs(distributionClasspath))
+    archiveBaseName = PublicApiVariants.LEGACY_MODULE_NAME
     destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api-legacy")
-}
-
-// The consumable configuration containing the public Gradle API artifact
-// and its external dependencies.
-val gradleApiElements = configurations.consumable("gradleApiElements") {
-    extendsFrom(externalApi.get())
-    outgoing.artifact(apiJarTask)
-    outgoing.capability(internalBaseName.map { "$group:$it:$version" })
-    configureAsApiElements(objects)
-}
-
-val legacyGradleApiElements = configurations.consumable("legacyGradleApiElements") {
-    extendsFrom(legacyExternalApi.get())
-    outgoing.artifact(legacyApiJarTask)
-    outgoing.capability(legacyBaseName.map { "$group:$it:$version" })
-    configureAsApiElements(objects)
-}
-
-val pathPrefixListTask = tasks.register<PathPrefixLister>("generateGradleApiPathPrefixList") {
-    apiJar.set(apiJarTask.flatMap { it.archiveFile} )
-    pathPrefixFile.set(layout.buildDirectory.file("public-api/path-prefix-list.txt"))
-}
-
-val sourceJarTask = tasks.register<Jar>("sourcesJar") {
-    val pathPrefixes = providers.of(FileLinesValueSource::class.java) {
-        parameters.inputFile.set(pathPrefixListTask.flatMap { it.pathPrefixFile })
-    }
-
-    val archiveOperations = project.serviceOf<ArchiveOperations>()
-    // We use the resolvable configuration, but leverage withVariantReselection to obtain the subset of sources
-    from(lenientProjectArtifactReselection(
-        distributionClasspath,
-        {
-                attribute(Category.CATEGORY_ATTRIBUTE, objects.named("documentation"))
-                attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("sources"))
-            },
-        { fileCollection -> fileCollection.elements.map { set -> set.map { file -> archiveOperations.zipTree(file.asFile) } }}
-    )) {
-        include { element ->
-            val parent = element.relativePath.parent
-            if (parent == null) false
-            else pathPrefixes.get().contains(parent.pathString)
-        }
-    }
-
-    inputs.files(pathPrefixListTask.flatMap { it.pathPrefixFile }).withPropertyName("pathPrefixList").withPathSensitivity(PathSensitivity.NONE)
-    archiveClassifier.set("sources")
-    destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api")
-    // This is needed because of the duplicate package-info.class files
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
-// TODO: SoftwareComponentFactoryProvider can be replaced with PublishingExtension#getSoftwareComponentFactory()
-open class SoftwareComponentFactoryProvider @Inject constructor(val factory: SoftwareComponentFactory)
-
-val softwareComponentFactory = project.objects.newInstance(SoftwareComponentFactoryProvider::class.java).factory
-val gradleApiComponent = softwareComponentFactory.adhoc("gradleApi")
-components.add(gradleApiComponent)
-
-// Published component containing the public Gradle API
-gradleApiComponent.addVariantsFromConfiguration(gradleApiElements) {
-    mapToMavenScope("compile")
-}
-
-val sourcesElements = configurations.consumable("sourcesElements") {
-    outgoing.artifact(sourceJarTask)
-    outgoing.capability(internalBaseName.map { "$group:$it:$version" })
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, named(Bundling.EXTERNAL))
-        attribute(Usage.USAGE_ATTRIBUTE, named(Usage.JAVA_RUNTIME))
-    }
-}
-
-gradleApiComponent.addVariantsFromConfiguration(sourcesElements) {
-    mapToOptional()
-}
-
-// Published component containing the legacy public Gradle API
-val legacyGradleApiComponent = softwareComponentFactory.adhoc("legacyGradleApi")
-components.add(legacyGradleApiComponent)
-legacyGradleApiComponent.addVariantsFromConfiguration(legacyGradleApiElements) {
-    mapToMavenScope("compile")
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-publish.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-publish.gradle.kts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gradlebuild.basics.PublicApiVariants
+import gradlebuild.configureAsApiElements
+import gradlebuild.configureAsRuntimeJarClasspath
+import gradlebuild.packaging.support.ArtifactViewHelper.lenientProjectArtifactReselection
+import gradlebuild.packaging.support.FileLinesValueSource
+import gradlebuild.packaging.support.includePublicApiAbiStubs
+import gradlebuild.packaging.support.publicApiAbiStubs
+import gradlebuild.packaging.tasks.PathPrefixLister
+import org.gradle.api.artifacts.ResolvableConfiguration
+import org.gradle.kotlin.dsl.support.serviceOf
+
+// Publishes the public API produced by `gradlebuild.public-api-jar` as Maven components, and exposes
+// it for consumption. Only `:public-api` applies this; distributions produce the jar but never publish it.
+plugins {
+    id("gradlebuild.public-api-jar")
+    id("maven-publish")
+    id("signing")
+}
+
+description = "Publishes the public API and corresponding components"
+
+// Defines configurations used to resolve external dependencies that the published API variants declare.
+// TODO: We should be able to derive these dependencies automatically.
+//       In fact, our public API should have no external dependencies.
+val externalApi = configurations.dependencyScope("externalApi") {
+    description = "External dependencies that the public Gradle API depends on"
+}
+val externalRuntimeOnly = configurations.dependencyScope("externalRuntimeOnly") {
+    dependencies.add(project.dependencies.create(project.dependencies.platform(project(":distributions-dependencies"))))
+}
+val externalRuntimeClasspath = configurations.resolvable("externalRuntimeClasspath") {
+    extendsFrom(externalApi.get())
+    extendsFrom(externalRuntimeOnly.get())
+    configureAsRuntimeJarClasspath(objects)
+}
+
+// The legacy variant inherits everything in the public API, minus the relocated impldeps qdox and javaparser-core.
+val legacyExternalApi = configurations.dependencyScope("legacyExternalApi") {
+    description = "External dependencies that the legacy public Gradle API depends on"
+    extendsFrom(externalApi.get())
+    exclude(module = "qdox")
+    exclude(module = "javaparser-core")
+}
+val legacyExternalRuntimeOnly = configurations.dependencyScope("legacyExternalRuntimeOnly") {
+    dependencies.add(project.dependencies.create(project.dependencies.platform(project(":distributions-dependencies"))))
+}
+val legacyExternalRuntimeClasspath = configurations.resolvable("legacyExternalRuntimeClasspath") {
+    extendsFrom(legacyExternalApi.get())
+    extendsFrom(legacyExternalRuntimeOnly.get())
+    configureAsRuntimeJarClasspath(objects)
+}
+
+val internalBaseName = gradleModule.identity.baseName.map { "$it${PublicApiVariants.INTERNAL_SUFFIX}" }
+val legacyBaseName = gradleModule.identity.baseName.map { "$it${PublicApiVariants.LEGACY_SUFFIX}" }
+
+// Stub source produced by gradlebuild.public-api-jar; reused for the internal jar and the sources jar.
+val distributionClasspath = configurations.named<ResolvableConfiguration>("distributionClasspath")
+
+val apiJarTask = tasks.register<Jar>("jarGradleApi") {
+    includePublicApiAbiStubs(publicApiAbiStubs(distributionClasspath))
+    archiveBaseName = internalBaseName
+    destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api")
+}
+
+// The consumable configuration containing the public Gradle API artifact and its external dependencies.
+val gradleApiElements = configurations.consumable("gradleApiElements") {
+    extendsFrom(externalApi.get())
+    outgoing.artifact(apiJarTask)
+    outgoing.capability(internalBaseName.map { "$group:$it:$version" })
+    configureAsApiElements(objects)
+}
+
+val legacyGradleApiElements = configurations.consumable("legacyGradleApiElements") {
+    extendsFrom(legacyExternalApi.get())
+    outgoing.artifact(tasks.named("jarGradleApiLegacy"))
+    outgoing.capability(legacyBaseName.map { "$group:$it:$version" })
+    configureAsApiElements(objects)
+}
+
+val pathPrefixListTask = tasks.register<PathPrefixLister>("generateGradleApiPathPrefixList") {
+    apiJar.set(apiJarTask.flatMap { it.archiveFile })
+    pathPrefixFile.set(layout.buildDirectory.file("public-api/path-prefix-list.txt"))
+}
+
+val sourceJarTask = tasks.register<Jar>("sourcesJar") {
+    val pathPrefixes = providers.of(FileLinesValueSource::class.java) {
+        parameters.inputFile.set(pathPrefixListTask.flatMap { it.pathPrefixFile })
+    }
+
+    val archiveOperations = project.serviceOf<ArchiveOperations>()
+    // We use the resolvable configuration, but leverage withVariantReselection to obtain the subset of sources
+    from(lenientProjectArtifactReselection(
+        distributionClasspath,
+        {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named("documentation"))
+                attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("sources"))
+            },
+        { fileCollection -> fileCollection.elements.map { set -> set.map { file -> archiveOperations.zipTree(file.asFile) } }}
+    )) {
+        include { element ->
+            val parent = element.relativePath.parent
+            if (parent == null) false
+            else pathPrefixes.get().contains(parent.pathString)
+        }
+    }
+
+    inputs.files(pathPrefixListTask.flatMap { it.pathPrefixFile }).withPropertyName("pathPrefixList").withPathSensitivity(PathSensitivity.NONE)
+    archiveClassifier.set("sources")
+    destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api")
+    // This is needed because of the duplicate package-info.class files
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// TODO: SoftwareComponentFactoryProvider can be replaced with PublishingExtension#getSoftwareComponentFactory()
+open class SoftwareComponentFactoryProvider @Inject constructor(val factory: SoftwareComponentFactory)
+
+val softwareComponentFactory = project.objects.newInstance(SoftwareComponentFactoryProvider::class.java).factory
+val gradleApiComponent = softwareComponentFactory.adhoc("gradleApi")
+components.add(gradleApiComponent)
+
+// Published component containing the public Gradle API
+gradleApiComponent.addVariantsFromConfiguration(gradleApiElements) {
+    mapToMavenScope("compile")
+}
+
+val sourcesElements = configurations.consumable("sourcesElements") {
+    outgoing.artifact(sourceJarTask)
+    outgoing.capability(internalBaseName.map { "$group:$it:$version" })
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, named(Bundling.EXTERNAL))
+        attribute(Usage.USAGE_ATTRIBUTE, named(Usage.JAVA_RUNTIME))
+    }
+}
+
+gradleApiComponent.addVariantsFromConfiguration(sourcesElements) {
+    mapToOptional()
+}
+
+// Published component containing the legacy public Gradle API
+val legacyGradleApiComponent = softwareComponentFactory.adhoc("legacyGradleApi")
+components.add(legacyGradleApiComponent)
+legacyGradleApiComponent.addVariantsFromConfiguration(legacyGradleApiElements) {
+    mapToMavenScope("compile")
+}

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/support/PublicApiJars.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/support/PublicApiJars.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.packaging.support
+
+import gradlebuild.packaging.support.ArtifactViewHelper.lenientProjectArtifactReselection
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvableConfiguration
+import org.gradle.api.attributes.Category
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.bundling.Jar
+
+/**
+ * The API stubs (signature-only `.class` files) reselected from every project on [classpath].
+ *
+ * Shared by the ABI jar production (`gradlebuild.public-api-jar`) and its publication
+ * (`gradlebuild.public-api-publish`) so both extract the same surface from the same classpath.
+ */
+fun Project.publicApiAbiStubs(classpath: Provider<ResolvableConfiguration>): Provider<FileCollection> =
+    lenientProjectArtifactReselection(
+        classpath,
+        { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, "api-stubs")) }
+    )
+
+/**
+ * Assembles the public API ABI [stubs] into this jar. Duplicate `package-info.class` across modules
+ * is expected and safe (guarded by PackageInfoTest).
+ */
+fun Jar.includePublicApiAbiStubs(stubs: Provider<FileCollection>) {
+    from(stubs) {
+        include("**/*.class")
+        include("META-INF/*.kotlin_module")
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
@@ -241,7 +241,7 @@ abstract class GenerateSingleModuleProperties : DefaultTask() {
     /**
      * Names follow the same scheme as [GenerateClasspathModuleProperties] (see [distributionModuleNameOrNull]).
      */
-    fun configureDependenciesFrom(configuration: Configuration, excludingProjectName: String) {
+    fun configureDependenciesFrom(configuration: Configuration, excludingProjectName: String? = null) {
         dependencyNames.set(
             configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
                 artifacts.mapNotNull { artifact ->

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -16,7 +16,7 @@
 
 plugins {
     id("gradlebuild.no-module-annotation")
-    id("gradlebuild.public-api-jar")
+    id("gradlebuild.public-api-publish")
     id("gradlebuild.publish-defaults")
     id("signing")
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -139,7 +139,8 @@ abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpeci
             classPath.collect { it.name } as List<String>,
             hasItems(
                 matching("gradle-kotlin-dsl-$version\\.jar"),
-                matching("gradle-api-$version\\.jar"),
+                // The public API jar is the generated gradle-api jar before 9.7, the embedded ABI jar from 9.7 on
+                matching("(gradle-api|gradle-public-api-legacy)-$version\\.jar"),
                 matching("gradle-kotlin-dsl-extensions-$version\\.jar")
             )
         )

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -87,8 +87,14 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
         kotlinModel.compileClassPath.find { it.name.contains("groovy-") && it.name.endsWith(".jar") }
         kotlinModel.compileClassPath.find { it.name.contains("kotlin-stdlib-") && it.name.endsWith(".jar") }
         kotlinModel.compileClassPath.find { it.name.contains("gradle-kotlin-dsl-") && it.name.endsWith(".jar") }
-        // This spec uses :distributions-jvm which does not embed the public-API ABI jar
-        kotlinModel.compileClassPath.find { it.name.contains("gradle-api-") && it.name.endsWith(".jar") }
+
+        and: "from 9.7 it compiles against the embedded ABI jar, before against the generated API jar"
+        if (targetEmbedsPublicApiAbiJar()) {
+            assert kotlinModel.compileClassPath.find { it.name.contains("gradle-public-api-legacy-") && it.name.endsWith(".jar") }
+            assert !kotlinModel.compileClassPath.find { it.name ==~ /gradle-api-\d.*\.jar/ }
+        } else {
+            assert kotlinModel.compileClassPath.find { it.name ==~ /gradle-api-\d.*\.jar/ }
+        }
 
         and: "Kotlin DSL script implicit imports"
         kotlinModel.implicitImports.find {it.equals("org.gradle.api.Action")}
@@ -235,5 +241,9 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
     private assumeApiSupportedOnVersion(ApiType apiType) {
         assumeTrue("Fetch requires Tooling API >= 9.3.0", apiType == ApiType.GET_MODEL
             || apiType == ApiType.FETCH && toolingApi.toolingApiVersion >= GradleVersion.version("9.3.0"))
+    }
+
+    private boolean targetEmbedsPublicApiAbiJar() {
+        GradleVersion.version(targetDist.version.baseVersion.version) >= GradleVersion.version("9.7")
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -78,19 +78,14 @@ class KotlinScriptClassPathProvider(
 
     private
     val gradleAbiClasspath: ClassPath by lazy {
-        // Matches gradlebuild.basics.PublicApiVariants.LEGACY_MODULE_NAME in build-logic,
-        moduleRegistry.findModule("gradle-public-api-legacy")
-            ?.let { moduleRegistry.getRuntimeClasspath(listOf(it)) }
-            ?.let { cp ->
-                when (gradleProperties.isDclEnabled) {
-                    // Declarative Gradle is not part of the public api yet, only add it to the compilation classpath if enabled
-                    // TODO:declarative drop once `org.gradle.features.*` graduates to PublicApi.include
-                    true -> cp + moduleRegistry.getRuntimeClasspath("gradle-project-features")
-                    false -> cp
-                }
-            }
-        // Support integ-tests on non-full distros (no ABI jar), fallback to the generated API jar
-            ?: gradleApiClasspath
+        // Matches gradlebuild.basics.PublicApiVariants.LEGACY_MODULE_NAME in build-logic.
+        val abiClasspath = moduleRegistry.getRuntimeClasspath("gradle-public-api-legacy")
+        when (gradleProperties.isDclEnabled) {
+            // Declarative Gradle is not part of the public api yet, only add it to the compilation classpath if enabled
+            // TODO:declarative drop once `org.gradle.features.*` graduates to PublicApi.include
+            true -> abiClasspath + moduleRegistry.getRuntimeClasspath("gradle-project-features")
+            false -> abiClasspath
+        }
     }
 
     private

--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GradleApiClasspathProvider.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GradleApiClasspathProvider.java
@@ -35,9 +35,6 @@ public interface GradleApiClasspathProvider {
 
     /**
      * Returns the classpath for the Kotlin DSL ABI.
-     *
-     * <p>Falls back to {@link #getGradleKotlinDslApi()} when the running distribution does
-     * not contain the ABI jar. Production distributions always have it.
      */
     ClassPath getGradleKotlinDslAbi();
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -815,13 +815,12 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPlu
     /**
      * Candidate jar name prefixes that may carry the Gradle public API.
      *
-     * Gradle 9.7+ embeds a {@code gradle-public-api-legacy} ABI jar in {@code :distributions-full}.
-     * When the running Gradle has no such jar (older versions, non-full distributions, and in-process
-     * tests), falls back to the generated {@code gradle-api} jar.
+     * Gradle 9.7+ compiles Kotlin DSL scripts against the embedded {@code gradle-public-api-legacy}
+     * ABI jar; earlier versions use the generated {@code gradle-api} jar.
      */
     List<String> expectedPublicApiJarPrefixes() {
         GradleVersion.version(targetDist.version.baseVersion.version) >= GradleVersion.version("9.7")
-            ? ["gradle-public-api-legacy", "gradle-api"]
+            ? ["gradle-public-api-legacy"]
             : ["gradle-api"]
     }
 

--- a/platforms/jvm/distributions-jvm/build.gradle.kts
+++ b/platforms/jvm/distributions-jvm/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.packaging")
+    id("gradlebuild.public-api-jar")
 }
 
 description = "The collector project for the 'jvm' portion of the Gradle distribution"

--- a/platforms/native/distributions-native/build.gradle.kts
+++ b/platforms/native/distributions-native/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.packaging")
+    id("gradlebuild.public-api-jar")
 }
 
 description = "The collector project for the 'native' portion of the Gradle distribution"

--- a/platforms/software/distributions-publishing/build.gradle.kts
+++ b/platforms/software/distributions-publishing/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.packaging")
+    id("gradlebuild.public-api-jar")
 }
 
 description = "The collector project for the 'publishing' portion of the Gradle distribution"

--- a/testing/distributions-basics/build.gradle.kts
+++ b/testing/distributions-basics/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.packaging")
+    id("gradlebuild.public-api-jar")
 }
 
 description = "The collector project for the 'basics' portion of the Gradle distribution"

--- a/testing/distributions-core/build.gradle.kts
+++ b/testing/distributions-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.packaging")
+    id("gradlebuild.public-api-jar")
 }
 
 description = "The collector project for the 'core' portion of the Gradle distribution"


### PR DESCRIPTION
Kotlin DSL script compilation only avoided generating the large gradle-api.jar in :distributions-full, the sole distribution that embedded the public API ABI jar. Every other distribution fell back to generating it, defeating the benefit for those distributions.

Each distribution now produces its own ABI jar scoped to its runtime, so the runtime fallback can be removed and script compilation resolves the embedded jar in all distributions.

Split gradlebuild.public-api-jar so jar production is reusable by the distributions, while publication stays specific to :public-api.

* Follow up for https://github.com/gradle/gradle/pull/33846

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
