### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ systemProp.develocity.internal.testacceleration.enableCustomValues=true
 # If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
 systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
-defaultRfnPerformanceBaselines=9.7.0-commit-df5f27e77c5
+defaultRfnPerformanceBaselines=9.7.0-commit-3874dcfcb0c
 # Default ReadyForRelease performance baseline
 defaultRfrPerformanceBaselines=9.6.0-commit-a2bfcc5455e
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Perf tests now failing on a test-only change: https://github.com/gradle/gradle/pull/38099/changes

This is a signal for us to rebasline.