### PR TITLE
Stop debug integration tests hanging on the wrong network interface

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
@@ -116,7 +116,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
         given:
         JDWPUtil jdwpClient = new JDWPUtil()
 
-        def jdwpHost = nonLoopbackAddress()
+        def jdwpHost = JDWPUtil.nonLoopbackAddress()
         Assume.assumeNotNull(jdwpHost)
         jdwpClient.host = jdwpHost
 
@@ -152,7 +152,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
         given:
         JDWPUtil jdwpClient = new JDWPUtil()
 
-        def address = nonLoopbackAddress()
+        def address = JDWPUtil.nonLoopbackAddress()
         Assume.assumeNotNull(address)
         jdwpClient.host = address
 
@@ -168,16 +168,6 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
 
         cleanup:
         jdwpClient.close()
-    }
-
-    private static String nonLoopbackAddress() {
-        println("Looking at network interfaces")
-        def address = Collections.list(NetworkInterface.getNetworkInterfaces())
-            .collectMany { it.isLoopback() ? [] : Collections.list(it.inetAddresses) }
-            .find { it instanceof Inet4Address && !it.isLoopbackAddress() }
-            .hostAddress
-        println("using address=$address")
-        return address
     }
 
     @Issue('https://github.com/gradle/gradle/issues/18084')

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -27,6 +27,9 @@ import org.gradle.test.preconditions.JdkVersionTestPreconditions
 import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Issue
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 @Flaky(because = "https://github.com/gradle/gradle-private/issues/3612")
 class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
@@ -95,8 +98,12 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://github.com/gradle/gradle/issues/20644")
     @Requires(JdkVersionTestPreconditions.Jdk9OrLater)
