### PR TITLE
Standardize variant name quoting in display messages

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -395,7 +395,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         assertFullMessageCorrect("""   > No variants of root project 'example' match the consumer attributes:
        - Configuration ':myElements' declares attribute 'color' with value 'blue':
            - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
-       - Configuration ':myElements' variant secondary declares attribute 'color' with value 'blue':
+       - Configuration ':myElements' variant 'secondary' declares attribute 'color' with value 'blue':
            - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'""")
 
         and: "Helpful resolutions are provided"
@@ -470,8 +470,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
         assertFullMessageCorrect("""   > More than one variant of root project 'example' matches the consumer attributes:
-       - Configuration ':default' variant v1
-       - Configuration ':default' variant v2""")
+       - Configuration ':default' variant 'v1'
+       - Configuration ':default' variant 'v2'""")
 
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -979,10 +979,10 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
   - Configuration ':lib:compile' declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
       - Unmatched attribute:
           - Provides buildType 'n/a' but the consumer didn't ask for it
-  - Configuration ':lib:compile' variant debug declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
+  - Configuration ':lib:compile' variant 'debug' declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
       - Unmatched attribute:
           - Provides buildType 'debug' but the consumer didn't ask for it
-  - Configuration ':lib:compile' variant release declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
+  - Configuration ':lib:compile' variant 'release' declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
       - Unmatched attribute:
           - Provides buildType 'release' but the consumer didn't ask for it""")
     }
@@ -1116,9 +1116,9 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
         failure.assertHasCause("""No variants of project ':lib' match the consumer attributes:
   - Configuration ':lib:compile' declares attribute 'usage' with value 'api':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
-  - Configuration ':lib:compile' variant debug declares attribute 'usage' with value 'api':
+  - Configuration ':lib:compile' variant 'debug' declares attribute 'usage' with value 'api':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
-  - Configuration ':lib:compile' variant release declares attribute 'usage' with value 'api':
+  - Configuration ':lib:compile' variant 'release' declares attribute 'usage' with value 'api':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'""")
 
         failure.assertHasCause("""No variants of test:test:1.2 match the consumer attributes:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -79,7 +79,7 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
         fails("resolve")
 
         then:
-        failure.assertHasCause "Cannot change attributes of configuration ':elements' variant classes after it has been locked for mutation"
+        failure.assertHasCause "Cannot change attributes of configuration ':elements' variant 'classes' after it has been locked for mutation"
     }
 
     def "cannot declare capabilities after configuration is observed"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -549,12 +549,12 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
-  - Configuration ':a:compile' variant var1 declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'var1' declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides buildType 'debug' but the consumer didn't ask for it
           - Provides flavor 'one' but the consumer didn't ask for it
-  - Configuration ':a:compile' variant var2 declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'var2' declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides buildType 'debug' but the consumer didn't ask for it
@@ -1095,10 +1095,10 @@ Searched in the following locations:
     ${m1.artifact.uri}""")
         outputContains("failure 5: Could not download broken-artifact-1.0.jar (org:broken-artifact:1.0)")
         outputContains("""failure 6: The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
-  - Configuration ':a:default' variant v1:
+  - Configuration ':a:default' variant 'v1':
       - Unmatched attribute:
           - Doesn't say anything about usage (required 'compile')
-  - Configuration ':a:default' variant v2:
+  - Configuration ':a:default' variant 'v2':
       - Unmatched attribute:
           - Doesn't say anything about usage (required 'compile')""")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -326,11 +326,11 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         expect:
         fails("show")
         failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
-  - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'free' declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides flavor 'free' but the consumer didn't ask for it
-  - Configuration ':a:compile' variant paid declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'paid' declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides flavor 'paid' but the consumer didn't ask for it""")
@@ -396,9 +396,9 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         expect:
         fails("show")
         failure.assertHasCause("""No variants of project ':a' match the consumer attributes:
-  - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'free' declares attribute 'usage' with value 'compile':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'free' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'
-  - Configuration ':a:compile' variant paid declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant 'paid' declares attribute 'usage' with value 'compile':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'paid' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'""")
 
         // Eager expressions (Set<File>) resolve all transitive dependencies and report all failures.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -64,7 +64,7 @@ public abstract class DefaultVariant implements ConfigurationVariantInternal {
         this.name = name;
         this.artifactNotationParser = artifactNotationParser;
 
