### PR TITLE
Compare canonical paths in FileLock.isLockFile

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -229,7 +229,22 @@ public class DefaultFileLockManager implements FileLockManager {
 
         @Override
         public boolean isLockFile(File file) {
-            return file.equals(lockFile);
+            if (file.equals(lockFile)) {
+                return true;
+            }
+            // The same physical lock file may be reachable via different path strings
+            // (symlinks, junctions, Windows `subst`-aliased drives). Fall back to a
+            // canonical-path comparison so the lock-file identity check survives that.
+            // Short-circuit on filename first to avoid filesystem I/O on entries that
+            // obviously cannot be the lock file.
+            if (!file.getName().equals(lockFile.getName())) {
+                return false;
+            }
+            try {
+                return file.getCanonicalFile().equals(lockFile.getCanonicalFile());
+            } catch (IOException e) {
+                return false;
+            }
         }
 
         @Override

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
@@ -141,6 +141,32 @@ abstract class AbstractFileLockManagerTest extends Specification {
         lockMode << [Exclusive, Shared]
     }
 
+    @Requires(FileSystemTestPreconditions.Symlinks)
+    def "isLockFile recognizes the lock file via a different path that resolves to the same canonical file"() {
+        // Simulates the Windows `subst` aliased-drive scenario: the same physical
+        // lock file is reachable via two distinct File paths (e.g. C:\... vs P:\...).
+        // On POSIX we approximate via a symlinked alias directory.
+        given:
+        def aliasDir = tmpDir.file("aliased").createDir()
+        def aliasParent = aliasDir.file(tmpDir.testDirectory.name).createLink(tmpDir.testDirectory)
+        def aliasedLockFile = new File(aliasParent, testFile.name + ".lock")
+        def unrelatedLockFile = tmpDir.file("unrelated.lock")
+
+        when:
+        def lock = createLock(lockMode)
+
+        then:
+        lock.isLockFile(testFileLock)
+        lock.isLockFile(aliasedLockFile)
+        !lock.isLockFile(unrelatedLockFile)
+
+        cleanup:
+        lock?.close()
+
+        where:
+        lockMode << [Exclusive, Shared]
+    }
+
     def "can lock a file after it has been closed"() {
         given:
         def fileLock = createLock(Exclusive)


### PR DESCRIPTION
## Summary

`DefaultFileLockManager$DefaultFileLock.isLockFile` compared paths with
`File.equals`, a structural path-string comparison. When the cache
directory is reachable via a path that differs from the stored lock
file path but resolves to the same physical location — symlinks,
junctions, or a Windows `subst`-aliased drive — two `File` instances
for the same lock file are not equal.

`DefaultPersistentDirectoryCache$Initializer.initialize` then failed to
skip the still-held lock file during re-initialization cleanup and
tried to delete it:

    java.io.IOException: Cannot delete file: ...lock

## Fix

Fall back to a canonical-path comparison when the fast `File.equals`
check fails, with a filename short-circuit so the canonicalization I/O
only runs for entries that could plausibly be the lock file. Both
checks only run during re-initialization, never on the hot read path.