+    // Backstop the interruptible wait (handle.waitForFinish()) so a hung resume can't run until the
+    // build-level execution timeout; the debugger attach itself is bounded separately in JDWPUtil.
+    // See https://github.com/gradle/gradle-private/issues/3612
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
     def "can debug Java exec with socket server debugger (server = true) on explicitly any host with task :#taskName"() {
-        def jdwpHost = nonLoopbackAddress()
+        def jdwpHost = JDWPUtil.nonLoopbackAddress()
         Assume.assumeNotNull(jdwpHost)
 
         debugClient.host = jdwpHost
@@ -128,8 +135,12 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/20644")
+    // Backstop the interruptible wait (handle.waitForFinish()) so a hung resume can't run until the
+    // build-level execution timeout; the debugger attach itself is bounded separately in JDWPUtil.
+    // See https://github.com/gradle/gradle-private/issues/3612
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
     def "can debug Java exec with socket server debugger (server = true) on via host with task :#taskName"() {
-        def jdwpHost = nonLoopbackAddress()
+        def jdwpHost = JDWPUtil.nonLoopbackAddress()
         Assume.assumeNotNull(jdwpHost)
 
         debugClient.host = jdwpHost
@@ -158,17 +169,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         taskName << ['runJavaExec', 'runExecOperationsJavaExec', 'test']
-    }
-
-    /** To test attaching the debugger via a non-loopback network interface, we need to choose an IP address of such an interface. */
-    private static final String nonLoopbackAddress() {
-        println("Looking at network interfaces")
-        def address = Collections.list(NetworkInterface.getNetworkInterfaces())
-            .collectMany { it.isLoopback() ? [] : Collections.list(it.inetAddresses) }
-            .find { it instanceof Inet4Address && !it.isLoopbackAddress() }
-            ?.hostAddress
-        println("using address=$address")
-        return address
     }
 
     def "debug options overrides debug property with task :#taskName"() {

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
@@ -25,10 +25,14 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
+import java.util.concurrent.atomic.AtomicReference
+
 /**
  * A utility for communicating with a VM in debug mode using JDWP.
  */
 class JDWPUtil implements TestRule {
+    private static final int ATTACH_TIMEOUT_SECONDS = 30
+
     String host
     Integer port
     def vm
@@ -67,13 +71,45 @@ class JDWPUtil implements TestRule {
     def connect() {
         if (vm == null) {
             def vmm = bootstrapClass.virtualMachineManager()
-            def connection = vmm.attachingConnectors().find { "dt_socket".equalsIgnoreCase(it.transport().name()) }
-            def connectionArgs = connection.defaultArguments()
+            def connector = vmm.attachingConnectors().find { "dt_socket".equalsIgnoreCase(it.transport().name()) }
+            def connectionArgs = connector.defaultArguments()
             connectionArgs.get("port").setValue(port as String)
             connectionArgs.get("hostname").setValue(host)
-            this.vm = connection.attach(connectionArgs)
+            this.vm = attachWithinTimeout(connector, connectionArgs)
         }
         vm
+    }
+
+    /**
+     * Performs {@code attach()} with a hard wall-clock bound.
+     *
+     * <p>{@code attach()} does a blocking JDWP handshake. That read is <em>not</em> interruptible: the
+     * connector's own {@code timeout} argument bounds only the TCP connect (not the handshake), and
+     * {@code Thread.interrupt()} / a Spock {@code @Timeout} cannot unblock a plain socket read. A stalled
+     * handshake would therefore hang until the build-level execution timeout. So run the attach on a
+     * watchdog thread and give up on it after a fixed timeout, failing the test fast instead.
+     * See <a href="https://github.com/gradle/gradle-private/issues/3612">gradle-private#3612</a>.
+     */
+    private attachWithinTimeout(connector, connectionArgs) {
+        def result = new AtomicReference()
+        def failure = new AtomicReference()
+        def attachThread = new Thread({
+            try {
+                result.set(connector.attach(connectionArgs))
+            } catch (Throwable t) {
+                failure.set(t)
+            }
+        }, "jdwp-attach-${host}:${port}")
+        attachThread.daemon = true // a stuck native read can't be interrupted, so let it leak until the debuggee dies
+        attachThread.start()
+        attachThread.join(ATTACH_TIMEOUT_SECONDS * 1000L)
+        if (attachThread.alive) {
+            throw new IllegalStateException("Timed out after ${ATTACH_TIMEOUT_SECONDS}s attaching the debugger to ${host}:${port}; the JDWP handshake stalled")
+        }
+        if (failure.get() != null) {
+            throw failure.get()
+        }
+        return result.get()
     }
 
     def listen(boolean acceptAsync = true) {
@@ -153,5 +189,43 @@ class JDWPUtil implements TestRule {
             ClassLoader classLoader = new URLClassLoader(Jvm.current().toolsJar.toURI().toURL())
             return classLoader.loadClass("com.sun.jdi.Bootstrap")
         }
+    }
+
+    /**
+     * Returns an address of a real, non-loopback network interface suitable for attaching a debugger over
+     * the network, or {@code null} if none can be found.
+     *
+     * <p>Uses the address of the interface that carries the default route (the real NIC) rather than the
+     * first non-loopback address that happens to be enumerated. On CI agents that first address is frequently
+     * a virtual bridge (docker0 = 172.17.0.1), and on dev machines a VPN tunnel (utunN) - neither is reliably
+     * usable for a JDWP connection, which made the debug integration tests hang.
+     * See <a href="https://github.com/gradle/gradle-private/issues/3612">gradle-private#3612</a>.
+     */
+    static String nonLoopbackAddress() {
+        println("Looking at network interfaces")
+        def address = primaryNetworkAddress() ?: firstNonLoopbackAddress()
+        println("using address=$address")
+        return address
+    }
+
+    private static String primaryNetworkAddress() {
+        try {
+            return new DatagramSocket().withCloseable { socket ->
+                // A UDP "connect" only performs a routing-table lookup (no packets are sent), so the socket's
+                // local address becomes the address of the interface that would be used to reach the target.
+                socket.connect(InetAddress.getByName("203.0.113.1"), 9) // TEST-NET-3 (RFC 5737): never routed
+                def local = socket.localAddress
+                (local instanceof Inet4Address && !local.anyLocalAddress && !local.loopbackAddress) ? local.hostAddress : null
+            }
+        } catch (Exception ignored) {
+            return null
+        }
+    }
+
+    private static String firstNonLoopbackAddress() {
+        return Collections.list(NetworkInterface.getNetworkInterfaces())
+            .collectMany { it.isLoopback() ? [] : Collections.list(it.inetAddresses) }
+            .find { it instanceof Inet4Address && !it.isLoopbackAddress() }
+            ?.hostAddress
     }
 }


### PR DESCRIPTION
### Context

`JavaExecDebugIntegrationTest` regularly hung for ~50 minutes and timed out the whole build on the **Flaky Test Quarantine – ConfigCache** pipeline (one iteration of the `server = true` tests consumed the entire 60-minute execution timeout, so the build failed with `Execution timeout` and the remaining tests never ran). `CommandLineIntegrationSpec` has the same bug.

#### Root cause: the debugger attaches over the wrong network interface

`nonLoopbackAddress()` returned the **first** non-loopback IPv4 it enumerated. On the CI agents that is `172.17.0.1` — the **`docker0` bridge** — and on dev machines it is often a **VPN tunnel** (`utunN`). Attaching a JDWP debugger across such an interface stalls intermittently, and the tests had no fast-failure path.

Reproduced locally:

```
OLD (first non-loopback) -> 172.16.0.2    # utun1, a VPN tunnel (wrong)
NEW (default route)      -> 192.168.8.126 # en0, the real interface (right)
```

Neither `isVirtual()` nor `isPointToPoint()` excludes both `docker0` and `utunN`, so the fix selects the interface that carries the **default route** (a UDP "connect" route lookup that sends no packets). The logic is shared via `JDWPUtil` rather than duplicated in each test.

### Fix

1. **Root cause** — `nonLoopbackAddress()` (now `JDWPUtil.nonLoopbackAddress()`) returns the default-route interface address, falling back to enumeration only if that can't be determined. Applied to both `JavaExecDebugIntegrationTest` and `CommandLineIntegrationSpec`.
2. **Defense in depth**, so a future stall can never again take down a whole build:
   - **`JDWPUtil`**: bound `attach()` with a **watchdog thread**. The JDWP handshake is a blocking, *uninterruptible* socket read — I verified the connector's own `timeout` argument bounds only the TCP connect, **not** the handshake (attach stayed blocked >12s with `timeout=2000`), and `Thread.interrupt()`/`@Timeout` can't unblock a plain socket read either. So the attach runs on a thread we abandon after a fixed timeout, failing fast.
   - **`JavaExecDebugIntegrationTest`**: `@Timeout` on the two `server = true` tests backstops the *other* wait — `handle.waitForFinish()` — which **is** interruptible (`DefaultExecHandle.waitForFinish()` aborts the process on interrupt).

### Verification

- Reproduced the wrong-interface selection locally and confirmed the default-route approach picks the real NIC.
- Empirically confirmed the connector `timeout` arg does not bound the handshake, and that the watchdog thread does (gives up at the bound instead of hanging).
- `:internal-distribution-testing:compileGroovy`, `:language-java:compileIntegTestGroovy`, `:launcher:compileIntegTestGroovy` all compile.
- The CI hang itself is a Docker-bridge race that does not reproduce locally, so no new regression test is added.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) (DCO)
- [x] Code is distributable under the Apache License 2.0
- [ ] "Allow edit from maintainers" — N/A, branch lives on `gradle/gradle`
- [x] Integration tests — fixes the existing integration tests / their shared fixture; the hang is a CI-only race that cannot be reliably reproduced in a test
- [ ] Unit tests — N/A (test infrastructure)
- [ ] User Guide / DSL Reference / Javadoc — N/A (no public-facing change)
- [ ] `./gradlew sanityCheck` — not run; verified the changed source sets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
