### PR TITLE
Spike of lower-ceremony project types and features

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -1325,7 +1325,7 @@
   {
     "name": "project-features-api",
     "path": "platforms/core-configuration/project-features-api",
-    "unitTests": false,
+    "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
@@ -175,7 +175,14 @@ public abstract class ProjectReportTask extends AbstractProjectBasedReportTask<P
                 textOutput.withStyle(Identifier).text(type.getFeatureName());
                 textOutput.append(" (").append(type.getDefinitionPublicType().getName()).append(")").println();
                 textOutput.append("        ").append("Defined in: ").append(type.getPluginClass().getName()).println();
-                textOutput.append("        ").append("Registered by: ").append(type.getRegisteringPluginClass().getName()).println();
+                Class<?> registeringPluginClass = type.getRegisteringPluginClass();
+                if (registeringPluginClass != null) {
+                    textOutput.append("        ").append("Registered by: ").append(registeringPluginClass.getName()).println();
+                } else {
+                    String registeringPluginId = type.getRegisteringPluginId();
+                    textOutput.append("        ").append("Registered by: ")
+                        .append(registeringPluginId != null ? "directly applied as " + registeringPluginId : "directly applied").println();
+                }
             });
         }
     }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/features/schemaFromProjectFeatures.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/features/schemaFromProjectFeatures.kt
