### PR TITLE
Fix a bug in FileHierarchySet for path calculating when both paths belong to root

### DIFF
--- a/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
@@ -212,7 +212,9 @@ public abstract class FileHierarchySet {
                             StringBuilder builder = new StringBuilder();
                             for (String prefix : prefixStack) {
                                 builder.append(prefix);
-                                builder.append(File.separatorChar);
+                                if (!prefix.isEmpty()) {
+                                    builder.append(File.separatorChar);
+                                }
                             }
                             builder.append(node.prefix);
                             root = builder.toString();

--- a/platforms/core-runtime/files/src/test/groovy/org/gradle/internal/file/FileHierarchySetTest.groovy
+++ b/platforms/core-runtime/files/src/test/groovy/org/gradle/internal/file/FileHierarchySetTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.file
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
@@ -359,11 +360,32 @@ class FileHierarchySetTest extends Specification {
         rootsOf(from(dir1, commonDir2, commonDir3)) == [dir1.absolutePath, commonDir2.absolutePath, commonDir3.absolutePath]
     }
 
+    def "handles two unrelated paths correctly"() {
+        def set = FileHierarchySet.empty()
+        def absolutePaths
+        if (OperatingSystem.current().isUnix()) {
+            absolutePaths = ['/some/dIR', '/another/dIR']
+        } else {
+            absolutePaths = ['C:\\Some\\DIR', 'D:\\Another\\DIR']
+        }
+
+        expect:
+        rootsOf(fromPaths(absolutePaths)) == absolutePaths
+    }
+
     private static FileHierarchySet from(File... roots) {
         from(roots as List)
     }
 
     private static FileHierarchySet from(Iterable<File> roots) {
+        def set = FileHierarchySet.empty()
+        for (def root : roots) {
+            set = set.plus(root)
+        }
+        return set
+    }
+
+    private static FileHierarchySet fromPaths(Iterable<String> roots) {
         def set = FileHierarchySet.empty()
         for (def root : roots) {
             set = set.plus(root)


### PR DESCRIPTION
Extracted from
* https://github.com/gradle/gradle/issues/26116

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
