### PR TITLE
Add violations when mutating StartParameter after settings evaluation

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
@@ -121,4 +121,98 @@ class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProj
         }
     }
 
+    def "mutating StartParameter from init script is allowed"() {
+        file("init.gradle") << """
+            gradle.startParameter.setContinueOnFailure(true)
+        """
+        buildFile("""
+            tasks.register("ok")
+        """)
+
+        when:
+        isolatedProjectsRun("ok", "-I", "init.gradle")
+
+        then:
+        postBuildOutputContains("Configuration cache entry stored.")
+    }
+
+    def "reading StartParameter from a build script after settings evaluation is not a violation"() {
+        // Only mutation is reported; reads stay silent, including reads that go through the
+        // mutation-notifying collection-view wrappers (Set/Map/List and their keySet/values/entrySet
+        // views, iterators and entries). These reads run at configuration time, which must complete for
+        // the build to reach projectsConfigured(":"), so asserting their values in the script is
+        // reliable: a wrong value fails the build, and the trailing marker proves every assert ran.
+        // The decisive check is still that none of these reads is reported: assertStateStored succeeds.
+        buildFile("""
+            def sp = gradle.startParameter
+            assert sp.offline == false
+            assert sp.excludedTaskNames.contains('x') == false
+            assert sp.excludedTaskNames.collect { it } == []
+            assert sp.projectProperties['seed'] == 'value'
+            assert sp.projectProperties.keySet().contains('seed')
+            assert sp.projectProperties.values().contains('value')
+            assert sp.projectProperties.entrySet().find { it.key == 'seed' }?.value == 'value'
+            assert sp.taskRequests.any { it.args.contains('ok') }
+            println("all reads verified")
+            tasks.register("ok")
+        """)
+
+        when:
+        isolatedProjectsRun("ok", "-Pseed=value")
+
+        then:
+        outputContains("all reads verified")
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+    }
+
+    def "replacing the requested tasks from a build script is currently allowed"() {
+        // setTaskNames and setTaskRequests are exempt from violation reporting for now: tooling model
+        // builders, e.g. during IDE sync, still legitimately replace the tasks to run while the build
+        // is already running. This pins the exemption until a better pattern exists for them.
+        buildFile("""
+            tasks.register('a')
+            tasks.register('b') { doLast { println 'b executed' } }
+            gradle.startParameter.setTaskNames(['b'])
+        """)
+
+        when:
+        isolatedProjectsRun("a")
+
+        then:
+        outputContains("b executed")
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+    }
+
+    def "mutating a StartParameter collection view is reported with the access path (#invocation)"() {
+        buildFile("""
+            gradle.startParameter.$invocation
+        """)
+
+        when:
+        // Fail-fast only: the violation is thrown before the delegate collection is touched, making
+        // the outcome independent of the delegate's mutability. In diagnostics mode the mutation
+        // proceeds into the delegate, and some backing collections (e.g. the project properties
+        // populated by the CLI converter) are immutable in real distributions, so the build would
+        // additionally fail with an UnsupportedOperationException there.
+        isolatedProjectsFailsUsing(IsolatedProjectsMode.FAIL_FAST, "help", "-Pseed=value")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(IsolatedProjectsMode.FAIL_FAST) {
+            projectsConfigured(":")
+            problem("Build file 'build.gradle': line 2: Cannot call '${signature}' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        invocation                                                                        | signature
+        "projectProperties.put('p', 'v')"                                                 | "getProjectProperties().put(Object, Object)"
+        "projectProperties.keySet().remove('seed')"                                       | "getProjectProperties().keySet().remove(Object)"
+        "projectProperties.keySet().with { def i = it.iterator(); i.next(); i.remove() }" | "getProjectProperties().keySet().iterator().remove()"
+        "projectProperties.entrySet().find { it.key == 'seed' }.setValue('x')"            | "getProjectProperties().entrySet().Entry.setValue(Object)"
+        "excludedTaskNames.removeIf { it == 'x' }"                                        | "getExcludedTaskNames().removeIf(Predicate)"
+    }
+
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    def "mutating StartParameter after settings evaluation is a violation (#location)"() {
+        // The violation pipeline (onMutableCall -> listener -> IP problem) is the same for every setter
+        // and only the call location varies, so one representative setter exercised from each location
+        // covers it; that every individual setter is instrumented is checked by the fast reflective unit
+        // test StartParameterMutationInstrumentationTest. The root case has no included build on purpose:
+        // adding one would make its configured-project set depend on the mode (in fail-fast the root
+        // throws before the included build is configured, in diagnostics everything is configured).
+        if (scriptPath.startsWith("included/")) {
+            settingsFile("""
+                includeBuild("included")
+            """)
+        }
+        file(scriptPath) << """
+            ${apiExpr}.setDryRun(true)
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(*configured)
+            problem("Build file '${scriptPath}': line 2: Cannot call 'setDryRun(boolean)' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        location           | scriptPath              | apiExpr                        | configured
+        "root project"     | "build.gradle"          | "gradle.startParameter"        | [":"]
+        "included project" | "included/build.gradle" | "gradle.startParameter"        | [":", ":included"]
+        "parent build"     | "included/build.gradle" | "gradle.parent.startParameter" | [":", ":included"]
+
+        combined:
+        mode << ALL_MODES
+    }
+
+    def "mutating StartParameter from root build settings script is allowed"() {
+        settingsFile("""
+            gradle.startParameter.setDryRun(true)
+        """)
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+    }
+
+    def "mutating StartParameter from included build settings script is allowed"() {
+        settingsFile("""
+            includeBuild("included")
+        """)
+        file("included/settings.gradle") << """
+            gradle.startParameter.setDryRun(true)
+        """
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":included")
+        }
+    }
+
+    def "configuring the StartParameter of a GradleBuild task is not a violation"() {
+        // The task's StartParameter is a copy created to define the nested build; mutating it
+        // configures a build that has not started yet, which is the window where mutation is legal.
+        // The mutation listener only guards a running build's own StartParameter.
+        settingsFile("""
+            rootProject.name = 'outer'
+        """)
+        buildFile("""
+            tasks.register('nested', GradleBuild) {
+                dir = file('other')
+                tasks = ['hello']
+                startParameter.setOffline(true)
+                startParameter.projectProperties.put('greeting', 'hi from outer')
+            }
+        """)
+        file("other/settings.gradle") << """
+            rootProject.name = 'inner'
+        """
+        file("other/build.gradle") << """
+            def greeting = providers.gradleProperty('greeting')
+            def offline = gradle.startParameter.offline
+            tasks.register('hello') {
+                doLast { println("inner says: \${greeting.get()}, offline=\$offline") }
+            }
+        """
+
+        when:
+        isolatedProjectsRun("nested")
+
+        then:
+        outputContains("inner says: hi from outer, offline=true")
+        fixture.assertStateStored {
+            // ":" is the outer build; ":other" is the nested build run by the task
+            projectsConfigured(":", ":other")
+        }
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -83,7 +83,6 @@ import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readEnum
 import org.gradle.internal.serialize.graph.readList
 import org.gradle.internal.serialize.graph.readNonNull
-import org.gradle.internal.serialize.graph.readStrings
 import org.gradle.internal.serialize.graph.readStringsSet
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.withDebugFrame
@@ -693,7 +692,6 @@ class ConfigurationCacheState(
     fun WriteContext.writeGradleState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             // per build
-            writeStartParameterOf(gradle)
             writeChildBuilds(gradle)
         }
     }
@@ -705,23 +703,8 @@ class ConfigurationCacheState(
         val gradle = build.gradle
         return withGradleIsolate(gradle, userTypesCodec) {
             // per build
-            readStartParameterOf(gradle)
             readChildBuilds()
         }
-    }
-
-    private
-    fun WriteContext.writeStartParameterOf(gradle: GradleInternal) {
-        val startParameterTaskNames = gradle.startParameter.taskNames
-        writeStrings(startParameterTaskNames)
-    }
-
-    private
-    fun ReadContext.readStartParameterOf(gradle: GradleInternal) {
-        // Restore startParameter.taskNames to enable `gradle.startParameter.setTaskNames(...)` idiom in included build scripts
-        // See org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy:134
-        val startParameterTaskNames = readStrings()
-        gradle.startParameter.setTaskNames(startParameterTaskNames)
     }
 
     private

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingCollection.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingCollection.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A generic decorator for a {@link Collection} that reports every mutating operation to an
+ * {@link Interceptor}, including mutations reached through {@link #iterator()}. Reads pass straight
+ * through. It owns the tricky mechanics (forwarding, wrapping the iterator, applying an element view,
+ * serializing as the delegate) so callers only supply the notification.
+ *
+ * @param <E> the element type
+ * @param <C> the delegate's concrete collection type, so subtypes can reach its specific methods
+ */
+public class InterceptingCollection<E, C extends Collection<E>> implements Collection<E>, Serializable {
+
+    /**
+     * Notified whenever a mutating method is called, with the source-level {@code methodSignature} of
+     * that method (e.g. {@code "add(Object)"}). A view prepends its path, e.g. {@code "keySet().clear()"}.
+     */
+    public interface Interceptor {
+        void onMutate(String methodSignature);
+    }
+
+    protected final C delegate;
+    final transient Interceptor interceptor;
+    private final transient Function<E, E> elementView;
+    private final transient boolean wrapsElements;
+
+    public InterceptingCollection(C delegate, Interceptor interceptor) {
+        this.delegate = delegate;
+        this.interceptor = interceptor;
+        this.elementView = Function.identity();
+        this.wrapsElements = false;
+    }
+
+    protected InterceptingCollection(C delegate, Interceptor interceptor, Function<E, E> elementView) {
+        this.delegate = delegate;
+        this.interceptor = interceptor;
+        this.elementView = elementView;
+        this.wrapsElements = true;
+    }
+
+    private E view(E element) {
+        return elementView.apply(element);
+    }
+
+    // Serialize as the delegate: the interceptor is runtime-only wiring and instances may be captured
+    // in task state and stored to the configuration cache.
+    protected Object writeReplace() {
+        return delegate;
+    }
+
+    // region reads
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        Iterator<E> it = delegate.iterator();
+        return new Iterator<E>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return view(it.next());
+            }
+
+            @Override
+            public void remove() {
+                interceptor.onMutate("iterator().remove()");
+                it.remove();
+            }
+        };
+    }
+
+    @Override
+    public Object[] toArray() {
+        return viewAll(delegate.toArray());
+    }
+
+    @Override
+    @SuppressWarnings("SuspiciousToArrayCall")
+    public <T> T[] toArray(T[] a) {
+        return viewAll(delegate.toArray(a));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T[] viewAll(T[] array) {
+        if (wrapsElements) {
+            for (int i = 0; i < array.length; i++) {
+                array[i] = (T) view((E) array[i]);
+            }
+        }
+        return array;
+    }
+
+    @Override
+    public Spliterator<E> spliterator() {
+        if (!wrapsElements) {
+            return delegate.spliterator();
+        }
+        // Elements are wrapped (e.g. entries whose setValue is intercepted), so stream/spliterator must
+        // hand out wrapped elements too. Route through the wrapping iterator at the cost of split quality.
+        return Spliterators.spliterator(iterator(), delegate.size(), Spliterator.DISTINCT);
+    }
+
+    @Override
+    public void forEach(Consumer<? super E> action) {
+        delegate.forEach(e -> action.accept(view(e)));
+    }
+
+    @Override
+    @SuppressWarnings("UndefinedEquals") // We're fine with having weak contract of Iterable/Collection.equals.
+    public boolean equals(@Nullable Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+    // endregion
+
+    // region mutations
+    @Override
+    public boolean add(E e) {
+        interceptor.onMutate("add(Object)");
+        return delegate.add(e);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        interceptor.onMutate("addAll(Collection)");
+        return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean remove(@Nullable Object o) {
+        interceptor.onMutate("remove(Object)");
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        interceptor.onMutate("removeAll(Collection)");
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        interceptor.onMutate("retainAll(Collection)");
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        interceptor.onMutate("removeIf(Predicate)");
+        return delegate.removeIf(filter);
+    }
+
+    @Override
+    public void clear() {
+        interceptor.onMutate("clear()");
+        delegate.clear();
+    }
+    // endregion
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingList.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingList.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.function.UnaryOperator;
+
+/**
+ * A generic {@link List} decorator over {@link InterceptingCollection}, additionally notifying the
+ * positional mutators and mutations reached through {@link #listIterator()} and {@link #subList}.
+ */
+public class InterceptingList<E> extends InterceptingCollection<E, List<E>> implements List<E> {
+
+    public InterceptingList(List<E> delegate, Interceptor interceptor) {
+        super(delegate, interceptor);
+    }
+
+    @Override
+    public E get(int index) {
+        return delegate.get(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return delegate.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return delegate.lastIndexOf(o);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        interceptor.onMutate("set(int, Object)");
+        return delegate.set(index, element);
+    }
+
+    @Override
+    public void add(int index, E element) {
+        interceptor.onMutate("add(int, Object)");
+        delegate.add(index, element);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        interceptor.onMutate("addAll(int, Collection)");
+        return delegate.addAll(index, c);
+    }
+
+    @Override
+    public E remove(int index) {
+        interceptor.onMutate("remove(int)");
+        return delegate.remove(index);
+    }
+
+    @Override
+    public void replaceAll(UnaryOperator<E> operator) {
+        interceptor.onMutate("replaceAll(UnaryOperator)");
+        delegate.replaceAll(operator);
+    }
+
+    @Override
+    public void sort(Comparator<? super E> c) {
+        interceptor.onMutate("sort(Comparator)");
+        delegate.sort(c);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        return interceptingListIterator(delegate.listIterator());
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        return interceptingListIterator(delegate.listIterator(index));
+    }
+
+    private ListIterator<E> interceptingListIterator(ListIterator<E> it) {
+        return new ListIterator<E>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return it.next();
+            }
+
+            @Override
+            public boolean hasPrevious() {
+                return it.hasPrevious();
+            }
+
+            @Override
+            public E previous() {
+                return it.previous();
+            }
+
+            @Override
+            public int nextIndex() {
+                return it.nextIndex();
+            }
+
+            @Override
+            public int previousIndex() {
+                return it.previousIndex();
+            }
+
+            @Override
+            public void remove() {
+                interceptor.onMutate("listIterator().remove()");
+                it.remove();
+            }
+
+            @Override
+            public void set(E e) {
+                interceptor.onMutate("listIterator().set(Object)");
+                it.set(e);
+            }
+
+            @Override
+            public void add(E e) {
+                interceptor.onMutate("listIterator().add(Object)");
+                it.add(e);
+            }
+        };
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        // A sublist is a live view; wrap it so its mutators notify too, with the path prefixed.
+        return new InterceptingList<>(delegate.subList(fromIndex, toIndex), sig -> interceptor.onMutate("subList()." + sig));
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingMap.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingMap.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.gradle.internal.collect.InterceptingCollection.Interceptor;
+
+/**
+ * A generic {@link Map} decorator that reports every mutating operation to an {@link Interceptor},
+ * including mutations reached through the {@code keySet()}, {@code values()} and {@code entrySet()}
+ * views and through {@link java.util.Map.Entry#setValue}. Reads pass straight through. Companion to
+ * {@link InterceptingCollection}.
+ */
+public class InterceptingMap<K, V> implements Map<K, V>, Serializable {
+
+    final Map<K, V> delegate;
+    private final transient Interceptor interceptor;
+
+    public InterceptingMap(Map<K, V> delegate, Interceptor interceptor) {
+        this.delegate = delegate;
+        this.interceptor = interceptor;
+    }
+
+    protected Object writeReplace() {
+        return delegate;
+    }
+
+    // region reads
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public @Nullable V get(Object key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        return delegate.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    @SuppressWarnings("UndefinedEquals")
+    public boolean equals(@Nullable Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+    // endregion
+
+    // region views
+    @Override
+    public Set<K> keySet() {
+        // Map views are live: removing from them removes the corresponding mappings from this map.
+        return new InterceptingSet<>(delegate.keySet(), sig -> interceptor.onMutate("keySet()." + sig));
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new InterceptingCollection<>(delegate.values(), sig -> interceptor.onMutate("values()." + sig));
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        Interceptor entrySetInterceptor = sig -> interceptor.onMutate("entrySet()." + sig);
+        Function<Entry<K, V>, Entry<K, V>> wrapEntry = entry -> interceptingEntry(entry, entrySetInterceptor);
+        return new InterceptingSet<>(delegate.entrySet(), entrySetInterceptor, wrapEntry);
+    }
+
+    private static <K, V> Entry<K, V> interceptingEntry(Entry<K, V> entry, Interceptor interceptor) {
+        return new Entry<K, V>() {
+            @Override
+            public K getKey() {
+                return entry.getKey();
+            }
+
+            @Override
+            public V getValue() {
+                return entry.getValue();
+            }
+
+            @Override
+            public V setValue(V value) {
+                interceptor.onMutate("Entry.setValue(Object)");
+                return entry.setValue(value);
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                return entry.equals(o);
+            }
+
+            @Override
+            public int hashCode() {
+                return entry.hashCode();
+            }
+
+            @Override
+            public String toString() {
+                return entry.toString();
+            }
+        };
+    }
+    // endregion
+
+    // region mutations
+    @Override
+    public @Nullable V put(K key, V value) {
+        interceptor.onMutate("put(Object, Object)");
+        return delegate.put(key, value);
+    }
+
+    @Override
+    public @Nullable V putIfAbsent(K key, V value) {
+        interceptor.onMutate("putIfAbsent(Object, Object)");
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        interceptor.onMutate("putAll(Map)");
+        delegate.putAll(m);
+    }
+
+    @Override
+    public V remove(@Nullable Object key) {
+        interceptor.onMutate("remove(Object)");
+        return delegate.remove(key);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        interceptor.onMutate("remove(Object, Object)");
+        return delegate.remove(key, value);
+    }
+
+    @Override
+    public @Nullable V replace(K key, V value) {
+        interceptor.onMutate("replace(Object, Object)");
+        return delegate.replace(key, value);
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        interceptor.onMutate("replace(Object, Object, Object)");
+        return delegate.replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        interceptor.onMutate("replaceAll(BiFunction)");
+        delegate.replaceAll(function);
+    }
+
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        interceptor.onMutate("merge(Object, Object, BiFunction)");
+        return delegate.merge(key, value, remappingFunction);
+    }
+
+    @Override
+    public @Nullable V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+        interceptor.onMutate("compute(Object, BiFunction)");
+        return delegate.compute(key, remappingFunction);
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        interceptor.onMutate("computeIfAbsent(Object, Function)");
+        return delegate.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public @Nullable V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        interceptor.onMutate("computeIfPresent(Object, BiFunction)");
+        return delegate.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public void clear() {
+        interceptor.onMutate("clear()");
+        delegate.clear();
+    }
+    // endregion
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingSet.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/InterceptingSet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A generic {@link Set} decorator over {@link InterceptingCollection}. {@code Set} adds no methods to
+ * {@code Collection}, so this only fixes the type.
+ */
+public class InterceptingSet<E> extends InterceptingCollection<E, Set<E>> implements Set<E> {
+
+    public InterceptingSet(Set<E> delegate, Interceptor interceptor) {
+        super(delegate, interceptor);
+    }
+
+    protected InterceptingSet(Set<E> delegate, Interceptor interceptor, Function<E, E> elementView) {
+        super(delegate, interceptor, elementView);
+    }
+}

--- a/platforms/core-runtime/collections/src/test/groovy/org/gradle/internal/collect/InterceptingCollectionsTest.groovy
+++ b/platforms/core-runtime/collections/src/test/groovy/org/gradle/internal/collect/InterceptingCollectionsTest.groovy
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect
+
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+class InterceptingCollectionsTest extends Specification {
+
+    def "InterceptingList notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def list = new InterceptingList<>(new ArrayList(["a", "b"]), { mutations << it })
+
+        when:
+        operation(list)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage              | operation
+        "add(Object)"                | { l -> l.add("x") }
+        "add(int, Object)"           | { l -> l.add(0, "x") }
+        "addAll(Collection)"         | { l -> l.addAll(["x"]) }
+        "addAll(int, Collection)"    | { l -> l.addAll(0, ["x"]) }
+        "set(int, Object)"           | { l -> l.set(0, "x") }
+        "remove(int)"                | { l -> l.remove(0) }
+        "remove(Object)"             | { l -> l.remove("a") }
+        "removeAll(Collection)"      | { l -> l.removeAll(["a"]) }
+        "retainAll(Collection)"      | { l -> l.retainAll(["a"]) }
+        "removeIf(Predicate)"        | { l -> l.removeIf { it == "nope" } }
+        "replaceAll(UnaryOperator)"  | { l -> l.replaceAll { it.toUpperCase() } }
+        "sort(Comparator)"           | { l -> l.sort({ x, y -> x <=> y } as Comparator) }
+        "clear()"                    | { l -> l.clear() }
+    }
+
+    def "InterceptingList does not notify on read operations"() {
+        List<String> mutations = []
+        def list = new InterceptingList<>(["a", "b"], { mutations << it })
+
+        when:
+        list.size()
+        list.isEmpty()
+        list.contains("a")
+        list.get(0)
+        list.indexOf("a")
+        list.toArray()
+        list.iterator()
+
+        then:
+        mutations.empty
+    }
+
+    def "InterceptingSet notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def set = new InterceptingSet<>(new LinkedHashSet(["a", "b"]), { mutations << it })
+
+        when:
+        operation(set)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage         | operation
+        "add(Object)"           | { s -> s.add("x") }
+        "addAll(Collection)"    | { s -> s.addAll(["x"]) }
+        "remove(Object)"        | { s -> s.remove("a") }
+        "removeAll(Collection)" | { s -> s.removeAll(["a"]) }
+        "retainAll(Collection)" | { s -> s.retainAll(["a"]) }
+        "removeIf(Predicate)"   | { s -> s.removeIf { it == "nope" } }
+        "clear()"               | { s -> s.clear() }
+    }
+
+    def "InterceptingSet does not notify on read operations"() {
+        List<String> mutations = []
+        def set = new InterceptingSet<>(new LinkedHashSet(["a", "b"]), { mutations << it })
+
+        when:
+        set.size()
+        set.isEmpty()
+        set.contains("a")
+        set.containsAll(["a"])
+        set.toArray()
+        set.iterator()
+
+        then:
+        mutations.empty
+    }
+
+    def "InterceptingMap notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def map = new InterceptingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        operation(map)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage                       | operation
+        "put(Object, Object)"                 | { m -> m.put("c", "3") }
+        "putIfAbsent(Object, Object)"         | { m -> m.putIfAbsent("c", "3") }
+        "putAll(Map)"                         | { m -> m.putAll(["c": "3"]) }
+        "remove(Object)"                      | { m -> m.remove("a") }
+        "remove(Object, Object)"              | { m -> m.remove("a", "1") }
+        "replace(Object, Object)"             | { m -> m.replace("a", "9") }
+        "replace(Object, Object, Object)"     | { m -> m.replace("a", "1", "9") }
+        "replaceAll(BiFunction)"              | { m -> m.replaceAll { k, v -> v } }
+        "merge(Object, Object, BiFunction)"   | { m -> m.merge("a", "9", { x, y -> y }) }
+        "compute(Object, BiFunction)"         | { m -> m.compute("a") { k, v -> "9" } }
+        "computeIfAbsent(Object, Function)"   | { m -> m.computeIfAbsent("c") { "9" } }
+        "computeIfPresent(Object, BiFunction)"| { m -> m.computeIfPresent("a") { k, v -> "9" } }
+        "clear()"                             | { m -> m.clear() }
+    }
+
+    def "InterceptingMap does not notify on read operations"() {
+        List<String> mutations = []
+        def map = new InterceptingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        map.size()
+        map.isEmpty()
+        map.containsKey("a")
+        map.containsValue("1")
+        map.get("a")
+        map.keySet()
+        map.values()
+        map.entrySet()
+
+        then:
+        mutations.empty
+    }
+
+    def "InterceptingList notifies on mutation through iterators and sublists"() {
+        List<String> mutations = []
+        def backing = ["a", "b", "c"]
+        def list = new InterceptingList<>(backing, { mutations << it })
+
+        when:
+        def it = list.iterator()
+        it.next()
+        it.remove()
+        then:
+        mutations == ["iterator().remove()"]
+        backing == ["b", "c"]
+
+        when:
+        mutations.clear()
+        def listIt = list.listIterator()
+        listIt.next()
+        listIt.set("x")
+        listIt.add("y")
+        listIt.previous()
+        listIt.remove()
+        then:
+        mutations == ["listIterator().set(Object)", "listIterator().add(Object)", "listIterator().remove()"]
+
+        when:
+        mutations.clear()
+        list.subList(0, 1).clear()
+        then:
+        mutations == ["subList().clear()"]
+
+        when:
+        mutations.clear()
+        list.subList(0, 1).iterator() // read-only use of a sublist
+        list.removeIf { it == "nope" }
+        then:
+        mutations == ["removeIf(Predicate)"]
+    }
+
+    def "InterceptingSet notifies on mutation through iterator and removeIf"() {
+        List<String> mutations = []
+        def backing = new LinkedHashSet(["a", "b"])
+        def set = new InterceptingSet<>(backing, { mutations << it })
+
+        when:
+        def it = set.iterator()
+        it.next()
+        it.remove()
+        then:
+        mutations == ["iterator().remove()"]
+        backing == ["b"] as Set
+
+        when:
+        mutations.clear()
+        set.removeIf { it == "nope" }
+        then:
+        mutations == ["removeIf(Predicate)"]
+    }
+
+    def "InterceptingMap notifies on mutation through its views"() {
+        List<String> mutations = []
+        def backing = ["a": "1", "b": "2", "c": "3"]
+        def map = new InterceptingMap<>(backing, { mutations << it })
+
+        when:
+        map.keySet().remove("a")
+        then:
+        mutations == ["keySet().remove(Object)"]
+        !backing.containsKey("a")
+
+        when:
+        mutations.clear()
+        def keyIt = map.keySet().iterator()
+        keyIt.next()
+        keyIt.remove()
+        then:
+        mutations == ["keySet().iterator().remove()"]
+        !backing.containsKey("b")
+
+        when:
+        mutations.clear()
+        map.values().remove("3")
+        then:
+        mutations == ["values().remove(Object)"]
+        backing.isEmpty()
+    }
+
+    def "InterceptingMap notifies on mutation through its entry set"() {
+        List<String> mutations = []
+        def backing = ["a": "1", "b": "2"]
+        def map = new InterceptingMap<>(backing, { mutations << it })
+
+        when:
+        def entryIt = map.entrySet().iterator()
+        def entry = entryIt.next()
+        entry.setValue("9")
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["a"] == "9"
+
+        when:
+        mutations.clear()
+        entryIt.remove()
+        then:
+        mutations == ["entrySet().iterator().remove()"]
+        !backing.containsKey("a")
+
+        when:
+        mutations.clear()
+        map.entrySet().forEach { it.setValue("7") }
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["b"] == "7"
+
+        when:
+        mutations.clear()
+        map.entrySet().stream().forEach { it.setValue("5") }
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["b"] == "5"
+
+        when:
+        mutations.clear()
+        map.entrySet().removeIf { it.key == "b" }
+        then:
+        mutations == ["entrySet().removeIf(Predicate)"]
+        backing.isEmpty()
+    }
+
+    def "map view reads do not notify"() {
+        List<String> mutations = []
+        def map = new InterceptingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        map.keySet().contains("a")
+        map.keySet().each { }
+        map.values().contains("1")
+        map.entrySet().each { it.key; it.value }
+        map.entrySet().stream().map { it.value }.count()
+
+        then:
+        mutations.empty
+    }
+
+    def "wrappers serialize as their delegate"() {
+        // Wrappers may be captured in task state and serialized to the configuration cache;
+        // the notification callback is runtime-only and must not be dragged along.
+        given:
+        def list = new InterceptingList<>(["a"], { })
+        def set = new InterceptingSet<>(new LinkedHashSet(["a"]), { })
+        def map = new InterceptingMap<>(["a": "1"], { })
+
+        expect:
+        javaRoundTrip(list) == ["a"]
+        javaRoundTrip(list) instanceof ArrayList
+        javaRoundTrip(set) == (["a"] as Set)
+        javaRoundTrip(set) instanceof LinkedHashSet
+        javaRoundTrip(map) == ["a": "1"]
+        javaRoundTrip(map) instanceof LinkedHashMap
+    }
+
+    private static Object javaRoundTrip(Object o) {
+        def bytes = new ByteArrayOutputStream()
+        new ObjectOutputStream(bytes).withCloseable { it.writeObject(o) }
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray())).withCloseable { it.readObject() }
+    }
+
+    def "InterceptingList notifies on mutation through positioned list iterator"() {
+        given:
+        List<String> mutations = []
+        def list = new InterceptingList<>(new ArrayList(["a", "b", "c"]), { mutations << it })
+
+        when:
+        def it = list.listIterator(1)
+        it.next()
+        it.remove()
+
+        then:
+        mutations == ["listIterator().remove()"]
+        !list.contains("b")
+    }
+
+    def "exotic map mutators delegate results and write through"() {
+        given:
+        List<String> mutations = []
+        def backing = ["a": "1"]
+        def map = new InterceptingMap<>(backing, { mutations << it })
+
+        expect:
+        map.merge("a", "2", { x, y -> x + y }) == "12"
+        backing["a"] == "12"
+        map.compute("a") { k, v -> v + "!" } == "12!"
+        backing["a"] == "12!"
+        map.computeIfAbsent("b") { "9" } == "9"
+        backing["b"] == "9"
+        map.computeIfPresent("missing") { k, v -> "x" } == null
+        !backing.containsKey("missing")
+        mutations.size() == 4
+    }
+
+    def "entrySet toArray returns wrapped entries that notify on setValue"() {
+        // The Intercepting skeleton applies the element view to toArray() too, so entries handed out
+        // this way are guarded as well — closing a gap the previous hand-rolled entry set left open.
+        given:
+        List<String> mutations = []
+        def backing = ["a": "1"]
+        def map = new InterceptingMap<>(backing, { mutations << it })
+
+        when:
+        def entry = map.entrySet().toArray()[0] as Map.Entry
+        entry.setValue("9")
+
+        then:
+        backing["a"] == "9"
+        mutations == ["entrySet().Entry.setValue(Object)"]
+    }
+
+    // Reads that are safe to inherit without overriding, since they cannot mutate the collection.
+    private static final List<String> COLLECTION_READS = ["stream()", "parallelStream()", "toArray(IntFunction)"]
+
+    // Mutating methods retrofitted onto List by Java 21's SequencedCollection. They are not overridden
+    // (the module may compile against an older Java release), but their default implementations delegate
+    // to add(int, Object) / add(Object) / remove(int), which are intercepted, so they are reported
+    // transitively. getFirst/getLast/reversed are reads.
+    private static final List<String> LIST_SEQUENCED = [
+        "addFirst(Object)", "addLast(Object)", "removeFirst()", "removeLast()", "getFirst()", "getLast()", "reversed()"
+    ]
+
+    def "every method of #interfaceType.simpleName is intercepted or a known non-mutating method of #wrapperType.simpleName"() {
+        // Locks down the interface surface so a future Java version cannot silently add a mutating
+        // method that escapes notification. Mutating methods are added to these interfaces as default
+        // methods (never abstract, to avoid breaking implementors), so they would otherwise be inherited
+        // unnoticed. When a new method appears, this test fails until someone classifies it: override it
+        // to notify if it mutates, or add it to the interface's allowlist if it is a read.
+        expect:
+        interfaceMethodSignatures(interfaceType).each { sig ->
+            assert overriddenSignatures(wrapperType).contains(sig) || knownInheritedReads.contains(sig):
+                "${interfaceType.simpleName}.$sig is neither intercepted by ${wrapperType.simpleName} " +
+                    "nor listed as a known non-mutating method. If it can mutate the collection, override " +
+                    "it so the mutation is notified; otherwise add it to this interface's allowlist."
+        }
+
+        where:
+        // The generic Intercepting* skeletons own the interception, so they are what must be complete.
+        // The iterators and the wrapped Map.Entry are anonymous inner classes of the skeletons; their
+        // mutators are covered functionally by the data-table tests above.
+        interfaceType | wrapperType             | knownInheritedReads
+        Collection    | InterceptingCollection  | COLLECTION_READS
+        Set           | InterceptingSet         | COLLECTION_READS
+        List          | InterceptingList        | COLLECTION_READS + LIST_SEQUENCED
+        Map           | InterceptingMap         | []
+    }
+
+    private static List<String> interfaceMethodSignatures(Class<?> type) {
+        type.methods
+            .findAll { !Modifier.isStatic(it.modifiers) }
+            .collect { signature(it) }
+            .unique()
+    }
+
+    private static Set<String> overriddenSignatures(Class<?> wrapperType) {
+        Set<String> result = [] as Set
+        for (Class<?> c = wrapperType; c != null && c != Object; c = c.superclass) {
+            c.declaredMethods
+                .findAll { !Modifier.isStatic(it.modifiers) && !it.synthetic }
+                .each { result << signature(it) }
+        }
+        result
+    }
+
+    private static String signature(Method m) {
+        "${m.name}(${m.parameterTypes.collect { it.simpleName }.join(', ')})"
+    }
+
+}

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -16,9 +16,9 @@
 
 package org.gradle.launcher.exec;
 
-import org.gradle.StartParameter;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -49,7 +49,7 @@ public class RootBuildLifecycleBuildActionExecutor {
     private final BuildTreeLifecycleListener lifecycleListener;
     private final ProblemsInternal problemsService;
     private final BuildOperationProgressEventEmitter eventEmitter;
-    private final StartParameter startParameter;
+    private final StartParameterInternal startParameter;
     private final ProblemStream problemsStream;
     private final BuildActionRunner buildActionRunner;
     private final BuildStateRegistry buildStateRegistry;
@@ -62,7 +62,7 @@ public class RootBuildLifecycleBuildActionExecutor {
         BuildTreeLifecycleListener lifecycleListener,
         ProblemsInternal problemsService,
         BuildOperationProgressEventEmitter eventEmitter,
-        StartParameter startParameter,
+        StartParameterInternal startParameter,
         ProblemStream problemsStream,
         BuildStateRegistry buildStateRegistry,
         BuildActionRunner buildActionRunner
@@ -98,6 +98,8 @@ public class RootBuildLifecycleBuildActionExecutor {
                 RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(action.getStartParameter(), null));
                 return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));
             } finally {
+                // Since continuous builds reuse the same StartParameter for multiple build trees.
+                startParameter.clearMutationListener();
                 lifecycleListener.beforeStop();
             }
         } finally {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -211,7 +211,7 @@ public class LauncherServices extends AbstractGradleModuleServices {
             List<ProblemReporter> problemReporters,
             BuildLoggerFactory buildLoggerFactory,
             InternalOptions options,
-            StartParameter startParameter,
+            StartParameterInternal startParameter,
             FailureFactory failureFactory,
             ProblemsInternal problemsService,
             ProblemStream problemStream,

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.launcher.exec
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.problems.internal.ProblemsInternal
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.RootBuildState
@@ -51,7 +51,7 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
             listener,
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),
-            Stub(StartParameter),
+            Stub(StartParameterInternal),
             Stub(ProblemStream),
             buildStateRegistry,
             buildActionRunner
@@ -77,7 +77,7 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
             Stub(BuildTreeLifecycleListener),
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),
-            Stub(StartParameter),
+            Stub(StartParameterInternal),
             Stub(ProblemStream),
             buildStateRegistry,
             Mock(BuildActionRunner)

--- a/platforms/core-runtime/start-parameter/build.gradle.kts
+++ b/platforms/core-runtime/start-parameter/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     api(libs.jspecify)
 
+    implementation(projects.collections)
     implementation(projects.logging)
     implementation(projects.inputTracking)
     implementation(projects.internalInstrumentationApi)

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -77,6 +77,9 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     private final DefaultLoggingConfiguration loggingConfiguration = new DefaultLoggingConfiguration();
     private final DefaultParallelismConfiguration parallelismConfiguration = new DefaultParallelismConfiguration();
+    // May be replaced or mutated by tooling model builders (e.g. during IDE sync) while parallel
+    // configuration is reading it concurrently: volatile makes the wholesale replacement by the
+    // setters safe to read, copy-on-write makes iterating the list safe during element mutation.
     private volatile List<TaskExecutionRequest> taskRequests = new CopyOnWriteArrayList<>();
     private Set<String> excludedTaskNames = new LinkedHashSet<>();
     private boolean buildProjectDependencies = true;

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -37,7 +37,11 @@ import org.gradle.initialization.DistributionInitScriptFinder;
 import org.gradle.initialization.UserHomeInitScriptFinder;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.RunDefaultTasksExecutionRequest;
+import org.gradle.internal.collect.InterceptingList;
+import org.gradle.internal.collect.InterceptingMap;
+import org.gradle.internal.collect.InterceptingSet;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.deprecation.StartParameterDeprecations;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
@@ -52,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.Collections.emptyList;
 
@@ -61,6 +66,7 @@ import static java.util.Collections.emptyList;
  *
  * <p>You can obtain an instance of a {@code StartParameter} by either creating a new one, or duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
  */
+@HasInternalProtocol
 public class StartParameter implements LoggingConfiguration, ParallelismConfiguration, Serializable {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = BuildLayoutParameters.GRADLE_USER_HOME_PROPERTY_KEY;
 
@@ -71,7 +77,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     private final DefaultLoggingConfiguration loggingConfiguration = new DefaultLoggingConfiguration();
     private final DefaultParallelismConfiguration parallelismConfiguration = new DefaultParallelismConfiguration();
-    private List<TaskExecutionRequest> taskRequests = new ArrayList<>();
+    private volatile List<TaskExecutionRequest> taskRequests = new CopyOnWriteArrayList<>();
     private Set<String> excludedTaskNames = new LinkedHashSet<>();
     private boolean buildProjectDependencies = true;
     private File currentDir;
@@ -107,6 +113,18 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private WelcomeMessageConfiguration welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.ONCE);
 
     /**
+     * Hook invoked by every setter when this start parameter is mutated. It is intentionally a no-op
+     * here: a plain {@code StartParameter} is a freely mutable value object, and this module knows
+     * nothing about how a mutation should be reported. {@code StartParameterInternal} overrides it to
+     * notify a listener, but only the running build's own start parameter has such a listener armed
+     * (after settings have been evaluated), so detached or user-constructed copies stay silent.
+     *
+     * @param methodSignature the source-level signature of the setter that was called
+     */
+    protected void onMutableCall(String methodSignature) {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -119,6 +137,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setLogLevel(LogLevel logLevel) {
+        onMutableCall("setLogLevel(LogLevel)");
         loggingConfiguration.setLogLevel(logLevel);
     }
 
@@ -135,6 +154,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setShowStacktrace(ShowStacktrace showStacktrace) {
+        onMutableCall("setShowStacktrace(ShowStacktrace)");
         loggingConfiguration.setShowStacktrace(showStacktrace);
     }
 
@@ -159,6 +179,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setConsoleOutput(ConsoleOutput consoleOutput) {
+        onMutableCall("setConsoleOutput(ConsoleOutput)");
         loggingConfiguration.setConsoleOutput(consoleOutput);
     }
 
@@ -167,6 +188,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setConsoleUnicodeSupport(ConsoleUnicodeSupport unicodeSupport) {
+        onMutableCall("setConsoleUnicodeSupport(ConsoleUnicodeSupport)");
         loggingConfiguration.setConsoleUnicodeSupport(unicodeSupport);
     }
 
@@ -191,6 +213,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setNonInteractive(boolean nonInteractive) {
+        onMutableCall("setNonInteractive(boolean)");
         this.loggingConfiguration.setNonInteractive(nonInteractive);
     }
 
@@ -199,6 +222,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setWarningMode(WarningMode warningMode) {
+        onMutableCall("setWarningMode(WarningMode)");
         loggingConfiguration.setWarningMode(warningMode);
     }
 
@@ -206,6 +230,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Sets the project's cache location. Set to null to use the default location.
      */
     public void setProjectCacheDir(@Nullable File projectCacheDir) {
+        onMutableCall("setProjectCacheDir(File)");
         this.projectCacheDir = projectCacheDir;
     }
 
@@ -257,7 +282,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;
-        p.taskRequests = new ArrayList<>(taskRequests);
+        p.taskRequests = new CopyOnWriteArrayList<>(taskRequests);
         p.excludedTaskNames = new LinkedHashSet<>(excludedTaskNames);
         p.buildProjectDependencies = buildProjectDependencies;
         p.currentDir = currentDir;
@@ -354,7 +379,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return the tasks to execute in this build. Never returns null.
      */
     public List<TaskExecutionRequest> getTaskRequests() {
-        return taskRequests;
+        return new InterceptingList<>(taskRequests, sig -> onMutableCall("getTaskRequests()." + sig));
     }
 
     /**
@@ -364,7 +389,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param taskParameters the tasks to execute in this build.
      */
     public void setTaskRequests(Iterable<? extends TaskExecutionRequest> taskParameters) {
-        this.taskRequests = Lists.newArrayList(taskParameters);
+        this.taskRequests = new CopyOnWriteArrayList<>(Lists.newArrayList(taskParameters));
     }
 
     /**
@@ -373,7 +398,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return The names of the excluded tasks. Returns an empty set if there are no such tasks.
      */
     public Set<String> getExcludedTaskNames() {
-        return excludedTaskNames;
+        return new InterceptingSet<>(excludedTaskNames, sig -> onMutableCall("getExcludedTaskNames()." + sig));
     }
 
     /**
@@ -382,6 +407,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param excludedTaskNames The task names.
      */
     public void setExcludedTaskNames(Iterable<String> excludedTaskNames) {
+        onMutableCall("setExcludedTaskNames(Iterable)");
         this.excludedTaskNames = Sets.newLinkedHashSet(excludedTaskNames);
     }
 
@@ -400,6 +426,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param currentDir The directory. Set to null to use the default.
      */
     public void setCurrentDir(@Nullable File currentDir) {
+        onMutableCall("setCurrentDir(File)");
         if (currentDir != null) {
             this.currentDir = FileUtils.canonicalize(currentDir);
         } else {
@@ -415,7 +442,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return map of properties
      */
     public Map<String, String> getProjectProperties() {
-        return projectProperties;
+        return new InterceptingMap<>(projectProperties, sig -> onMutableCall("getProjectProperties()." + sig));
     }
 
     /**
@@ -426,6 +453,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param projectProperties new map of properties
      */
     public void setProjectProperties(Map<String, String> projectProperties) {
+        onMutableCall("setProjectProperties(Map)");
         this.projectProperties = projectProperties;
     }
 
@@ -438,7 +466,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return map of properties
      */
     public Map<String, String> getSystemPropertiesArgs() {
-        return systemPropertiesArgs;
+        return new InterceptingMap<>(systemPropertiesArgs, sig -> onMutableCall("getSystemPropertiesArgs()." + sig));
     }
 
     /**
@@ -449,6 +477,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param systemPropertiesArgs new map of properties
      */
     public void setSystemPropertiesArgs(Map<String, String> systemPropertiesArgs) {
+        onMutableCall("setSystemPropertiesArgs(Map)");
         this.systemPropertiesArgs = systemPropertiesArgs;
     }
 
@@ -467,6 +496,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param gradleUserHomeDir The home directory. May be null.
      */
     public void setGradleUserHomeDir(@Nullable File gradleUserHomeDir) {
+        onMutableCall("setGradleUserHomeDir(File)");
         this.gradleUserHomeDir = gradleUserHomeDir == null ? new BuildLayoutParameters().getGradleUserHomeDir() : FileUtils.canonicalize(gradleUserHomeDir);
     }
 
@@ -483,6 +513,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return this
      */
     public StartParameter setBuildProjectDependencies(boolean build) {
+        onMutableCall("setBuildProjectDependencies(boolean)");
         this.buildProjectDependencies = build;
         return this;
     }
@@ -502,6 +533,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param dryRun true if the build should run as a dry-run
      */
     public void setDryRun(boolean dryRun) {
+        onMutableCall("setDryRun(boolean)");
         this.dryRun = dryRun;
     }
 
@@ -511,6 +543,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param initScriptFile The init scripts.
      */
     public void addInitScript(File initScriptFile) {
+        onMutableCall("addInitScript(File)");
         initScripts.add(initScriptFile);
     }
 
@@ -520,6 +553,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param initScripts The init scripts.
      */
     public void setInitScripts(List<File> initScripts) {
+        onMutableCall("setInitScripts(List)");
         this.initScripts = initScripts;
     }
 
@@ -555,6 +589,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param projectDir The project directory. May be null.
      */
     public void setProjectDir(@Nullable File projectDir) {
+        onMutableCall("setProjectDir(File)");
         if (projectDir == null) {
             setCurrentDir(null);
             this.projectDir = null;
@@ -583,6 +618,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param profile true if a profile report should be generated
      */
     public void setProfile(boolean profile) {
+        onMutableCall("setProfile(boolean)");
         this.profile = profile;
     }
 
@@ -604,6 +640,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the build should continue on task failure. The default is false.
      */
     public void setContinueOnFailure(boolean continueOnFailure) {
+        onMutableCall("setContinueOnFailure(boolean)");
         this.continueOnFailure = continueOnFailure;
     }
 
@@ -618,6 +655,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the build should be performed offline (ie without network access).
      */
     public void setOffline(boolean offline) {
+        onMutableCall("setOffline(boolean)");
         this.offline = offline;
     }
 
@@ -632,6 +670,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the dependencies should be refreshed..
      */
     public void setRefreshDependencies(boolean refreshDependencies) {
+        onMutableCall("setRefreshDependencies(boolean)");
         this.refreshDependencies = refreshDependencies;
     }
 
@@ -646,6 +685,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the cached task results should be ignored and each task should be forced to be executed.
      */
     public void setRerunTasks(boolean rerunTasks) {
+        onMutableCall("setRerunTasks(boolean)");
         this.rerunTasks = rerunTasks;
     }
 
@@ -664,6 +704,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 9.1.0
      */
     public void setTaskGraph(boolean taskGraph) {
+        onMutableCall("setTaskGraph(boolean)");
         this.taskGraph = taskGraph;
     }
 
@@ -680,6 +721,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setParallelProjectExecutionEnabled(boolean parallelProjectExecution) {
+        onMutableCall("setParallelProjectExecutionEnabled(boolean)");
         parallelismConfiguration.setParallelProjectExecutionEnabled(parallelProjectExecution);
     }
 
@@ -698,6 +740,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.5
      */
     public void setBuildCacheEnabled(boolean buildCacheEnabled) {
+        onMutableCall("setBuildCacheEnabled(boolean)");
         this.buildCacheEnabled = buildCacheEnabled;
     }
 
@@ -716,6 +759,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.6
      */
     public void setBuildCacheDebugLogging(boolean buildCacheDebugLogging) {
+        onMutableCall("setBuildCacheDebugLogging(boolean)");
         this.buildCacheDebugLogging = buildCacheDebugLogging;
     }
 
@@ -732,6 +776,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setMaxWorkerCount(int maxWorkerCount) {
+        onMutableCall("setMaxWorkerCount(int)");
         parallelismConfiguration.setMaxWorkerCount(maxWorkerCount);
     }
 
@@ -791,11 +836,13 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Package scope for testing purposes.
      */
     void setGradleHomeDir(File gradleHomeDir) {
+        onMutableCall("setGradleHomeDir(File)");
         this.gradleHomeDir = gradleHomeDir;
     }
 
     @Incubating
     public void setConfigureOnDemand(boolean configureOnDemand) {
+        onMutableCall("setConfigureOnDemand(boolean)");
         this.configureOnDemand = configureOnDemand;
     }
 
@@ -804,14 +851,17 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     }
 
     public void setContinuous(boolean enabled) {
+        onMutableCall("setContinuous(boolean)");
         this.continuous = enabled;
     }
 
     public void includeBuild(File includedBuild) {
+        onMutableCall("includeBuild(File)");
         includedBuilds.add(includedBuild);
     }
 
     public void setIncludedBuilds(List<File> includedBuilds) {
+        onMutableCall("setIncludedBuilds(List)");
         this.includedBuilds = includedBuilds;
     }
 
@@ -834,6 +884,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.4
      */
     public void setBuildScan(boolean buildScan) {
+        onMutableCall("setBuildScan(boolean)");
         this.buildScan = buildScan;
     }
 
@@ -852,6 +903,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.4
      */
     public void setNoBuildScan(boolean noBuildScan) {
+        onMutableCall("setNoBuildScan(boolean)");
         this.noBuildScan = noBuildScan;
     }
 
@@ -861,6 +913,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public void setWriteDependencyLocks(boolean writeDependencyLocks) {
+        onMutableCall("setWriteDependencyLocks(boolean)");
         this.writeDependencyLocks = writeDependencyLocks;
     }
 
@@ -882,6 +935,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public void setLockedDependenciesToUpdate(List<String> lockedDependenciesToUpdate) {
+        onMutableCall("setLockedDependenciesToUpdate(List)");
         this.lockedDependenciesToUpdate = Lists.newArrayList(lockedDependenciesToUpdate);
         this.writeDependencyLocks = true;
     }
@@ -895,7 +949,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.1
      */
     public List<String> getWriteDependencyVerifications() {
-        return writeDependencyVerifications;
+        return new InterceptingList<>(writeDependencyVerifications, sig -> onMutableCall("getWriteDependencyVerifications()." + sig));
     }
 
     /**
@@ -906,6 +960,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.1
      */
     public void setWriteDependencyVerifications(List<String> checksums) {
+        onMutableCall("setWriteDependencyVerifications(List)");
         this.writeDependencyVerifications = checksums;
     }
 
@@ -916,7 +971,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public List<String> getLockedDependenciesToUpdate() {
-        return lockedDependenciesToUpdate;
+        return new InterceptingList<>(lockedDependenciesToUpdate, sig -> onMutableCall("getLockedDependenciesToUpdate()." + sig));
     }
 
     /**
@@ -932,6 +987,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setDependencyVerificationMode(DependencyVerificationMode verificationMode) {
+        onMutableCall("setDependencyVerificationMode(DependencyVerificationMode)");
         this.verificationMode = verificationMode;
     }
 
@@ -951,6 +1007,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setRefreshKeys(boolean refresh) {
+        onMutableCall("setRefreshKeys(boolean)");
         refreshKeys = refresh;
     }
 
@@ -988,6 +1045,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setExportKeys(boolean exportKeys) {
+        onMutableCall("setExportKeys(boolean)");
         this.exportKeys = exportKeys;
     }
 
@@ -1012,6 +1070,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Incubating
     public void setWelcomeMessageConfiguration(WelcomeMessageConfiguration welcomeMessageConfiguration) {
+        onMutableCall("setWelcomeMessageConfiguration(WelcomeMessageConfiguration)");
         this.welcomeMessageConfiguration = welcomeMessageConfiguration;
     }
 

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class StartParameterInternal extends StartParameter {
     private WatchMode watchFileSystemMode = WatchMode.DEFAULT;
@@ -62,12 +63,34 @@ public class StartParameterInternal extends StartParameter {
     private Option.Value<Boolean> parallelToolingModelBuilding = Option.Value.defaultValue(false);
     private @Nullable String develocityUrl;
     private @Nullable String develocityPluginVersion;
+    // Runtime-only wiring, deliberately transient: a StartParameter captured in task state must be
+    // serializable to the configuration cache without dragging the listener (and its services) along.
+    private transient @Nullable Consumer<String> mutationListener;
 
     public StartParameterInternal() {
     }
 
     protected StartParameterInternal(BuildLayoutParameters layoutParameters) {
         super(layoutParameters);
+    }
+
+    public void setMutationListener(Consumer<String> mutationListener) {
+        if (this.mutationListener != null) {
+            throw new IllegalStateException("Mutation listener already set on StartParameterInternal");
+        }
+        this.mutationListener = mutationListener;
+    }
+
+    public void clearMutationListener() {
+        this.mutationListener = null;
+    }
+
+    @Override
+    protected void onMutableCall(String methodSignature) {
+        Consumer<String> listener = this.mutationListener;
+        if (listener != null) {
+            listener.accept(methodSignature);
+        }
     }
 
     @Override
@@ -132,6 +155,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setGradleHomeDir(File gradleHomeDir) {
+        onMutableCall("setGradleHomeDir(File)");
         this.gradleHomeDir = gradleHomeDir;
     }
 
@@ -140,6 +164,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void doNotSearchUpwards() {
+        onMutableCall("doNotSearchUpwards()");
         this.searchUpwards = false;
     }
 
@@ -148,6 +173,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void useEmptySettings() {
+        onMutableCall("useEmptySettings()");
         this.useEmptySettings = true;
     }
 
@@ -156,6 +182,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setWatchFileSystemMode(WatchMode watchFileSystemMode) {
+        onMutableCall("setWatchFileSystemMode(WatchMode)");
         this.watchFileSystemMode = watchFileSystemMode;
     }
 
@@ -164,6 +191,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setVfsVerboseLogging(boolean vfsVerboseLogging) {
+        onMutableCall("setVfsVerboseLogging(boolean)");
         this.vfsVerboseLogging = vfsVerboseLogging;
     }
 
@@ -177,6 +205,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCache(Option.Value<Boolean> configurationCache) {
+        onMutableCall("setConfigurationCache(Option.Value)");
         this.configurationCache = configurationCache;
     }
 
@@ -192,6 +221,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setIsolatedProjects(Option.Value<Boolean> isolatedProjects) {
+        onMutableCall("setIsolatedProjects(Option.Value)");
         this.isolatedProjects = isolatedProjects;
     }
 
@@ -200,6 +230,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value configurationCacheProblems) {
+        onMutableCall("setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value)");
         this.configurationCacheProblems = configurationCacheProblems;
     }
 
@@ -208,6 +239,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheDebug(boolean configurationCacheDebug) {
+        onMutableCall("setConfigurationCacheDebug(boolean)");
         this.configurationCacheDebug = configurationCacheDebug;
     }
 
@@ -216,10 +248,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheIgnoreInputsDuringStore(boolean ignoreInputsDuringStore) {
+        onMutableCall("setConfigurationCacheIgnoreInputsDuringStore(boolean)");
         configurationCacheIgnoreInputsDuringStore = ignoreInputsDuringStore;
     }
 
     public void setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(boolean configurationCacheIgnoreUnsupportedBuildEventsListeners) {
+        onMutableCall("setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(boolean)");
         this.configurationCacheIgnoreUnsupportedBuildEventsListeners = configurationCacheIgnoreUnsupportedBuildEventsListeners;
     }
 
@@ -232,6 +266,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheParallel(boolean parallel) {
+        onMutableCall("setConfigurationCacheParallel(boolean)");
         this.configurationCacheParallel = parallel;
     }
 
@@ -240,6 +275,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheReadOnly(boolean readOnly) {
+        onMutableCall("setConfigurationCacheReadOnly(boolean)");
         this.configurationCacheReadOnly = readOnly;
     }
 
@@ -248,6 +284,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheEntriesPerKey(int configurationCacheEntriesPerKey) {
+        onMutableCall("setConfigurationCacheEntriesPerKey(int)");
         this.configurationCacheEntriesPerKey = configurationCacheEntriesPerKey;
     }
 
@@ -256,6 +293,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheMaxProblems(int configurationCacheMaxProblems) {
+        onMutableCall("setConfigurationCacheMaxProblems(int)");
         this.configurationCacheMaxProblems = configurationCacheMaxProblems;
     }
 
@@ -265,6 +303,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheIgnoredFileSystemCheckInputs(@Nullable String configurationCacheIgnoredFileSystemCheckInputs) {
+        onMutableCall("setConfigurationCacheIgnoredFileSystemCheckInputs(String)");
         this.configurationCacheIgnoredFileSystemCheckInputs = configurationCacheIgnoredFileSystemCheckInputs;
     }
 
@@ -273,6 +312,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheRecreateCache(boolean configurationCacheRecreateCache) {
+        onMutableCall("setConfigurationCacheRecreateCache(boolean)");
         this.configurationCacheRecreateCache = configurationCacheRecreateCache;
     }
 
@@ -281,10 +321,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheQuiet(boolean configurationCacheQuiet) {
+        onMutableCall("setConfigurationCacheQuiet(boolean)");
         this.configurationCacheQuiet = configurationCacheQuiet;
     }
 
     public void setConfigurationCacheIntegrityCheckEnabled(boolean configurationCacheIntegrityCheck) {
+        onMutableCall("setConfigurationCacheIntegrityCheckEnabled(boolean)");
         this.configurationCacheIntegrityCheckEnabled = configurationCacheIntegrityCheck;
     }
 
@@ -293,6 +335,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheHeapDumpDir(@Nullable String configurationCacheHeapDumpDir) {
+        onMutableCall("setConfigurationCacheHeapDumpDir(String)");
         this.configurationCacheHeapDumpDir = configurationCacheHeapDumpDir;
     }
 
@@ -301,6 +344,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheFineGrainedPropertyTracking(boolean configurationCacheFineGrainedPropertyTracking) {
+        onMutableCall("setConfigurationCacheFineGrainedPropertyTracking(boolean)");
         this.configurationCacheFineGrainedPropertyTracking = configurationCacheFineGrainedPropertyTracking;
     }
 
@@ -313,6 +357,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setIsolatedProjectsDiagnostics(boolean isolatedProjectsDiagnostics) {
+        onMutableCall("setIsolatedProjectsDiagnostics(boolean)");
         this.isolatedProjectsDiagnostics = isolatedProjectsDiagnostics;
     }
 
@@ -321,10 +366,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setIsolatedProjectsDangerouslyIgnoreProblems(boolean isolatedProjectsDangerouslyIgnoreProblems) {
+        onMutableCall("setIsolatedProjectsDangerouslyIgnoreProblems(boolean)");
         this.isolatedProjectsDangerouslyIgnoreProblems = isolatedProjectsDangerouslyIgnoreProblems;
     }
 
     public void setContinuousBuildQuietPeriod(Duration continuousBuildQuietPeriod) {
+        onMutableCall("setContinuousBuildQuietPeriod(Duration)");
         this.continuousBuildQuietPeriod = continuousBuildQuietPeriod;
     }
 
@@ -337,10 +384,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setPropertyUpgradeReportEnabled(boolean propertyUpgradeReportEnabled) {
+        onMutableCall("setPropertyUpgradeReportEnabled(boolean)");
         this.propertyUpgradeReportEnabled = propertyUpgradeReportEnabled;
     }
 
     public void enableProblemReportGeneration(boolean enableProblemReportGeneration) {
+        onMutableCall("enableProblemReportGeneration(boolean)");
         this.enableProblemReportGeneration = enableProblemReportGeneration;
     }
 
@@ -353,6 +402,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDaemonJvmCriteriaConfigured(boolean daemonJvmCriteriaConfigured) {
+        onMutableCall("setDaemonJvmCriteriaConfigured(boolean)");
         this.daemonJvmCriteriaConfigured = daemonJvmCriteriaConfigured;
     }
 
@@ -361,6 +411,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setParallelToolingModelBuilding(Option.Value<Boolean> parallelToolingModelBuilding) {
+        onMutableCall("setParallelToolingModelBuilding(Option.Value)");
         this.parallelToolingModelBuilding = parallelToolingModelBuilding;
     }
 
@@ -370,6 +421,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDevelocityUrl(@Nullable String develocityUrl) {
+        onMutableCall("setDevelocityUrl(String)");
         this.develocityUrl = develocityUrl;
     }
 
@@ -379,6 +431,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDevelocityPluginVersion(@Nullable String develocityPluginVersion) {
+        onMutableCall("setDevelocityPluginVersion(String)");
         this.develocityPluginVersion = develocityPluginVersion;
     }
 

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterMutationInstrumentationTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterMutationInstrumentationTest.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal
+
+import org.gradle.StartParameter
+import org.gradle.internal.buildoption.Option
+import spock.lang.Specification
+
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.time.Duration
+
+/**
+ * Verifies that every mutating method of {@link StartParameter} and {@link StartParameterInternal} is
+ * instrumented to notify the mutation listener (via {@code onMutableCall}). Reflection makes this an
+ * instrumentation-completeness check: a newly added setter that forgets the hook fails this test, with
+ * no table to remember to update.
+ */
+class StartParameterMutationInstrumentationTest extends Specification {
+
+    // Mutators that deliberately do not notify, plus the listener-wiring method itself (a setter by name).
+    private static final Set<String> NOT_NOTIFYING = [
+        // Task requests are exempt from violation reporting for now: tooling model builders still
+        // legitimately replace the tasks to run while the build is already running.
+        "setTaskNames(Iterable)",
+        "setTaskRequests(Iterable)",
+        // Infrastructure for installing the listener, not tracked state.
+        "setMutationListener(Consumer)",
+    ] as Set
+
+    def "every mutating method of StartParameter(Internal) notifies the mutation listener"() {
+        given:
+        def notified = []
+        def parameter = new StartParameterInternal()
+        parameter.setMutationListener { notified << it }
+
+        expect:
+        // Guard against the reflective enumeration silently matching nothing (a vacuous pass).
+        def methods = mutatingMethods()
+        println "Checking ${methods.size()} mutating methods for onMutableCall instrumentation"
+        methods.size() >= 30
+
+        and:
+        methods.each { method ->
+            notified.clear()
+            try {
+                method.invoke(parameter, argumentsFor(method))
+            } catch (InvocationTargetException ignored) {
+                // A setter may validate its argument and throw; that is fine as long as the mutation hook
+                // has already fired, since the contract is "notify first, then mutate".
+            }
+            assert !notified.isEmpty():
+                "${signature(method)} does not call onMutableCall(). Instrument it, or if the mutation " +
+                    "is intentionally not reported, add it to NOT_NOTIFYING."
+        }
+    }
+
+    private static List<Method> mutatingMethods() {
+        (StartParameter.methods.toList() + StartParameterInternal.methods.toList())
+            .findAll { isCandidateMutator(it) }
+            .unique { signature(it) }
+            .findAll { !NOT_NOTIFYING.contains(signature(it)) }
+            .sort { signature(it) }
+    }
+
+    private static boolean isCandidateMutator(Method m) {
+        if (Modifier.isStatic(m.modifiers) || m.synthetic) {
+            return false
+        }
+        m.name.startsWith("set") ||
+            m.name.startsWith("add") ||
+            m.name in ["doNotSearchUpwards", "useEmptySettings", "includeBuild", "enableProblemReportGeneration"]
+    }
+
+    private static Object[] argumentsFor(Method m) {
+        m.parameterTypes.collect { sampleValue(it) } as Object[]
+    }
+
+    private static Object sampleValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false
+        }
+        if (type == int.class) {
+            return 1
+        }
+        if (type == File.class) {
+            return new File(".")
+        }
+        if (type == String.class) {
+            return ""
+        }
+        if (type == Duration.class) {
+            return Duration.ZERO
+        }
+        if (type == Option.Value.class) {
+            return Option.Value.defaultValue(false)
+        }
+        if (type.isEnum()) {
+            return type.enumConstants[0]
+        }
+        if (Map.isAssignableFrom(type)) {
+            return [:]
+        }
+        if (Iterable.isAssignableFrom(type)) {
+            return []
+        }
+        if (type.isPrimitive()) {
+            throw new IllegalArgumentException("No sample value for primitive ${type.name}; extend sampleValue()")
+        }
+        // Any other reference type: null is enough, since onMutableCall fires before the argument is used
+        // and we tolerate the setter throwing afterwards.
+        return null
+    }
+
+    private static String signature(Method m) {
+        "${m.name}(${m.parameterTypes.collect { it.simpleName }.join(', ')})"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/features/internal/initialization/SharedModelDefaultsSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/features/internal/initialization/SharedModelDefaultsSettingsProcessor.java
@@ -16,7 +16,7 @@
 
 package org.gradle.features.internal.initialization;
 
-import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
@@ -33,7 +33,7 @@ public class SharedModelDefaultsSettingsProcessor implements SettingsProcessor {
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameter startParameter) {
+    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
         SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         SettingsInternal settings = state.getSettings();
         ((SharedModelDefaultsInternal)settings.getDefaults()).processRegistrations();

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization;
 
-import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -42,7 +42,7 @@ public class BuildOperationSettingsProcessor implements SettingsProcessor {
     }
 
     @Override
-    public SettingsState process(final GradleInternal gradle, final SettingsLocation settingsLocation, final ClassLoaderScope buildRootClassLoaderScope, final StartParameter startParameter) {
+    public SettingsState process(final GradleInternal gradle, final SettingsLocation settingsLocation, final ClassLoaderScope buildRootClassLoaderScope, final StartParameterInternal startParameter) {
         return buildOperationRunner.call(new CallableBuildOperation<SettingsState>() {
             @Override
             public SettingsState call(BuildOperationContext context) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -273,9 +273,9 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
         return startParameter.getProjectDir() != null && loadedSettings.getSettingsDir().equals(startParameter.getProjectDir());
     }
 
-    private SettingsState createEmptySettings(GradleInternal gradle, StartParameter startParameter, ClassLoaderScope classLoaderScope) {
+    private SettingsState createEmptySettings(GradleInternal gradle, StartParameterInternal startParameter, ClassLoaderScope classLoaderScope) {
         logger.debug("Creating empty settings for build: '{}'", gradle.getIdentityPath());
-        StartParameterInternal noSearchParameter = (StartParameterInternal) startParameter.newInstance();
+        StartParameterInternal noSearchParameter = startParameter.newInstance();
         noSearchParameter.useEmptySettings();
         noSearchParameter.doNotSearchUpwards();
         BuildLayout layout = buildLayoutFactory.getLayoutFor(noSearchParameter.toBuildLayoutConfiguration());
@@ -289,7 +289,7 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
      */
     private SettingsState findSettingsAndLoadIfAppropriate(
         GradleInternal gradle,
-        StartParameter startParameter,
+        StartParameterInternal startParameter,
         BuildLayout buildLayout,
         ClassLoaderScope classLoaderScope
     ) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization;
 
-import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
@@ -43,7 +43,7 @@ public class RootBuildCacheControllerSettingsProcessor implements SettingsProces
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameter startParameter) {
+    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
         SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         process(gradle);
         return state;

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization;
 
-import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
@@ -60,7 +60,7 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
         GradleInternal gradle,
         SettingsLocation settingsLocation,
         ClassLoaderScope baseClassLoaderScope,
-        StartParameter startParameter
+        StartParameterInternal startParameter
     ) {
         Timer settingsProcessingClock = Time.startTimer();
         TextResourceScriptSource settingsScript = new TextResourceScriptSource(textFileResourceLoader.loadFile("settings file", settingsLocation.getSettingsFile()));

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -16,25 +16,39 @@
 
 package org.gradle.initialization;
 
-import org.gradle.StartParameter;
+import kotlin.Unit;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
 
 public class SettingsEvaluatedCallbackFiringSettingsProcessor implements SettingsProcessor {
 
     private final SettingsProcessor delegate;
+    private final IsolatedProjectsProblemsReporter problems;
 
-    public SettingsEvaluatedCallbackFiringSettingsProcessor(SettingsProcessor delegate) {
+    public SettingsEvaluatedCallbackFiringSettingsProcessor(SettingsProcessor delegate, IsolatedProjectsProblemsReporter problems) {
         this.delegate = delegate;
+        this.problems = problems;
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameter startParameter) {
+    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
         SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         SettingsInternal settings = state.getSettings();
         gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
         settings.preventFromFurtherMutation();
+        startParameter.setMutationListener(methodSignature ->
+            problems.report(factory ->
+                factory.problem(null, messageBuilder -> {
+                    messageBuilder.text(
+                        "Cannot call '" + methodSignature + "' on StartParameter after settings have been evaluated when Isolated Projects is enabled."
+                    );
+                    return Unit.INSTANCE;
+                }).exception().build()
+            )
+        );
         return state;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsProcessor.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.initialization;
 
-import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
@@ -34,6 +34,6 @@ public interface SettingsProcessor {
         GradleInternal gradle,
         SettingsLocation settingsLocation,
         ClassLoaderScope buildRootClassLoaderScope,
-        StartParameter startParameter
+        StartParameterInternal startParameter
     );
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -626,7 +626,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         GradleProperties gradleProperties,
         BuildOperationRunner buildOperationRunner,
         TextFileResourceLoader textFileResourceLoader,
-        BuildIncludeListener buildIncludeListener
+        BuildIncludeListener buildIncludeListener,
+        IsolatedProjectsProblemsReporter isolatedProjectsProblemsReporter
     ) {
         return new BuildOperationSettingsProcessor(
             new RootBuildCacheControllerSettingsProcessor(
@@ -642,7 +643,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
                             gradleProperties,
                             textFileResourceLoader,
                             buildIncludeListener
-                        )
+                        ),
+                        isolatedProjectsProblemsReporter
                     )
                 )
             ),

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
@@ -32,7 +32,7 @@ class BuildOperationSettingsProcessorTest extends Specification {
     def settingsLocation = Mock(SettingsLocation)
     def buildOperationScriptPlugin = new BuildOperationSettingsProcessor(settingsProcessor, buildOperationRunner)
     def classLoaderScope = Mock(ClassLoaderScope)
-    def startParameter = Mock(StartParameter)
+    def startParameter = Mock(StartParameterInternal)
     def state = Mock(SettingsState)
     def settingsInternal = Mock(SettingsInternal)
     def rootDir = new File("root")

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.onMutableCall(java.lang.String)",
+            "acceptation": "We don't want to advertise this new API. It can only be used if you derive from it and the only accepted derived class is \"StartParameterInternal\"",
+            "changes": []
+        }
+    ]
 }


### PR DESCRIPTION
IP violations are not emitted when mutating StartParameter after settings for a build has completed evaluation. This is the same instant where we prevent some state on settings from being mutated.

Perhaps we should do this earlier, after init scripts are evaluated, but this is a reasonable instant for now.

We achieve this by having StartParameterInternal store a listener to be called whenever its state is mutated. We set this listener after settings are evaluated to a callback which emits violations.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
