### PR TITLE
Make :language-java and :testing-jvm integ tests Isolated Projects compatible

### DIFF
--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -118,7 +118,3 @@ packageCycles {
     // These public packages have classes that are tangled with the corresponding internal package.
     excludePatterns.add("org/gradle/api/tasks/**")
 }
-
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.internal.util.LongCommandLineDetectionUtil
@@ -25,6 +26,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
 
+import static org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects.Skip.FLAKY
 import static org.gradle.util.Matchers.containsText
 
 class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
@@ -74,6 +76,7 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Flaky(because = "https://github.com/gradle/gradle-private/issues/5122")
+    @ToBeFixedForIsolatedProjects(skip = FLAKY, because = "Long command line detection is non-deterministic under IP, so the build does not reliably fail as expected")
     def "still fail when classpath doesn't shorten the command line enough with #method"() {
         def veryLongCommandLineArgs = getLongCommandLine(getMaxArgs() * 16)
         buildFile << """

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -44,13 +44,12 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
 
         settingsFile << """
             include "annotation", "library", "processor"
+            gradle.lifecycle.beforeProject {
+                apply plugin: 'java'
+            }
         """
 
         buildFile << """
-            allprojects {
-                apply plugin: 'java'
-            }
-
             dependencies {
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -44,12 +44,11 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
 
         settingsFile << """
             include "annotation", "library", "processor"
-            gradle.lifecycle.beforeProject {
-                apply plugin: 'java'
-            }
         """
 
         buildFile << """
+            apply plugin: 'java'
+
             dependencies {
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")
@@ -59,7 +58,17 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
             }
         """
 
+        annotationProjectDir.file("build.gradle") << """
+            apply plugin: 'java'
+        """
+
+        libraryProjectDir.file("build.gradle") << """
+            apply plugin: 'java'
+        """
+
         processorProjectDir.file("build.gradle") << """
+            apply plugin: 'java'
+
             dependencies {
                 implementation project(":annotation")
                 implementation project(":library")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingCompileAvoidanceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingCompileAvoidanceIntegrationTest.groovy
@@ -23,15 +23,18 @@ import org.gradle.test.preconditions.TestExecutionPreconditions
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
 class JavaAnnotationProcessingCompileAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
-        settingsFile << "include 'a', 'b'"
+        settingsFile << '''
+            include 'a', 'b'
+        '''
+
         buildFile << '''
-            allprojects {
-                apply plugin: 'java'
-            }
+            apply plugin: 'java'
         '''
 
         // annotation processor path uses @Classpath
         file('a/build.gradle') << '''
+            apply plugin: 'java'
+
             configurations {
                 annotationProcessor
             }
@@ -53,6 +56,9 @@ class JavaAnnotationProcessingCompileAvoidanceIntegrationTest extends AbstractIn
             aprop=avalue
         '''
 
+        file('b/build.gradle') << '''
+            apply plugin: 'java'
+        '''
         file('b/src/main/java/B.java') << '''
             public class B {
                 public int truth() { return 0; }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
@@ -170,13 +170,15 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
     }
 
     void project_a_depends_on_project_b() {
-        settingsFile << "include 'a', 'b'"
+        settingsFile << '''
+            include 'a', 'b'
+        '''
         buildFile << '''
-            allprojects {
-                apply plugin: 'java'
-            }
+            apply plugin: 'java'
         '''
         file('a/build.gradle') << '''
+            apply plugin: 'java'
+
             dependencies {
                 implementation project(':b')
             }
@@ -188,6 +190,9 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
                     int x = truth();
                 }
             }
+        '''
+        file('b/build.gradle') << '''
+            apply plugin: 'java'
         '''
         file('b/src/main/java/B.java') << '''
             public class B {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -117,17 +117,17 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "don't implicitly compile source files from classpath"() {
         settingsFile << "include 'a', 'b'"
-        buildFile << """
-            subprojects {
-                apply plugin: 'java'
-                tasks.withType(JavaCompile) {
-                    options.compilerArgs << '-Xlint:all' << '-Werror'
-                }
+        def subprojectConfig = """
+            apply plugin: 'java'
+            tasks.withType(JavaCompile) {
+                options.compilerArgs << '-Xlint:all' << '-Werror'
             }
-            project(':b') {
-                dependencies {
-                    implementation project(':a')
-                }
+        """
+        file("a/build.gradle") << subprojectConfig
+        file("b/build.gradle") << subprojectConfig
+        file("b/build.gradle") << """
+            dependencies {
+                implementation project(':a')
             }
         """
 
@@ -141,7 +141,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         // This makes sure the test above is correct AND you can get back javac's default behavior if needed
         when:
-        buildFile << "project(':b').compileJava { options.sourcepath = classpath }"
+        file("b/build.gradle") << "compileJava { options.sourcepath = classpath }"
         run("compileJava")
         then:
         file("b/build/classes/java/main/Bar.class").exists()
@@ -283,15 +283,16 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         given:
         settingsFile << "include 'a', 'b'"
-        buildFile << """
-            allprojects {
-                apply plugin: 'java-library'
+        def projectConfig = """
+            apply plugin: 'java-library'
 
-                repositories {
-                   maven { url = '$mavenRepo.uri' }
-                }
+            repositories {
+               maven { url = '$mavenRepo.uri' }
             }
         """
+        buildFile << projectConfig
+        file('a/build.gradle') << projectConfig
+        file('b/build.gradle') << projectConfig
 
         file('a/build.gradle') << '''
             dependencies {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -38,32 +38,27 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
         def jdks = Iterables.cycle(java8CompatibleJdks).iterator()
 
         settingsFile << "include ${projectNames.collect { "'$it'" }.join(', ')}"
-        buildFile << """
-            subprojects {
-                apply plugin: 'java'
-
-                ${mavenCentralRepository()}
-
-                dependencies {
-                    implementation 'commons-lang:commons-lang:2.5'
-                }
-            }
-        """
 
         projectNames.each { projectName ->
             def jdk = jdks.next()
             def javaHome = TextUtil.escapeString(jdk.javaHome.absolutePath)
             def version = jdk.javaVersion
-            buildFile << """
-project(':$projectName') {
-    tasks.withType(JavaCompile) {
-        sourceCompatibility = '${version}'
-        targetCompatibility = '${version}'
+            file("${projectName}/build.gradle") << """
+apply plugin: 'java'
 
-        options.with {
-            fork = true
-            forkOptions.javaHome = file("${javaHome}")
-        }
+${mavenCentralRepository()}
+
+dependencies {
+    implementation 'commons-lang:commons-lang:2.5'
+}
+
+tasks.withType(JavaCompile) {
+    sourceCompatibility = '${version}'
+    targetCompatibility = '${version}'
+
+    options.with {
+        fork = true
+        forkOptions.javaHome = file("${javaHome}")
     }
 }
 """

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
@@ -26,13 +26,15 @@ class JavaCompileTaskOperationResultIntegTest extends AbstractIntegrationSpec {
             include 'processor'
         """
         buildFile << """
-            allprojects {
-                apply plugin: 'java'
-            }
+            apply plugin: 'java'
+
             dependencies {
                 compileOnly project(':processor')
                 annotationProcessor project(':processor')
             }
+        """
+        file("processor/build.gradle") << """
+            apply plugin: 'java'
         """
         file("src/main/java/SomeClass.java") << """
             @Helper class SomeClass {}

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -25,14 +25,17 @@ import spock.lang.Issue
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
 class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
-        settingsFile << "include 'a', 'b'"
+        settingsFile << '''
+            include 'a', 'b'
+        '''
+
         buildFile << '''
-            allprojects {
-                apply plugin: 'java'
-            }
+            apply plugin: 'java'
         '''
 
         file('a/build.gradle') << '''
+            apply plugin: 'java'
+
             dependencies {
                 implementation project(':b')
             }
@@ -48,6 +51,9 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             aprop=avalue
         '''
 
+        file('b/build.gradle') << '''
+            apply plugin: 'java'
+        '''
         file('b/src/main/java/B.java') << '''
             public class B {
                 public int truth() { return 0; }
@@ -78,11 +84,6 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def "order of upstream jar entries does not matter"() {
         given:
         file("a/build.gradle") << '''
-            dependencies {
-                implementation rootProject.orderedJar.outputs.files
-            }
-        '''
-        buildFile << """
             task orderedJar(type: Jar) {
                 def reverse = Boolean.getBoolean("reverse")
                 inputs.property("reverse", reverse)
@@ -100,12 +101,16 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
 
                 archiveFileName = "external.jar"
             }
-        """
+
+            dependencies {
+                implementation orderedJar.outputs.files
+            }
+        '''
         ['a', 'b', 'c', 'd'].each {
-            file("external/$it").touch()
+            file("a/external/$it").touch()
         }
         // Generate external jar with entries in alphabetical order
-        def externalJar = file('build/libs/external.jar')
+        def externalJar = file('a/build/libs/external.jar')
         succeeds(":a:javadoc", "-Dreverse=false")
         new ZipTestFixture(externalJar).hasDescendantsInOrder('META-INF/MANIFEST.MF', 'a', 'b', 'c', 'd')
 
@@ -122,11 +127,6 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def "timestamp of upstream jar entries does not matter"() {
         given:
         file("a/build.gradle") << '''
-            dependencies {
-                implementation rootProject.timedJar.outputs.files
-            }
-        '''
-        buildFile << """
             task timedJar(type: Jar) {
                 from("external/a")
                 from("external/b")
@@ -136,10 +136,14 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
                 archiveFileName = "external.jar"
                 preserveFileTimestamps = Boolean.getBoolean("oldTime")
             }
-        """
-        def externalJar = file("build/libs/external.jar")
+
+            dependencies {
+                implementation timedJar.outputs.files
+            }
+        '''
+        def externalJar = file("a/build/libs/external.jar")
         ['a', 'b', 'c', 'd'].each {
-            file("external/$it").touch()
+            file("a/external/$it").touch()
         }
         // Generate external jar with entries with a current timestamp
         succeeds(":a:javadoc", "-DoldTime=false")
@@ -157,11 +161,6 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def "duplicates in an upstream jar are not ignored"() {
         given:
         file("a/build.gradle") << '''
-            dependencies {
-                implementation rootProject.duplicate.outputs.files
-            }
-        '''
-        buildFile << """
             task duplicate(type: Jar) {
                 duplicatesStrategy = DuplicatesStrategy.INCLUDE
                 from("external/a")
@@ -171,23 +170,27 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
                 from("duplicate/a")
                 archiveFileName = "external.jar"
             }
-        """
-        def externalJar = file("build/libs/external.jar")
+
+            dependencies {
+                implementation duplicate.outputs.files
+            }
+        '''
+        def externalJar = file("a/build/libs/external.jar")
         ['a', 'b', 'c', 'd'].each {
-            file("external/$it").text = "original"
+            file("a/external/$it").text = "original"
         }
-        def original = file("external/a")
-        def duplicate = file("duplicate/a")
+        def original = file("a/external/a")
+        def duplicate = file("a/duplicate/a")
         duplicate.text = "duplicate"
 
         // Generate external jar with entries with a duplicate 'a' file
-        succeeds("duplicate", ":a:javadoc")
+        succeeds(":a:duplicate", ":a:javadoc")
         def oldHash = externalJar.md5Hash
 
         when:
         // change the second duplicate
         duplicate.text = "changed to something else"
-        succeeds("duplicate")
+        succeeds(":a:duplicate")
         then:
         // check that the upstream jar definitely changed
         oldHash != externalJar.md5Hash
@@ -197,11 +200,11 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.assertTasksExecuted(":a:javadoc")
         result.assertTasksSkipped(":b:compileJava", ":b:processResources", ":b:classes", ":b:jar",
-            ":a:compileJava", ":a:processResources", ":a:classes", ":duplicate")
+            ":a:compileJava", ":a:processResources", ":a:classes", ":a:duplicate")
         when:
         // change the first duplicate
         original.text = "changed to something else"
-        succeeds("duplicate")
+        succeeds(":a:duplicate")
         then:
         // check that the upstream jar definitely changed
         oldHash != externalJar.md5Hash
@@ -211,7 +214,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.assertTasksExecuted(":a:javadoc")
         result.assertTasksSkipped(":b:compileJava", ":b:processResources", ":b:classes", ":b:jar",
-            ":a:compileJava", ":a:processResources", ":a:classes", ":duplicate")
+            ":a:compileJava", ":a:processResources", ":a:classes", ":a:duplicate")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6168")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest.groovy
@@ -17,14 +17,6 @@
 package org.gradle.java.compile.incremental
 
 abstract class AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
-    def setup() {
-        buildFile << """
-            allprojects {
-                ${mavenCentralRepository()}
-            }
-       """
-    }
-
     def "doesn't recompile if implementation dependency changed in ABI compatible way"() {
         given:
         file('settings.gradle') << "include 'a'\n"
@@ -32,16 +24,16 @@ abstract class AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest
             import org.apache.commons.math3.util.BigReal;
             public class ToolImpl { public void execute() { BigReal read = BigReal.ONE; } }
 '''
-        buildFile << """
-            project(':a') {
-                apply plugin: '${language.name}'
+        file("a/build.gradle") << """
+            apply plugin: '${language.name}'
 
-                dependencies {
-                    implementation 'org.apache.commons:commons-math3:3.4'
-                }
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation 'org.apache.commons:commons-math3:3.4'
             }
             """
-        configureGroovyIncrementalCompilation("subprojects")
+        configureGroovyIncrementalCompilation("a")
 
         when:
         succeeds "a:${language.compileTaskName}"
@@ -50,7 +42,8 @@ abstract class AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest
         executedAndNotSkipped ":a:${language.compileTaskName}"
 
         when:
-        buildFile.text = buildFile.text.replace("3.4", "3.4.1")
+        def aBuildFile = file("a/build.gradle")
+        aBuildFile.text = aBuildFile.text.replace("3.4", "3.4.1")
 
         then:
         succeeds "a:${language.compileTaskName}"

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
@@ -45,11 +45,9 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
 
     def "doesn't recompile if external dependency has ABI incompatible change but not on class we use"() {
         given:
-        buildFile << """
-            project(':impl') {
-                ${mavenCentralRepository()}
-                dependencies { implementation 'org.apache.commons:commons-lang3:3.3' }
-            }
+        file("impl/build.gradle") << """
+            ${mavenCentralRepository()}
+            dependencies { implementation 'org.apache.commons:commons-lang3:3.3' }
         """
         source api: ["class A {}", "class B { }"], impl: ["class ImplA extends A {}", """import org.apache.commons.lang3.StringUtils;
 
@@ -59,7 +57,8 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.snapshot { run language.compileTaskName }
 
         when:
-        buildFile.text = buildFile.text.replace('3.3', '3.3.1')
+        def implBuildFile = file("impl/build.gradle")
+        implBuildFile.text = implBuildFile.text.replace('3.3', '3.3.1')
         run "impl:${language.compileTaskName}"
 
         then:
@@ -114,8 +113,7 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
     }
 
     def "handles multiple compile tasks in the same project"() {
-        createDirs("other")
-        settingsFile << "\n include 'other'" //add an extra project
+        subproject("other") //add an extra project
         source impl: ["class ImplA extends A {}"], api: ["class A {}"], other: ["class Other {}"]
 
         //new separate compile task (compileIntegTest${language.captalizedName}) depends on class from the extra project
@@ -294,8 +292,10 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.snapshot { run("impl:${language.compileTaskName}") }
 
         when:
-        file("impl/build.gradle").text = """
-            configurations.implementation.dependencies.clear()  //kill project dependency
+        // Re-create impl from scratch with only the junit dependency (no api project dependency)
+        file("impl/build.gradle").text = ""
+        configureSubprojectBuildScript("impl")
+        file("impl/build.gradle") << """
             dependencies {
                 implementation 'junit:junit:4.11'
                 implementation localGroovy()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationSupport.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationSupport.groovy
@@ -25,48 +25,46 @@ abstract class AbstractCrossTaskIncrementalCompilationSupport extends AbstractJa
 
     def setup() {
         impl = new CompilationOutputsFixture(file("impl/build/classes"))
-        buildFile << """
-            subprojects {
-                apply plugin: '${language.name}'
-                apply plugin: 'java-library'
-                ${mavenCentralRepository()}
-                configurations.compileClasspath.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.${useJar ? 'JAR' : 'CLASSES'}))
-            }
-            $projectDependencyBlock
-        """
-        createDirs("api", "impl")
-        settingsFile << "include 'api', 'impl'\n"
+        subproject("api")
+        subproject("impl")
+        applyProjectDependencies()
+    }
 
+    protected void subproject(String name) {
+        createDirs(name)
+        settingsFile << "include '$name'\n"
+        configureSubprojectBuildScript(name)
+    }
+
+    protected void configureSubprojectBuildScript(String name) {
+        file("$name/build.gradle") << """
+            apply plugin: '${language.name}'
+            apply plugin: 'java-library'
+            ${mavenCentralRepository()}
+            configurations.compileClasspath.attributes.attribute(org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(org.gradle.api.attributes.LibraryElements, org.gradle.api.attributes.LibraryElements.${useJar ? 'JAR' : 'CLASSES'}))
+        """
         if (language == CompiledLanguage.GROOVY) {
-            configureGroovyIncrementalCompilation('subprojects')
+            configureGroovyIncrementalCompilation(name)
         }
     }
 
-    protected String getProjectDependencyBlock() {
-        '''
-            project(':impl') {
-                dependencies { api project(':api') }
-            }
-        '''
+    protected void applyProjectDependencies() {
+        addDependency("impl", "api")
     }
 
     protected void addDependency(String from, String to) {
-        buildFile << """
-            project(':$from') {
-                dependencies { api project(':$to') }
-            }
+        file("$from/build.gradle") << """
+            dependencies { api project(':$to') }
         """
     }
 
     protected abstract boolean isUseJar()
 
     protected void clearImplProjectDependencies() {
-        buildFile << """
-            project(':impl') {
-                configurations.api.dependencies.clear() //so that api jar is no longer on classpath
-            }
+        file("impl/build.gradle") << """
+            configurations.api.dependencies.clear() //so that api jar is no longer on classpath
         """
-        configureGroovyIncrementalCompilation('subprojects')
+        configureGroovyIncrementalCompilation("api", "impl")
     }
 
     File source(Map projectToClassBodies) {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractJavaGroovyIncrementalCompilationSupport.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractJavaGroovyIncrementalCompilationSupport.groovy
@@ -80,16 +80,20 @@ abstract class AbstractJavaGroovyIncrementalCompilationSupport extends AbstractI
         """
     }
 
-    def configureGroovyIncrementalCompilation(String allprojectsOrSubprojects = 'allprojects') {
+    def configureGroovyIncrementalCompilation(String... projects) {
         if (language == CompiledLanguage.GROOVY) {
-            buildFile << language.projectGroovyDependencies(allprojectsOrSubprojects)
-            buildFile << """
-                ${allprojectsOrSubprojects} {
-                    tasks.withType(GroovyCompile) {
+            def targetProjects = projects.length == 0 ? [""] : projects.toList()
+            targetProjects.each { project ->
+                def buildScript = project.isEmpty() ? buildFile : file("${project}/build.gradle")
+                buildScript << """
+                    dependencies {
+                        implementation localGroovy()
+                    }
+                    tasks.withType(GroovyCompile).configureEach {
                         options.incremental = true
                     }
-                }
-            """
+                """
+            }
             FeaturePreviewsFixture.enableGroovyCompilationAvoidance(settingsFile)
         }
     }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskClassChangesIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskClassChangesIncrementalCompilationIntegrationTest.groovy
@@ -34,10 +34,7 @@ abstract class CrossTaskClassChangesIncrementalCompilationIntegrationTest extend
     }
 
     def "detects change to transitive superclass in an upstream project"() {
-        createDirs("app")
-        settingsFile << """
-            include 'app'
-        """
+        subproject("app")
         addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         source api: ["class A {}"]
@@ -54,10 +51,7 @@ abstract class CrossTaskClassChangesIncrementalCompilationIntegrationTest extend
     }
 
     def "detects change to transitive dependency in an upstream project"() {
-        createDirs("app")
-        settingsFile << """
-            include 'app'
-        """
+        subproject("app")
         addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         source api: ["class A {}"]
@@ -74,10 +68,7 @@ abstract class CrossTaskClassChangesIncrementalCompilationIntegrationTest extend
     }
 
     def "distinguishes between api and implementation changes"() {
-        createDirs("app")
-        settingsFile << """
-            include 'app'
-        """
+        subproject("app")
         addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         source api: ["class A {}"]
@@ -94,10 +85,7 @@ abstract class CrossTaskClassChangesIncrementalCompilationIntegrationTest extend
     }
 
     def "detects deletions of transitive dependency in an upstream project"() {
-        createDirs("app")
-        settingsFile << """
-            include 'app'
-        """
+        subproject("app")
         addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         source api: ["class A {}"]

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -209,7 +209,7 @@ abstract class CrossTaskIncrementalJavaCompilationIntegrationTest extends Abstra
     @Requires(JdkVersionTestPreconditions.Jdk9OrLater)
     def "recompiles when upstream module-info changes"() {
         given:
-        settingsFile << "include 'otherApi'"
+        subproject("otherApi")
         file("impl/build.gradle") << "dependencies { implementation(project(':otherApi')) }"
 
         file("api/src/main/${language.name}/module-info.${language.name}") << """

--- a/platforms/jvm/testing-jvm/build.gradle.kts
+++ b/platforms/jvm/testing-jvm/build.gradle.kts
@@ -91,7 +91,3 @@ strictCompile {
 packageCycles {
     excludePatterns.add("org/gradle/api/internal/tasks/testing/**")
 }
-
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
@@ -40,19 +40,17 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
 
     def setup() {
         buildFile << """
-            allprojects {
-                apply plugin: 'java'
+            apply plugin: 'java'
 
-                repositories {
-                    mavenCentral()
-                }
-
-                dependencies {
-                    ${testFrameworkDependencies}
-                }
-
-                test.${configureTestFramework}
+            repositories {
+                mavenCentral()
             }
+
+            dependencies {
+                ${testFrameworkDependencies}
+            }
+
+            test.${configureTestFramework}
         """
     }
 
@@ -196,6 +194,9 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
         """
         settingsFile << """
             include 'dependency'
+        """
+        file("dependency/build.gradle") << """
+            apply plugin: 'java'
         """
         file("src/test/java/MyTest.java") << """
             ${testFrameworkImports}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
@@ -214,11 +214,12 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     def 'can add dependencies to other projects to #suiteDesc'() {
         given:
         multiProjectBuild('root', ['consumer', 'util']) {
-            buildFile << """
-                subprojects { apply plugin: 'java-library'}
-                project(':util') {
-                    dependencies { api 'org.apache.commons:commons-lang3:3.11' }
-                }
+            project('consumer').buildFile << """
+                apply plugin: 'java-library'
+            """
+            project('util').buildFile << """
+                apply plugin: 'java-library'
+                dependencies { api 'org.apache.commons:commons-lang3:3.11' }
             """
         }
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
@@ -232,23 +232,31 @@ class TestSuitesKotlinDSLDependenciesIntegrationTest extends AbstractIntegration
         """
 
         buildKotlinFile << """
-            allprojects {
-                group = "org.test"
-                version = "1.0"
-            }
-
-            subprojects {
-                apply(plugin = "java-library")
-            }
+            group = "org.test"
+            version = "1.0"
         """
 
         file('util/build.gradle.kts') << """
+            plugins {
+                `java-library`
+            }
+
+            group = "org.test"
+            version = "1.0"
+
             dependencies {
                 api("org.apache.commons:commons-lang3:3.11")
             }
         """
 
         file('consumer/build.gradle.kts') << """
+            plugins {
+                `java-library`
+            }
+
+            group = "org.test"
+            version = "1.0"
+
             ${mavenCentralRepository(GradleDsl.KOTLIN)}
 
             testing {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractTaskRelocationIntegrationTest.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractTaskRelocationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures
 
 abstract class AbstractTaskRelocationIntegrationTest extends AbstractIntegrationSpec {
 
+    @ToBeFixedForIsolatedProjects(bottomSpecs = "TestTaskJdkRelocationIntegrationTest", because = "Test task is not relocatable under IP: the relocated run re-executes and produces a different test report")
     def "task is relocatable"() {
         setupProjectInOriginalLocation()
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
@@ -35,6 +35,14 @@ import java.lang.annotation.Target
     String because() default "";
 
     /**
+     * Restricts the annotation to the named bottom (most derived) spec classes.
+     * Useful when annotating a test declared in an abstract base class that should only be
+     * marked for some of its subclasses. When empty (the default) the annotation applies to
+     * every spec that inherits the annotated element.
+     */
+    String[] bottomSpecs() default [];
+
+    /**
      * Reason for skipping a test with isolated projects.
      */
     enum Skip {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
@@ -35,6 +35,9 @@ class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtensio
 
     @Override
     void visitFeatureAnnotation(ToBeFixedForIsolatedProjects annotation, FeatureInfo feature) {
+        if (!isEnabledBottomSpec(annotation.bottomSpecs(), feature.spec.bottomSpec.name)) {
+            return
+        }
         visitAnnotation(annotation, feature)
     }
 
@@ -49,5 +52,9 @@ class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtensio
         }
 
         toBeFixedSpecInterceptor.intercept(specElementInfo, new String[0])
+    }
+
+    private static boolean isEnabledBottomSpec(String[] bottomSpecs, String bottomSpecName) {
+        bottomSpecs.length == 0 || bottomSpecs.contains(bottomSpecName)
     }
 }


### PR DESCRIPTION
### Context

`isolatedProjectsIntegTest` was disabled for `:language-java` and `:testing-jvm`, so we were not running their integration tests under Isolated Projects (IP). This PR makes those suites IP-compatible and re-enables the task for both subprojects.

The bulk of the work replaces cross-project configuration that IP forbids (`allprojects {}`, `subprojects {}`, inline `project(':x') {}`, `rootProject.<task>`) by **configuring each project explicitly**:

- Plugins, repositories and shared conventions are applied in each project's own build script (`build.gradle` / `build.gradle.kts`), rather than from the root build.
- Single-project fixtures move their configuration straight into the root build script.
- The cross-task incremental fixture gains a `subproject(name)` helper that includes a project and writes its build script, so fixtures that add extra projects configure each one on its own; `configureGroovyIncrementalCompilation()` now takes the projects to configure.
- The Kotlin DSL test-suite fixtures use a `plugins {}` block (not `apply(plugin = …)`) so the type-safe `testing`/`suites`/`api` accessors resolve.

Two tests exercise behavior that genuinely differs under IP and are annotated rather than rewritten:

- `JavaExecWithLongCommandLineIntegrationTest` — long-command-line detection is non-deterministic under IP, so the expected failure is flaky (`skip = FLAKY`).
- `TestTaskJdkRelocationIntegrationTest` — the relocated `:test` run re-executes and produces a different report under IP. This test is **inherited** from `AbstractTaskRelocationIntegrationTest`, and the IP extension's expect-fail path only intercepts a spec's own features, so the annotation has to live on the base method scoped to the leaf subclass.

To support that last case, this PR adds a `bottomSpecs` attribute to `@ToBeFixedForIsolatedProjects` (mirroring the existing `@ToBeFixedForConfigurationCache`), letting a base-method annotation target specific subclasses. It is backward-compatible (default `[]` → applies to all specs).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
