### PR TITLE
Do not drop project lock in BuildOperationQueue when disallowing lock changes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.operations;
 
+import org.gradle.internal.Factories;
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.time.ExponentialBackoff;
 import org.gradle.internal.work.DefaultWorkerLimits;
@@ -173,7 +175,8 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
         }
 
         // Need to wait for work to complete, so release worker lease while waiting
-        workerLeases.blocking(() -> {
+        // We purposefully only drop the project lock if the work might need it (allowAccessToProjectState)
+        withProjectLockChangePolicy(Factories.toFactory(() -> workerLeases.blocking(() -> {
             lock.lock();
             try {
                 // Wait for any work still running in other threads
@@ -189,7 +192,21 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             } finally {
                 lock.unlock();
             }
-        });
+        })));
+    }
+
+    /**
+     * Runs the given work, disallowing changes to the set of project locks held by the current
+     * thread unless this queue's operations are allowed to access project state.
+     *
+     * <p>See <a href="https://github.com/gradle/gradle/issues/38154">gradle/gradle#38154</a> and
+     * {@link org.gradle.internal.resources.ProjectLeaseRegistry#whileDisallowingProjectLockChanges}.
+     */
+    private <R> R withProjectLockChangePolicy(Factory<R> factory) {
+        if (allowAccessToProjectState) {
+            return factory.create();
+        }
+        return workerLeases.whileDisallowingProjectLockChanges(factory);
     }
 
     private void markFinished() {
@@ -343,21 +360,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
         }
 
         private int executePendingWork() {
-            if (allowAccessToProjectState) {
-                return doRunBatch();
-            } else {
-                // Disallow this thread from making any changes to the project locks while it is running the work. This implies that this thread will not
-                // block waiting for access to some other project, which means it can proceed even if some other thread is waiting for a project lock it
-                // holds without causing a deadlock. This in turn implies that this thread does not need to release the project locks it holds while
-                // blocking waiting for an operation to complete and does not need to deal with another thread stealing its project lock(s) while blocking.
-                //
-                // Eventually, this should become the default and only behaviour for all worker threads and changes to locks made only when starting or
-                // finishing an execution node. Adding this constraint here means that we can make all build operation queue workers compliant with this
-                // constraint and then gradually roll this out to other worker threads, such as task action workers.
-                //
-                // See {@link ProjectLeaseRegistry#whileDisallowingProjectLockChanges} for more details
-                return workerLeases.whileDisallowingProjectLockChanges(this::doRunBatch);
-            }
+            return withProjectLockChangePolicy(this::doRunBatch);
         }
 
         /**

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationQueueTest.groovy
@@ -28,14 +28,19 @@ import org.gradle.internal.work.DefaultWorkerLimits
 import org.gradle.internal.work.ResourceLockStatistics
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.util.Path
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Timeout
 
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
 
 class DefaultBuildOperationQueueTest extends Specification {
 
@@ -373,6 +378,249 @@ class DefaultBuildOperationQueueTest extends Specification {
 
         then:
         terminated
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    def "waiting for completion #policyDesc project lock changes when allowAccessToProjectState is #allowAccessToProjectState"() {
+        given:
+        def mainThread = Thread.currentThread()
+        def disallowDepth = ThreadLocal.withInitial { 0 }
+        def lockChangesDisallowedDuringWait = new AtomicBoolean()
+        def blockingCalled = new CountDownLatch(1)
+        def releaseLatch = new CountDownLatch(1)
+
+        coordinationService = new DefaultResourceLockCoordinationService()
+        workerRegistry = new DefaultWorkerLeaseService(coordinationService, new DefaultWorkerLimits(2), ResourceLockStatistics.NO_OP) {
+            @Override
+            <T> T whileDisallowingProjectLockChanges(Factory<T> action) {
+                disallowDepth.set(disallowDepth.get() + 1)
+                try {
+                    return super.whileDisallowingProjectLockChanges(action)
+                } finally {
+                    disallowDepth.set(disallowDepth.get() - 1)
+                }
+            }
+
+            @Override
+            void blocking(Runnable action) {
+                if (Thread.currentThread() === mainThread) {
+                    lockChangesDisallowedDuringWait.set(disallowDepth.get() > 0)
+                    blockingCalled.countDown()
+                    // Unblock the in-flight operation only once the main thread has reached the wait,
+                    // guaranteeing pendingOperations > 0 when waitForWorkToComplete() checks it
+                    releaseLatch.countDown()
+                }
+                super.blocking(action)
+            }
+        }
+        workerRegistry.startProjectExecution(true)
+        lease = workerRegistry.startWorker()
+        // requiresWorkerLease=false so the main thread skips the self-drain and goes straight to the blocking wait
+        def executionContext = new BuildOperationExecutionContext(
+            new ManagedExecutorImpl(Executors.newFixedThreadPool(2), new ExecutorPolicy.CatchAndRecordFailures()),
+            2,
+            false
+        )
+        operationQueue = new DefaultBuildOperationQueue(allowAccessToProjectState, workerRegistry, executionContext, new SimpleWorker(), null)
+
+        when:
+        operationQueue.add(new SynchronizedBuildOperation({}, new CountDownLatch(1), releaseLatch))
+        operationQueue.waitForCompletion()
+
+        then:
+        blockingCalled.await(10, TimeUnit.SECONDS)
+        lockChangesDisallowedDuringWait.get() == lockChangesDisallowed
+
+        where:
+        allowAccessToProjectState | lockChangesDisallowed
+        false                     | true
+        true                      | false
+        policyDesc = lockChangesDisallowed ? "disallows" : "allows"
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    def "executing work #policyDesc project lock changes when allowAccessToProjectState is #allowAccessToProjectState"() {
+        given:
+        def disallowDepth = ThreadLocal.withInitial { 0 }
+        def lockChangesDisallowedDuringWork = new CopyOnWriteArrayList<Boolean>()
+        def recordingWorker = { TestBuildOperation op ->
+            lockChangesDisallowedDuringWork.add(disallowDepth.get() > 0)
+            op.run(null)
+        } as BuildOperationQueue.QueueWorker<TestBuildOperation>
+
+        coordinationService = new DefaultResourceLockCoordinationService()
+        workerRegistry = new DefaultWorkerLeaseService(coordinationService, new DefaultWorkerLimits(1), ResourceLockStatistics.NO_OP) {
+            @Override
+            <T> T whileDisallowingProjectLockChanges(Factory<T> action) {
+                disallowDepth.set(disallowDepth.get() + 1)
+                try {
+                    return super.whileDisallowingProjectLockChanges(action)
+                } finally {
+                    disallowDepth.set(disallowDepth.get() - 1)
+                }
+            }
+        }
+        workerRegistry.startProjectExecution(true)
+        lease = workerRegistry.startWorker()
+        def executionContext = new BuildOperationExecutionContext(
+            new ManagedExecutorImpl(Executors.newFixedThreadPool(1), new ExecutorPolicy.CatchAndRecordFailures()),
+            1,
+            true
+        )
+        operationQueue = new DefaultBuildOperationQueue(allowAccessToProjectState, workerRegistry, executionContext, recordingWorker, null)
+
+        when:
+        operationQueue.add(new Success())
+        operationQueue.waitForCompletion()
+
+        then:
+        lockChangesDisallowedDuringWork == [lockChangesDisallowed]
+
+        where:
+        allowAccessToProjectState | lockChangesDisallowed
+        false                     | true
+        true                      | false
+        policyDesc = lockChangesDisallowed ? "disallows" : "allows"
+    }
+
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    def "runAll does not lend project lock while waiting, avoiding deadlock against a resource held across the queue"() {
+        given:
+        // Mirrors the CI hang: the waiter owns some resource (there, cache ownership) plus a
+        // project lock; the other thread takes the project lock and then wants the resource
+        def resource = new ReentrantLock()
+        def blockingStarted = new CountDownLatch(1)
+        def releaseOperation = new CountDownLatch(1)
+        def failure = new AtomicReference<Throwable>()
+
+        setupLockLendingQueue(false, blockingStarted)
+        def projectLock = workerRegistry.getProjectLock(Path.path(":build"), Path.path(":build:project"))
+
+        def waiter = lockLendingWaiterThread(projectLock, resource, releaseOperation, failure)
+        def other = lockLendingOtherThread(projectLock, resource, new CountDownLatch(1), failure)
+
+        when:
+        waiter.start()
+        assert blockingStarted.await(10, TimeUnit.SECONDS)
+        boolean lockHeldDuringWait = false
+        coordinationService.withStateLock({ lockHeldDuringWait = projectLock.locked } as Runnable)
+        other.start()
+        releaseOperation.countDown()
+        waiter.join(10_000)
+        other.join(10_000)
+
+        then:
+        // The wait kept the project lock, so the other thread could never interleave into it
+        lockHeldDuringWait
+        !waiter.alive
+        !other.alive
+        failure.get() == null
+
+        cleanup:
+        releaseOperation.countDown()
+        other.interrupt()
+        waiter.join(10_000)
+        other.join(10_000)
+    }
+
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    def "runAllWithAccessToProjectState lends project lock while waiting, deadlocking against a resource held across the queue"() {
+        given:
+        def resource = new ReentrantLock()
+        def blockingStarted = new CountDownLatch(1)
+        def releaseOperation = new CountDownLatch(1)
+        def otherHasProjectLock = new CountDownLatch(1)
+        def failure = new AtomicReference<Throwable>()
+
+        setupLockLendingQueue(true, blockingStarted)
+        def projectLock = workerRegistry.getProjectLock(Path.path(":build"), Path.path(":build:project"))
+
+        def waiter = lockLendingWaiterThread(projectLock, resource, releaseOperation, failure)
+        def other = lockLendingOtherThread(projectLock, resource, otherHasProjectLock, failure)
+
+        when:
+        waiter.start()
+        assert blockingStarted.await(10, TimeUnit.SECONDS)
+        boolean lockHeldDuringWait = true
+        coordinationService.withStateLock({ lockHeldDuringWait = projectLock.locked } as Runnable)
+        other.start()
+        // Only possible because the wait lent out the project lock
+        assert otherHasProjectLock.await(10, TimeUnit.SECONDS)
+        releaseOperation.countDown()
+        waiter.join(2_000)
+
+        then:
+        // The queue's work is done, but the waiter cannot take its project lock back from the
+        // other thread, which in turn cannot acquire the resource the waiter still holds
+        !lockHeldDuringWait
+        waiter.alive
+        other.alive
+        failure.get() == null
+
+        cleanup:
+        // Break the deadlock so the registry can shut down cleanly
+        other.interrupt()
+        waiter.join(10_000)
+        other.join(10_000)
+    }
+
+    private void setupLockLendingQueue(boolean allowAccessToProjectState, CountDownLatch blockingStarted) {
+        coordinationService = new DefaultResourceLockCoordinationService()
+        workerRegistry = new DefaultWorkerLeaseService(coordinationService, new DefaultWorkerLimits(2), ResourceLockStatistics.NO_OP) {
+            @Override
+            void blocking(Runnable action) {
+                // Count down inside the action so the lend/keep decision has already been made
+                super.blocking({
+                    blockingStarted.countDown()
+                    action.run()
+                } as Runnable)
+            }
+        }
+        workerRegistry.startProjectExecution(true)
+        // requiresWorkerLease=false so the waiter skips the self-drain and goes straight to the blocking wait
+        def executionContext = new BuildOperationExecutionContext(
+            new ManagedExecutorImpl(Executors.newFixedThreadPool(2), new ExecutorPolicy.CatchAndRecordFailures()),
+            2,
+            false
+        )
+        operationQueue = new DefaultBuildOperationQueue(allowAccessToProjectState, workerRegistry, executionContext, new SimpleWorker(), null)
+    }
+
+    private Thread lockLendingWaiterThread(projectLock, ReentrantLock resource, CountDownLatch releaseOperation, AtomicReference<Throwable> failure) {
+        def waiter = new Thread({
+            try {
+                workerRegistry.withLocks([projectLock]) {
+                    resource.lock()
+                    try {
+                        operationQueue.add(new SynchronizedBuildOperation({}, new CountDownLatch(1), releaseOperation))
+                        operationQueue.waitForCompletion()
+                    } finally {
+                        resource.unlock()
+                    }
+                }
+            } catch (Throwable t) {
+                failure.set(t)
+            }
+        })
+        waiter.daemon = true
+        return waiter
+    }
+
+    private Thread lockLendingOtherThread(projectLock, ReentrantLock resource, CountDownLatch hasProjectLock, AtomicReference<Throwable> failure) {
+        def other = new Thread({
+            try {
+                workerRegistry.withLocks([projectLock]) {
+                    hasProjectLock.countDown()
+                    resource.lockInterruptibly()
+                    resource.unlock()
+                }
+            } catch (InterruptedException ignored) {
+            } catch (Throwable t) {
+                failure.set(t)
+            }
+        })
+        other.daemon = true
+        return other
     }
 
     static class SynchronizedBuildOperation extends TestBuildOperation {


### PR DESCRIPTION
This leads to deadlocks when a lock for a resource is held above.

The behavior is kept for allowAccessToProjectState as there is potential for a different kind of deadlock to occur if the work being done needs the project lock in order to progress. In the future, we should work to ensure this is not necessary.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
