### PR TITLE
Configure PTS server from DEVELOCITY_SERVER_URL env var

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -35,6 +35,7 @@ import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
 import gradlebuild.basics.BuildParams.DEFAULT_RFN_PERFORMANCE_BASELINES
 import gradlebuild.basics.BuildParams.DEFAULT_RFR_PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.DEVELOCITY_SERVER_URL_ENV
 import gradlebuild.basics.BuildParams.ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS
 import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
@@ -126,6 +127,7 @@ object BuildParams {
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val PERFORMANCE_STAGE_ENV = "PERFORMANCE_STAGE"
     const val RERUN_ALL_TESTS = "rerunAllTests"
+    const val DEVELOCITY_SERVER_URL_ENV = "DEVELOCITY_SERVER_URL"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
@@ -385,6 +387,10 @@ val Project.testSplitExcludeTestClasses: String
 
 val Project.testSplitOnlyTestGradleVersion: String
     get() = project.stringPropertyOrEmpty(TEST_SPLIT_ONLY_TEST_GRADLE_VERSION)
+
+
+val Project.develocityServerUrl: Provider<String>
+    get() = environmentVariable(DEVELOCITY_SERVER_URL_ENV)
 
 
 val Project.predictiveTestSelectionEnabled: Provider<Boolean>

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -20,6 +20,7 @@ import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
+import gradlebuild.basics.develocityServerUrl
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionLocalExecutors
@@ -364,12 +365,13 @@ fun configureTests() {
         }
 
         if (project.supportsPredictiveTestSelection() && !isUnitTest()) {
-            // GitHub actions for contributor PRs use a public Build Scan instance
-            // in this case we need to explicitly configure the PTS server
+            // Falling back to https://ge.gradle.org when absent (e.g. GitHub actions for contributor PRs,
+            // which use a public Build Scan instance).
             // Don't move this line into the lambda as it may cause config cache problems
+            val ptsServerUrl = project.develocityServerUrl.getOrElse("https://ge.gradle.org")
             extensions.findByType<DevelocityTestConfiguration>()?.predictiveTestSelection {
                 this as PredictiveTestSelectionConfigurationInternal
-                server = uri("https://ge.gradle.org")
+                server = uri(ptsServerUrl)
                 enabled.convention(project.predictiveTestSelectionEnabled)
             }
         }


### PR DESCRIPTION
### Context

Fixes https://github.com/gradle/gradle-private/issues/5257

#38100 introduced the `DEVELOCITY_SERVER_URL` env var on CI, pointing the Develocity plugin at the public DV server. This made the Develocity server differ from the Predictive Test Selection server, which was hardcoded to `https://ge.gradle.org` in `gradlebuild.unittest-and-compile.gradle.kts`.

The Develocity plugin shares a single `TestAccelerationService` client across all test tasks of a build and refuses to serve tasks presenting a different TD or PTS server URL. With the two URLs diverging, builds failed with:

```
Client was already created for a different server
```

### Change

- The PTS server is now configured from the `DEVELOCITY_SERVER_URL` environment variable (added to `BuildParams` as `Project.develocityServerUrl`, resolved outside the configuration lambda to stay configuration-cache friendly).
- When the env var is absent (local builds, contributor PRs on GitHub Actions), it falls back to `https://ge.gradle.org`, preserving the previous behavior.

This keeps the PTS server consistent with the Develocity server on CI, so the shared client guard no longer trips, while builds without the env var behave exactly as before.