### PR TITLE
Fix a clean-up bug in the `GenerateClasspathModuleProperties` task 

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
@@ -34,12 +34,10 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.Properties
 import javax.inject.Inject
@@ -52,13 +50,13 @@ import javax.inject.Inject
  * This task assumes each component in the graph has a single variant and each variant
  * has at most one artifact.
  */
-@DisableCachingByDefault(because = "Unable to snapshot ComponentIdentifier") // Can be made cacheable after https://github.com/gradle/gradle/pull/36174
+@CacheableTask
 abstract class GenerateClasspathModuleProperties : DefaultTask() {
 
     @get:Input
     abstract val artifactNames: ListProperty<String>
 
-    @get:Internal // Can be declared input after https://github.com/gradle/gradle/pull/36174
+    @get:Input
     abstract val artifactComponentIds: ListProperty<ComponentIdentifier>
 
     @get:Nested
@@ -159,7 +157,7 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
     data class GraphNode(
         @get:Input val moduleName: String,
         @get:Nested @get:Optional val alias: ModuleAlias?,
-        @get:Internal val dependencyComponentIds: Set<ComponentIdentifier> // Can be declared input after https://github.com/gradle/gradle/pull/36174
+        @get:Input val dependencyComponentIds: Set<ComponentIdentifier>
     )
 
     @TaskAction

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
@@ -26,7 +26,9 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -40,6 +42,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.Properties
+import javax.inject.Inject
 
 /**
  * Given a configuration, produces a .properties for each node in the configuration's resolved
@@ -63,6 +66,9 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
 
     fun configureFrom(configuration: Configuration) {
         val artifacts = configuration.incoming.artifacts.resolvedArtifacts
@@ -158,7 +164,8 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
 
     @TaskAction
     fun generate() {
-        val outputDirectory = outputDir.get()
+        val outputDirectory = cleanOutputDirectory()
+
         val nodesByComponentId = graphNodes.get()
 
         val nodesWithoutArtifacts = nodesByComponentId.toMutableMap()
@@ -200,6 +207,17 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
                 outputDirectory.file(node.moduleName + ".properties").asFile
             )
         }
+    }
+
+    /*
+     * Remove leftovers from a previous run so a component dropped from the graph (e.g. by a
+     * dependency upgrade) doesn't survive as a phantom .properties.
+     */
+    private fun cleanOutputDirectory(): Directory {
+        val outputDirectory = outputDir.get()
+        fileSystemOperations.delete { delete(outputDirectory) }
+        outputDirectory.asFile.mkdirs()
+        return outputDirectory
     }
 
     private


### PR DESCRIPTION
<!--- The issue this PR addresses -->

This change was triggered by repeatedly experiencing the following error while working on embedded Kotlin upgrades:

```
Execution failed for task ':distributions-core:generateLicenseFile' (registered by plugin 'gradlebuild.distributions').
  > The following dependencies have no license data in their POM or any parent POM.
    Add an entry to the licenseOverrides map in GenerateLicenseFile.kt.
    Use "groupId:artifactId" for a single artifact or "groupId" for an entire group:
      org.jetbrains.kotlin:kotlin-scripting-jvm-host:2.3.21
```

While doing so a simple follow-up to https://github.com/gradle/gradle/pull/36174 was also done.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
