### PR TITLE
Update DV env vars

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -34,7 +34,7 @@ class CheckProject(
             param("teamcity.ui.settings.readOnly", "true")
             // Avoid rebuilding same revision if it's already built on another branch
             param("teamcity.vcsTrigger.runBuildOnSameRevisionInEveryBranch", "false")
-            param("env.DEVELOCITY_ACCESS_KEY", "%ge.gradle.org.access.key%;%gbt-td.grdev.net.access.key%")
+            param("env.DEVELOCITY_SERVER_URL", "%gbt.public.develocity.server.url%")
             param("env.CHROME_BIN", "%linux.chrome.bin.path%")
 
             text(

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -44,10 +44,6 @@ abstract class BasePromotionBuildType(
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)
 
         params {
-            password(
-                "env.DEVELOCITY_ACCESS_KEY",
-                "%ge.gradle.org.access.key%;%develocity.grdev.net.access.key%;%develocity-ext-hetzner.grdev.net.access.key%",
-            )
             password("env.ORG_GRADLE_PROJECT_botGradleGitHubToken", "%github.bot-gradle.token%")
         }
 

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -62,6 +62,13 @@ class PromotionProject(
             param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
             param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
             param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
+            param("env.DEVELOCITY_SERVER_URL", "%gbt.internal.develocity.server.url%")
+            // https://github.com/gradle/gradle-private/issues/5256
+            param("env.PROMOTED_GBT_BUILD_DEVELOCITY_SERVER_URL", "%gbt.public.develocity.server.url%")
+            param(
+                "env.DEVELOCITY_ACCESS_KEY",
+                "%usw2-edge.gradle.org.access.key%;%eun-edge.gradle.org.access.key%;%develocity.grdev.net.access.key%;%develocity-ext-hetzner.grdev.net.access.key%;%gbt-td.grdev.net.access.key%",
+            )
         }
 
         buildTypesOrder =


### PR DESCRIPTION
Following up https://github.com/gradle/dev-infrastructure/pull/3108, we've made the following changes in this PR:

- Move `DEVELOCITY_ACCESS_KEY` to web UI, including all edge servers and `gbt-td.grdev.net` access keys.
- Make `DEVELOCITY_SERVER_URL` point to `%gbt.public.develocity.server.url%` based on agent type.
- Also, we change the promotion build to use `DEVELOCITY_SERVER_URL=%gbt.internal.develocity.server.url%`