### PR TITLE
Nag on deprecated Project.container(...) methods

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
-import org.gradle.util.internal.ToBeImplemented
 
 class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
     def "instantiated Named does not interfere with instantiating other objects"() {
@@ -33,7 +32,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
             c.create("foo")
         """
         then:
-        // executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
         when:
         buildFile """
@@ -45,7 +44,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
             cc.create("foo")
         """
         then:
-        // executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
     }
 
@@ -70,12 +69,10 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         """
 
         expect:
-        // https://github.com/gradle/gradle/issues/34693
-        // executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/34693")
     def "project.container(Class) is deprecated"() {
         buildFile  """
             def container = project.container(Named)
@@ -85,7 +82,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         """
 
         expect:
-        // executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        executer.expectDocumentedDeprecationWarning("The Project.container(Class) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
     }
 
@@ -102,7 +99,6 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         succeeds()
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/34693")
     def "project.container(Class,NamedDomainObjectFactory) is deprecated"() {
         buildFile  """
             def container = project.container(Named, new NamedDomainObjectFactory<Named>() {
@@ -117,7 +113,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         """
 
         expect:
-        // executer.expectDocumentedDeprecationWarning("The Project.container(Class, NamedDomainObjectFactory) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class, NamedDomainObjectFactory) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        executer.expectDocumentedDeprecationWarning("The Project.container(Class, NamedDomainObjectFactory) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class, NamedDomainObjectFactory) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
+import org.gradle.util.internal.ToBeImplemented
 
 class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
     def "instantiated Named does not interfere with instantiating other objects"() {
@@ -99,6 +100,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         succeeds()
     }
 
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/34693")
     def "project.container(Class,NamedDomainObjectFactory) is deprecated"() {
         buildFile  """
             def container = project.container(Named, new NamedDomainObjectFactory<Named>() {
@@ -113,7 +115,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("The Project.container(Class, NamedDomainObjectFactory) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class, NamedDomainObjectFactory) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
+        // executer.expectDocumentedDeprecationWarning("The Project.container(Class, NamedDomainObjectFactory) method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the objects.domainObjectContainer(Class, NamedDomainObjectFactory) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#project_container_methods")
         succeeds()
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1451,25 +1451,22 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     @Deprecated
     public <T> NamedDomainObjectContainer<T> container(Class<T> type) {
-// KGP uses this method to create a container for the Kotlin DSL
-//        DeprecationLogger.deprecateMethod(Project.class, "container(Class)").
-//            replaceWith("objects.domainObjectContainer(Class)").
-//            willBeRemovedInGradle10().
-//            withUpgradeGuideSection(9, "project_container_methods").
-//            nagUser();
+        DeprecationLogger.deprecateMethod(Project.class, "container(Class)").
+            replaceWith("objects.domainObjectContainer(Class)").
+            willBeRemovedInGradle10().
+            withUpgradeGuideSection(9, "project_container_methods").
+            nagUser();
         return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainerUndecorated(type);
     }
 
     @Override
     @Deprecated
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
-// KGP uses this method to create a container for the Kotlin DSL
-// https://youtrack.jetbrains.com/issue/KT-80186
-//        DeprecationLogger.deprecateMethod(Project.class, "container(Class, NamedDomainObjectFactory)").
-//            replaceWith("objects.domainObjectContainer(Class, NamedDomainObjectFactory)").
-//            willBeRemovedInGradle10().
-//            withUpgradeGuideSection(9, "project_container_methods").
-//            nagUser();
+        DeprecationLogger.deprecateMethod(Project.class, "container(Class, NamedDomainObjectFactory)").
+            replaceWith("objects.domainObjectContainer(Class, NamedDomainObjectFactory)").
+            willBeRemovedInGradle10().
+            withUpgradeGuideSection(9, "project_container_methods").
+            nagUser();
         return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainer(type, factory);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1462,11 +1462,13 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     @Deprecated
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
-        DeprecationLogger.deprecateMethod(Project.class, "container(Class, NamedDomainObjectFactory)").
-            replaceWith("objects.domainObjectContainer(Class, NamedDomainObjectFactory)").
-            willBeRemovedInGradle10().
-            withUpgradeGuideSection(9, "project_container_methods").
-            nagUser();
+// KGP uses this method to create a container for the Kotlin DSL
+// https://youtrack.jetbrains.com/issue/KT-80186
+//        DeprecationLogger.deprecateMethod(Project.class, "container(Class, NamedDomainObjectFactory)").
+//            replaceWith("objects.domainObjectContainer(Class, NamedDomainObjectFactory)").
+//            willBeRemovedInGradle10().
+//            withUpgradeGuideSection(9, "project_container_methods").
+//            nagUser();
         return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainer(type, factory);
     }
 


### PR DESCRIPTION
Partially fixes #34693

### Context

The runtime deprecation nags for `Project.container(Class)` and `Project.container(Class, NamedDomainObjectFactory)` were written but left commented out, because the Kotlin Gradle Plugin called these methods to build the Kotlin DSL container. Enabling them earlier would have warned on essentially every build that applied a Kotlin plugin.

Kotlin has since removed that usage ([KT-80186](https://youtrack.jetbrains.com/issue/KT-80186)), so this enables the nags to match the already-active `container(Class, Closure)` variant. Both methods were already `@Deprecated` and documented under the existing `project_container_methods` upgrade-guide section, so there is no API or doc change — only the runtime warning is now emitted.

The integration tests for these two methods were previously marked `@ToBeImplemented` against this issue; they are now activated and assert the deprecation warnings fire.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.