-        this.displayName = Describables.of(parentDisplayName, "variant", name);
+        this.displayName = Describables.of(parentDisplayName, Describables.quoted("variant", name));
         this.attributes = attributesFactory.freezable(attributesFactory.mutable(parentAttributes), displayName);
         this.artifacts = new DefaultPublishArtifactSet(displayName, domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
@@ -66,7 +66,7 @@ public abstract class AmbiguousArtifactTransformsFailureDescriber extends Abstra
         Map<SourceVariantData, List<TransformationChainData>> transformationPaths = failure.getPotentialVariants().stream()
             .collect(Collectors.groupingBy(
                 TransformationChainData::getInitialVariant,
-                () -> new TreeMap<>(Comparator.comparing(SourceVariantData::getVariantName)),
+                () -> new TreeMap<>(Comparator.comparing(SourceVariantData::getVariantDisplayName)),
                 Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().sorted(variantDataComparator).collect(Collectors.toList()))));
 
         formatter.startChildren();
@@ -98,7 +98,7 @@ public abstract class AmbiguousArtifactTransformsFailureDescriber extends Abstra
     }
 
     private void formatSourceVariant(SourceVariantData sourceVariantData, TreeFormatter formatter) {
-        formatter.node("From " + sourceVariantData.getFormattedVariantName());
+        formatter.node("From " + sourceVariantData.getVariantDisplayName());
         formatter.startChildren();
         formatter.node("With source attributes");
         formatSortedAttributes(formatter, sourceVariantData.getAttributes());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -47,12 +47,7 @@ public final class SourceVariantData {
     }
 
     public String getFormattedVariantName() {
-        int variantIdx = variantName.indexOf(" variant ");
-        if (variantIdx == -1) {
-            return variantName;
-        } else {
-            return variantName.substring(0, variantIdx + 9) + "'" + variantName.substring(variantIdx + 9) + "'";
-        }
+        return variantName;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -30,24 +30,20 @@ import java.util.Objects;
  * properly implement {@link #equals(Object)} and {@link #hashCode()}.
  */
 public final class SourceVariantData {
-    private final String variantName;
+    private final String variantDisplayName;
     private final ImmutableAttributes attributes;
 
-    public SourceVariantData(String variantName, ImmutableAttributes attributes) {
-        this.variantName = variantName;
+    public SourceVariantData(String variantDisplayName, ImmutableAttributes attributes) {
+        this.variantDisplayName = variantDisplayName;
         this.attributes = attributes;
-    }
-
-    public String getVariantName() {
-        return variantName;
     }
 
     public ImmutableAttributes getAttributes() {
         return attributes;
     }
 
-    public String getFormattedVariantName() {
-        return variantName;
+    public String getVariantDisplayName() {
+        return variantDisplayName;
     }
 
     @Override
@@ -60,12 +56,12 @@ public final class SourceVariantData {
         }
 
         SourceVariantData that = (SourceVariantData) o;
-        return Objects.equals(variantName, that.variantName) && Objects.equals(attributes, that.attributes);
+        return Objects.equals(variantDisplayName, that.variantDisplayName) && Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hashCode(variantName);
+        int result = Objects.hashCode(variantDisplayName);
         result = 31 * result + Objects.hashCode(attributes);
         return result;
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -125,7 +125,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
         variants.size() == 1
 
         def child = variants.first()
-        child.displayName.displayName == '<config> variant child'
+        child.displayName.displayName == "<config> variant 'child'"
         child.attributes == AttributeTestUtil.attributes(["thing": "value"])
         child.artifacts == variantDef.artifacts
     }
@@ -151,7 +151,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
         implicit.artifacts == allArtifacts
 
         def explicit = (variants as List)[1]
-        explicit.displayName.displayName == '<config> variant child'
+        explicit.displayName.displayName == "<config> variant 'child'"
         explicit.attributes == AttributeTestUtil.attributes(["thing": "value2"])
         explicit.artifacts == variantDef.artifacts
     }
@@ -177,7 +177,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
         implicit.artifacts == allArtifacts
 
         def explicit = (variants as List)[1]
-        explicit.displayName.displayName == '<config> variant child'
+        explicit.displayName.displayName == "<config> variant 'child'"
         explicit.attributes == AttributeTestUtil.attributes(["thing": "value2"])
         explicit.artifacts == variantDef.artifacts
     }


### PR DESCRIPTION
Ensure variant names are consistently quoted in user-facing messages, such as error reports. This improves readability and reduces ambiguity by clearly delineating variant names from surrounding text.

Replaces:
- https://github.com/gradle/gradle/pull/38021