### PR TITLE
Remove deprecated bits of `KotlinCoreEnvironment` usage from `KotlinSourceParser`

### DIFF
--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
         because("For manually defined KotlinSourceSet accessor - sourceSets.main.get().kotlin")
     }
 
+    testImplementation(buildLibs.kotlinCompilerEmbeddable) {
+        because("KotlinSourceParserTest parses Kotlin sources with the embeddable compiler")
+    }
 }
 
 @Suppress("UnstableApiUsage")

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
@@ -17,6 +17,7 @@
 package gradlebuild.basics.util
 
 
+import com.google.common.annotations.VisibleForTesting
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironmentMode
@@ -65,6 +66,8 @@ class KotlinSourceParser {
 
     private
     fun Disposable.parseKotlinFiles(sourceRoots: List<File>): List<KtFile> {
+        val applicationEnvironment = SharedKotlinApplicationEnvironment.acquire()
+        Disposer.register(this, SharedKotlinApplicationEnvironment.newReleaseDisposable())
         val psiManager = PsiManager.getInstance(KotlinCoreProjectEnvironment(this, applicationEnvironment).project)
         val localFileSystem = applicationEnvironment.localFileSystem
         return sourceRoots.asSequence()
@@ -80,22 +83,61 @@ class KotlinSourceParser {
 
 
 /**
- * A single, process-wide Kotlin compiler application environment shared by all parsers.
+ * The Kotlin compiler application environment shared by all live [KotlinCoreProjectEnvironment]s.
  *
- * Creating one is expensive (it registers all the IntelliJ core services and the Kotlin parser) and it
- * installs a global [org.jetbrains.kotlin.com.intellij.openapi.application.Application], so we create it once
- * and reuse it for every parse, handing each parse its own short-lived [KotlinCoreProjectEnvironment]. It is
- * intentionally never disposed: it lives for as long as the (short-lived) build/worker process.
+ * It is expensive to create and installs a process-global [org.jetbrains.kotlin.com.intellij.openapi.application.Application].
+ * A single parsing spans multiple source roots, each kept open in its own project environment until the parsing
+ * is done, so they share one reference-counted application environment: created with the first project environment,
+ * disposed once the last is closed. Disposal resets the global `ApplicationManager`, keeping it out of the
+ * long-lived Gradle daemon between runs.
  */
-private
-val applicationEnvironment: KotlinCoreApplicationEnvironment by lazy {
-    setIdeaIoUseFallback()
-    setupIdeaStandaloneExecution()
-    val disposable = Disposer.newDisposable("Disposable for the application environment of KotlinSourceParser")
-    KotlinCoreApplicationEnvironment.create(disposable, KotlinCoreApplicationEnvironmentMode.Production).apply {
-        registerFileType(KotlinFileType.INSTANCE, KotlinFileType.EXTENSION)
-        registerFileType(KotlinFileType.INSTANCE, KotlinFileType.SCRIPT_EXTENSION)
-        registerParserDefinition(KotlinParserDefinition())
+internal
+object SharedKotlinApplicationEnvironment {
+
+    @get:VisibleForTesting
+    var environment: KotlinCoreApplicationEnvironment? = null
+        private set
+
+    private
+    var openProjectEnvironments = 0
+
+    @Synchronized
+    fun acquire(): KotlinCoreApplicationEnvironment {
+        val environment = environment ?: create().also { environment = it }
+        openProjectEnvironments++
+        return environment
+    }
+
+    @Synchronized
+    private
+    fun release() {
+        if (--openProjectEnvironments <= 0) {
+            openProjectEnvironments = 0
+            environment?.let { Disposer.dispose(it.parentDisposable) }
+            environment = null
+        }
+    }
+
+    /**
+     * Returns a fresh [Disposable] that releases the shared environment when disposed; each parse registers one for cleanup.
+     *
+     * It must be a new instance per parse: [Disposer] disposes any given [Disposable] only once, so sharing one across
+     * parses would release only once (hence a non-capturing lambda won't do).
+     */
+    fun newReleaseDisposable(): Disposable = object : Disposable {
+        override fun dispose() = release()
+    }
+
+    private
+    fun create(): KotlinCoreApplicationEnvironment {
+        setIdeaIoUseFallback()
+        setupIdeaStandaloneExecution()
+        val disposable = Disposer.newDisposable("Disposable for the application environment of KotlinSourceParser")
+        return KotlinCoreApplicationEnvironment.create(disposable, KotlinCoreApplicationEnvironmentMode.Production).apply {
+            registerFileType(KotlinFileType.INSTANCE, KotlinFileType.EXTENSION)
+            registerFileType(KotlinFileType.INSTANCE, KotlinFileType.SCRIPT_EXTENSION)
+            registerParserDefinition(KotlinParserDefinition())
+        }
     }
 }
 

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
@@ -17,23 +17,17 @@
 package gradlebuild.basics.util
 
 
-import gradlebuild.basics.kotlindsl.configureKotlinCompilerForGradleBuild
-import org.gradle.internal.jvm.Jvm
-import org.jetbrains.kotlin.K1Deprecation
-import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
-import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironmentMode
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreProjectEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.setupIdeaStandaloneExecution
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.parsing.KotlinParserDefinition
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
 
 
@@ -53,71 +47,61 @@ class KotlinSourceParser {
         }
     }
 
-    private
-    val messageCollector: MessageCollector
-        get() = PrintingMessageCollector(System.out, MessageRenderer.PLAIN_RELATIVE_PATHS, false)
-
     fun <T : Any> mapParsedKotlinFiles(vararg sourceRoots: File, block: (KtFile) -> T): List<T> =
         withParsedKotlinSource(sourceRoots.toList()) { ktFiles ->
             ktFiles.map(block)
         }
 
-    fun parseSourceRoots(sourceRoots: List<File>, compilationClasspath: List<File>): ParsedKotlinFiles =
+    fun parseSourceRoots(sourceRoots: List<File>): ParsedKotlinFiles =
         Disposer.newDisposable().let { disposable ->
-            ParsedKotlinFiles(disposable.parseKotlinFiles(sourceRoots, compilationClasspath), disposable)
+            ParsedKotlinFiles(disposable.parseKotlinFiles(sourceRoots), disposable)
         }
 
     private
-    fun <T : Any?> withParsedKotlinSource(sourceRoots: List<File>, block: (List<KtFile>) -> T) =
+    fun <T> withParsedKotlinSource(sourceRoots: List<File>, block: (List<KtFile>) -> T) =
         Disposer.newDisposable().use {
-            parseKotlinFiles(sourceRoots, emptyList()).let(block)
+            parseKotlinFiles(sourceRoots).let(block)
         }
 
-    @OptIn(K1Deprecation::class)
     private
-    fun Disposable.parseKotlinFiles(sourceRoots: List<File>, compilationClasspath: List<File>): List<KtFile> {
-        configureKotlinCompilerIoForWindowsSupport()
-        val configuration = newCompilerConfiguration().apply {
-
-            put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
-            put(JVMConfigurationKeys.DISABLE_OPTIMIZATION, true)
-            put(CommonConfigurationKeys.MODULE_NAME, "parser")
-
-            configureKotlinCompilerForGradleBuild()
-
-            addJvmClasspathRoots(PathUtil.getJdkClassesRoots(Jvm.current().javaHome))
-            addJvmClasspathRoots(compilationClasspath)
-            addKotlinSourceRoots(sourceRoots.map { it.canonicalPath })
-        }
-        val environment = KotlinCoreEnvironment.createForProduction(this, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
-        return environment.getSourceFiles()
+    fun Disposable.parseKotlinFiles(sourceRoots: List<File>): List<KtFile> {
+        val psiManager = PsiManager.getInstance(KotlinCoreProjectEnvironment(this, applicationEnvironment).project)
+        val localFileSystem = applicationEnvironment.localFileSystem
+        return sourceRoots.asSequence()
+            .flatMap { it.walkTopDown() }
+            .filter { it.isFile && (it.extension == KotlinFileType.EXTENSION || it.extension == KotlinFileType.SCRIPT_EXTENSION) }
+            .mapNotNull { sourceFile ->
+                localFileSystem.findFileByPath(sourceFile.canonicalFile.invariantSeparatorsPath)
+                    ?.let { psiManager.findFile(it) as? KtFile }
+            }
+            .toList()
     }
+}
 
-    private
-    fun configureKotlinCompilerIoForWindowsSupport() =
-        org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
 
-    // Prefer `CompilerConfiguration.Companion.create()` (Kotlin 2.4+ exposes it as an extension in `org.jetbrains.kotlin.cli`)
-    // and fall back to the no-arg constructor on older versions, where the constructor is still part of the public API.
-    // TODO: remove this once the wrapper is based on Kotlin 2.4.0-RC or later, just call the create() method directly
-    private val newCompilerConfiguration: () -> CompilerConfiguration = run {
-        val viaCreate = runCatching {
-            val createKt = Class.forName("org.jetbrains.kotlin.cli.CreateKt")
-            val companion = CompilerConfiguration::class.java.getField("Companion").get(null)
-            val createMethod = createKt.getMethod("create", companion.javaClass)
-            return@runCatching { createMethod.invoke(null, companion) as CompilerConfiguration }
-        }.getOrNull()
-        viaCreate ?: run {
-            val ctor = CompilerConfiguration::class.java.getDeclaredConstructor()
-            val factory: () -> CompilerConfiguration = { ctor.newInstance() }
-            factory
-        }
+/**
+ * A single, process-wide Kotlin compiler application environment shared by all parsers.
+ *
+ * Creating one is expensive (it registers all the IntelliJ core services and the Kotlin parser) and it
+ * installs a global [org.jetbrains.kotlin.com.intellij.openapi.application.Application], so we create it once
+ * and reuse it for every parse, handing each parse its own short-lived [KotlinCoreProjectEnvironment]. It is
+ * intentionally never disposed: it lives for as long as the (short-lived) build/worker process.
+ */
+private
+val applicationEnvironment: KotlinCoreApplicationEnvironment by lazy {
+    setIdeaIoUseFallback()
+    setupIdeaStandaloneExecution()
+    val disposable = Disposer.newDisposable("Disposable for the application environment of KotlinSourceParser")
+    KotlinCoreApplicationEnvironment.create(disposable, KotlinCoreApplicationEnvironmentMode.Production).apply {
+        registerFileType(KotlinFileType.INSTANCE, KotlinFileType.EXTENSION)
+        registerFileType(KotlinFileType.INSTANCE, KotlinFileType.SCRIPT_EXTENSION)
+        registerParserDefinition(KotlinParserDefinition())
     }
 }
 
 
 private
-inline fun <T : Any?> Disposable.use(action: Disposable.() -> T) =
+inline fun <T> Disposable.use(action: Disposable.() -> T) =
     try {
         action(this)
     } finally {

--- a/build-logic-commons/basics/src/test/kotlin/gradlebuild/basics/util/KotlinSourceParserTest.kt
+++ b/build-logic-commons/basics/src/test/kotlin/gradlebuild/basics/util/KotlinSourceParserTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.basics.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+
+class KotlinSourceParserTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    /**
+     * Each open [KotlinSourceParser.ParsedKotlinFiles] keeps its own project environment alive, so two of them open at
+     * once must share the single, reference-counted application environment (the pattern binary-compatibility uses, with
+     * one parse per source root). The assertions track the actual lifecycle: one environment is created and reused while
+     * both parses are open, stays alive until the last one closes, then is disposed.
+     */
+    @Test
+    fun `shares a single environment across overlapping parses and disposes it when the last one closes`() {
+        val rootA = sourceRoot("a", "Apple.kt", "package a\n\nclass Apple")
+        val rootB = sourceRoot("b", "Banana.kt", "package b\n\nclass Banana")
+        val parser = KotlinSourceParser()
+
+        val parsedA = parser.parseSourceRoots(listOf(rootA))
+        val environment = SharedKotlinApplicationEnvironment.environment
+        assertNotNull(environment, "environment is created with the first parse")
+
+        val parsedB = parser.parseSourceRoots(listOf(rootB))
+        assertSame(
+            environment, SharedKotlinApplicationEnvironment.environment,
+            "a second overlapping parse reuses the same environment instead of creating another"
+        )
+
+        // both overlapping parses parse correctly against the shared environment
+        assertEquals(listOf("Apple.kt"), parsedA.ktFiles.map { it.name })
+        assertEquals(listOf("Banana.kt"), parsedB.ktFiles.map { it.name })
+
+        parsedA.close()
+        assertNotNull(SharedKotlinApplicationEnvironment.environment, "environment stays alive while another parse is still open")
+
+        parsedB.close()
+        assertNull(SharedKotlinApplicationEnvironment.environment, "environment is disposed once the last parse closes")
+    }
+
+    /**
+     * Closing the last open parse disposes the shared application environment and resets the global `ApplicationManager`,
+     * so a later parse has to transparently recreate it - something the old, never-disposed environment never had to do.
+     */
+    @Test
+    fun `recreates a fresh environment for a parse that starts after the previous one was disposed`() {
+        val parser = KotlinSourceParser()
+
+        val firstRoot = sourceRoot("first", "First.kt", "package p\n\nclass First")
+        val firstEnvironment = parser.parseSourceRoots(listOf(firstRoot)).use { parsed ->
+            assertEquals(listOf("First.kt"), parsed.ktFiles.map { it.name })
+            SharedKotlinApplicationEnvironment.environment
+        }
+        assertNotNull(firstEnvironment, "environment is created for the first parse")
+        assertNull(SharedKotlinApplicationEnvironment.environment, "environment is disposed after the first parse closes")
+
+        val secondRoot = sourceRoot("second", "Second.kt", "package p\n\nclass Second")
+        parser.parseSourceRoots(listOf(secondRoot)).use { parsed ->
+            val secondEnvironment = SharedKotlinApplicationEnvironment.environment
+            assertNotNull(secondEnvironment, "a fresh environment is created for the second parse")
+            assertNotSame(firstEnvironment, secondEnvironment, "the second parse builds a fresh environment, not the disposed one")
+            assertEquals(listOf("Second.kt"), parsed.ktFiles.map { it.name })
+        }
+    }
+
+    private
+    fun sourceRoot(name: String, fileName: String, code: String): File =
+        File(tempDir, name).apply {
+            resolve(fileName).apply {
+                parentFile.mkdirs()
+                writeText(code)
+            }
+        }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -90,8 +90,7 @@ class BinaryCompatibilityHelper {
                     addSetupRule(AcceptedRegressionsRuleSetup, [acceptedApiChanges: acceptedChanges])
                     addSetupRule(SinceAnnotationRuleCurrentGradleVersionSetup, [currentVersion: currentVersion])
                     addSetupRule(BinaryCompatibilityRepositorySetupRule, [
-                        (BinaryCompatibilityRepositorySetupRule.Params.sourceRoots): sourceRoots.collect { it.absolutePath } as Set,
-                        (BinaryCompatibilityRepositorySetupRule.Params.sourceCompilationClasspath): newClasspath.collect { it.absolutePath } as Set
+                        (BinaryCompatibilityRepositorySetupRule.Params.sourceRoots): sourceRoots.collect { it.absolutePath } as Set
                     ])
                     addSetupRule(UpgradePropertiesRuleSetup, [
                         currentUpgradedProperties: currentUpgradedPropertiesFile.absolutePath,

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/BinaryCompatibilityRepository.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/BinaryCompatibilityRepository.kt
@@ -44,8 +44,8 @@ class BinaryCompatibilityRepository internal constructor(
     companion object {
 
         @JvmStatic
-        fun openRepositoryFor(sourceRoots: List<File>, compilationClasspath: List<File>) =
-            BinaryCompatibilityRepository(SourcesRepository(sourceRoots, compilationClasspath))
+        fun openRepositoryFor(sourceRoots: List<File>) =
+            BinaryCompatibilityRepository(SourcesRepository(sourceRoots))
     }
 
     @VisibleForTesting

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/BinaryCompatibilityRepositoryLifecycle.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/BinaryCompatibilityRepositoryLifecycle.kt
@@ -35,14 +35,12 @@ class BinaryCompatibilityRepositorySetupRule(private val params: Map<String, Any
      */
     object Params {
         const val sourceRoots = "sourceRoots"
-        const val sourceCompilationClasspath = "sourceCompilationClasspath"
     }
 
     @Suppress("unchecked_cast")
     override fun execute(context: ViolationCheckContext) {
         (context.userData as MutableMap<String, Any?>)[REPOSITORY_CONTEXT_KEY] = BinaryCompatibilityRepository.openRepositoryFor(
-            param(Params.sourceRoots),
-            param(Params.sourceCompilationClasspath)
+            param(Params.sourceRoots)
         )
     }
 

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/SourcesRepository.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/SourcesRepository.kt
@@ -65,10 +65,7 @@ internal
 class SourcesRepository(
 
     private
-    val sourceRoots: List<File>,
-
-    private
-    val compilationClasspath: List<File>
+    val sourceRoots: List<File>
 
 ) : AutoCloseable {
 
@@ -90,8 +87,7 @@ class SourcesRepository(
             openKotlinCompilationUnitsByRoot
                 .computeIfAbsent(apiSourceFile.currentSourceRoot) {
                     KotlinSourceParser().parseSourceRoots(
-                        listOf(apiSourceFile.currentSourceRoot),
-                        compilationClasspath
+                        listOf(apiSourceFile.currentSourceRoot)
                     )
                 }
                 .ktFiles

--- a/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/PublicAPIRulesTest.groovy
+++ b/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/PublicAPIRulesTest.groovy
@@ -72,7 +72,7 @@ class PublicAPIRulesTest extends Specification {
         overrideAnnotation.fullyQualifiedName >> Override.name
         injectAnnotation.fullyQualifiedName >> Inject.name
 
-        repository = BinaryCompatibilityRepository.openRepositoryFor([new File(tmp.absolutePath)], [])
+        repository = BinaryCompatibilityRepository.openRepositoryFor([new File(tmp.absolutePath)])
     }
 
     def cleanup() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes (as far as `KotlinSourceParser` is concerned):
* https://github.com/gradle/gradle/issues/34952

This PR reduces our usage of the Kotlin compiler environment code, thus making the deprecated cleanup unnecessary; what makes this possible is that we only need PSI KtFiles for static analysis, not a full-blown compilation support.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
