### PR TITLE
Add AGP version-update PRs to the TIDE board

### DIFF
--- a/.github/workflows/update-agp-versions.yml
+++ b/.github/workflows/update-agp-versions.yml
@@ -65,10 +65,12 @@ jobs:
           git push origin --delete tide/update-agp 2>/dev/null || true
           git push origin tide/update-agp
 
-          gh pr create \
+          pr_url=$(gh pr create \
             --base master \
             --title "Update tested AGP versions" \
             --body "Update tested AGP versions" \
             --reviewer "gradle/bt-tide" \
-            --label "a:chore,in:performance-test,in:smoke-test,re:android"
-          gh pr comment tide/update-agp --body '@bot-gradle test and merge'
+            --label "a:chore,in:performance-test,in:smoke-test,re:android")
+          # Add the PR to the TIDE team's board (project 147)
+          gh project item-add 147 --owner gradle --url "$pr_url"
+          gh pr comment "$pr_url" --body '@bot-gradle test and merge'


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5254

The weekly **Update tested AGP versions** automation (`update-agp-versions.yml`) opens a PR with labels and a `gradle/bt-tide` reviewer, but never placed it on the TIDE team board — so these PRs were easy to miss during triage.