### PR TITLE
Propagate ambient read-only dependency cache to forked test builds

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -184,7 +184,12 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
                 builder.environment("JAVA_HOME", "");
                 builder.environment("GRADLE_OPTS", "");
                 builder.environment("JAVA_OPTS", "");
-                builder.environment(ArtifactCachesProvider.READONLY_CACHE_ENV_VAR, "");
+                // Propagate the ambient read-only dependency cache (seeded on CI agents from the global
+                // Gradle user home) so that forked builds resolve from it instead of downloading, matching
+                // what embedded executions see via System.getenv(). Tests that need a specific value or no
+                // cache at all override this via withReadOnlyCacheDir().
+                String ambientRoDepCache = System.getenv(ArtifactCachesProvider.READONLY_CACHE_ENV_VAR);
+                builder.environment(ArtifactCachesProvider.READONLY_CACHE_ENV_VAR, ambientRoDepCache == null ? "" : ambientRoDepCache);
 
                 GradleInvocation invocation = buildInvocation();
 


### PR DESCRIPTION
### Context

[Gradle_Master_Check_Platform_3_bucket15 #113799838](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_3_bucket15/113799838) failed because `GradleImplDepsCompatibilityIntegrationTest` forks an inner Gradle build with a fresh, isolated Gradle user home (`requireOwnGradleUserHomeDir()`), which had to download its dependencies from `repo.grdev.net` and hit a read timeout (fatal with `-Dorg.gradle.internal.repository.max.tentatives=1`).

The artifact cache CLI pre-build hook restores the *global* Gradle user home (`/home/tcagent1/.gradle`), but that only benefits the outer CI build: `NoDaemonGradleExecuter` unconditionally cleared `GRADLE_RO_DEP_CACHE` for forked builds, so inner test builds could never resolve from any agent-provided cache.

### Change

Propagate the ambient `GRADLE_RO_DEP_CACHE` environment variable to forked builds instead of clearing it. This matches embedded executions, which already see the variable via `System.getenv()` in-process, and covers all forking executers (`DaemonGradleExecuter`, `ParallelForkingGradleExecuter`).

The clearing was introduced in 3d7210f5171 to keep the read-only-cache feature tests deterministic; those tests set their own directory via `withReadOnlyCacheDir()`, which is applied after this default and still overrides it. Any test that needs no read-only cache at all can opt out with `executer.withReadOnlyCacheDir("")`.

### Companion change

The CI side (preparing a read-only snapshot of the restored global Gradle user home and exporting `env.GRADLE_RO_DEP_CACHE`) is implemented in the `dev-infrastructure` pre-build hook and requires an AMI rebake to take effect. Until then this change is a no-op on CI, because the variable is unset.

### Known limitation

The snapshot only contains dependencies the outer build resolves. Inner test projects using `useSpock()` / `useJUnitJupiter()` pull the distribution-default framework versions (e.g. Spock 2.3-groovy-4.0), which gradle/gradle itself does not resolve (it uses Spock 2.4), so those are still downloaded from the mirror. A follow-up will seed the cache with those default versions, resolved against the exact mirror URL so the repository metadata cache ids match.