### PR TITLE
Enhance error for unscheduled project transforms

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -3005,7 +3005,7 @@ Found the following transformation chains:
         if (configurationCache) {
             failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
             failure.assertThatCause(matchesRegexp("Failed to transform lib\\.jar \\(project ':lib'\\) to match attributes \\{.*\\}\\."))
-            failure.assertHasCause("Could not access project :lib. No task declared :lib as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
+            failure.assertHasCause("Could not access project ':lib'. No task declared this project as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
             failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
             failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
         } else {
@@ -3086,7 +3086,7 @@ Found the following transformation chains:
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
-        failure.assertHasCause("Could not access project :lib-build:producer. No task declared :lib-build:producer as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
+        failure.assertHasCause("Could not access project ':lib-build:producer'. No task declared this project as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
         failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
         failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.integtests.resolve.transform
 
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.internal.file.FileType
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
@@ -2925,6 +2927,168 @@ Found the following transformation chains:
         then:
         // Previously, this test would fail with an OOM.
         failure.assertHasCause("No variants of root project 'root' match the consumer attributes")
+    }
+
+    @UnsupportedWithConfigurationCache(because = "drives Configuration Cache explicitly via the test parameter")
+    @Issue(["https://github.com/gradle/gradle/issues/13567", "https://github.com/gradle/gradle/issues/37219"])
+    def "task that does not declare dependency resolution queries transform output mixing project and external artifacts [CC=#configurationCache]"() {
+        // The 'resolve' task captures the 'sizes' configuration in a closure and reads its files in
+        // doLast without declaring them as a task input. The configuration mixes a project dependency
+        // and an external dependency, and the registered transform converts jar -> txt for both.
+        //
+        // Without Configuration Cache, the transforms run and the task succeeds.
+        //
+        // With Configuration Cache, the producer project ':lib' is not part of the execution plan,
+        // so its state is not registered when the task action queries the configuration. The build
+        // fails with a three-tier cause chain:
+        //   1. Could not resolve all files for configuration ':sizes'.
+        //   2. Failed to transform lib.jar (project ':lib') to match attributes {...}.
+        //   3. Could not access project :lib. (Helpful root-cause hint from UnknownProjectStateException.)
+
+        mavenRepo.module("test", "commons-math", "3.6.1").publish()
+
+        file("lib/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+        """
+
+        buildFile << """
+            repositories {
+                maven { url = '${mavenRepo.uri}' }
+            }
+
+            dependencies {
+                registerTransform(FileSizer) {
+                    from.attribute(artifactType, "jar")
+                    to.attribute(artifactType, "txt")
+                }
+            }
+
+            configurations {
+                sizes {
+                    canBeResolved = true
+                    canBeConsumed = false
+                    attributes {
+                        attribute(artifactType, "txt")
+                    }
+                }
+            }
+
+            dependencies {
+                sizes 'test:commons-math:3.6.1'
+                sizes project(':lib')
+            }
+
+            tasks.register("resolve") {
+                def inputText = configurations.sizes
+                doLast {
+                    inputText.files.each {
+                        println it
+                    }
+                }
+            }
+        """
+
+        when:
+        if (configurationCache) {
+            executer.withArgument("--configuration-cache")
+        }
+
+        if (configurationCache) {
+            fails "resolve"
+        } else {
+            succeeds "resolve"
+        }
+
+        then:
+        if (configurationCache) {
+            failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
+            failure.assertThatCause(matchesRegexp("Failed to transform lib\\.jar \\(project ':lib'\\) to match attributes \\{.*\\}\\."))
+            failure.assertHasCause("Could not access project :lib. No task declared :lib as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
+            failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
+            failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
+        } else {
+            outputContains("commons-math-3.6.1.jar.txt")
+            outputContains("lib.jar.txt")
+        }
+
+        where:
+        configurationCache << [false, true]
+    }
+
+    @UnsupportedWithConfigurationCache(because = "drives Configuration Cache explicitly")
+    @Issue("https://github.com/gradle/gradle/issues/13567")
+    def "task that does not declare dependency resolution queries transform output of included-build project artifact under CC"() {
+        // Same shape as the previous test, but the producing project lives in an included build.
+        // Verifies that the new actionable error message uses the full build-tree path (which
+        // includes the included-build segment) so composite-build scenarios are unambiguous.
+
+        mavenRepo.module("test", "commons-math", "3.6.1").publish()
+
+        file("lib-build/settings.gradle") << """
+            rootProject.name = 'lib-build'
+            include 'producer'
+        """
+        file("lib-build/producer/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'org.test'
+            version = '1.0'
+        """
+
+        settingsFile << """
+            includeBuild('lib-build')
+        """
+
+        buildFile << """
+            repositories {
+                maven { url = '${mavenRepo.uri}' }
+            }
+
+            dependencies {
+                registerTransform(FileSizer) {
+                    from.attribute(artifactType, "jar")
+                    to.attribute(artifactType, "txt")
+                }
+            }
+
+            configurations {
+                sizes {
+                    canBeResolved = true
+                    canBeConsumed = false
+                    attributes {
+                        attribute(artifactType, "txt")
+                    }
+                }
+            }
+
+            dependencies {
+                sizes 'test:commons-math:3.6.1'
+                sizes 'org.test:producer:1.0'
+            }
+
+            tasks.register("resolve") {
+                def inputText = configurations.sizes
+                doLast {
+                    inputText.files.each {
+                        println it
+                    }
+                }
+            }
+        """
+
+        executer.withArgument("--configuration-cache")
+
+        when:
+        fails "resolve"
+
+        then:
+        failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
+        failure.assertHasCause("Could not access project :lib-build:producer. No task declared :lib-build:producer as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
+        failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
+        failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
     }
 
     def declareTransform(String transformImplementation) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -3004,10 +3004,10 @@ Found the following transformation chains:
         then:
         if (configurationCache) {
             failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
-            failure.assertThatCause(matchesRegexp("Failed to transform lib\\.jar \\(project ':lib'\\) to match attributes \\{.*\\}\\."))
+            failure.assertHasCause("Failed to transform lib.jar (project ':lib') to match attributes {artifactType=txt, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=17, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.")
             failure.assertHasCause("Could not access project ':lib'. No task declared this project as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
             failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
-            failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
+            failure.assertHasResolution("Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#undeclared_artifact_transform_input")
         } else {
             outputContains("commons-math-3.6.1.jar.txt")
             outputContains("lib.jar.txt")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.resolve.transform
 
-import org.gradle.api.internal.DocumentationRegistry
+
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
@@ -3004,7 +3004,7 @@ Found the following transformation chains:
         then:
         if (configurationCache) {
             failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
-            failure.assertHasCause("Failed to transform lib.jar (project ':lib') to match attributes {artifactType=txt, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=17, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.")
+            failure.assertThatCause(matchesRegexp("Failed to transform lib\\.jar \\(project ':lib'\\) to match attributes \\{artifactType=txt, org\\.gradle\\.category=library, org\\.gradle\\.dependency\\.bundling=external, org\\.gradle\\.jvm\\.version=\\d+, org\\.gradle\\.libraryelements=jar, org\\.gradle\\.usage=java-runtime\\}\\."))
             failure.assertHasCause("Could not access project ':lib'. No task declared this project as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
             failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
             failure.assertHasResolution("Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#undeclared_artifact_transform_input")
@@ -3088,7 +3088,7 @@ Found the following transformation chains:
         failure.assertHasCause("Could not resolve all files for configuration ':sizes'.")
         failure.assertHasCause("Could not access project ':lib-build:producer'. No task declared this project as part of an input, so it was not scheduled. Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.")
         failure.assertHasResolution("Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.")
-        failure.assertHasResolution("Consult the upgrading guide for further information: " + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input"))
+        failure.assertHasResolution("Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#undeclared_artifact_transform_input")
     }
 
     def declareTransform(String transformImplementation) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType;
 import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.project.UnknownProjectStateException;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -78,6 +80,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         Collection<? extends ResolvableArtifact> resolvedArtifacts;
         try {
             resolvedArtifacts = componentArtifactResolver.resolveArtifacts(artifacts);
+        } catch (UnknownProjectStateException e) {
+            return new UnavailableResolvedArtifactSet(new GradleException("Could not resolve " + displayName.getDisplayName() + ".", e));
         } catch (Exception e) {
             return new UnavailableResolvedArtifactSet(e);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -176,7 +176,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         synchronized (lock) {
             ProjectState projectState = projectsById.get(identifier);
             if (projectState == null) {
-                throw new IllegalArgumentException(identifier.getDisplayName() + " not found.");
+                throw new UnknownProjectStateException(identifier);
             }
             return projectState;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/UnknownProjectStateException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/UnknownProjectStateException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.project;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.internal.exceptions.ResolutionProvider;
+
+import java.util.List;
+
+/**
+ * Thrown when a lookup for a {@link org.gradle.api.internal.project.ProjectState ProjectState} by
+ * {@link ProjectComponentIdentifier} fails.
+ * <p>
+ * One common cause is that a task action queried an artifact whose producing project was not
+ * declared as a task input, leaving the project off the execution plan.  This is particularly
+ * likely to occur with {@code ArtifactTransform}s and the Configuration Cache.
+ * <p>
+ * Extends {@link IllegalArgumentException} for source-level backward compatibility with any
+ * existing {@code catch (IllegalArgumentException)} sites in callers.
+ */
+public final class UnknownProjectStateException extends IllegalArgumentException implements ResolutionProvider {
+    private static final List<String> RESOLUTIONS = ImmutableList.of(
+        "Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.",
+        "Consult the upgrading guide for further information: "
+            + new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input")
+    );
+
+    private final ProjectComponentIdentifier identifier;
+
+    public UnknownProjectStateException(ProjectComponentIdentifier identifier) {
+        super(buildMessage(identifier));
+        this.identifier = identifier;
+    }
+
+    public ProjectComponentIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    private static String buildMessage(ProjectComponentIdentifier identifier) {
+        String path = identifier.getBuildTreePath();
+        return "Could not access project " + path + ". "
+            + "No task declared " + path + " as part of an input, so it was not scheduled. "
+            + "Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.";
+    }
+
+    @Override
+    public List<String> getResolutions() {
+        return RESOLUTIONS;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/UnknownProjectStateException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/UnknownProjectStateException.java
@@ -52,9 +52,8 @@ public final class UnknownProjectStateException extends IllegalArgumentException
     }
 
     private static String buildMessage(ProjectComponentIdentifier identifier) {
-        String path = identifier.getBuildTreePath();
-        return "Could not access project " + path + ". "
-            + "No task declared " + path + " as part of an input, so it was not scheduled. "
+        return "Could not access " + identifier.getDisplayName() + ". "
+            + "No task declared this project as part of an input, so it was not scheduled. "
             + "Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution.";
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/UnknownProjectStateExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/UnknownProjectStateExceptionTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.project
+
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.internal.DocumentationRegistry
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link UnknownProjectStateException}.
+ */
+class UnknownProjectStateExceptionTest extends Specification {
+    def "message names the project and points at the missing input declaration"() {
+        given:
+        def identifier = Stub(ProjectComponentIdentifier) {
+            getBuildTreePath() >> ":lib"
+        }
+
+        when:
+        def exception = new UnknownProjectStateException(identifier)
+
+        then:
+        exception.message == "Could not access project :lib. " +
+            "No task declared :lib as part of an input, so it was not scheduled. " +
+            "Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution."
+    }
+
+    def "exposes the project component identifier"() {
+        given:
+        def identifier = Stub(ProjectComponentIdentifier) {
+            getBuildTreePath() >> ":lib"
+        }
+
+        when:
+        def exception = new UnknownProjectStateException(identifier)
+
+        then:
+        exception.identifier.is(identifier)
+    }
+
+    def "is an IllegalArgumentException for source-level backward compatibility"() {
+        given:
+        def identifier = Stub(ProjectComponentIdentifier) {
+            getBuildTreePath() >> ":lib"
+        }
+
+        expect:
+        new UnknownProjectStateException(identifier) instanceof IllegalArgumentException
+    }
+
+    def "uses build tree path so composite-build paths are unambiguous"() {
+        given:
+        def identifier = Stub(ProjectComponentIdentifier) {
+            getBuildTreePath() >> ":includedBuild:lib"
+        }
+
+        when:
+        def exception = new UnknownProjectStateException(identifier)
+
+        then:
+        exception.message.contains("Could not access project :includedBuild:lib.")
+        exception.message.contains("No task declared :includedBuild:lib as part of an input")
+    }
+
+    def "provides two actionable resolutions including the upgrading-guide URL"() {
+        given:
+        def identifier = Stub(ProjectComponentIdentifier) {
+            getBuildTreePath() >> ":lib"
+        }
+        def expectedUrl = new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "undeclared_artifact_transform_input")
+
+        when:
+        def exception = new UnknownProjectStateException(identifier)
+
+        then:
+        exception.resolutions == [
+            "Declare the files or artifacts produced by the configuration using the transform as a task input to properly wire it into the execution plan.",
+            "Consult the upgrading guide for further information: " + expectedUrl
+        ]
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/UnknownProjectStateExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/UnknownProjectStateExceptionTest.groovy
@@ -26,15 +26,15 @@ class UnknownProjectStateExceptionTest extends Specification {
     def "message names the project and points at the missing input declaration"() {
         given:
         def identifier = Stub(ProjectComponentIdentifier) {
-            getBuildTreePath() >> ":lib"
+            getDisplayName() >> "project ':lib'"
         }
 
         when:
         def exception = new UnknownProjectStateException(identifier)
 
         then:
-        exception.message == "Could not access project :lib. " +
-            "No task declared :lib as part of an input, so it was not scheduled. " +
+        exception.message == "Could not access project ':lib'. " +
+            "No task declared this project as part of an input, so it was not scheduled. " +
             "Properly declare all task inputs (including the result of any dependency resolutions) to ensure this project is scheduled for execution."
     }
 
@@ -64,15 +64,15 @@ class UnknownProjectStateExceptionTest extends Specification {
     def "uses build tree path so composite-build paths are unambiguous"() {
         given:
         def identifier = Stub(ProjectComponentIdentifier) {
-            getBuildTreePath() >> ":includedBuild:lib"
+            getDisplayName() >> "project ':includedBuild:lib'"
         }
 
         when:
         def exception = new UnknownProjectStateException(identifier)
 
         then:
-        exception.message.contains("Could not access project :includedBuild:lib.")
-        exception.message.contains("No task declared :includedBuild:lib as part of an input")
+        exception.message.contains("Could not access project ':includedBuild:lib'.")
+        exception.message.contains("No task declared this project as part of an input")
     }
 
     def "provides two actionable resolutions including the upgrading-guide URL"() {


### PR DESCRIPTION
When a task resolves a project artifact via an artifact transform without declaring the producing project as a task input, the Configuration Cache prevents the project from being scheduled. This previously resulted in a vague 'project not found' error.

Introduce `UnknownProjectStateException` to provide a clear, actionable message that guides users to declare their task inputs and references the upgrading guide.

Fixes #13567

Related to #38105 (which adds a deprecation for a similar, but not identical, scenario).
