### PR TITLE
Upgrade wrapper to 9.6.0-rc-1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-rc-1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
The merge conflict resolution was wrong in https://github.com/gradle/gradle/pull/38060: we should use `9.6.0-rc-1` instead of `9.6.0-milestone-3`.

