### PR TITLE
Propagate DEVELOCITY_SERVER_URL to smoke test JVMs

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -276,7 +276,7 @@ fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "w
  * environment variable. This allows build scans to be published for integration tests.
  */
 fun Test.inheritedEnvVars(): List<String> = when {
-    project.name == "smoke-test" -> listOf("DEVELOCITY_ACCESS_KEY", "CI")
+    project.name == "smoke-test" -> listOf("DEVELOCITY_ACCESS_KEY", "DEVELOCITY_SERVER_URL", "DEVELOCITY_EDGE_DISCOVERY", "CI")
     else -> emptyList()
 }
 


### PR DESCRIPTION
### Problem

[`GradleBuildSmokeTest.can build Gradle distribution` and `GradleBuildUnitTestConfigurationCacheSmokeTest.can run Gradle unit tests with configuration cache enabled` failed](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SmokeTest_GradleBuildSmokeTests_virtual_Batch_1_1/113815188) with:

```
java.lang.AssertionError: Standard output line 379 contains an unexpected stack trace: 	at com.gradle.enterprise.agent.c.a.b.a(SourceFile:81)
```

The offending stack traces come from remote build cache load failures in the inner Gradle builds launched by the smoke tests:

```
Loading entry from 'https://ge.gradle.org/cache/3144eba24e87b545a1364553923ea5ba' failed: java.net.SocketTimeoutException: Read timed out
Loading entry from 'https://ge.gradle.org/cache/ca617d6c095a8b62ff5e8329a356a0fb' response status 503: Service Unavailable
```

### Root cause

CI agents set `DEVELOCITY_SERVER_URL=https://usw2-edge.gradle.org` (the outer build and the HooksPlugin use it correctly). But the smoke test JVM environment is filtered by `gradlebuild.filterEnvironmentVariables`, and `DEVELOCITY_SERVER_URL` was not in the inherited list — only `DEVELOCITY_ACCESS_KEY` and `CI` were. The inner gradle/gradle builds inherit the test JVM's environment, so the [develocity-conventions-plugin](https://github.com/gradle/gradle-org-conventions-plugin) (which reads the `develocity.server.url` system property, then the `DEVELOCITY_SERVER_URL` env var since gradle/gradle-org-conventions-plugin#127) fell back to its default `https://ge.gradle.org` and configured it as an explicit remote cache server — hence the `A build cache server address was configured overriding the result of Edge discovery.` messages in the inner builds. Timeouts/503s from that origin then failed the no-stack-trace assertion.

### Fix

Propagate `DEVELOCITY_SERVER_URL` (and `DEVELOCITY_EDGE_DISCOVERY`, which the plugin reads the same way) to smoke test JVMs so inner builds talk to the same Develocity edge as the outer build.