### PR TITLE
Fix version change failing to retarget edges after capability conflict resolution

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -1034,6 +1034,56 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
         }
     }
 
+    def "capability conflict winner's constraint can upgrade the losing module to a version without the conflicting capability"() {
+        mavenRepo.module("org", "f", "1.0").publish()
+        def f2 = mavenRepo.module("org", "f", "2.0").publish()
+
+        def b1 = mavenRepo.module("org", "b", "1.0")
+            .dependencyConstraint(f2)
+            .withModuleMetadata()
+            .publish()
+
+        mavenRepo.module("org", "t", "1.0")
+            .dependsOn(b1)
+            .publish()
+
+        given:
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:f:1.0")
+                implementation("org:t:1.0")
+            }
+        """
+
+        capability("org", "cap") {
+            forComponent("org:f", "1.0")
+            forModule("org:b")
+            selectModule("org", "b")
+        }
+
+        when:
+        succeeds(':checkDeps')
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:f:1.0", "org:f:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
+                module("org:t:1.0") {
+                    module("org:b:1.0") {
+                        constraint("org:f:2.0", "org:f:2.0") {
+                            byConstraint()
+                        }
+                        byConflictResolution("Explicit selection of org:b:1.0 variant runtime")
+                    }
+                }
+            }
+        }
+    }
+
     // region test fixtures
 
     class CapabilityClosure {
@@ -1054,6 +1104,20 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
                     allVariants {
                         withCapabilities {
                             addCapability('$group', '$artifactId', id.version)
+                        }
+                    }
+                }
+            """
+        }
+
+        def forComponent(String module, String version) {
+            buildFile << """
+                dependencies.components.withModule('$module') {
+                    if (id.version == '$version') {
+                        allVariants {
+                            withCapabilities {
+                                addCapability('$group', '$artifactId', id.version)
+                            }
                         }
                     }
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -359,18 +359,25 @@ public class DependencyGraphBuilder {
         }
 
         for (ModuleResolveState module : resolveState.getModules()) {
+            // TODO: This condition currently fails, but should pass!
+//            if (!module.getUnattachedEdges().isEmpty()) {
+//                throw new IllegalStateException(String.format(
+//                    "Module %s has unattached edges: [%s]",
+//                    module,
+//                    module.getUnattachedEdges().stream().map(EdgeState::toString).collect(Collectors.joining(", "))
+//                ));
+//            }
             for (ComponentState component : module.getVersions()) {
                 for (NodeState node : component.getNodes()) {
                     for (EdgeState incomingEdge : node.getIncomingEdges()) {
                         NodeState from = incomingEdge.getFrom();
-                        // TODO: This condition currently fails, but should pass!
-//                        if (!from.getOutgoingEdges().contains(incomingEdge)) {
-//                            throw new IllegalStateException(String.format(
-//                                "Node %s has incoming edge from %s, but source node does not declare outgoing edge.",
-//                                node.getDisplayName(),
-//                                from.getDisplayName()
-//                            ));
-//                        }
+                        if (!from.getOutgoingEdges().contains(incomingEdge)) {
+                            throw new IllegalStateException(String.format(
+                                "Node %s has incoming edge from %s, but source node does not declare outgoing edge.",
+                                node.getDisplayName(),
+                                from.getDisplayName()
+                            ));
+                        }
                         if (!from.isSelected()) {
                             throw new IllegalStateException(String.format(
                                 "Node %s has an incoming edge from %s, but source node is not part of the graph.",
@@ -379,18 +386,17 @@ public class DependencyGraphBuilder {
                             ));
                         }
                     }
-//                    for (EdgeState outgoingEdge : node.getOutgoingEdges()) {
-//                        for (NodeState target : outgoingEdge.getTargetNodes()) {
-//                            // TODO: This condition currently fails, but should pass!
-//                            if (!target.getIncomingEdges().contains(outgoingEdge)) {
-//                                throw new IllegalStateException(String.format(
-//                                    "Node %s has an outgoing edge to node %s, but target node does not declare incoming edge.",
-//                                    node.getDisplayName(),
-//                                    target.getDisplayName()
-//                                ));
-//                            }
-//                        }
-//                    }
+                    for (EdgeState outgoingEdge : node.getOutgoingEdges()) {
+                        for (NodeState target : outgoingEdge.getTargetNodes()) {
+                            if (!target.getIncomingEdges().contains(outgoingEdge)) {
+                                throw new IllegalStateException(String.format(
+                                    "Node %s has an outgoing edge to node %s, but target node does not declare incoming edge.",
+                                    node.getDisplayName(),
+                                    target.getDisplayName()
+                                ));
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -259,9 +259,7 @@ class EdgeState implements DependencyGraphEdge {
 
             // A constraint by definition attaches to any other nodes in the component it constrains.
             for (NodeState node : targetComponent.getNodes()) {
-                while (node.getReplacement() != null) {
-                    node = node.getReplacement();
-                }
+                node = node.maybeResolveReplacement();
                 if (node.isSelected() && !node.isRoot()) {
                     targetNodes.add(node);
                 }
@@ -298,11 +296,9 @@ class EdgeState implements DependencyGraphEdge {
         }
 
         for (VariantGraphResolveState targetVariant : targetVariants.getVariants()) {
-            NodeState targetNodeState = resolveState.getNode(targetComponent, targetVariant, targetVariants.isSelectedByVariantAwareResolution());
-            while (targetNodeState.getReplacement() != null) {
-                targetNodeState = targetNodeState.getReplacement();
-            }
-            this.targetNodes.add(targetNodeState);
+            NodeState requestedNode = resolveState.getNode(targetComponent, targetVariant, targetVariants.isSelectedByVariantAwareResolution());
+            NodeState resolvedNode = requestedNode.maybeResolveReplacement();
+            this.targetNodes.add(resolvedNode);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -259,7 +259,7 @@ public class ModuleResolveState implements CandidateModule {
 
         if (oldSelected != null && oldSelected != newSelection) {
             for (NodeState node : oldSelected.getNodes()) {
-                node.restartIncomingEdges();
+                node.maybeResolveReplacement().restartIncomingEdges();
             }
         }
         for (SelectorState selector : selectors) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -172,6 +172,14 @@ public class NodeState implements DependencyGraphNode {
         this.dependenciesMayChange = component.getModule().isVirtualPlatform();
     }
 
+    NodeState maybeResolveReplacement() {
+        NodeState node = this;
+        while (node.getReplacement() != null) {
+            node = node.getReplacement();
+        }
+        return node;
+    }
+
     // the enqueue and dequeue methods are used for performance reasons
     // in order to avoid tracking the set of enqueued nodes
     boolean enqueue() {
@@ -1234,23 +1242,29 @@ public class NodeState implements DependencyGraphNode {
     }
 
     /**
-     * Called on losing nodes after conflict resolution to retarget their existing incoming
-     * edges to the winning node. This method must be called after any relevant state is updated
-     * so that retargeting chooses the correct new target node.
+     * Retarget all incoming edges of this node. Called in two contexts:
+     * <ul>
+     *     <li>On losing nodes of capability conflicts, to move their edges to the winner.</li>
+     *     <li>On nodes (and their replacements) of components losing version or module conflicts
+     *         in {@link ModuleResolveState#changeSelection}, to retarget edges to the new selection.</li>
+     * </ul>
+     * In the second case, the node may be a capability conflict replacement that has its own
+     * legitimate incoming edges from other modules. Those edges re-attach to this node after
+     * retargeting, so the node may still have incoming edges when this method returns.
      */
     void restartIncomingEdges() {
         if (incomingEdges.size() == 1) {
             EdgeState singleEdge = incomingEdges.get(0);
             singleEdge.retarget();
-        } else if (incomingEdges.size() > 1){
+            // The edge should have retargeted away from this node, unless it targets
+            // this node's own module and re-attached (replacement during version change).
+            assert !singleEdge.getTargetNodes().contains(this) || singleEdge.getSelector().getTargetModule() == getComponent().getModule();
+        } else if (incomingEdges.size() > 1) {
             for (EdgeState edge : new ArrayList<>(incomingEdges)) {
                 edge.retarget();
+                assert !edge.getTargetNodes().contains(this) || edge.getSelector().getTargetModule() == getComponent().getModule();
             }
         }
-
-        // This method is called on a node that fails conflict resolution. If, after retargeting,
-        // we still have incoming edges, something went wrong.
-        assert incomingEdges.isEmpty();
     }
 
     void prepareForConstraintNoLongerPending(ModuleIdentifier moduleIdentifier) {


### PR DESCRIPTION
When a capability conflict is resolved (e.g., F:1 loses to B:1), the losing node's incoming edges are moved to the winner. If a subsequent constraint from the winner upgrades the losing module (F:1 → F:2), changeSelection needs to find those edges on the replacement node, not the original.

Follow the replacement chain in changeSelection so edges that were moved during capability conflict resolution are correctly retargeted to the new version.

Also:
- Extract NodeState.maybeResolveReplacement() to deduplicate the replacement-chain-walking pattern
- Relax assertions in restartIncomingEdges() to allow edges targeting the node's own module to remain after retargeting
- Enable previously commented-out graph structure assertions in DependencyGraphBuilder
- Add CapabilityClosure.forComponent() test fixture for version-specific capability metadata rules

Fixes https://github.com/gradle/gradle/issues/38151

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
