### PR TITLE
Rework allIncubationReports into a rich single-page report

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.incubation-report-aggregation.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.incubation-report-aggregation.gradle.kts
@@ -1,5 +1,7 @@
 import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.capitalize
+import gradlebuild.basics.releasedVersionsFile
+import gradlebuild.basics.repoRoot
 import gradlebuild.incubation.tasks.IncubatingApiAggregateReportTask
 
 plugins {
@@ -18,6 +20,8 @@ val allIncubationReports = tasks.register<IncubatingApiAggregateReportTask>("all
     htmlReportFile = project.layout.buildDirectory.file("reports/incubation/all-incubating.html")
     csvReportFile = project.layout.buildDirectory.file("reports/incubation/all-incubating.csv")
     currentCommit = project.buildCommitId
+    versionFile = repoRoot().file("version.txt")
+    releasedVersionsFile = releasedVersionsFile()
 }
 
 tasks.register<Zip>("allIncubationReportsZip") {

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiKind.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiKind.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,24 @@
 
 package gradlebuild.incubation.action
 
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
-import org.gradle.workers.WorkParameters
 
+/**
+ * The kind of an incubating API declaration. Emitted by the per-project producer into the
+ * intermediate txt report and consumed by the aggregator to surface a "Kind" column.
+ */
+enum class IncubatingApiKind {
+    CLASS,
+    INTERFACE,
+    ENUM,
+    ANNOTATION,
+    METHOD,
+    FIELD,
+    PROPERTY,
+    PACKAGE,
+    OTHER;
 
-interface IncubatingApiReportAggregationParameter : WorkParameters {
-    val reports: ConfigurableFileCollection
-    val htmlReportFile: RegularFileProperty
-    val csvReportFile: RegularFileProperty
-    val currentCommit: Property<String>
-    val versionFile: RegularFileProperty
-    val releasedVersionsFile: RegularFileProperty
+    companion object {
+        fun fromString(value: String): IncubatingApiKind =
+            entries.firstOrNull { it.name == value } ?: OTHER
+    }
 }

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
@@ -68,7 +68,7 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
         generateHtmlReport(entries, timeline)
         LOGGER.lifecycle("Generated incubating html report to file://${parameters.htmlReportFile.get().asFile.absolutePath}")
 
-        generateCsvReport(entries, currentCommit)
+        generateCsvReport(entries)
         LOGGER.lifecycle("Generated incubating csv report to file://${parameters.csvReportFile.get().asFile.absolutePath}")
     }
 
@@ -132,7 +132,7 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
     }
 
     private
-    fun generateCsvReport(entries: List<Entry>, currentCommit: String) {
+    fun generateCsvReport(entries: List<Entry>) {
         val outputFile = parameters.csvReportFile.get().asFile
         outputFile.parentFile.mkdirs()
         outputFile.printWriter(Charsets.UTF_8).use { writer ->
@@ -160,6 +160,7 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
         append("}")
     }
 
+    @Suppress("LongMethod")
     private
     fun htmlPage(
         currentCommit: String,

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
@@ -26,26 +26,87 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(IncubatingApiReportAggregationWorkAction::class.java.name) as Logger
         const val GITHUB_BASE_URL = "https://github.com/gradle/gradle/blob"
+
+        /**
+         * APIs that have been incubating for strictly more than this many minor releases are
+         * flagged as "long-incubating" and highlighted in the report. Single source of truth,
+         * surfaced both in the table highlighting and in the page footer.
+         */
+        const val LONG_INCUBATING_THRESHOLD = 4
+
+        private const val VERSION_NOT_FOUND = "Not found"
     }
 
     override fun execute() {
-        val byCategory = mutableMapOf<String, ProjectNameToProblems>()
+        val timeline = buildVersionTimeline()
+        val currentCommit = parameters.currentCommit.get()
+
+        val entries = mutableListOf<Entry>()
         parameters.reports.files.sorted().forEach { file ->
-            file.forEachLine(Charsets.UTF_8) {
-                val (version, _, problem, relativePath, lineNumber) = it.split(';')
-                byCategory.getOrPut(toCategory(version, file.nameWithoutExtension)) {
-                    mutableMapOf()
-                }.getOrPut(file.nameWithoutExtension) {
-                    mutableSetOf()
-                }.add(Problem(name = problem, relativePath = relativePath, lineNumber = lineNumber.toInt()))
+            val project = file.nameWithoutExtension
+            file.forEachLine(Charsets.UTF_8) { line ->
+                if (line.isBlank()) return@forEachLine
+                val record = parseLine(line)
+                val sinceKnown = record.version != VERSION_NOT_FOUND
+                val minor = if (sinceKnown) ReleasedVersions.toMinor(record.version) else null
+                entries.add(
+                    Entry(
+                        name = record.name,
+                        kind = IncubatingApiKind.fromString(record.kind),
+                        since = if (sinceKnown) record.version else "",
+                        sinceKnown = sinceKnown,
+                        sinceDate = minor?.let { timeline.dateOf(it) },
+                        project = project,
+                        age = minor?.let { timeline.ageOf(it) },
+                        url = githubUrl(record.relativePath, record.lineNumber, currentCommit),
+                        category = toCategory(record.version, project)
+                    )
+                )
             }
         }
-        generateHtmlReport(byCategory)
+
+        generateHtmlReport(entries, timeline)
         LOGGER.lifecycle("Generated incubating html report to file://${parameters.htmlReportFile.get().asFile.absolutePath}")
 
-        generateCsvReport(byCategory)
+        generateCsvReport(entries, currentCommit)
         LOGGER.lifecycle("Generated incubating csv report to file://${parameters.csvReportFile.get().asFile.absolutePath}")
     }
+
+    /**
+     * Parses a `version;releaseDate;kind;name;relativePath;lineNumber` record. The `name` field
+     * may itself contain semicolons, so the surrounding fixed fields are peeled off from both ends.
+     */
+    private
+    fun parseLine(line: String): Record {
+        val parts = line.split(';')
+        require(parts.size >= 5) {
+            "Malformed incubating report record (expected 'version;releaseDate;kind;name;relativePath;lineNumber' but got ${parts.size} fields): $line"
+        }
+        val version = parts[0]
+        val kind = parts[2]
+        val lineNumber = parts.last().toIntOrNull() ?: -1
+        val relativePath = parts[parts.size - 2]
+        val name = parts.subList(3, parts.size - 2).joinToString(";")
+        return Record(version, kind, name, relativePath, lineNumber)
+    }
+
+    private
+    fun buildVersionTimeline(): VersionTimeline {
+        val released = ReleasedVersions.parse(parameters.releasedVersionsFile.get().asFile)
+        // released is newest-first; build an oldest-first, distinct list of minors keeping the earliest date.
+        val orderedMinorDates = LinkedHashMap<String, String>()
+        released.asReversed().forEach { rv ->
+            orderedMinorDates.putIfAbsent(ReleasedVersions.toMinor(rv.version), rv.date)
+        }
+        val currentVersion = parameters.versionFile.get().asFile.readText().trim()
+        // The version under development is the newest point on the timeline, even though it is not released yet.
+        orderedMinorDates.putIfAbsent(ReleasedVersions.toMinor(currentVersion), "unreleased")
+        return VersionTimeline(currentVersion, orderedMinorDates)
+    }
+
+    private
+    fun githubUrl(relativePath: String, lineNumber: Int, currentCommit: String) =
+        "$GITHUB_BASE_URL/$currentCommit/$relativePath#L$lineNumber".urlEncodeSpace()
 
     private
     fun toCategory(version: String, gradleModule: String) = when {
@@ -54,76 +115,499 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
     }
 
     private
-    fun generateHtmlReport(data: Map<String, ProjectNameToProblems>) {
+    fun generateHtmlReport(entries: List<Entry>, timeline: VersionTimeline) {
         val outputFile = parameters.htmlReportFile.get().asFile
         outputFile.parentFile.mkdirs()
+        val currentCommit = parameters.currentCommit.get()
+        val commitUrl = "https://github.com/gradle/gradle/commit/$currentCommit"
+        val csvFileName = parameters.csvReportFile.get().asFile.name
+        val rowsJson = entries
+            .sortedBy { it.name.lowercase() }
+            .joinToString(separator = ",\n", prefix = "[", postfix = "]") { it.toJson() }
+        val versionOrderJson = timeline.orderedMinors.joinToString(separator = ",", prefix = "[", postfix = "]") {
+            "\"${it.jsonEscape()}\""
+        }
+
+        outputFile.writeText(htmlPage(currentCommit, commitUrl, csvFileName, entries.size, rowsJson, versionOrderJson), Charsets.UTF_8)
+    }
+
+    private
+    fun generateCsvReport(entries: List<Entry>, currentCommit: String) {
+        val outputFile = parameters.csvReportFile.get().asFile
+        outputFile.parentFile.mkdirs()
         outputFile.printWriter(Charsets.UTF_8).use { writer ->
-            writer.println(
-                """<html lang="en">
-    <head>
-       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-       <title>Incubating APIs</title>
-       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
-       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
-       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
-
-    </head>
-    <body>
-       <h1>Incubating APIs</h1>
-       <h2>Index</h2>
-       <ul>
-    """
-            )
-
-            data.toSortedMap().forEach { (category, _) ->
-                writer.println("<li><a href=\"#$category\">$category</a><br></li>")
-            }
-            writer.println("</ul>")
-            data.toSortedMap().forEach { (category, projectsWithProblems) ->
-                writer.println("<a name=\"$category\"></a>")
-                writer.println("<h2>$category</h2>")
-                projectsWithProblems.forEach { (project, problems) ->
-                    writer.println("<h3>In $project</h3>")
-                    writer.println("<ul>")
-                    problems.forEach {
-                        writer.println("   <li>${it.name.escape()}</li>")
-                    }
-                    writer.println("</ul>")
+            writer.println("Link;Platform/Subproject;Incubating since")
+            entries
+                .sortedWith(compareBy({ it.category }, { it.project }, { it.name }))
+                .forEach { entry ->
+                    val since = entry.category.removePrefix("Incubating since ")
+                    writer.println("=HYPERLINK(\"${entry.url}\",\"${entry.name}\");${entry.project};$since;")
                 }
-            }
-            writer.println("</body></html>")
         }
     }
 
     private
-    fun generateCsvReport(data: Map<String, ProjectNameToProblems>) {
-        val outputFile = parameters.csvReportFile.get().asFile
-        val currentCommit = parameters.currentCommit.get()
-        outputFile.parentFile.mkdirs()
-        outputFile.printWriter(Charsets.UTF_8).use { writer ->
-            writer.println("Link;Platform/Subproject;Incubating since")
-            data.toSortedMap().forEach { (category, projectsWithProblems) ->
-                projectsWithProblems.forEach { (project, problems) ->
-                    problems.forEach {
-                        val url = "$GITHUB_BASE_URL/$currentCommit/${it.relativePath}#L${it.lineNumber}".urlEncodeSpace()
-                        writer.println("=HYPERLINK(\"$url\",\"${it.name}\");$project;${category.removePrefix("Incubating since ")};")
-                    }
+    fun Entry.toJson(): String = buildString {
+        append("{")
+        append("\"name\":\"${name.jsonEscape()}\",")
+        append("\"kind\":\"${kind.name.lowercase()}\",")
+        append("\"since\":\"${since.jsonEscape()}\",")
+        append("\"sinceKnown\":$sinceKnown,")
+        append("\"sinceDate\":${sinceDate?.let { "\"${it.jsonEscape()}\"" } ?: "null"},")
+        append("\"project\":\"${project.jsonEscape()}\",")
+        append("\"age\":${age ?: "null"},")
+        append("\"url\":\"${url.jsonEscape()}\"")
+        append("}")
+    }
+
+    private
+    fun htmlPage(
+        currentCommit: String,
+        commitUrl: String,
+        csvFileName: String,
+        total: Int,
+        rowsJson: String,
+        versionOrderJson: String
+    ): String {
+        val shortCommit = currentCommit.take(10)
+        return """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Incubating APIs</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <link type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
+    <style>
+        :root {
+            --warn-bg: #fff6e5;
+            --warn-border: #e0a800;
+            --unknown-bg: #f1f1f4;
+            --accent: #1ba0c4;
+            --muted: #6b6f76;
+            --border: #d7d9dd;
+        }
+        body { font-family: Lato, sans-serif; margin: 0 auto; max-width: 1200px; padding: 1rem 1.5rem 4rem; color: #1c2126; }
+        h1 { margin-bottom: .25rem; }
+        .subtitle { color: var(--muted); margin: 0 0 1.5rem; font-size: .95rem; }
+        .subtitle a { color: var(--accent); }
+        .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+        .card { border: 1px solid var(--border); border-radius: 8px; padding: .9rem 1rem; background: #fff; }
+        .card h3 { margin: 0 0 .6rem; font-size: .85rem; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+        .big-number { font-size: 2rem; font-weight: 700; line-height: 1; }
+        .big-number .label { font-size: .9rem; font-weight: 400; color: var(--muted); margin-left: .4rem; }
+        .dist-row, .top-row { display: grid; grid-template-columns: 5.5rem 1fr 2.5rem; align-items: center; gap: .5rem; font-size: .82rem; margin: .15rem 0; }
+        .top-row { grid-template-columns: 1fr 2.5rem; }
+        .bar { background: var(--accent); height: 11px; border-radius: 3px; min-width: 2px; }
+        .bar-track { background: #eef0f3; border-radius: 3px; }
+        .count { text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; }
+        .dist-row { cursor: pointer; border-radius: 4px; }
+        .dist-row:hover { background: #eef6f9; }
+        .dist-row.active { background: #d9f0f6; }
+        .dist-row.active span { font-weight: 700; color: #14708a; }
+        .card h3 .hint { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--muted); }
+        .actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; margin-bottom: 1rem; }
+        .actions input[type=search] { flex: 1 1 220px; min-width: 180px; padding: .45rem .6rem; border: 1px solid var(--border); border-radius: 6px; font-size: .9rem; }
+        .actions select { padding: .42rem .5rem; border: 1px solid var(--border); border-radius: 6px; font-size: .85rem; background: #fff; }
+        .btn { padding: .45rem .8rem; border: 1px solid var(--accent); border-radius: 6px; background: var(--accent); color: #fff; text-decoration: none; font-size: .85rem; cursor: pointer; }
+        .btn.secondary { background: #fff; color: var(--accent); }
+        :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+        table { border-collapse: collapse; width: 100%; font-size: .88rem; }
+        thead th { text-align: left; border-bottom: 2px solid var(--border); padding: .55rem .6rem; cursor: pointer; user-select: none; white-space: nowrap; position: sticky; top: 0; background: #fff; }
+        thead th .arrow { color: var(--muted); font-size: .75rem; }
+        tbody td { border-bottom: 1px solid #edeef1; padding: .45rem .6rem; vertical-align: top; }
+        tbody tr.row-long { background: var(--warn-bg); }
+        tbody tr.row-unknown { background: var(--unknown-bg); }
+        td.api a { color: var(--accent); text-decoration: none; word-break: break-word; }
+        td.api a:hover { text-decoration: underline; }
+        .kind-pill { display: inline-block; font-size: .72rem; padding: .05rem .45rem; border-radius: 10px; background: #eef0f3; color: #3a3f45; text-transform: lowercase; }
+        .badge-warn { color: var(--warn-border); font-weight: 700; }
+        .badge-unknown { color: var(--muted); font-style: italic; }
+        .nowrap { white-space: nowrap; }
+        .empty { padding: 2rem; text-align: center; color: var(--muted); }
+        footer { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: .82rem; }
+        footer a { color: var(--accent); }
+    </style>
+</head>
+<body>
+    <h1>Incubating APIs</h1>
+    <p class="subtitle">
+        Gradle <strong>${timelineVersion()}</strong> &middot;
+        <strong>$total</strong> incubating declarations &middot;
+        source commit <a href="$commitUrl" target="_blank" rel="noopener"><code>$shortCommit</code></a>
+    </p>
+
+    <section class="summary" id="summary" aria-label="Summary"></section>
+
+    <div class="actions">
+        <input type="search" id="search" placeholder="Search API name&hellip;" aria-label="Search API name">
+        <label>since <select id="filter-since" aria-label="Filter by since version"></select></label>
+        <label>project <select id="filter-project" aria-label="Filter by project"></select></label>
+        <label>kind <select id="filter-kind" aria-label="Filter by kind"></select></label>
+        <label>age <select id="filter-age" aria-label="Filter by age">
+            <option value="">any</option>
+            <option value="fresh">within threshold</option>
+            <option value="long">long-incubating</option>
+            <option value="unknown">unknown since</option>
+        </select></label>
+        <a class="btn" id="download-csv" href="$csvFileName" download>Download CSV</a>
+        <a class="btn secondary" href="#" id="clear-filters">Clear filters</a>
+    </div>
+
+    <table id="report">
+        <thead>
+            <tr>
+                <th scope="col" data-key="name" aria-sort="ascending">API <span class="arrow"></span></th>
+                <th scope="col" data-key="kind">Kind <span class="arrow"></span></th>
+                <th scope="col" data-key="since">Since <span class="arrow"></span></th>
+                <th scope="col" data-key="project">Project <span class="arrow"></span></th>
+                <th scope="col" data-key="age">Age <span class="arrow"></span></th>
+            </tr>
+        </thead>
+        <tbody id="rows"></tbody>
+    </table>
+    <p class="empty" id="empty" hidden>No incubating APIs match the current filters.</p>
+
+    <footer>
+        <p>
+            Rows highlighted in amber have been incubating for more than <strong>$LONG_INCUBATING_THRESHOLD</strong>
+            minor releases. Rows in grey have no resolvable <code>@since</code> tag ("unknown since").
+        </p>
+        <p>The data behind this page is available as <a href="$csvFileName">$csvFileName</a> and inline as
+            <a href="#" id="view-json">JSON</a> (logged to the browser console for scraping).</p>
+    </footer>
+
+    <script id="data" type="application/json">$rowsJson</script>
+    <script>
+        var THRESHOLD = $LONG_INCUBATING_THRESHOLD;
+        var VERSION_ORDER = $versionOrderJson;
+        var DATA = JSON.parse(document.getElementById('data').textContent);
+
+        // The @since tags are inconsistent (some "9.3.0", some "8.5"); normalise to major.minor so
+        // they line up with VERSION_ORDER for chronological sorting.
+        function minorOf(v) {
+            var parts = String(v).split('.');
+            if (parts.length >= 2) {
+                var digits = parts[1].match(/^[0-9]+/);
+                return parts[0] + '.' + (digits ? digits[0] : parts[1]);
+            }
+            return v;
+        }
+        function versionRank(v) {
+            var idx = VERSION_ORDER.indexOf(minorOf(v));
+            return idx < 0 ? -1 : idx;
+        }
+
+        function el(tag, attrs, text) {
+            var node = document.createElement(tag);
+            if (attrs) { for (var k in attrs) { if (attrs[k] != null) node.setAttribute(k, attrs[k]); } }
+            if (text != null) node.textContent = text;
+            return node;
+        }
+
+        function ageBucket(row) {
+            if (!row.sinceKnown) return 'unknown';
+            if (row.age == null) return 'unknown';
+            return row.age > THRESHOLD ? 'long' : 'fresh';
+        }
+
+        function uniqueSorted(values, orderFn) {
+            var seen = {}, out = [];
+            values.forEach(function (v) { if (!seen[v]) { seen[v] = true; out.push(v); } });
+            out.sort(orderFn);
+            return out;
+        }
+
+        function fillSelect(select, options) {
+            select.appendChild(el('option', { value: '' }, 'any'));
+            options.forEach(function (o) { select.appendChild(el('option', { value: o }, o)); });
+        }
+
+        var search = document.getElementById('search');
+        var fSince = document.getElementById('filter-since');
+        var fProject = document.getElementById('filter-project');
+        var fKind = document.getElementById('filter-kind');
+        var fAge = document.getElementById('filter-age');
+        var tbody = document.getElementById('rows');
+        var empty = document.getElementById('empty');
+
+        fillSelect(fSince, uniqueSorted(DATA.filter(function (r) { return r.sinceKnown; }).map(function (r) { return r.since; }),
+            function (a, b) { return versionRank(a) - versionRank(b); }));
+        fillSelect(fProject, uniqueSorted(DATA.map(function (r) { return r.project; }), undefined));
+        fillSelect(fKind, uniqueSorted(DATA.map(function (r) { return r.kind; }), undefined));
+
+        var sortKey = 'name', sortDir = 1;
+
+        function compare(a, b) {
+            var primary;
+            if (sortKey === 'age') {
+                primary = (a.age == null ? Infinity : a.age) - (b.age == null ? Infinity : b.age);
+            } else if (sortKey === 'since') {
+                primary = versionRank(a.since) - versionRank(b.since);
+            } else {
+                primary = String(a[sortKey]).toLowerCase().localeCompare(String(b[sortKey]).toLowerCase());
+            }
+            if (primary !== 0) return primary * sortDir;
+            // Stable multi-key: ties fall back to alphabetical API name.
+            return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+        }
+
+        function currentFilter() {
+            var q = search.value.trim().toLowerCase();
+            return function (r) {
+                if (q && r.name.toLowerCase().indexOf(q) === -1) return false;
+                if (fSince.value && r.since !== fSince.value) return false;
+                if (fProject.value && r.project !== fProject.value) return false;
+                if (fKind.value && r.kind !== fKind.value) return false;
+                if (fAge.value && ageBucket(r) !== fAge.value) return false;
+                return true;
+            };
+        }
+
+        function renderSummary() {
+            var summary = document.getElementById('summary');
+            summary.innerHTML = '';
+            var total = DATA.length;
+            var longCount = DATA.filter(function (r) { return ageBucket(r) === 'long'; }).length;
+            var unknownCount = DATA.filter(function (r) { return !r.sinceKnown; }).length;
+
+            var totals = el('div', { class: 'card' });
+            totals.appendChild(el('h3', null, 'Totals'));
+            var n = el('div', { class: 'big-number' }, String(total));
+            n.appendChild(el('span', { class: 'label' }, 'incubating APIs'));
+            totals.appendChild(n);
+            totals.appendChild(el('div', { class: 'top-row' }))
+                .appendChild(el('span', null, longCount + ' long-incubating (> ' + THRESHOLD + ' releases)'));
+            totals.appendChild(el('div', { class: 'top-row' }))
+                .appendChild(el('span', null, unknownCount + ' with unknown since'));
+            summary.appendChild(totals);
+
+            // Per-since distribution
+            var bySince = {};
+            DATA.forEach(function (r) { var k = r.sinceKnown ? r.since : 'unknown'; bySince[k] = (bySince[k] || 0) + 1; });
+            var sinceKeys = Object.keys(bySince).sort(function (a, b) {
+                if (a === 'unknown') return 1;
+                if (b === 'unknown') return -1;
+                return versionRank(a) - versionRank(b);
+            });
+            var maxSince = Math.max.apply(null, sinceKeys.map(function (k) { return bySince[k]; }));
+            var distCard = el('div', { class: 'card' });
+            var distHeader = el('h3', null, 'By since version ');
+            distHeader.appendChild(el('span', { class: 'hint' }, '(click to filter)'));
+            distCard.appendChild(distHeader);
+            sinceKeys.forEach(function (k) {
+                var active = (k === 'unknown') ? (fAge.value === 'unknown') : (fSince.value === k);
+                var row = el('div', { class: 'dist-row' + (active ? ' active' : ''), role: 'button', tabindex: '0' });
+                row.setAttribute('aria-label', 'Filter table to APIs incubating since ' + k);
+                row.appendChild(el('span', null, k));
+                var track = el('div', { class: 'bar-track' });
+                var bar = el('div', { class: 'bar' });
+                bar.style.width = Math.max(2, Math.round(bySince[k] / maxSince * 100)) + '%';
+                track.appendChild(bar);
+                row.appendChild(track);
+                row.appendChild(el('span', { class: 'count' }, String(bySince[k])));
+                row.addEventListener('click', function () { applyDistFilter(k); });
+                row.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); applyDistFilter(k); }
+                });
+                distCard.appendChild(row);
+            });
+            summary.appendChild(distCard);
+
+            // Top projects
+            var byProject = {};
+            DATA.forEach(function (r) { byProject[r.project] = (byProject[r.project] || 0) + 1; });
+            var topProjects = Object.keys(byProject).sort(function (a, b) { return byProject[b] - byProject[a]; }).slice(0, 8);
+            var projCard = el('div', { class: 'card' });
+            projCard.appendChild(el('h3', null, 'Top projects'));
+            topProjects.forEach(function (p) {
+                var row = el('div', { class: 'top-row' });
+                row.appendChild(el('span', null, p));
+                row.appendChild(el('span', { class: 'count' }, String(byProject[p])));
+                projCard.appendChild(row);
+            });
+            summary.appendChild(projCard);
+        }
+
+        function renderRows() {
+            var rows = DATA.filter(currentFilter()).slice().sort(compare);
+            tbody.innerHTML = '';
+            empty.hidden = rows.length !== 0;
+            rows.forEach(function (r) {
+                var tr = el('tr');
+                var bucket = ageBucket(r);
+                if (bucket === 'long') tr.className = 'row-long';
+                else if (!r.sinceKnown) tr.className = 'row-unknown';
+
+                var apiTd = el('td', { class: 'api' });
+                apiTd.appendChild(el('a', { href: r.url, target: '_blank', rel: 'noopener' }, r.name));
+                tr.appendChild(apiTd);
+
+                var kindTd = el('td');
+                kindTd.appendChild(el('span', { class: 'kind-pill' }, r.kind));
+                tr.appendChild(kindTd);
+
+                var sinceTd = el('td', { class: 'nowrap' });
+                if (r.sinceKnown) {
+                    sinceTd.textContent = r.since;
+                    sinceTd.title = r.sinceDate ? ('Released ' + r.sinceDate) : 'Unreleased';
+                } else {
+                    sinceTd.appendChild(el('span', { class: 'badge-unknown' }, 'unknown'));
                 }
+                tr.appendChild(sinceTd);
+
+                tr.appendChild(el('td', null, r.project));
+
+                var ageTd = el('td', { class: 'nowrap' });
+                if (!r.sinceKnown || r.age == null) {
+                    ageTd.appendChild(el('span', { class: 'badge-unknown' }, r.sinceKnown ? '—' : 'unknown'));
+                } else if (r.age > THRESHOLD) {
+                    ageTd.appendChild(el('span', { class: 'badge-warn' }, r.age + ' releases ⚠'));
+                } else {
+                    ageTd.textContent = r.age + ' releases';
+                }
+                tr.appendChild(ageTd);
+
+                tbody.appendChild(tr);
+            });
+        }
+
+        function updateAriaSort() {
+            var headers = document.querySelectorAll('thead th');
+            headers.forEach(function (th) {
+                var arrow = th.querySelector('.arrow');
+                if (th.getAttribute('data-key') === sortKey) {
+                    th.setAttribute('aria-sort', sortDir === 1 ? 'ascending' : 'descending');
+                    arrow.textContent = sortDir === 1 ? '▲' : '▼';
+                } else {
+                    th.removeAttribute('aria-sort');
+                    arrow.textContent = '';
+                }
+            });
+        }
+
+        document.querySelectorAll('thead th').forEach(function (th) {
+            th.addEventListener('click', function () {
+                var key = th.getAttribute('data-key');
+                if (key === sortKey) { sortDir = -sortDir; } else { sortKey = key; sortDir = 1; }
+                updateAriaSort();
+                renderRows();
+            });
+        });
+
+        // Re-render the summary too so the "By since version" active highlight tracks the filters.
+        function update() {
+            renderSummary();
+            renderRows();
+        }
+
+        // Clicking a distribution row sets up the matching filter (toggling it off if already active).
+        function applyDistFilter(k) {
+            var selected;
+            if (k === 'unknown') {
+                selected = fAge.value !== 'unknown';
+                fAge.value = selected ? 'unknown' : '';
+                fSince.value = '';
+            } else {
+                selected = fSince.value !== k;
+                fSince.value = selected ? k : '';
+                if (fAge.value === 'unknown') fAge.value = '';
+            }
+            update();
+            // Only jump to the table when turning a filter on, not when clearing it.
+            if (selected) {
+                var report = document.getElementById('report');
+                if (report.scrollIntoView) report.scrollIntoView({ behavior: 'smooth', block: 'start' });
             }
         }
+
+        [search, fSince, fProject, fKind, fAge].forEach(function (c) {
+            c.addEventListener('input', update);
+        });
+
+        document.getElementById('clear-filters').addEventListener('click', function (e) {
+            e.preventDefault();
+            search.value = ''; fSince.value = ''; fProject.value = ''; fKind.value = ''; fAge.value = '';
+            update();
+        });
+
+        document.getElementById('view-json').addEventListener('click', function (e) {
+            e.preventDefault();
+            console.log(JSON.stringify(DATA, null, 2));
+            window.alert('The full JSON dataset has been logged to the browser console.');
+        });
+
+        renderSummary();
+        updateAriaSort();
+        renderRows();
+    </script>
+</body>
+</html>
+"""
     }
+
+    private
+    fun timelineVersion(): String = parameters.versionFile.get().asFile.readText().trim()
 
     private
     fun String.urlEncodeSpace() = replace(" ", "%20")
 
     private
-    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
+    fun String.jsonEscape(): String = buildString {
+        for (c in this@jsonEscape) {
+            when (c) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                '<' -> append("\\u003c")
+                '>' -> append("\\u003e")
+                '&' -> append("\\u0026")
+                else -> if (c < ' ') append("\\u%04x".format(c.code)) else append(c)
+            }
+        }
+    }
 }
 
-data class Problem(
+
+private
+data class Record(
+    val version: String,
+    val kind: String,
     val name: String,
     val relativePath: String,
     val lineNumber: Int
 )
 
-typealias ProjectNameToProblems = MutableMap<String, MutableSet<Problem>>
+
+private
+data class Entry(
+    val name: String,
+    val kind: IncubatingApiKind,
+    val since: String,
+    val sinceKnown: Boolean,
+    val sinceDate: String?,
+    val project: String,
+    val age: Int?,
+    val url: String,
+    val category: String
+)
+
+
+private
+class VersionTimeline(
+    val currentVersion: String,
+    private val orderedMinorDates: LinkedHashMap<String, String>
+) {
+    /** Distinct minor versions, oldest-first, including the version currently under development. */
+    val orderedMinors: List<String> = orderedMinorDates.keys.toList()
+
+    /** Number of minor releases between [minor] and the newest point on the timeline, or null if unknown. */
+    fun ageOf(minor: String): Int? {
+        val idx = orderedMinors.indexOf(minor)
+        return if (idx < 0) null else orderedMinors.size - 1 - idx
+    }
+
+    fun dateOf(minor: String): String? = orderedMinorDates[minor]?.takeIf { it != "unreleased" }
+}

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
@@ -39,9 +39,15 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import gradlebuild.basics.util.KotlinSourceParser
 import org.gradle.workers.WorkAction
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.startOffsetSkippingComments
 import java.io.File
@@ -125,29 +131,15 @@ abstract class IncubatingApiReportWorkAction : WorkAction<IncubatingApiReportPar
             versionToIncubating.toSortedMap().forEach { (version, incubatingDescriptions) ->
                 val releaseDate = versions[version] ?: "unreleased"
                 incubatingDescriptions.sortedBy { it.name }.forEach { incubating ->
-                    writer.println("$version;$releaseDate;${incubating.name};${incubating.sourceRelativePath};${incubating.lineNumber}")
+                    writer.println("$version;$releaseDate;${incubating.kind};${incubating.name};${incubating.sourceRelativePath};${incubating.lineNumber}")
                 }
             }
         }
     }
 
     private
-    fun versionsDates(): Map<Version, String> {
-        val versions = mutableMapOf<Version, String>()
-        var version: String? = null
-        parameters.releasedVersionsFile.get().asFile.forEachLine(Charsets.UTF_8) {
-            val line = it.trim()
-            if (line.startsWith("\"version\"")) {
-                version = line.substring(line.indexOf("\"", 11) + 1, line.lastIndexOf("\""))
-            }
-            if (line.startsWith("\"buildTime\"")) {
-                var date = line.substring(line.indexOf("\"", 12) + 1, line.lastIndexOf("\""))
-                date = date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6, 8)
-                versions[version!!] = date
-            }
-        }
-        return versions
-    }
+    fun versionsDates(): Map<Version, String> =
+        ReleasedVersions.versionDates(parameters.releasedVersionsFile.get().asFile)
 
 
     private
@@ -160,7 +152,7 @@ typealias Version = String
 
 
 private
-data class IncubatingDescription(val name: String, val sourceRelativePath: Path, val lineNumber: Int)
+data class IncubatingDescription(val name: String, val kind: IncubatingApiKind, val sourceRelativePath: Path, val lineNumber: Int)
 
 
 private
@@ -239,9 +231,21 @@ class JavaVersionsToIncubatingCollector(srcDir: File, val repositoryRoot: Path) 
         val nodeName = nodeName(node, unit, file)
         return IncubatingDescription(
             name = nodeName,
+            kind = kindOf(node),
             sourceRelativePath = repositoryRoot.relativize(file.toPath()),
             lineNumber = node.begin.map { it.line }.orElse(-1)
         )
+    }
+
+    private
+    fun kindOf(node: Node): IncubatingApiKind = when (node) {
+        is EnumDeclaration -> IncubatingApiKind.ENUM
+        is AnnotationDeclaration -> IncubatingApiKind.ANNOTATION
+        is ClassOrInterfaceDeclaration -> if (node.isInterface) IncubatingApiKind.INTERFACE else IncubatingApiKind.CLASS
+        is MethodDeclaration -> IncubatingApiKind.METHOD
+        is FieldDeclaration -> IncubatingApiKind.FIELD
+        is PackageDeclaration -> IncubatingApiKind.PACKAGE
+        else -> IncubatingApiKind.OTHER
     }
 
     private
@@ -312,9 +316,24 @@ class KotlinVersionsToIncubatingCollector(val repositoryRoot: Path) : VersionsTo
         }
         return IncubatingDescription(
             name = incubating.replace(NEWLINE_REGEX, " "),
+            kind = kindOf(declaration),
             sourceRelativePath = repositoryRoot.relativize(sourceFile.toPath()),
             lineNumber = getLineNumber(declaration, ktFile)
         )
+    }
+
+    private
+    fun kindOf(declaration: KtNamedDeclaration): IncubatingApiKind = when {
+        declaration is KtClass && declaration.isInterface() -> IncubatingApiKind.INTERFACE
+        declaration is KtClass && declaration.isEnum() -> IncubatingApiKind.ENUM
+        declaration is KtClass && declaration.isAnnotation() -> IncubatingApiKind.ANNOTATION
+        declaration is KtClass -> IncubatingApiKind.CLASS
+        declaration is KtObjectDeclaration -> IncubatingApiKind.CLASS
+        declaration is KtConstructor<*> -> IncubatingApiKind.METHOD
+        declaration is KtNamedFunction -> IncubatingApiKind.METHOD
+        declaration is KtProperty -> IncubatingApiKind.PROPERTY
+        declaration is KtParameter -> IncubatingApiKind.PROPERTY
+        else -> IncubatingApiKind.OTHER
     }
 
     private

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/ReleasedVersions.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/ReleasedVersions.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.incubation.action
+
+import java.io.File
+
+
+/**
+ * Shared parsing of the `released-versions.json` file used by both the per-project producer
+ * (to attach release dates) and the aggregator (to compute the age of an incubating API in
+ * terms of minor releases). The file is parsed line-by-line in the same lenient way it has
+ * always been, to avoid pulling in a JSON dependency into the worker classpath.
+ */
+object ReleasedVersions {
+
+    data class ReleasedVersion(val version: String, val date: String)
+
+    /**
+     * All released versions in the order they appear in the file (newest first), each with its
+     * release date formatted as `yyyy-MM-dd`.
+     */
+    fun parse(releasedVersionsFile: File): List<ReleasedVersion> {
+        val result = mutableListOf<ReleasedVersion>()
+        var version: String? = null
+        releasedVersionsFile.forEachLine(Charsets.UTF_8) {
+            val line = it.trim()
+            if (line.startsWith("\"version\"")) {
+                version = line.substring(line.indexOf("\"", 11) + 1, line.lastIndexOf("\""))
+            }
+            if (line.startsWith("\"buildTime\"")) {
+                val raw = line.substring(line.indexOf("\"", 12) + 1, line.lastIndexOf("\""))
+                val date = raw.substring(0, 4) + "-" + raw.substring(4, 6) + "-" + raw.substring(6, 8)
+                version?.let { v -> result.add(ReleasedVersion(v, date)) }
+            }
+        }
+        return result
+    }
+
+    /**
+     * Map of full version string (e.g. `8.4.1`) to its release date.
+     */
+    fun versionDates(releasedVersionsFile: File): Map<String, String> =
+        parse(releasedVersionsFile).associate { it.version to it.date }
+
+    /**
+     * The `major.minor` part of a version string, e.g. `9.7.0` -> `9.7`, `9.6.0-rc-1` -> `9.6`.
+     */
+    fun toMinor(version: String): String {
+        val parts = version.split('.')
+        return when {
+            parts.size >= 2 -> "${parts[0]}.${parts[1].takeWhile { it.isDigit() }}"
+            else -> version
+        }
+    }
+}

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiAggregateReportTask.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/tasks/IncubatingApiAggregateReportTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -44,6 +45,14 @@ abstract class IncubatingApiAggregateReportTask : DefaultTask() {
     @get:Input
     abstract val currentCommit: Property<String>
 
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val versionFile: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val releasedVersionsFile: RegularFileProperty
+
     @get:OutputFile
     abstract val htmlReportFile: RegularFileProperty
 
@@ -59,5 +68,7 @@ abstract class IncubatingApiAggregateReportTask : DefaultTask() {
         htmlReportFile = this@IncubatingApiAggregateReportTask.htmlReportFile
         csvReportFile = this@IncubatingApiAggregateReportTask.csvReportFile
         currentCommit = this@IncubatingApiAggregateReportTask.currentCommit
+        versionFile = this@IncubatingApiAggregateReportTask.versionFile
+        releasedVersionsFile = this@IncubatingApiAggregateReportTask.releasedVersionsFile
     }
 }

--- a/build-logic/buildquality/src/test/kotlin/gradlebuild/incubation/action/ReleasedVersionsTest.kt
+++ b/build-logic/buildquality/src/test/kotlin/gradlebuild/incubation/action/ReleasedVersionsTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.incubation.action
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+
+class ReleasedVersionsTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `parses versions in file order with formatted dates`() {
+        val file = releasedVersionsFile(
+            """
+            {
+              "latestReleaseSnapshot": {
+                "version": "9.6.0-20260604021548+0000",
+                "buildTime": "20260604021548+0000"
+              },
+              "latestRc": {
+                "version": "9.6.0-rc-1",
+                "buildTime": "20260528120535+0000"
+              },
+              "finalReleases": [
+                {
+                  "version": "9.5.1",
+                  "buildTime": "20260512131942+0000"
+                },
+                {
+                  "version": "9.5.0",
+                  "buildTime": "20260428120530+0000"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val parsed = ReleasedVersions.parse(file)
+
+        assertEquals(
+            listOf(
+                ReleasedVersions.ReleasedVersion("9.6.0-20260604021548+0000", "2026-06-04"),
+                ReleasedVersions.ReleasedVersion("9.6.0-rc-1", "2026-05-28"),
+                ReleasedVersions.ReleasedVersion("9.5.1", "2026-05-12"),
+                ReleasedVersions.ReleasedVersion("9.5.0", "2026-04-28"),
+            ),
+            parsed
+        )
+    }
+
+    @Test
+    fun `builds a version to date map`() {
+        val file = releasedVersionsFile(
+            """
+            {
+              "finalReleases": [
+                {
+                  "version": "8.14",
+                  "buildTime": "20250425110700+0000"
+                },
+                {
+                  "version": "8.0.2",
+                  "buildTime": "20230301000000+0000"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(
+            mapOf("8.14" to "2025-04-25", "8.0.2" to "2023-03-01"),
+            ReleasedVersions.versionDates(file)
+        )
+    }
+
+    @Test
+    fun `parses an empty release list`() {
+        val file = releasedVersionsFile("""{ "finalReleases": [] }""")
+
+        assertEquals(emptyList<ReleasedVersions.ReleasedVersion>(), ReleasedVersions.parse(file))
+    }
+
+    @Test
+    fun `reduces versions to their major minor component`() {
+        assertEquals("9.7", ReleasedVersions.toMinor("9.7.0"))
+        assertEquals("8.4", ReleasedVersions.toMinor("8.4"))
+        assertEquals("8.10", ReleasedVersions.toMinor("8.10"))
+        assertEquals("9.6", ReleasedVersions.toMinor("9.6.0-rc-1"))
+        assertEquals("9.6", ReleasedVersions.toMinor("9.6.0-20260604021548+0000"))
+        assertEquals("1.0", ReleasedVersions.toMinor("1.0-milestone-3"))
+    }
+
+    @Test
+    fun `keeps single component versions unchanged`() {
+        assertEquals("9", ReleasedVersions.toMinor("9"))
+    }
+
+    private
+    fun releasedVersionsFile(content: String): File =
+        File(tempDir, "released-versions.json").apply { writeText(content) }
+}


### PR DESCRIPTION
The aggregated incubating-API report was a bare list of names grouped by version with no links or metadata. Replace it with a self-contained HTML page: a sortable/searchable table (API/Kind/Since/Project/Age), a summary block (totals, per-since distribution, top projects), GitHub source links, age-in-releases highlighting for long-incubating APIs, and an on-page CSV download. All client-side behaviour is vanilla inline JS/CSS over a single JSON data block; no CDN libraries.

The per-since distribution doubles as a filter: clicking a version (or the "unknown since" bucket) sets up the matching filter and scrolls to the table.

To support this:
- emit the API kind (class/interface/.../method/property/...) into the intermediate txt report (new IncubatingApiKind enum), parsed by the aggregator; the name field is split robustly so semicolons are safe
- thread version.txt and released-versions.json into the aggregator and compute each API's age in minor releases (shared ReleasedVersions helper, reused by the per-project producer)
- lift the GitHub blob-URL builder into a helper shared by CSV and HTML

The CSV output format is unchanged. The task name, output paths, and configuration-cache compatibility are preserved.