@@ -229,7 +229,8 @@ data class ProjectFeatureInfo<T : Definition<V>, V : BuildModel>(
 private fun ProjectFeatureInfo<*, *>.projectFeatureOriginMetadata(): DefaultProjectFeatureOrigin = DefaultProjectFeatureOrigin(
     delegate.featureName,
     delegate.pluginClass.name,
-    delegate.registeringPluginClass.name,
+    // Null for schema declarations applied directly in settings (no registering ecosystem plugin).
+    delegate.registeringPluginClass?.name ?: "",
     delegate.registeringPluginId,
     (delegate.targetDefinitionType as? DefinitionTargetTypeInformation)?.definitionType?.name,
     (delegate.targetDefinitionType as? BuildModelTargetTypeInformation<*>)?.buildModelType?.name,

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/ActionBasedModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/ActionBasedModelDefaultsHandler.kt
@@ -17,7 +17,6 @@ package org.gradle.internal.declarativedsl.interpreter.defaults
 
 import org.gradle.api.Action
 import org.gradle.api.GradleException
-import org.gradle.api.Plugin
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.initialization.internal.SharedModelDefaultsInternal
 import org.gradle.api.internal.DynamicObjectAware
@@ -38,7 +37,7 @@ class ActionBasedModelDefaultsHandler(
     private val projectFeatureDeclarations: ProjectFeatureDeclarations,
 ) : ModelDefaultsHandler {
 
-    override fun apply(target: Any, definition: Any, classLoaderContext: ClassLoaderContext, projectFeatureName: String, plugin: Plugin<*>) {
+    override fun apply(target: Any, definition: Any, classLoaderContext: ClassLoaderContext, projectFeatureName: String) {
         val projectFeatureImplementations: Set<ProjectFeatureImplementation<*, *>> = projectFeatureDeclarations.getProjectFeatureImplementations()[projectFeatureName]!!
 
         val projectFeatureImplementation: ProjectFeatureImplementation<*, *>? = projectFeatureImplementations.find {

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/DeclarativeModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/interpreter/defaults/DeclarativeModelDefaultsHandler.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.declarativedsl.interpreter.defaults
 
-import org.gradle.api.Plugin
 import org.gradle.declarative.dsl.evaluation.EvaluationSchema
 import org.gradle.declarative.dsl.schema.CustomAccessorIdentifier.ProjectFeatureIdentifier
 import org.gradle.internal.declarativedsl.analysis.AssignmentRecord
@@ -67,7 +66,7 @@ abstract class DeclarativeModelDefaultsHandler @Inject constructor(
     private
     val modelDefaultsRepository = projectFeatureRegistryBasedModelDefaultsRepository(projectFeatureDeclarations)
 
-    override fun apply(target: Any, definition: Any, classLoaderContext: ClassLoaderContext, projectFeatureName: String, plugin: Plugin<*>) {
+    override fun apply(target: Any, definition: Any, classLoaderContext: ClassLoaderContext, projectFeatureName: String) {
         // TODO - this works because there should only be one implementation for each project type.  We'll need to revisit this
         // when we support defaults for project features which can have multiple implementations.
         val projectFeature = projectFeatureDeclarations.projectFeatureImplementations.getValue(projectFeatureName).first()

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/ProjectFeature.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/ProjectFeature.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.annotations;
+
+import org.gradle.api.Incubating;
+import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation placed on a {@link SchemaProjectFeatureApplyAction} implementation to register it as a
+ * project feature. When the plugin id whose descriptor points at the annotated apply action is applied
+ * in a settings {@code plugins { }} block, the project feature is registered directly under the given
+ * {@link #name()} — no project plugin shell or binding class is required.
+ *
+ * <p>The project feature's definition type and parent (target) definition type are inferred from the
+ * apply action's generic type parameters.
+ *
+ * @since 9.7.0
+ */
+@Incubating
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProjectFeature {
+    /**
+     * The name of the project feature. This is how it will be referenced in the DSL.
+     *
+     * @since 9.7.0
+     */
+    String name();
+}

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/ProjectType.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/ProjectType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.annotations;
+
+import org.gradle.api.Incubating;
+import org.gradle.features.binding.SchemaProjectTypeApplyAction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation placed on a {@link SchemaProjectTypeApplyAction} implementation to register it as a
+ * project type. When the plugin id whose descriptor points at the annotated apply action is applied
+ * in a settings {@code plugins { }} block, the project type is registered directly under the given
+ * {@link #name()} — no project plugin shell or binding class is required.
+ *
+ * <p>The project type's definition type is inferred from the apply action's generic type parameter.
+ *
+ * @since 9.7.0
+ */
+@Incubating
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProjectType {
+    /**
+     * The name of the project type. This is how it will be referenced in the DSL.
+     *
+     * @since 9.7.0
+     */
+    String name();
+}

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/RegistersProjectFeatures.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/annotations/RegistersProjectFeatures.java
@@ -17,8 +17,6 @@
 package org.gradle.features.annotations;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -35,9 +33,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RegistersProjectFeatures {
     /**
-     * The {@link Project} plugins that provide the project features.
+     * The classes that provide the project features. Each may be either a {@code Plugin<Project>}
+     * carrying a {@code @BindsProjectType}/{@code @BindsProjectFeature} annotation, or a schema apply
+     * action ({@code SchemaProjectTypeApplyAction}/{@code SchemaProjectFeatureApplyAction}) carrying a
+     * {@code @ProjectType}/{@code @ProjectFeature} annotation.
      *
      * @since 8.9
      */
-    Class<? extends Plugin<Project>>[] value();
+    Class<?>[] value();
 }

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaDefinition.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaDefinition.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.binding;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A {@link Definition} that has no build model. Used by project types and project
+ * features whose apply actions only need the definition (a schema), not a build
+ * model or application context.
+ *
+ * @since 9.7.0
+ */
+@Incubating
+public interface SchemaDefinition extends Definition<BuildModel.None> {
+}

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaProjectFeatureApplyAction.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaProjectFeatureApplyAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.binding;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A {@link ProjectFeatureApplyAction} for project features whose definition has no
+ * build model. Implementations provide build logic by overriding
+ * {@link #apply(SchemaDefinition, Object)}, which receives only the definition and
+ * its parent definition — no application context or build model.
+ *
+ * @param <OwnDefinition> the type of the project feature definition
+ * @param <ParentDefinition> the type of the parent project feature definition
+ *
+ * @since 9.7.0
+ */
+@Incubating
+public interface SchemaProjectFeatureApplyAction<OwnDefinition extends SchemaDefinition, ParentDefinition>
+    extends ProjectFeatureApplyAction<OwnDefinition, BuildModel.None, ParentDefinition> {
+
+    @Override
+    default void apply(ProjectFeatureApplicationContext context, OwnDefinition definition, BuildModel.None buildModel, ParentDefinition parentDefinition) {
+        apply(definition, parentDefinition);
+    }
+
+    /**
+     * Apply build logic using only the project feature definition and its parent.
+     *
+     * @param definition the project feature definition
+     * @param parentDefinition the parent project feature definition
+     *
+     * @since 9.7.0
+     */
+    void apply(OwnDefinition definition, ParentDefinition parentDefinition);
+}

--- a/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaProjectTypeApplyAction.java
+++ b/platforms/core-configuration/project-features-api/src/main/java/org/gradle/features/binding/SchemaProjectTypeApplyAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.binding;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A {@link ProjectTypeApplyAction} for project types whose definition has no build
+ * model. Implementations provide build logic by overriding {@link #apply(SchemaDefinition)},
+ * which receives only the definition — no application context or build model.
+ *
+ * @param <OwnDefinition> the type of the project type definition
+ *
+ * @since 9.7.0
+ */
+@Incubating
+public interface SchemaProjectTypeApplyAction<OwnDefinition extends SchemaDefinition>
+    extends ProjectTypeApplyAction<OwnDefinition, BuildModel.None> {
+
+    @Override
+    default void apply(ProjectFeatureApplicationContext context, OwnDefinition definition, BuildModel.None buildModel) {
+        apply(definition);
+    }
+
+    /**
+     * Apply build logic using only the project type definition.
+     *
+     * @param definition the project type definition
+     *
+     * @since 9.7.0
+     */
+    void apply(OwnDefinition definition);
+}

--- a/platforms/core-configuration/project-features-api/src/test/groovy/org/gradle/features/binding/SchemaProjectFeatureApplyActionTest.groovy
+++ b/platforms/core-configuration/project-features-api/src/test/groovy/org/gradle/features/binding/SchemaProjectFeatureApplyActionTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.binding
+
+import spock.lang.Specification
+
+class SchemaProjectFeatureApplyActionTest extends Specification {
+
+    def definition = Mock(SchemaDefinition)
+    def parent = new Object()
+
+    def "delegates to the simplified apply with the definition and parent definition"() {
+        given:
+        def capturedDefinition = []
+        def capturedParent = []
+        def action = new SchemaProjectFeatureApplyAction<SchemaDefinition, Object>() {
+            @Override
+            void apply(SchemaDefinition d, Object p) {
+                capturedDefinition << d
+                capturedParent << p
+            }
+        }
+
+        when:
+        action.apply(null, definition, null, parent)
+
+        then:
+        capturedDefinition == [definition]
+        capturedParent == [parent]
+    }
+
+    def "delegates when invoked through the ProjectFeatureApplyAction supertype reference"() {
+        given:
+        def capturedDefinition = []
+        def capturedParent = []
+        ProjectFeatureApplyAction<SchemaDefinition, BuildModel.None, Object> action = new SchemaProjectFeatureApplyAction<SchemaDefinition, Object>() {
+            @Override
+            void apply(SchemaDefinition d, Object p) {
+                capturedDefinition << d
+                capturedParent << p
+            }
+        }
+
+        when:
+        action.apply(null, definition, null, parent)
+
+        then:
+        capturedDefinition == [definition]
+        capturedParent == [parent]
+    }
+
+    def "ignores the context and build model"() {
+        given:
+        def capturedDefinition = []
+        def capturedParent = []
+        def action = new SchemaProjectFeatureApplyAction<SchemaDefinition, Object>() {
+            @Override
+            void apply(SchemaDefinition d, Object p) {
+                capturedDefinition << d
+                capturedParent << p
+            }
+        }
+        def context = Mock(ProjectFeatureApplicationContext)
+        def buildModel = new BuildModel.None()
+
+        when:
+        action.apply(context, definition, buildModel, parent)
+
+        then:
+        capturedDefinition == [definition]
+        capturedParent == [parent]
+        0 * context._
+    }
+}

--- a/platforms/core-configuration/project-features-api/src/test/groovy/org/gradle/features/binding/SchemaProjectTypeApplyActionTest.groovy
+++ b/platforms/core-configuration/project-features-api/src/test/groovy/org/gradle/features/binding/SchemaProjectTypeApplyActionTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.binding
+
+import spock.lang.Specification
+
+class SchemaProjectTypeApplyActionTest extends Specification {
+
+    def definition = Mock(SchemaDefinition)
+
+    def "delegates to the simplified apply with the definition"() {
+        given:
+        def captured = []
+        def action = new SchemaProjectTypeApplyAction<SchemaDefinition>() {
+            @Override
+            void apply(SchemaDefinition d) {
+                captured << d
+            }
+        }
+
+        when:
+        action.apply(null, definition, null)
+
+        then:
+        captured == [definition]
+    }
+
+    def "delegates when invoked through the ProjectTypeApplyAction supertype reference"() {
+        given:
+        def captured = []
+        ProjectTypeApplyAction<SchemaDefinition, BuildModel.None> action = new SchemaProjectTypeApplyAction<SchemaDefinition>() {
+            @Override
+            void apply(SchemaDefinition d) {
+                captured << d
+            }
+        }
+
+        when:
+        action.apply(null, definition, null)
+
+        then:
+        captured == [definition]
+    }
+
+    def "ignores the context and build model"() {
+        given:
+        def captured = []
+        def action = new SchemaProjectTypeApplyAction<SchemaDefinition>() {
+            @Override
+            void apply(SchemaDefinition d) {
+                captured << d
+            }
+        }
+        def context = Mock(ProjectFeatureApplicationContext)
+        def buildModel = new BuildModel.None()
+
+        when:
+        action.apply(context, definition, buildModel)
+
+        then:
+        captured == [definition]
+        0 * context._
+    }
+}

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.features.internal.TestScenarioFixture
+import org.gradle.test.fixtures.plugin.PluginBuilder
+
+/**
+ * Exercises the {@code SchemaDefinition} / {@code SchemaProjectTypeApplyAction} /
+ * {@code SchemaProjectFeatureApplyAction} API end-to-end through the real
+ * feature-application pipeline, using a hand-authored plugin (the shared
+ * {@code testScenario} fixtures still emit the non-schema apply-action types).
+ *
+ * <p>Each apply action registers a task that prints a marker literal emitted only
+ * from inside the simplified {@code apply(...)} method, so a passing assertion proves
+ * the default {@code apply(...)} delegated to the simplified one through the pipeline.</p>
+ */
+class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements TestScenarioFixture {
+
+    def 'project type with a SchemaDefinition runs its schema apply action'() {
+        given:
+        schemaPlugins()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        file("build.gradle.dcl") << """
+            myProjectType {
+                id = "abc"
+            }
+        """
+
+        when:
+        run("printMyProjectType")
+
+        then:
+        outputContains("SCHEMA_TYPE_APPLY_RAN id=abc")
+    }
+
+    def 'project feature with a SchemaDefinition runs its schema apply action with the parent'() {
+        given:
+        schemaPlugins()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        file("build.gradle.dcl") << """
+            myProjectType {
+                id = "abc"
+
+                myFeature {
+                    value = "xyz"
+                }
+            }
+        """
+
+        when:
+        run("printMyFeature")
+
+        then:
+        outputContains("SCHEMA_FEATURE_APPLY_RAN value=xyz parentId=abc")
+    }
+
+    /**
+     * Writes an included "plugins" build containing a no-build-model project type and a
+     * no-build-model project feature bound to it, plus a settings plugin that registers
+     * them, exposed under the {@code com.example.test-software-ecosystem} plugin id.
+     */
+    private void schemaPlugins() {
+        PluginBuilder pluginBuilder = new PluginBuilder(file("plugins"))
+        pluginBuilder.packageName = "org.gradle.test"
+
+        pluginBuilder.java("MyProjectTypeDefinition.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.features.binding.SchemaDefinition;
+
+            public interface MyProjectTypeDefinition extends SchemaDefinition {
+                Property<String> getId();
+            }
+        '''
+
+        pluginBuilder.java("MyProjectTypePlugin.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.features.annotations.BindsProjectType;
+            import org.gradle.features.binding.ProjectTypeBinding;
+            import org.gradle.features.binding.ProjectTypeBindingBuilder;
+            import org.gradle.features.binding.SchemaProjectTypeApplyAction;
+            import org.gradle.features.registration.TaskRegistrar;
+
+            import javax.inject.Inject;
+
+            @BindsProjectType(MyProjectTypePlugin.Binding.class)
+            public abstract class MyProjectTypePlugin implements Plugin<Project> {
+
+                static class Binding implements ProjectTypeBinding {
+                    @Override
+                    public void bind(ProjectTypeBindingBuilder builder) {
+                        builder.bindProjectType("myProjectType", MyProjectTypeDefinition.class, ApplyAction.class);
+                    }
+                }
+
+                static abstract class ApplyAction implements SchemaProjectTypeApplyAction<MyProjectTypeDefinition> {
+                    @Inject
+                    public ApplyAction() { }
+
+                    @Inject
+                    protected abstract TaskRegistrar getTaskRegistrar();
+
+                    @Override
+                    public void apply(MyProjectTypeDefinition definition) {
+                        getTaskRegistrar().register("printMyProjectType", task -> {
+                            String id = definition.getId().get();
+                            task.doLast(t -> System.out.println("SCHEMA_TYPE_APPLY_RAN id=" + id));
+                        });
+                    }
+                }
+
+                @Override
+                public void apply(Project project) {
+                }
+            }
+        '''
+
+        pluginBuilder.java("MyFeatureDefinition.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.features.binding.SchemaDefinition;
+
+            public interface MyFeatureDefinition extends SchemaDefinition {
+                Property<String> getValue();
+            }
+        '''
+
+        pluginBuilder.java("MyFeaturePlugin.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.features.annotations.BindsProjectFeature;
+            import org.gradle.features.binding.ProjectFeatureBinding;
+            import org.gradle.features.binding.ProjectFeatureBindingBuilder;
+            import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+            import org.gradle.features.registration.TaskRegistrar;
+
+            import javax.inject.Inject;
+
+            @BindsProjectFeature(MyFeaturePlugin.Binding.class)
+            public abstract class MyFeaturePlugin implements Plugin<Project> {
+
+                static class Binding implements ProjectFeatureBinding {
+                    @Override
+                    public void bind(ProjectFeatureBindingBuilder builder) {
+                        builder.bindProjectFeatureToDefinition("myFeature", MyFeatureDefinition.class, MyProjectTypeDefinition.class, ApplyAction.class);
+                    }
+                }
+
+                static abstract class ApplyAction implements SchemaProjectFeatureApplyAction<MyFeatureDefinition, MyProjectTypeDefinition> {
+                    @Inject
+                    public ApplyAction() { }
+
+                    @Inject
+                    protected abstract TaskRegistrar getTaskRegistrar();
+
+                    @Override
+                    public void apply(MyFeatureDefinition definition, MyProjectTypeDefinition parent) {
+                        getTaskRegistrar().register("printMyFeature", task -> {
+                            String value = definition.getValue().get();
+                            String parentId = parent.getId().get();
+                            task.doLast(t -> System.out.println("SCHEMA_FEATURE_APPLY_RAN value=" + value + " parentId=" + parentId));
+                        });
+                    }
+                }
+
+                @Override
+                public void apply(Project project) {
+                }
+            }
+        '''
+
+        pluginBuilder.java("ProjectTypeRegistrationPlugin.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.initialization.Settings;
+            import org.gradle.features.annotations.RegistersProjectFeatures;
+
+            @RegistersProjectFeatures({ MyProjectTypePlugin.class, MyFeaturePlugin.class })
+            public abstract class ProjectTypeRegistrationPlugin implements Plugin<Settings> {
+                @Override
+                public void apply(Settings settings) {
+                }
+            }
+        '''
+
+        pluginBuilder.addPluginId("com.example.test-software-ecosystem", "ProjectTypeRegistrationPlugin")
+        pluginBuilder.addBuildScriptContent(pluginBuildScriptForJava)
+        pluginBuilder.prepareToExecute()
+    }
+}

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
@@ -20,13 +20,16 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.features.internal.TestScenarioFixture
 import org.gradle.test.fixtures.plugin.PluginBuilder
 
+import static org.hamcrest.CoreMatchers.containsString
+
 /**
  * Exercises the {@code SchemaDefinition} / {@code SchemaProjectTypeApplyAction} /
- * {@code SchemaProjectFeatureApplyAction} API end-to-end through the real
- * feature-application pipeline, registered via the <em>aggregation</em> path: a settings plugin
- * annotated with {@code @RegistersProjectFeatures} lists the schema apply actions directly — no
- * {@code Plugin<Project>} shell and no {@code Binding}/{@code bind()} class. (The direct
- * settings-application path is covered by {@code SchemaDirectApplicationIntegrationTest}.)
+ * {@code SchemaProjectFeatureApplyAction} API end-to-end through the real feature-application
+ * pipeline, registered via an {@code EcosystemApplyAction} (research Option 6): the ecosystem
+ * aggregates the schema apply actions via {@code @RegistersProjectFeatures} and seeds defaults via
+ * {@code apply(SharedModelDefaults)} — no {@code Plugin<Settings>} registrar, no {@code Plugin<Project>}
+ * shell, and no {@code Binding}/{@code bind()} class. (The direct settings-application path is covered
+ * by {@code SchemaDirectApplicationIntegrationTest}.)
  *
  * <p>Each apply action registers a task that prints a marker literal emitted only
  * from inside the simplified {@code apply(...)} method, so a passing assertion proves
@@ -76,11 +79,53 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
         outputContains("SCHEMA_FEATURE_APPLY_RAN value=xyz parentId=abc")
     }
 
+    def 'ecosystem-seeded default applies when the build does not set it'() {
+        given:
+        schemaPlugins()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        file("build.gradle.dcl") << """
+            myProjectType {
+            }
+        """
+
+        when:
+        run("printMyProjectType")
+
+        then:
+        outputContains("SCHEMA_TYPE_APPLY_RAN id=default-id")
+    }
+
+    def 'applying an ecosystem to a project fails with a clear settings-only error'() {
+        given:
+        schemaPlugins()
+
+        settingsFile << """
+            pluginManagement {
+                includeBuild("plugins")
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id("com.example.test-software-ecosystem")
+            }
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertThatCause(containsString("can only be applied in a settings 'plugins { }' block"))
+    }
+
     /**
      * Writes an included "plugins" build containing a no-build-model project type and a
      * no-build-model project feature, authored as schema apply actions (no {@code Plugin}/{@code Binding}
-     * shells), plus a settings plugin that registers them directly via {@code @RegistersProjectFeatures},
-     * exposed under the {@code com.example.test-software-ecosystem} plugin id.
+     * shells), plus an {@code EcosystemApplyAction} that aggregates them via {@code @RegistersProjectFeatures}
+     * and seeds a default {@code id} via {@code apply(SharedModelDefaults)}, exposed under the
+     * {@code com.example.test-software-ecosystem} plugin id.
      */
     private void schemaPlugins() {
         PluginBuilder pluginBuilder = new PluginBuilder(file("plugins"))
@@ -163,22 +208,29 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
             }
         '''
 
-        pluginBuilder.java("ProjectTypeRegistrationPlugin.java") << '''
+        pluginBuilder.java("MyEcosystem.java") << '''
             package org.gradle.test;
 
-            import org.gradle.api.Plugin;
-            import org.gradle.api.initialization.Settings;
+            import org.gradle.api.initialization.EcosystemApplyAction;
+            import org.gradle.api.initialization.SharedModelDefaults;
             import org.gradle.features.annotations.RegistersProjectFeatures;
 
+            import javax.inject.Inject;
+
             @RegistersProjectFeatures({ MyProjectTypeAction.class, MyFeatureAction.class })
-            public abstract class ProjectTypeRegistrationPlugin implements Plugin<Settings> {
+            public class MyEcosystem implements EcosystemApplyAction {
+                @Inject
+                public MyEcosystem() { }
+
                 @Override
-                public void apply(Settings settings) {
+                public void apply(SharedModelDefaults defaults) {
+                    defaults.add("myProjectType", MyProjectTypeDefinition.class,
+                        definition -> definition.getId().convention("default-id"));
                 }
             }
         '''
 
-        pluginBuilder.addPluginId("com.example.test-software-ecosystem", "ProjectTypeRegistrationPlugin")
+        pluginBuilder.addPluginId("com.example.test-software-ecosystem", "MyEcosystem")
         pluginBuilder.addBuildScriptContent(pluginBuildScriptForJava)
         pluginBuilder.prepareToExecute()
     }

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDefinitionIntegrationTest.groovy
@@ -23,8 +23,10 @@ import org.gradle.test.fixtures.plugin.PluginBuilder
 /**
  * Exercises the {@code SchemaDefinition} / {@code SchemaProjectTypeApplyAction} /
  * {@code SchemaProjectFeatureApplyAction} API end-to-end through the real
- * feature-application pipeline, using a hand-authored plugin (the shared
- * {@code testScenario} fixtures still emit the non-schema apply-action types).
+ * feature-application pipeline, registered via the <em>aggregation</em> path: a settings plugin
+ * annotated with {@code @RegistersProjectFeatures} lists the schema apply actions directly — no
+ * {@code Plugin<Project>} shell and no {@code Binding}/{@code bind()} class. (The direct
+ * settings-application path is covered by {@code SchemaDirectApplicationIntegrationTest}.)
  *
  * <p>Each apply action registers a task that prints a marker literal emitted only
  * from inside the simplified {@code apply(...)} method, so a passing assertion proves
@@ -76,8 +78,9 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
 
     /**
      * Writes an included "plugins" build containing a no-build-model project type and a
-     * no-build-model project feature bound to it, plus a settings plugin that registers
-     * them, exposed under the {@code com.example.test-software-ecosystem} plugin id.
+     * no-build-model project feature, authored as schema apply actions (no {@code Plugin}/{@code Binding}
+     * shells), plus a settings plugin that registers them directly via {@code @RegistersProjectFeatures},
+     * exposed under the {@code com.example.test-software-ecosystem} plugin id.
      */
     private void schemaPlugins() {
         PluginBuilder pluginBuilder = new PluginBuilder(file("plugins"))
@@ -94,47 +97,29 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
             }
         '''
 
-        pluginBuilder.java("MyProjectTypePlugin.java") << '''
+        pluginBuilder.java("MyProjectTypeAction.java") << '''
             package org.gradle.test;
 
-            import org.gradle.api.Plugin;
-            import org.gradle.api.Project;
-            import org.gradle.features.annotations.BindsProjectType;
-            import org.gradle.features.binding.ProjectTypeBinding;
-            import org.gradle.features.binding.ProjectTypeBindingBuilder;
+            import org.gradle.api.tasks.TaskContainer;
+            import org.gradle.features.annotations.ProjectType;
             import org.gradle.features.binding.SchemaProjectTypeApplyAction;
-            import org.gradle.features.registration.TaskRegistrar;
 
             import javax.inject.Inject;
 
-            @BindsProjectType(MyProjectTypePlugin.Binding.class)
-            public abstract class MyProjectTypePlugin implements Plugin<Project> {
+            @ProjectType(name = "myProjectType")
+            public abstract class MyProjectTypeAction implements SchemaProjectTypeApplyAction<MyProjectTypeDefinition> {
+                @Inject
+                public MyProjectTypeAction() { }
 
-                static class Binding implements ProjectTypeBinding {
-                    @Override
-                    public void bind(ProjectTypeBindingBuilder builder) {
-                        builder.bindProjectType("myProjectType", MyProjectTypeDefinition.class, ApplyAction.class);
-                    }
-                }
-
-                static abstract class ApplyAction implements SchemaProjectTypeApplyAction<MyProjectTypeDefinition> {
-                    @Inject
-                    public ApplyAction() { }
-
-                    @Inject
-                    protected abstract TaskRegistrar getTaskRegistrar();
-
-                    @Override
-                    public void apply(MyProjectTypeDefinition definition) {
-                        getTaskRegistrar().register("printMyProjectType", task -> {
-                            String id = definition.getId().get();
-                            task.doLast(t -> System.out.println("SCHEMA_TYPE_APPLY_RAN id=" + id));
-                        });
-                    }
-                }
+                @Inject
+                protected abstract TaskContainer getTasks();
 
                 @Override
-                public void apply(Project project) {
+                public void apply(MyProjectTypeDefinition definition) {
+                    getTasks().register("printMyProjectType", task -> {
+                        String id = definition.getId().get();
+                        task.doLast(t -> System.out.println("SCHEMA_TYPE_APPLY_RAN id=" + id));
+                    });
                 }
             }
         '''
@@ -150,48 +135,30 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
             }
         '''
 
-        pluginBuilder.java("MyFeaturePlugin.java") << '''
+        pluginBuilder.java("MyFeatureAction.java") << '''
             package org.gradle.test;
 
-            import org.gradle.api.Plugin;
-            import org.gradle.api.Project;
-            import org.gradle.features.annotations.BindsProjectFeature;
-            import org.gradle.features.binding.ProjectFeatureBinding;
-            import org.gradle.features.binding.ProjectFeatureBindingBuilder;
+            import org.gradle.api.tasks.TaskContainer;
+            import org.gradle.features.annotations.ProjectFeature;
             import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
-            import org.gradle.features.registration.TaskRegistrar;
 
             import javax.inject.Inject;
 
-            @BindsProjectFeature(MyFeaturePlugin.Binding.class)
-            public abstract class MyFeaturePlugin implements Plugin<Project> {
+            @ProjectFeature(name = "myFeature")
+            public abstract class MyFeatureAction implements SchemaProjectFeatureApplyAction<MyFeatureDefinition, MyProjectTypeDefinition> {
+                @Inject
+                public MyFeatureAction() { }
 
-                static class Binding implements ProjectFeatureBinding {
-                    @Override
-                    public void bind(ProjectFeatureBindingBuilder builder) {
-                        builder.bindProjectFeatureToDefinition("myFeature", MyFeatureDefinition.class, MyProjectTypeDefinition.class, ApplyAction.class);
-                    }
-                }
-
-                static abstract class ApplyAction implements SchemaProjectFeatureApplyAction<MyFeatureDefinition, MyProjectTypeDefinition> {
-                    @Inject
-                    public ApplyAction() { }
-
-                    @Inject
-                    protected abstract TaskRegistrar getTaskRegistrar();
-
-                    @Override
-                    public void apply(MyFeatureDefinition definition, MyProjectTypeDefinition parent) {
-                        getTaskRegistrar().register("printMyFeature", task -> {
-                            String value = definition.getValue().get();
-                            String parentId = parent.getId().get();
-                            task.doLast(t -> System.out.println("SCHEMA_FEATURE_APPLY_RAN value=" + value + " parentId=" + parentId));
-                        });
-                    }
-                }
+                @Inject
+                protected abstract TaskContainer getTasks();
 
                 @Override
-                public void apply(Project project) {
+                public void apply(MyFeatureDefinition definition, MyProjectTypeDefinition parent) {
+                    getTasks().register("printMyFeature", task -> {
+                        String value = definition.getValue().get();
+                        String parentId = parent.getId().get();
+                        task.doLast(t -> System.out.println("SCHEMA_FEATURE_APPLY_RAN value=" + value + " parentId=" + parentId));
+                    });
                 }
             }
         '''
@@ -203,7 +170,7 @@ class SchemaDefinitionIntegrationTest extends AbstractIntegrationSpec implements
             import org.gradle.api.initialization.Settings;
             import org.gradle.features.annotations.RegistersProjectFeatures;
 
-            @RegistersProjectFeatures({ MyProjectTypePlugin.class, MyFeaturePlugin.class })
+            @RegistersProjectFeatures({ MyProjectTypeAction.class, MyFeatureAction.class })
             public abstract class ProjectTypeRegistrationPlugin implements Plugin<Settings> {
                 @Override
                 public void apply(Settings settings) {

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDirectApplicationIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/SchemaDirectApplicationIntegrationTest.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.features.internal.TestScenarioFixture
+import org.gradle.test.fixtures.plugin.PluginBuilder
+
+import static org.hamcrest.CoreMatchers.containsString
+
+/**
+ * Exercises the low-ceremony "direct application" path: a plugin id whose descriptor points directly
+ * at a {@code SchemaProjectTypeApplyAction}/{@code SchemaProjectFeatureApplyAction} (annotated with
+ * {@code @ProjectType}/{@code @ProjectFeature}) is applied in a settings {@code plugins { }} block,
+ * registering the project type/feature with no project plugin shell, binding class, or settings plugin.
+ *
+ * <p>This is the low-ceremony twin of {@link SchemaDefinitionIntegrationTest}.</p>
+ */
+class SchemaDirectApplicationIntegrationTest extends AbstractIntegrationSpec implements TestScenarioFixture {
+
+    def 'schema project type and feature applied directly in settings run their apply actions'() {
+        given:
+        schemaPlugins()
+
+        file("settings.gradle.dcl") << """
+            pluginManagement {
+                includeBuild("plugins")
+            }
+            plugins {
+                id("com.example.my-project-type")
+                id("com.example.my-feature")
+            }
+        """
+
+        file("build.gradle.dcl") << """
+            myProjectType {
+                id = "abc"
+
+                myFeature {
+                    value = "xyz"
+                }
+            }
+        """
+
+        when:
+        run("printMyProjectType", "printMyFeature")
+
+        then:
+        outputContains("SCHEMA_TYPE_APPLY_RAN id=abc")
+        outputContains("SCHEMA_FEATURE_APPLY_RAN value=xyz parentId=abc")
+    }
+
+    def 'applying a schema apply action to a project fails with a clear settings-only error'() {
+        given:
+        schemaPlugins()
+
+        settingsFile << """
+            pluginManagement {
+                includeBuild("plugins")
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id("com.example.my-project-type")
+            }
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertThatCause(containsString("can only be applied in a settings 'plugins { }' block"))
+    }
+
+    /**
+     * Writes an included "plugins" build whose plugin descriptors point directly at schema apply
+     * action classes — there is no project plugin, binding class, or settings plugin.
+     */
+    private void schemaPlugins() {
+        PluginBuilder pluginBuilder = new PluginBuilder(file("plugins"))
+        pluginBuilder.packageName = "org.gradle.test"
+
+        pluginBuilder.java("MyProjectTypeDefinition.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.features.binding.SchemaDefinition;
+
+            public interface MyProjectTypeDefinition extends SchemaDefinition {
+                Property<String> getId();
+            }
+        '''
+
+        pluginBuilder.java("MyProjectTypeAction.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.features.annotations.ProjectType;
+            import org.gradle.features.binding.SchemaProjectTypeApplyAction;
+            import org.gradle.api.tasks.TaskContainer;
+
+            import javax.inject.Inject;
+
+            @ProjectType(name = "myProjectType")
+            public abstract class MyProjectTypeAction implements SchemaProjectTypeApplyAction<MyProjectTypeDefinition> {
+                @Inject
+                public MyProjectTypeAction() { }
+
+                @Inject
+                protected abstract TaskContainer getTasks();
+
+                @Override
+                public void apply(MyProjectTypeDefinition definition) {
+                    getTasks().register("printMyProjectType", task -> {
+                        String id = definition.getId().get();
+                        task.doLast(t -> System.out.println("SCHEMA_TYPE_APPLY_RAN id=" + id));
+                    });
+                }
+            }
+        '''
+
+        pluginBuilder.java("MyFeatureDefinition.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.features.binding.SchemaDefinition;
+
+            public interface MyFeatureDefinition extends SchemaDefinition {
+                Property<String> getValue();
+            }
+        '''
+
+        pluginBuilder.java("MyFeatureAction.java") << '''
+            package org.gradle.test;
+
+            import org.gradle.features.annotations.ProjectFeature;
+            import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+            import org.gradle.api.tasks.TaskContainer;
+
+            import javax.inject.Inject;
+
+            @ProjectFeature(name = "myFeature")
+            public abstract class MyFeatureAction implements SchemaProjectFeatureApplyAction<MyFeatureDefinition, MyProjectTypeDefinition> {
+                @Inject
+                public MyFeatureAction() { }
+
+                @Inject
+                protected abstract TaskContainer getTasks();
+
+                @Override
+                public void apply(MyFeatureDefinition definition, MyProjectTypeDefinition parent) {
+                    getTasks().register("printMyFeature", task -> {
+                        String value = definition.getValue().get();
+                        String parentId = parent.getId().get();
+                        task.doLast(t -> System.out.println("SCHEMA_FEATURE_APPLY_RAN value=" + value + " parentId=" + parentId));
+                    });
+                }
+            }
+        '''
+
+        pluginBuilder.addPluginId("com.example.my-project-type", "MyProjectTypeAction")
+        pluginBuilder.addPluginId("com.example.my-feature", "MyFeatureAction")
+        pluginBuilder.addBuildScriptContent(pluginBuildScriptForJava)
+        pluginBuilder.prepareToExecute()
+    }
+}

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ModelDefaultsApplicator.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ModelDefaultsApplicator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.features.internal.binding;
 
-import org.gradle.api.Plugin;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -25,7 +24,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  */
 @ServiceScope(Scope.Project.class)
 public interface ModelDefaultsApplicator {
-    void applyDefaultsTo(Object target, Object definition, ClassLoaderContext classLoaderContext, Plugin<?> plugin, ProjectFeatureImplementation<?, ?> projectFeatureImplementation);
+    void applyDefaultsTo(Object target, Object definition, ClassLoaderContext classLoaderContext, ProjectFeatureImplementation<?, ?> projectFeatureImplementation);
 
     interface ClassLoaderContext {
         ClassLoader getClassLoader();

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ModelDefaultsHandler.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ModelDefaultsHandler.java
@@ -16,7 +16,6 @@
 
 package org.gradle.features.internal.binding;
 
-import org.gradle.api.Plugin;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -25,5 +24,5 @@ import org.gradle.internal.service.scopes.ServiceScope;
  */
 @ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface ModelDefaultsHandler {
-    void apply(Object target, Object definition, ModelDefaultsApplicator.ClassLoaderContext classLoaderScope, String projectFeatureName, Plugin<?> plugin);
+    void apply(Object target, Object definition, ModelDefaultsApplicator.ClassLoaderContext classLoaderScope, String projectFeatureName);
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureDeclarations.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureDeclarations.java
@@ -39,13 +39,14 @@ public interface ProjectFeatureDeclarations {
     void addDeclaration(@Nullable String pluginId, Class<? extends Plugin<Project>> pluginClass, Class<? extends Plugin<Settings>> registeringPluginClass);
 
     /**
-     * Declares a schema apply action class as providing a project type or feature directly (applied in a
-     * settings {@code plugins { }} block, with no registering settings plugin). The class must implement
+     * Declares a schema apply action class as providing a project type or feature. The class must implement
      * {@code SchemaProjectTypeApplyAction} or {@code SchemaProjectFeatureApplyAction} and carry the matching
-     * {@code @ProjectType}/{@code @ProjectFeature} annotation. Cannot be called once the list of project
+     * {@code @ProjectType}/{@code @ProjectFeature} annotation. {@code registeringPluginClass} is the settings
+     * plugin that registered it via {@code @RegistersProjectFeatures}, or {@code null} when the action was
+     * applied directly in a settings {@code plugins { }} block. Cannot be called once the list of project
      * features has been queried via {@link #getProjectFeatureImplementations()}.
      */
-    void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass);
+    void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass, @Nullable Class<? extends Plugin<Settings>> registeringPluginClass);
 
     /**
      * Returns a map of available project features, along with their types and associated plugins, keyed by project feature name.  Note that once

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureDeclarations.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureDeclarations.java
@@ -39,6 +39,15 @@ public interface ProjectFeatureDeclarations {
     void addDeclaration(@Nullable String pluginId, Class<? extends Plugin<Project>> pluginClass, Class<? extends Plugin<Settings>> registeringPluginClass);
 
     /**
+     * Declares a schema apply action class as providing a project type or feature directly (applied in a
+     * settings {@code plugins { }} block, with no registering settings plugin). The class must implement
+     * {@code SchemaProjectTypeApplyAction} or {@code SchemaProjectFeatureApplyAction} and carry the matching
+     * {@code @ProjectType}/{@code @ProjectFeature} annotation. Cannot be called once the list of project
+     * features has been queried via {@link #getProjectFeatureImplementations()}.
+     */
+    void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass);
+
+    /**
      * Returns a map of available project features, along with their types and associated plugins, keyed by project feature name.  Note that once
      * method is called, calling {@link #addDeclaration(String, Class, Class)} will result in an error.
      */

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureImplementation.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/ProjectFeatureImplementation.java
@@ -17,7 +17,6 @@
 package org.gradle.features.internal.binding;
 
 import org.gradle.api.Plugin;
-import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.features.binding.BuildModel;
 import org.gradle.features.binding.Definition;
@@ -53,9 +52,19 @@ public interface ProjectFeatureImplementation<OwnDefinition extends Definition<O
 
     Map<Class<?>, Class<?>> getNestedBuildModelTypes();
 
-    Class<? extends Plugin<Project>> getPluginClass();
+    /**
+     * The class that defines this feature. For the binding path this is the {@link Plugin} that
+     * hosts the binding; for the schema (direct-application) path this is the schema apply action
+     * class itself, which is not a {@link Plugin}. Used for reporting and (when it is actually a
+     * {@link Plugin}) for applying the project plugin when the feature is first used.
+     */
+    Class<?> getPluginClass();
 
-    Class<? extends Plugin<Settings>> getRegisteringPluginClass();
+    /**
+     * The settings plugin that registered this feature via {@code @RegistersProjectFeatures}, or
+     * {@code null} when the feature was applied directly in settings (the schema/direct path).
+     */
+    @Nullable Class<? extends Plugin<Settings>> getRegisteringPluginClass();
 
     @Nullable String getRegisteringPluginId();
 

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/SchemaBindingFactory.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/features/internal/binding/SchemaBindingFactory.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.internal.binding;
+
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.features.annotations.ProjectFeature;
+import org.gradle.features.annotations.ProjectType;
+import org.gradle.features.binding.BuildModel;
+import org.gradle.features.binding.Definition;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectFeatureApplyAction;
+import org.gradle.features.binding.SchemaDefinition;
+import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+import org.gradle.features.binding.SchemaProjectTypeApplyAction;
+import org.gradle.features.binding.TargetTypeInformation;
+import org.gradle.internal.inspection.DefaultTypeParameterInspection;
+import org.gradle.internal.inspection.TypeParameterInspection;
+import org.gradle.util.Path;
+
+/**
+ * Builds a {@link ProjectFeatureBindingDeclaration} from a schema apply action class
+ * ({@code SchemaProjectTypeApplyAction} or {@code SchemaProjectFeatureApplyAction}) that was applied
+ * directly in a settings {@code plugins { }} block. The DSL name comes from the
+ * {@link ProjectType}/{@link ProjectFeature} annotation; the definition type (and parent type, for
+ * features) is inferred from the apply action's generic type parameters. Bindings produced this way
+ * are always unsafe, use a managed definition and {@link BuildModel.None}.
+ */
+public class SchemaBindingFactory {
+
+    @SuppressWarnings("rawtypes")
+    private static final TypeParameterInspection<SchemaProjectTypeApplyAction, SchemaDefinition> TYPE_DEFINITION_INSPECTION =
+        new DefaultTypeParameterInspection<>(SchemaProjectTypeApplyAction.class, SchemaDefinition.class, SchemaDefinition.class);
+
+    @SuppressWarnings("rawtypes")
+    private static final TypeParameterInspection<SchemaProjectFeatureApplyAction, SchemaDefinition> FEATURE_DEFINITION_INSPECTION =
+        new DefaultTypeParameterInspection<>(SchemaProjectFeatureApplyAction.class, SchemaDefinition.class, SchemaDefinition.class);
+
+    @SuppressWarnings("rawtypes")
+    private static final TypeParameterInspection<SchemaProjectFeatureApplyAction, Object> FEATURE_PARENT_INSPECTION =
+        new DefaultTypeParameterInspection<>(SchemaProjectFeatureApplyAction.class, Object.class, Object.class);
+
+    private SchemaBindingFactory() {
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static ProjectFeatureBindingDeclaration<?, ?> buildBinding(Class<?> schemaApplyActionClass) {
+        if (SchemaProjectTypeApplyAction.class.isAssignableFrom(schemaApplyActionClass)) {
+            String name = schemaApplyActionClass.getAnnotation(ProjectType.class).name();
+            Class definitionType = TYPE_DEFINITION_INSPECTION.parameterTypeFor((Class) schemaApplyActionClass);
+            return buildBinding(name, definitionType, new TargetTypeInformation.DefinitionTargetTypeInformation<>(Project.class), typeApplyActionFactory(schemaApplyActionClass));
+        } else {
+            String name = schemaApplyActionClass.getAnnotation(ProjectFeature.class).name();
+            Class definitionType = FEATURE_DEFINITION_INSPECTION.parameterTypeFor((Class) schemaApplyActionClass);
+            Class parentType = FEATURE_PARENT_INSPECTION.parameterTypeFor((Class) schemaApplyActionClass, 1);
+            return buildBinding(name, definitionType, new TargetTypeInformation.DefinitionTargetTypeInformation<>(parentType), featureApplyActionFactory(schemaApplyActionClass));
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ProjectFeatureBindingDeclaration<?, ?> buildBinding(
+        String name,
+        Class definitionType,
+        TargetTypeInformation<?> targetDefinitionType,
+        ProjectFeatureApplyActionFactory applyActionFactory
+    ) {
+        DefaultDeclaredProjectFeatureBindingBuilder builder = new DefaultDeclaredProjectFeatureBindingBuilder(
+            definitionType,
+            BuildModel.None.class,
+            targetDefinitionType,
+            Path.path(name),
+            applyActionFactory
+        );
+        builder.withUnsafeDefinition();
+        builder.withUnsafeApplyAction();
+        return builder.build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ProjectFeatureApplyActionFactory typeApplyActionFactory(Class<?> actionClass) {
+        // Must use anonymous classes (not lambdas) for configuration cache compatibility.
+        return new ProjectFeatureApplyActionFactory() {
+            @Override
+            public ProjectFeatureApplyAction create(ObjectFactory objectFactory) {
+                return new ProjectFeatureApplyAction() {
+                    @Override
+                    public void apply(ProjectFeatureApplicationContext context, Definition definition, BuildModel buildModel, Object parentDefinition) {
+                        SchemaProjectTypeApplyAction action = (SchemaProjectTypeApplyAction) objectFactory.newInstance(actionClass);
+                        action.apply(context, (SchemaDefinition) definition, (BuildModel.None) buildModel);
+                    }
+                };
+            }
+        };
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ProjectFeatureApplyActionFactory featureApplyActionFactory(Class<?> actionClass) {
+        // A SchemaProjectFeatureApplyAction is already a ProjectFeatureApplyAction (its 4-arg apply
+        // default-delegates to the simplified apply), so the instance can be used directly.
+        return new ProjectFeatureApplyActionFactory() {
+            @Override
+            public ProjectFeatureApplyAction create(ObjectFactory objectFactory) {
+                return (ProjectFeatureApplyAction) objectFactory.newInstance(actionClass);
+            }
+        };
+    }
+}

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultModelDefaultsApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultModelDefaultsApplicator.java
@@ -16,8 +16,6 @@
 
 package org.gradle.features.internal.binding;
 
-import org.gradle.api.Plugin;
-
 import java.util.List;
 
 /**
@@ -31,7 +29,7 @@ public class DefaultModelDefaultsApplicator implements ModelDefaultsApplicator {
     }
 
     @Override
-    public void applyDefaultsTo(Object target, Object definition, ClassLoaderContext classLoaderContext, Plugin<?> plugin, ProjectFeatureImplementation<?, ?> projectFeatureImplementation) {
-        defaultsHandlers.forEach(handler -> handler.apply(target, definition, classLoaderContext, projectFeatureImplementation.getFeatureName(), plugin));
+    public void applyDefaultsTo(Object target, Object definition, ClassLoaderContext classLoaderContext, ProjectFeatureImplementation<?, ?> projectFeatureImplementation) {
+        defaultsHandlers.forEach(handler -> handler.apply(target, definition, classLoaderContext, projectFeatureImplementation.getFeatureName()));
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
@@ -104,7 +104,12 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
                 checkSingleProjectTypeApplication(parentDefinitionContext, projectFeature);
             }
 
-            getPluginManager().apply(projectFeature.getPluginClass());
+            // Schema declarations point getPluginClass() at the apply action class (not a Plugin), so
+            // there is no project plugin to apply for those; only apply when it is actually a Plugin.
+            Class<?> pluginClass = projectFeature.getPluginClass();
+            if (Plugin.class.isAssignableFrom(pluginClass)) {
+                getPluginManager().apply(pluginClass);
+            }
 
             return instantiateBoundFeatureObjects(parentDefinition, projectFeature);
         });
@@ -118,8 +123,7 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
 
         if (result.isNew) {
             pendingFeatureApplications.add(result.featureApplication);
-            Plugin<Project> plugin = getPluginManager().getPluginContainer().getPlugin(projectFeature.getPluginClass());
-            getModelDefaultsApplicator().applyDefaultsTo(parentDefinition, result.featureApplication.getDefinitionInstance(), new ClassLoaderContextFromScope(classLoaderScope), plugin, projectFeature);
+            getModelDefaultsApplicator().applyDefaultsTo(parentDefinition, result.featureApplication.getDefinitionInstance(), new ClassLoaderContextFromScope(classLoaderScope), projectFeature);
         }
 
         return result.featureApplication;

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
@@ -59,6 +59,7 @@ import static java.util.Collections.singletonList;
  */
 public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarations {
     private final Map<RegisteringPluginKey, Set<Class<? extends Plugin<Project>>>> pluginClasses = new LinkedHashMap<>();
+    private final List<SchemaDeclaration> schemaDeclarations = new ArrayList<>();
 
     @Nullable
     private Map<String, Set<ProjectFeatureImplementation<?, ?>>> projectFeatureImplementations;
@@ -83,6 +84,14 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
         pluginClasses.computeIfAbsent(pluginKey, k -> new LinkedHashSet<>()).add(pluginClass);
     }
 
+    @Override
+    public void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass) {
+        if (projectFeatureImplementations != null) {
+            throw new IllegalStateException("Cannot register a plugin after project types have been discovered");
+        }
+        schemaDeclarations.add(new SchemaDeclaration(pluginId, schemaApplyActionClass));
+    }
+
     private Map<String, Set<ProjectFeatureImplementation<?, ?>>> discoverProjectFeatureImplementations() {
         Map<String, Set<ProjectFeatureImplementation<?, ?>>> projectFeatureDeclarations = new LinkedHashMap<>();
         pluginClasses.forEach((registeringPluginClass, registeredPluginClasses) ->
@@ -93,12 +102,23 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 registerFeaturesIfPresent(registeringPluginClass, pluginClass, pluginClassAnnotationMetadata, projectFeatureDeclarations);
             })
         );
+        schemaDeclarations.forEach(declaration -> registerSchemaDeclaration(declaration, projectFeatureDeclarations));
         return ImmutableMap.copyOf(projectFeatureDeclarations);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void registerSchemaDeclaration(
+        SchemaDeclaration declaration,
+        Map<String, Set<ProjectFeatureImplementation<?, ?>>> projectFeatureDeclarations
+    ) {
+        ProjectFeatureBindingDeclaration<?, ?> binding = SchemaBindingFactory.buildBinding(declaration.applyActionClass);
+        RegisteringPluginKey registeringPluginKey = new RegisteringPluginKey(null, declaration.pluginId);
+        registerFeature(registeringPluginKey, declaration.applyActionClass, (ProjectFeatureBindingDeclaration) binding, projectFeatureDeclarations);
     }
 
     private <T extends Definition<V>, V extends BuildModel> void registerFeature(
         RegisteringPluginKey registeringPlugin,
-        Class<? extends Plugin<Project>> pluginClass,
+        Class<?> pluginClass,
         ProjectFeatureBindingDeclaration<T, V> binding,
         Map<String, Set<ProjectFeatureImplementation<?, ?>>> projectFeatureDeclarations
     ) {
@@ -127,7 +147,7 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
             k -> new LinkedHashSet<>()
         );
 
-        List<Class<? extends Plugin<Project>>> existingPluginClasses = implementations.stream().filter(existingFeature ->
+        List<Class<?>> existingPluginClasses = implementations.stream().filter(existingFeature ->
                 // If the feature name matches another registration, check if the target types are ambiguous
                 existingFeature.getFeatureName().equals(binding.getName()) && TargetTypeInformationChecks.isOverlappingBindingType(existingFeature.getTargetDefinitionType(), binding.targetDefinitionType()))
             .map(ProjectFeatureImplementation::getPluginClass)
@@ -276,11 +296,22 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
         }
     }
 
+    private static class SchemaDeclaration {
+        @Nullable
+        private final String pluginId;
+        private final Class<?> applyActionClass;
+
+        private SchemaDeclaration(@Nullable String pluginId, Class<?> applyActionClass) {
+            this.pluginId = pluginId;
+            this.applyActionClass = applyActionClass;
+        }
+    }
+
     public static class RegisteringPluginKey {
-        public final Class<? extends Plugin<Settings>> pluginClass;
+        public final @Nullable Class<? extends Plugin<Settings>> pluginClass;
         public final @Nullable String pluginId;
 
-        public RegisteringPluginKey(Class<? extends Plugin<Settings>> pluginClass, @Nullable String pluginId) {
+        public RegisteringPluginKey(@Nullable Class<? extends Plugin<Settings>> pluginClass, @Nullable String pluginId) {
             this.pluginClass = pluginClass;
             this.pluginId = pluginId;
         }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
@@ -85,11 +85,11 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
     }
 
     @Override
-    public void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass) {
+    public void addSchemaDeclaration(@Nullable String pluginId, Class<?> schemaApplyActionClass, @Nullable Class<? extends Plugin<Settings>> registeringPluginClass) {
         if (projectFeatureImplementations != null) {
             throw new IllegalStateException("Cannot register a plugin after project types have been discovered");
         }
-        schemaDeclarations.add(new SchemaDeclaration(pluginId, schemaApplyActionClass));
+        schemaDeclarations.add(new SchemaDeclaration(pluginId, schemaApplyActionClass, registeringPluginClass));
     }
 
     private Map<String, Set<ProjectFeatureImplementation<?, ?>>> discoverProjectFeatureImplementations() {
@@ -112,7 +112,7 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
         Map<String, Set<ProjectFeatureImplementation<?, ?>>> projectFeatureDeclarations
     ) {
         ProjectFeatureBindingDeclaration<?, ?> binding = SchemaBindingFactory.buildBinding(declaration.applyActionClass);
-        RegisteringPluginKey registeringPluginKey = new RegisteringPluginKey(null, declaration.pluginId);
+        RegisteringPluginKey registeringPluginKey = new RegisteringPluginKey(declaration.registeringPluginClass, declaration.pluginId);
         registerFeature(registeringPluginKey, declaration.applyActionClass, (ProjectFeatureBindingDeclaration) binding, projectFeatureDeclarations);
     }
 
@@ -300,10 +300,13 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
         @Nullable
         private final String pluginId;
         private final Class<?> applyActionClass;
+        @Nullable
+        private final Class<? extends Plugin<Settings>> registeringPluginClass;
 
-        private SchemaDeclaration(@Nullable String pluginId, Class<?> applyActionClass) {
+        private SchemaDeclaration(@Nullable String pluginId, Class<?> applyActionClass, @Nullable Class<? extends Plugin<Settings>> registeringPluginClass) {
             this.pluginId = pluginId;
             this.applyActionClass = applyActionClass;
+            this.registeringPluginClass = registeringPluginClass;
         }
     }
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureImplementation.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureImplementation.java
@@ -17,7 +17,6 @@
 package org.gradle.features.internal.binding;
 
 import org.gradle.api.Plugin;
-import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.features.binding.BuildModel;
 import org.gradle.features.binding.Definition;
@@ -43,7 +42,8 @@ public class DefaultProjectFeatureImplementation<OwnDefinition extends Definitio
     private final Class<OwnBuildModel> buildModelType;
     private final Class<? extends OwnBuildModel> buildModelImplementationType;
     private final Map<Class<?>, Class<?>> nestedBuildModelTypesToImplementationTypes;
-    private final Class<? extends Plugin<Project>> pluginClass;
+    private final Class<?> pluginClass;
+    @Nullable
     private final Class<? extends Plugin<Settings>> registeringPluginClass;
     private final List<ModelDefault<?>> defaults = new ArrayList<>();
     @Nullable
@@ -60,8 +60,8 @@ public class DefaultProjectFeatureImplementation<OwnDefinition extends Definitio
         Class<OwnBuildModel> buildModelType,
         Class<? extends OwnBuildModel> buildModelImplementationType,
         Map<Class<?>, Class<?>> nestedBuildModelTypesToImplementationTypes,
-        Class<? extends Plugin<Project>> pluginClass,
-        Class<? extends Plugin<Settings>> registeringPluginClass,
+        Class<?> pluginClass,
+        @Nullable Class<? extends Plugin<Settings>> registeringPluginClass,
         @Nullable String registeringPluginId,
         ProjectFeatureApplyActionFactory<OwnDefinition, OwnBuildModel, ?> applyActionFactory
     ) {
@@ -126,10 +126,11 @@ public class DefaultProjectFeatureImplementation<OwnDefinition extends Definitio
     }
 
     @Override
-    public Class<? extends Plugin<Project>> getPluginClass() {
+    public Class<?> getPluginClass() {
         return pluginClass;
     }
 
+    @Nullable
     @Override
     public Class<? extends Plugin<Settings>> getRegisteringPluginClass() {
         return registeringPluginClass;

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/features/internal/binding/DefaultProjectFeatureApplicatorTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/features/internal/binding/DefaultProjectFeatureApplicatorTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.features.binding.ProjectFeatureApplyAction
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.problems.internal.ProblemReporterInternal
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.internal.Cast
@@ -68,7 +67,6 @@ class DefaultProjectFeatureApplicatorTest extends Specification {
     def instantiator = TestUtil.instantiatorFactory().inject(new Services())
     def applicator = instantiator.newInstance(DefaultProjectFeatureApplicator.class, classLoaderScope, objectFactory, internalProblemReporter, services)
     def plugin = Mock(Plugin)
-    def plugins = Mock(PluginContainer)
     def boundProjectTypeImplementation = Mock(BoundProjectFeatureImplementation)
     def applyActionFactory = Mock(ProjectFeatureApplyActionFactory)
     def foo = definitionOf(Foo)
@@ -111,15 +109,13 @@ class DefaultProjectFeatureApplicatorTest extends Specification {
         _ * boundProjectTypeImplementation.buildModelImplementationType >> Bar
         _ * boundProjectTypeImplementation.applyActionFactory >> applyActionFactory
         _ * applyActionFactory.create(_) >> Mock(ProjectFeatureApplyAction)
-        1 * modelDefaultsApplicator.applyDefaultsTo(target, _, _, plugin, boundProjectTypeImplementation)
+        1 * modelDefaultsApplicator.applyDefaultsTo(target, _, _, boundProjectTypeImplementation)
         1 * objectFactoryFactory.createObjectFactory(_) >> featureObjectFactory
         1 * featureObjectFactory.newInstance(Foo) >> foo
         1 * typeAnnotationMetadataStore.getTypeAnnotationMetadata(Foo) >> Mock(TypeAnnotationMetadata) {
             _ * it.getPropertiesAnnotationMetadata() >> ImmutableSortedSet.of()
         }
         1 * boundProjectTypeImplementation.definitionPublicType >> Foo
-        1 * pluginManager.pluginContainer >> plugins
-        1 * plugins.getPlugin(plugin.class) >> plugin
 
         and:
         returned.definitionInstance == foo
@@ -145,10 +141,8 @@ class DefaultProjectFeatureApplicatorTest extends Specification {
         _ * boundProjectTypeImplementation.buildModelImplementationType >> Bar
         _ * boundProjectTypeImplementation.applyActionFactory >> applyActionFactory
         _ * applyActionFactory.create(_) >> Mock(ProjectFeatureApplyAction)
-        _ * pluginManager.pluginContainer >> plugins
-        _ * plugins.getPlugin(plugin.class) >> plugin
         1 * pluginManager.apply(plugin.class)
-        1 * modelDefaultsApplicator.applyDefaultsTo(project, _, _, plugin, boundProjectTypeImplementation)
+        1 * modelDefaultsApplicator.applyDefaultsTo(project, _, _, boundProjectTypeImplementation)
         1 * objectFactoryFactory.createObjectFactory(_) >> featureObjectFactory
         1 * featureObjectFactory.newInstance(Foo) >> foo
         1 * typeAnnotationMetadataStore.getTypeAnnotationMetadata(Foo) >> Mock(TypeAnnotationMetadata) {
@@ -175,15 +169,13 @@ class DefaultProjectFeatureApplicatorTest extends Specification {
         _ * boundProjectTypeImplementation.buildModelImplementationType >> Bar
         _ * boundProjectTypeImplementation.applyActionFactory >> applyActionFactory
         _ * applyActionFactory.create(_) >> applyAction
-        _ * modelDefaultsApplicator.applyDefaultsTo(target, _, _, plugin, boundProjectTypeImplementation)
+        _ * modelDefaultsApplicator.applyDefaultsTo(target, _, _, boundProjectTypeImplementation)
         _ * objectFactoryFactory.createObjectFactory(_) >> featureObjectFactory
         _ * featureObjectFactory.newInstance(Foo) >> foo
         _ * typeAnnotationMetadataStore.getTypeAnnotationMetadata(Foo) >> Mock(TypeAnnotationMetadata) {
             _ * it.getPropertiesAnnotationMetadata() >> ImmutableSortedSet.of()
         }
         _ * boundProjectTypeImplementation.definitionPublicType >> Foo
-        _ * pluginManager.pluginContainer >> plugins
-        _ * plugins.getPlugin(plugin.class) >> plugin
 
         def featureApplication = applicator.registerFeatureApplicationFor(target as DynamicObjectAware, boundProjectTypeImplementation)
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/EcosystemApplyAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/EcosystemApplyAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.initialization;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A settings-time unit that aggregates project features (via {@code @RegistersProjectFeatures}) and
+ * optionally seeds their model defaults. An ecosystem is applied by id in a settings
+ * {@code plugins { }} block.
+ *
+ * @since 9.7.0
+ */
+@Incubating
+public interface EcosystemApplyAction {
+    /**
+     * Seed model defaults for the project types and features that this ecosystem registers. Defaults to
+     * a no-op so an aggregation-only ecosystem need not implement it. Called at most once, at settings
+     * time, after the aggregated features have been discovered.
+     *
+     * @param defaults the shared model defaults to configure
+     *
+     * @since 9.7.0
+     */
+    default void apply(SharedModelDefaults defaults) {
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/internal/SharedModelDefaultsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/internal/SharedModelDefaultsInternal.java
@@ -17,9 +17,20 @@
 package org.gradle.api.initialization.internal;
 
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.initialization.EcosystemApplyAction;
 import org.gradle.api.initialization.SharedModelDefaults;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Build.class)
 public interface SharedModelDefaultsInternal extends SharedModelDefaults {
+
+    /**
+     * Registers an ecosystem whose {@link EcosystemApplyAction#apply(SharedModelDefaults)} is run (at most
+     * once) when shared model defaults are processed, at settings time, after feature discovery. Registering
+     * the same ecosystem class more than once has no additional effect.
+     */
+    void registerEcosystem(Class<? extends EcosystemApplyAction> ecosystemClass);
 
     /**
      * Specifies the current project when interpreting defaults configuration

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultSharedModelDefaults.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultSharedModelDefaults.java
@@ -20,32 +20,39 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.initialization.EcosystemApplyAction;
 import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.internal.Cast;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.features.internal.binding.ProjectFeatureImplementation;
 import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.gradle.util.internal.ClosureBackedAction;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 public class DefaultSharedModelDefaults implements SharedModelDefaultsInternal, MethodMixIn {
     private final ProjectFeatureDeclarations projectFeatureDeclarations;
+    private final Instantiator instantiator;
     private final DynamicMethods dynamicMethods = new DynamicMethods();
     private final List<ModelDefaultRegistration<?>> registrations = new ArrayList<>();
+    // Deduped by class so each ecosystem's apply(...) runs at most once.
+    private final Set<Class<? extends EcosystemApplyAction>> ecosystems = new LinkedHashSet<>();
     boolean processed = false;
 
     @SuppressWarnings("ThreadLocalUsage")
     private final ThreadLocal<ProjectLayout> projectLayout = new ThreadLocal<>();
 
     @Inject
-    public DefaultSharedModelDefaults(ProjectFeatureDeclarations projectFeatureDeclarations) {
+    public DefaultSharedModelDefaults(ProjectFeatureDeclarations projectFeatureDeclarations, Instantiator instantiator) {
         this.projectFeatureDeclarations = projectFeatureDeclarations;
+        this.instantiator = instantiator;
     }
 
     @Override
@@ -68,10 +75,22 @@ public class DefaultSharedModelDefaults implements SharedModelDefaultsInternal, 
     }
 
     @Override
+    public void registerEcosystem(Class<? extends EcosystemApplyAction> ecosystemClass) {
+        if (processed) {
+            throw new IllegalStateException("Cannot register an ecosystem after processing.");
+        }
+        ecosystems.add(ecosystemClass);
+    }
+
+    @Override
     public void processRegistrations() {
         if (processed) {
             return;
         }
+
+        // Run each ecosystem's apply(...) first so its add(...) calls are recorded before the replay
+        // loop. The deduping set guarantees each ecosystem's apply runs at most once.
+        ecosystems.forEach(ecosystemClass -> instantiator.newInstance(ecosystemClass).apply(this));
 
         registrations.forEach(registration -> {
             if (projectFeatureDeclarations.getProjectFeatureImplementations().containsKey(registration.name)) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -197,6 +197,9 @@ public class DefaultPluginManager implements PluginManagerInternal {
         } else if (plugin.getType() == PotentialPlugin.Type.PROJECT_FEATURE_DECLARATION_CLASS) {
             // Register-only, like the rules branch: there is no Plugin instance to produce or store.
             target.applyProjectFeatureDeclaration(pluginId, pluginClass);
+        } else if (plugin.getType() == PotentialPlugin.Type.ECOSYSTEM_APPLY_ACTION) {
+            // Register-only: registers the aggregated features and the ecosystem; no Plugin instance.
+            target.applyEcosystemAction(pluginId, pluginClass);
         } else {
             target.applyRules(pluginId, pluginClass);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -194,6 +194,9 @@ public class DefaultPluginManager implements PluginManagerInternal {
             // plugins.withType() callbacks waiting to build on what the plugin did
             instances.put(pluginClass, pluginInstance);
             pluginContainer.pluginAdded(pluginInstance);
+        } else if (plugin.getType() == PotentialPlugin.Type.PROJECT_FEATURE_DECLARATION_CLASS) {
+            // Register-only, like the rules branch: there is no Plugin instance to produce or store.
+            target.applyProjectFeatureDeclaration(pluginId, pluginClass);
         } else {
             target.applyRules(pluginId, pluginClass);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -90,6 +90,19 @@ public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implement
     }
 
     @Override
+    public void applyProjectFeatureDeclaration(@Nullable String pluginId, Class<?> declarationClass) {
+        String idSuffix = pluginId == null ? "" : " (id '" + pluginId + "')";
+        String message = String.format(
+            "Schema project type/feature '%s'%s can only be applied in a settings 'plugins { }' block, but was applied %s.",
+            declarationClass.getName(), idSuffix, targetType.getApplyTargetDescription());
+        ProblemId id = ProblemId.create("schema-feature-wrong-target", "Schema project type or feature applied to an unsupported target", GradleCoreProblemGroup.pluginApplication());
+        throw problems.getInternalReporter()
+            .throwing(new IllegalArgumentException(message), id, spec ->
+                spec.contextualLabel(message)
+                    .documentedAt(Documentation.userManual("custom_plugins", "project_vs_settings_vs_init_plugins").toString()));
+    }
+
+    @Override
     public String toString() {
         return target.toString();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -103,6 +103,19 @@ public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implement
     }
 
     @Override
+    public void applyEcosystemAction(@Nullable String pluginId, Class<?> ecosystemClass) {
+        String idSuffix = pluginId == null ? "" : " (id '" + pluginId + "')";
+        String message = String.format(
+            "Ecosystem '%s'%s can only be applied in a settings 'plugins { }' block, but was applied %s.",
+            ecosystemClass.getName(), idSuffix, targetType.getApplyTargetDescription());
+        ProblemId id = ProblemId.create("ecosystem-wrong-target", "Ecosystem applied to an unsupported target", GradleCoreProblemGroup.pluginApplication());
+        throw problems.getInternalReporter()
+            .throwing(new IllegalArgumentException(message), id, spec ->
+                spec.contextualLabel(message)
+                    .documentedAt(Documentation.userManual("custom_plugins", "project_vs_settings_vs_init_plugins").toString()));
+    }
+
+    @Override
     public String toString() {
         return target.toString();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginInspector.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.plugins;
 
 import org.gradle.api.Plugin;
+import org.gradle.api.initialization.EcosystemApplyAction;
 import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
 import org.gradle.features.binding.SchemaProjectTypeApplyAction;
 import org.gradle.internal.Cast;
@@ -43,6 +44,10 @@ public class PluginInspector {
         if (implementsInterface) {
             @SuppressWarnings("unchecked") Class<? extends Plugin<?>> cast = (Class<? extends Plugin<?>>) type;
             return Cast.uncheckedCast(toImperative(cast, hasRules));
+        } else if (EcosystemApplyAction.class.isAssignableFrom(type)) {
+            // An ecosystem aggregates members; a schema apply action is a member. They are disjoint roles,
+            // so checking ecosystem before schema is a deliberate, harmless precedence.
+            return new PotentialEcosystemApplyActionPlugin<T>(type);
         } else if (isSchemaApplyAction(type)) {
             return new PotentialProjectFeatureDeclarationPlugin<T>(type);
         } else if (hasRules) {
@@ -179,6 +184,35 @@ public class PluginInspector {
         @Override
         public Type getType() {
             return Type.PROJECT_FEATURE_DECLARATION_CLASS;
+        }
+    }
+
+    private static class PotentialEcosystemApplyActionPlugin<T> implements PotentialPlugin<T> {
+
+        private final Class<T> clazz;
+
+        public PotentialEcosystemApplyActionPlugin(Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Class<T> asClass() {
+            return clazz;
+        }
+
+        @Override
+        public boolean isImperative() {
+            return false;
+        }
+
+        @Override
+        public boolean isHasRules() {
+            return false;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.ECOSYSTEM_APPLY_ACTION;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginInspector.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.plugins;
 
 import org.gradle.api.Plugin;
+import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+import org.gradle.features.binding.SchemaProjectTypeApplyAction;
 import org.gradle.internal.Cast;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -41,11 +43,18 @@ public class PluginInspector {
         if (implementsInterface) {
             @SuppressWarnings("unchecked") Class<? extends Plugin<?>> cast = (Class<? extends Plugin<?>>) type;
             return Cast.uncheckedCast(toImperative(cast, hasRules));
+        } else if (isSchemaApplyAction(type)) {
+            return new PotentialProjectFeatureDeclarationPlugin<T>(type);
         } else if (hasRules) {
             return new PotentialPureRuleSourceClassPlugin<T>(type);
         } else {
             return new PotentialUnknownTypePlugin<T>(type);
         }
+    }
+
+    private static boolean isSchemaApplyAction(Class<?> type) {
+        return SchemaProjectTypeApplyAction.class.isAssignableFrom(type)
+            || SchemaProjectFeatureApplyAction.class.isAssignableFrom(type);
     }
 
     private <T extends Plugin<?>> PotentialPlugin<T> toImperative(Class<T> type, boolean hasRules) {
@@ -141,6 +150,35 @@ public class PluginInspector {
         @Override
         public boolean isHasRules() {
             return false;
+        }
+    }
+
+    private static class PotentialProjectFeatureDeclarationPlugin<T> implements PotentialPlugin<T> {
+
+        private final Class<T> clazz;
+
+        public PotentialProjectFeatureDeclarationPlugin(Class<T> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Class<T> asClass() {
+            return clazz;
+        }
+
+        @Override
+        public boolean isImperative() {
+            return false;
+        }
+
+        @Override
+        public boolean isHasRules() {
+            return false;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.PROJECT_FEATURE_DECLARATION_CLASS;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
@@ -36,4 +36,11 @@ public interface PluginTarget {
     void applyRules(@Nullable String pluginId, Class<?> clazz);
 
     void applyImperativeRulesHybrid(@Nullable String pluginId, Plugin<?> plugin, Class<?> declaringClass);
+
+    /**
+     * Applies a schema project type/feature declaration: a class that is a schema apply action rather than a
+     * {@link Plugin}. Only the settings target supports this (it registers the declaration); other targets
+     * reject it with a clear error.
+     */
+    void applyProjectFeatureDeclaration(@Nullable String pluginId, Class<?> declarationClass);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
@@ -43,4 +43,12 @@ public interface PluginTarget {
      * reject it with a clear error.
      */
     void applyProjectFeatureDeclaration(@Nullable String pluginId, Class<?> declarationClass);
+
+    /**
+     * Applies an ecosystem apply action: a class that aggregates project features (via
+     * {@code @RegistersProjectFeatures}) and seeds defaults, rather than a {@link Plugin}. Only the settings
+     * target supports this (it registers the members and the ecosystem); other targets reject it with a clear
+     * error.
+     */
+    void applyEcosystemAction(@Nullable String pluginId, Class<?> ecosystemClass);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PotentialPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PotentialPlugin.java
@@ -30,7 +30,8 @@ public interface PotentialPlugin<T> {
         IMPERATIVE_CLASS,
         PURE_RULE_SOURCE_CLASS,
         HYBRID_IMPERATIVE_AND_RULES_CLASS,
-        PROJECT_FEATURE_DECLARATION_CLASS
+        PROJECT_FEATURE_DECLARATION_CLASS,
+        ECOSYSTEM_APPLY_ACTION
     }
 
     Class<? extends T> asClass();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PotentialPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PotentialPlugin.java
@@ -29,7 +29,8 @@ public interface PotentialPlugin<T> {
         UNKNOWN,
         IMPERATIVE_CLASS,
         PURE_RULE_SOURCE_CLASS,
-        HYBRID_IMPERATIVE_AND_RULES_CLASS
+        HYBRID_IMPERATIVE_AND_RULES_CLASS,
+        PROJECT_FEATURE_DECLARATION_CLASS
     }
 
     Class<? extends T> asClass();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
@@ -22,12 +22,17 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.features.annotations.BindsProjectFeature;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.annotations.ProjectFeature;
+import org.gradle.features.annotations.ProjectType;
 import org.gradle.features.annotations.RegistersProjectFeatures;
+import org.gradle.features.binding.SchemaProjectFeatureApplyAction;
+import org.gradle.features.binding.SchemaProjectTypeApplyAction;
 import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.gradle.internal.Cast;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
@@ -81,6 +86,36 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
     @Override
     public void applyImperativeRulesHybrid(@Nullable String pluginId, Plugin<?> plugin, Class<?> declaringClass) {
         delegate.applyImperativeRulesHybrid(pluginId, plugin, declaringClass);
+    }
+
+    @Override
+    public void applyProjectFeatureDeclaration(@Nullable String pluginId, Class<?> declarationClass) {
+        // Register-only: a schema apply action applied directly in settings registers a project
+        // type/feature declaration. There is no imperative plugin to apply, so we do not delegate.
+        validateSchemaDeclaration(declarationClass);
+        projectFeatureDeclarations.addSchemaDeclaration(pluginId, declarationClass);
+    }
+
+    private void validateSchemaDeclaration(Class<?> declarationClass) {
+        boolean isType = SchemaProjectTypeApplyAction.class.isAssignableFrom(declarationClass);
+        boolean isFeature = SchemaProjectFeatureApplyAction.class.isAssignableFrom(declarationClass);
+
+        if (isType == isFeature) {
+            throw invalidSchemaDeclaration(declarationClass, "must implement exactly one of SchemaProjectTypeApplyAction or SchemaProjectFeatureApplyAction");
+        }
+        if (isType && !declarationClass.isAnnotationPresent(ProjectType.class)) {
+            throw invalidSchemaDeclaration(declarationClass, "is a SchemaProjectTypeApplyAction but is not annotated with @ProjectType");
+        }
+        if (isFeature && !declarationClass.isAnnotationPresent(ProjectFeature.class)) {
+            throw invalidSchemaDeclaration(declarationClass, "is a SchemaProjectFeatureApplyAction but is not annotated with @ProjectFeature");
+        }
+    }
+
+    private RuntimeException invalidSchemaDeclaration(Class<?> declarationClass, String reason) {
+        String message = "Project feature declaration '" + declarationClass.getName() + "' " + reason + ".";
+        ProblemId id = ProblemId.create("invalid-schema-feature-declaration", "Invalid schema project type or feature declaration", GradleCoreProblemGroup.validation().type());
+        return problems.getInternalReporter()
+            .throwing(new InvalidUserDataException(message), id, spec -> spec.contextualLabel(message));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
@@ -54,12 +55,14 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
     private final PluginTarget delegate;
     private final ProjectFeatureDeclarations projectFeatureDeclarations;
+    private final SharedModelDefaultsInternal sharedModelDefaults;
     private final InspectionScheme inspectionScheme;
     private final ProblemsInternal problems;
 
-    public ProjectFeatureDeclarationPluginTarget(PluginTarget delegate, ProjectFeatureDeclarations projectFeatureDeclarations, InspectionScheme inspectionScheme, ProblemsInternal problems) {
+    public ProjectFeatureDeclarationPluginTarget(PluginTarget delegate, ProjectFeatureDeclarations projectFeatureDeclarations, SharedModelDefaultsInternal sharedModelDefaults, InspectionScheme inspectionScheme, ProblemsInternal problems) {
         this.delegate = delegate;
         this.projectFeatureDeclarations = projectFeatureDeclarations;
+        this.sharedModelDefaults = sharedModelDefaults;
         this.inspectionScheme = inspectionScheme;
         this.problems = problems;
     }
@@ -95,6 +98,16 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
         validateSchemaDeclaration(declarationClass);
         // Applied directly in settings, so there is no registering settings plugin.
         projectFeatureDeclarations.addSchemaDeclaration(pluginId, declarationClass, null);
+    }
+
+    @Override
+    public void applyEcosystemAction(@Nullable String pluginId, Class<?> ecosystemClass) {
+        // Register-only: register the ecosystem's @RegistersProjectFeatures members (recording the ecosystem
+        // as their registering class) and register the ecosystem itself so its apply(SharedModelDefaults) runs
+        // at processRegistrations() time. There is no imperative plugin to apply, so we do not delegate.
+        TypeMetadata ecosystemMetadata = inspectionScheme.getMetadataStore().getTypeMetadata(ecosystemClass);
+        findAndAddProjectFeatures(pluginId, ecosystemMetadata);
+        sharedModelDefaults.registerEcosystem(Cast.uncheckedCast(ecosystemClass));
     }
 
     private static boolean isSchemaApplyAction(Class<?> type) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
@@ -93,7 +93,13 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
         // Register-only: a schema apply action applied directly in settings registers a project
         // type/feature declaration. There is no imperative plugin to apply, so we do not delegate.
         validateSchemaDeclaration(declarationClass);
-        projectFeatureDeclarations.addSchemaDeclaration(pluginId, declarationClass);
+        // Applied directly in settings, so there is no registering settings plugin.
+        projectFeatureDeclarations.addSchemaDeclaration(pluginId, declarationClass, null);
+    }
+
+    private static boolean isSchemaApplyAction(Class<?> type) {
+        return SchemaProjectTypeApplyAction.class.isAssignableFrom(type)
+            || SchemaProjectFeatureApplyAction.class.isAssignableFrom(type);
     }
 
     private void validateSchemaDeclaration(Class<?> declarationClass) {
@@ -130,10 +136,16 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
         });
     }
 
-    private void addFeatureDeclarations(Class<? extends Plugin<Project>>[] featurePlugins, Class<? extends Plugin<Settings>> registeringPlugin, @Nullable String pluginId) {
-        for (Class<? extends Plugin<Project>> projectFeatureImplClass : featurePlugins) {
-            validateProjectFeatures(projectFeatureImplClass, registeringPlugin);
-            projectFeatureDeclarations.addDeclaration(pluginId, projectFeatureImplClass, registeringPlugin);
+    private void addFeatureDeclarations(Class<?>[] featureClasses, Class<? extends Plugin<Settings>> registeringPlugin, @Nullable String pluginId) {
+        for (Class<?> featureClass : featureClasses) {
+            if (isSchemaApplyAction(featureClass)) {
+                validateSchemaDeclaration(featureClass);
+                projectFeatureDeclarations.addSchemaDeclaration(pluginId, featureClass, registeringPlugin);
+            } else {
+                Class<? extends Plugin<Project>> projectFeatureImplClass = Cast.uncheckedCast(featureClass);
+                validateProjectFeatures(projectFeatureImplClass, registeringPlugin);
+                projectFeatureDeclarations.addDeclaration(pluginId, projectFeatureImplClass, registeringPlugin);
+            }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
@@ -76,6 +76,11 @@ public class RuleBasedPluginTarget implements PluginTarget {
     }
 
     @Override
+    public void applyEcosystemAction(@Nullable String pluginId, Class<?> ecosystemClass) {
+        imperativeTarget.applyEcosystemAction(pluginId, ecosystemClass);
+    }
+
+    @Override
     public String toString() {
         return target.toString();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/RuleBasedPluginTarget.java
@@ -71,6 +71,11 @@ public class RuleBasedPluginTarget implements PluginTarget {
     }
 
     @Override
+    public void applyProjectFeatureDeclaration(@Nullable String pluginId, Class<?> declarationClass) {
+        imperativeTarget.applyProjectFeatureDeclaration(pluginId, declarationClass);
+    }
+
+    @Override
     public String toString() {
         return target.toString();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -21,7 +21,7 @@ import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.flow.FlowScope;
-import org.gradle.api.initialization.SharedModelDefaults;
+import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.ClassPathRegistry;
@@ -825,8 +825,9 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected SharedModelDefaults createSharedModelDefaults(Instantiator instantiator, ProjectFeatureDeclarations projectFeatureDeclarations) {
-        return instantiator.newInstance(DefaultSharedModelDefaults.class, projectFeatureDeclarations);
+    protected SharedModelDefaultsInternal createSharedModelDefaults(ServiceRegistry buildScopeServices, Instantiator instantiator, InstantiatorFactory instantiatorFactory, ProjectFeatureDeclarations projectFeatureDeclarations) {
+        // The injecting instantiator lets ecosystems declared with @Inject constructors resolve build-scope services.
+        return instantiator.newInstance(DefaultSharedModelDefaults.class, projectFeatureDeclarations, instantiatorFactory.inject(buildScopeServices));
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.file.BuildLayout;
+import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
@@ -106,11 +107,13 @@ public class SettingsScopeServices implements ServiceRegistrationProvider {
         DomainObjectCollectionFactory domainObjectCollectionFactory,
         PluginScheme pluginScheme,
         ProjectFeatureDeclarations projectFeatureRegistry,
+        SharedModelDefaultsInternal sharedModelDefaults,
         ProblemsInternal problems
     ) {
         PluginTarget target = new ProjectFeatureDeclarationPluginTarget(
             new ImperativeOnlyPluginTarget<>(PluginTargetType.SETTINGS, settings, problems),
             projectFeatureRegistry,
+            sharedModelDefaults,
             pluginScheme.getInspectionScheme(),
             problems
         );

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultSharedModelDefaultsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultSharedModelDefaultsTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization
+
+import org.gradle.api.initialization.EcosystemApplyAction
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations
+import org.gradle.internal.reflect.Instantiator
+import spock.lang.Specification
+
+class DefaultSharedModelDefaultsTest extends Specification {
+
+    def projectFeatureDeclarations = Mock(ProjectFeatureDeclarations)
+    def instantiator = Mock(Instantiator)
+    def defaults = new DefaultSharedModelDefaults(projectFeatureDeclarations, instantiator)
+
+    def "runs each registered ecosystem's apply exactly once, even when registered twice"() {
+        given:
+        def ecosystem = Mock(EcosystemApplyAction)
+
+        when:
+        defaults.registerEcosystem(TestEcosystem)
+        defaults.registerEcosystem(TestEcosystem)
+        defaults.processRegistrations()
+
+        then:
+        1 * instantiator.newInstance(TestEcosystem) >> ecosystem
+        1 * ecosystem.apply(defaults)
+        // No add(...) registrations were recorded, so the replay loop touches nothing.
+        0 * projectFeatureDeclarations._
+    }
+
+    def "a second processRegistrations does not run ecosystems again"() {
+        given:
+        def ecosystem = Mock(EcosystemApplyAction)
+        defaults.registerEcosystem(TestEcosystem)
+
+        when:
+        defaults.processRegistrations()
+        defaults.processRegistrations()
+
+        then:
+        1 * instantiator.newInstance(TestEcosystem) >> ecosystem
+        1 * ecosystem.apply(defaults)
+    }
+
+    def "registering an ecosystem after processing throws"() {
+        given:
+        defaults.processRegistrations()
+
+        when:
+        defaults.registerEcosystem(TestEcosystem)
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    static class TestEcosystem implements EcosystemApplyAction {
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/PluginInspectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/PluginInspectorTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.features.binding.SchemaDefinition
+import org.gradle.features.binding.SchemaProjectFeatureApplyAction
+import org.gradle.features.binding.SchemaProjectTypeApplyAction
+import org.gradle.model.internal.inspect.ModelRuleSourceDetector
+import spock.lang.Specification
+
+class PluginInspectorTest extends Specification {
+
+    def ruleDetector = Mock(ModelRuleSourceDetector) {
+        hasRules(_) >> false
+    }
+    def inspector = new PluginInspector(ruleDetector)
+
+    def "recognizes a schema project type apply action as a project feature declaration"() {
+        when:
+        def potential = inspector.inspect(SchemaType)
+
+        then:
+        potential.type == PotentialPlugin.Type.PROJECT_FEATURE_DECLARATION_CLASS
+        !potential.imperative
+        !potential.hasRules
+    }
+
+    def "recognizes a schema project feature apply action as a project feature declaration"() {
+        expect:
+        inspector.inspect(SchemaFeature).type == PotentialPlugin.Type.PROJECT_FEATURE_DECLARATION_CLASS
+    }
+
+    def "recognizes an imperative plugin"() {
+        expect:
+        inspector.inspect(ImperativePlugin).type == PotentialPlugin.Type.IMPERATIVE_CLASS
+    }
+
+    def "treats a plain class as unknown"() {
+        expect:
+        inspector.inspect(String).type == PotentialPlugin.Type.UNKNOWN
+    }
+
+    interface MyDefinition extends SchemaDefinition {}
+
+    static abstract class SchemaType implements SchemaProjectTypeApplyAction<MyDefinition> {
+        @Override
+        void apply(MyDefinition definition) {}
+    }
+
+    static abstract class SchemaFeature implements SchemaProjectFeatureApplyAction<MyDefinition, Object> {
+        @Override
+        void apply(MyDefinition definition, Object parent) {}
+    }
+
+    static class ImperativePlugin implements Plugin<Project> {
+        @Override
+        void apply(Project project) {}
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/PluginInspectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/PluginInspectorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.initialization.EcosystemApplyAction
 import org.gradle.features.binding.SchemaDefinition
 import org.gradle.features.binding.SchemaProjectFeatureApplyAction
 import org.gradle.features.binding.SchemaProjectTypeApplyAction
@@ -46,6 +47,16 @@ class PluginInspectorTest extends Specification {
         inspector.inspect(SchemaFeature).type == PotentialPlugin.Type.PROJECT_FEATURE_DECLARATION_CLASS
     }
 
+    def "recognizes an ecosystem apply action"() {
+        when:
+        def potential = inspector.inspect(Ecosystem)
+
+        then:
+        potential.type == PotentialPlugin.Type.ECOSYSTEM_APPLY_ACTION
+        !potential.imperative
+        !potential.hasRules
+    }
+
     def "recognizes an imperative plugin"() {
         expect:
         inspector.inspect(ImperativePlugin).type == PotentialPlugin.Type.IMPERATIVE_CLASS
@@ -71,5 +82,8 @@ class PluginInspectorTest extends Specification {
     static class ImperativePlugin implements Plugin<Project> {
         @Override
         void apply(Project project) {}
+    }
+
+    static class Ecosystem implements EcosystemApplyAction {
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTargetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTargetTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Project
 import org.gradle.features.annotations.BindsProjectFeature
 import org.gradle.features.annotations.BindsProjectType
 import org.gradle.features.annotations.RegistersProjectFeatures
+import org.gradle.api.initialization.internal.SharedModelDefaultsInternal
 import org.gradle.api.internal.tasks.properties.InspectionScheme
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.properties.annotations.TypeMetadata
@@ -34,9 +35,10 @@ import spock.lang.Specification
 class ProjectFeatureDeclarationPluginTargetTest extends Specification {
     def delegate = Mock(PluginTarget)
     def projectFeatureDeclarations = Mock(ProjectFeatureDeclarations)
+    def sharedModelDefaults = Mock(SharedModelDefaultsInternal)
     def inspectionScheme = Mock(InspectionScheme)
     def problems = TestUtil.problemsService()
-    def pluginTarget = new ProjectFeatureDeclarationPluginTarget(delegate, projectFeatureDeclarations, inspectionScheme, problems)
+    def pluginTarget = new ProjectFeatureDeclarationPluginTarget(delegate, projectFeatureDeclarations, sharedModelDefaults, inspectionScheme, problems)
     def registrationPlugin = Mock(Plugin)
     def metadataStore = Mock(TypeMetadataStore)
     def registrationPluginTypeMetadata = Mock(TypeMetadata)

--- a/testing/architecture-test/src/changes/archunit-store/classes-in-generic-packages.txt
+++ b/testing/architecture-test/src/changes/archunit-store/classes-in-generic-packages.txt
@@ -57,6 +57,7 @@ Class <org.gradle.api.UnknownTaskException> is in a generic package in (UnknownT
 Class <org.gradle.api.XmlProvider> is in a generic package in (XmlProvider.java:0)
 Class <org.gradle.api.initialization.ConfigurableIncludedBuild> is in a generic package in (ConfigurableIncludedBuild.java:0)
 Class <org.gradle.api.initialization.ConfigurableIncludedPluginBuild> is in a generic package in (ConfigurableIncludedPluginBuild.java:0)
+Class <org.gradle.api.initialization.EcosystemApplyAction> is in a generic package in (EcosystemApplyAction.java:0)
 Class <org.gradle.api.initialization.IncludedBuild> is in a generic package in (IncludedBuild.java:0)
 Class <org.gradle.api.initialization.ProjectDescriptor> is in a generic package in (ProjectDescriptor.java:0)
 Class <org.gradle.api.initialization.Settings> is in a generic package in (Settings.java:0)


### PR DESCRIPTION
Allow schema (no-build-model) project types and features, applied directly in settings

This is an exploratory slice of the low-ceremony build logic work for Declarative Gradle. It reduces the boilerplate needed to author a project type or feature in two steps:

1. Schema apply actions: a project type/feature whose definition has no build model. The apply action receives only the definition (and, for features, the parent definition); no application context or build model.
2. Direct application (research Option 3, scoped to schema apply actions): a plugin id whose descriptor points directly at the apply action class can be applied in a settings plugins { } block and registers the type/feature directly: no Plugin<Project> shell, no Binding/bind() class, and no @RegistersProjectFeatures settings plugin.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
