### PR TITLE
Avoid internal mutation of StartParameter task requests

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    def "mutating StartParameter method from root project build script is a violation"() {
+        buildFile("""
+            gradle.startParameter.${call}
+        """)
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":")
+            problem("Build file 'build.gradle': line 2: Cannot call '${method}' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        method                              | call
+        "setDryRun(boolean)"                | 'setDryRun(true)'
+        "setBuildCacheEnabled(boolean)"     | 'setBuildCacheEnabled(true)'
+        "setOffline(boolean)"               | 'setOffline(true)'
+
+        combined:
+        mode << ALL_MODES
+    }
+
+    def "mutating StartParameterInternal method from root project build script is a violation"() {
+        buildFile("""
+            gradle.startParameter.${call}
+        """)
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":")
+            problem("Build file 'build.gradle': line 2: Cannot call '${method}' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        method                                      | call
+        "setConfigurationCacheDebug(boolean)"       | 'setConfigurationCacheDebug(true)'
+        "setVfsVerboseLogging(boolean)"             | 'setVfsVerboseLogging(true)'
+
+        combined:
+        mode << ALL_MODES
+    }
+
+    def "mutating StartParameter from included build project script is a violation"() {
+        settingsFile("""
+            includeBuild("included")
+        """)
+        file("included/build.gradle") << """
+            gradle.startParameter.setOffline(true)
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":", ":included")
+            problem("Build file 'included/build.gradle': line 2: Cannot call 'setOffline(boolean)' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        mode << ALL_MODES
+    }
+
+    def "mutating StartParameter from root build settings script is allowed"() {
+        settingsFile("""
+            gradle.startParameter.setDryRun(true)
+        """)
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+    }
+
+    def "mutating StartParameter from included build settings script is allowed"() {
+        settingsFile("""
+            includeBuild("included")
+        """)
+        file("included/settings.gradle") << """
+            gradle.startParameter.setDryRun(true)
+        """
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":included")
+        }
+    }
+
+    def "mutating parent build StartParameter from included build project script is a violation"() {
+        settingsFile("""
+            includeBuild("included")
+        """)
+        file("included/build.gradle") << """
+            gradle.parent.startParameter.setDryRun(true)
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":", ":included")
+            problem("Build file 'included/build.gradle': line 2: Cannot call 'setDryRun(boolean)' on StartParameter after settings have been evaluated when Isolated Projects is enabled.")
+        }
+
+        where:
+        mode << ALL_MODES
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
@@ -160,5 +160,23 @@ class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProj
             projectsConfigured(":buildSrc", ":")
         }
     }
+    @spock.lang.Issue("https://github.com/gradle/gradle/issues/37944")
+    def "build relying on default tasks does not report StartParameter violations"() {
+        // Gradle internally resolves the default-tasks request at scheduling time; this must not
+        // mutate the StartParameter (it used to write the resolved task names back into it).
+        buildFile("""
+            defaultTasks 'ok'
+            tasks.register('ok') { doLast { println 'default task ran' } }
+        """)
+
+        when:
+        isolatedProjectsRun()
+
+        then:
+        outputContains("default task ran")
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+    }
 
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsStartParameterIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import spock.lang.Issue
+
 class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
 
     def "mutating StartParameter method from root project build script is a violation"() {
@@ -136,6 +138,27 @@ class IsolatedProjectsStartParameterIntegrationTest extends AbstractIsolatedProj
 
         where:
         mode << ALL_MODES
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37944")
+    def "build with buildSrc does not report StartParameter violations"() {
+        // Gradle internally configures the buildSrc build's task requests; this must not be
+        // reported as a StartParameter mutation (it used to mutate them after settings evaluation).
+        file("buildSrc/build.gradle") << """
+            plugins { id 'java' }
+        """
+        file("buildSrc/src/main/java/Dummy.java") << "public class Dummy {}"
+        buildFile("""
+            tasks.register("ok")
+        """)
+
+        when:
+        isolatedProjectsRun("ok")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":buildSrc", ":")
+        }
     }
 
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -83,7 +83,6 @@ import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readEnum
 import org.gradle.internal.serialize.graph.readList
 import org.gradle.internal.serialize.graph.readNonNull
-import org.gradle.internal.serialize.graph.readStrings
 import org.gradle.internal.serialize.graph.readStringsSet
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.withDebugFrame
@@ -693,7 +692,6 @@ class ConfigurationCacheState(
     fun WriteContext.writeGradleState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             // per build
-            writeStartParameterOf(gradle)
             writeChildBuilds(gradle)
         }
     }
@@ -705,23 +703,8 @@ class ConfigurationCacheState(
         val gradle = build.gradle
         return withGradleIsolate(gradle, userTypesCodec) {
             // per build
-            readStartParameterOf(gradle)
             readChildBuilds()
         }
-    }
-
-    private
-    fun WriteContext.writeStartParameterOf(gradle: GradleInternal) {
-        val startParameterTaskNames = gradle.startParameter.taskNames
-        writeStrings(startParameterTaskNames)
-    }
-
-    private
-    fun ReadContext.readStartParameterOf(gradle: GradleInternal) {
-        // Restore startParameter.taskNames to enable `gradle.startParameter.setTaskNames(...)` idiom in included build scripts
-        // See org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy:134
-        val startParameterTaskNames = readStrings()
-        gradle.startParameter.setTaskNames(startParameterTaskNames)
     }
 
     private

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingCollection.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingCollection.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A {@link Collection} wrapper that notifies a callback when any mutating method is called,
+ * including mutation through {@link #iterator()}.
+ *
+ * <p>The delegate type parameter {@code C} lets subclasses access the delegate through its
+ * specific interface, e.g. {@link MutationNotifyingList} calling {@link java.util.List#get(int)}.
+ *
+ * <p>Serializes as its delegate: the notification callback is runtime-only wiring, and instances
+ * may be captured in task state and serialized to the configuration cache.
+ */
+public class MutationNotifyingCollection<E, C extends Collection<E>> implements Collection<E>, Serializable {
+
+    final C delegate;
+    final transient Consumer<String> onMutation;
+
+    public MutationNotifyingCollection(C delegate, Consumer<String> onMutation) {
+        this.delegate = delegate;
+        this.onMutation = onMutation;
+    }
+
+    // protected so that it is inherited by the Set, List and entry-set subclasses.
+    protected Object writeReplace() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return new MutationNotifyingIterator<E>(delegate.iterator(), onMutation);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return delegate.toArray(a);
+    }
+
+    @Override
+    public Spliterator<E> spliterator() {
+        return delegate.spliterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super E> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    @SuppressWarnings("UndefinedEquals") // We're fine with having weak contract of Iterable/Collection.equals.
+    public boolean equals(@Nullable Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public boolean add(E e) {
+        onMutation.accept("add(Object)");
+        return delegate.add(e);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        onMutation.accept("addAll(Collection)");
+        return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean remove(@Nullable Object o) {
+        onMutation.accept("remove(Object)");
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        onMutation.accept("removeAll(Collection)");
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        onMutation.accept("retainAll(Collection)");
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        onMutation.accept("removeIf(Predicate)");
+        return delegate.removeIf(filter);
+    }
+
+    @Override
+    public void clear() {
+        onMutation.accept("clear()");
+        delegate.clear();
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingEntry.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingEntry.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * A {@link Map.Entry} wrapper that notifies a callback when {@link #setValue(Object)} is called.
+ *
+ * <p>Entries obtained from a map's entry set are live: {@code setValue} writes through to the
+ * backing map, so it must be guarded like any other mutator.
+ */
+class MutationNotifyingEntry<K, V> implements Map.Entry<K, V> {
+
+    private final Map.Entry<K, V> delegate;
+    private final Consumer<String> onMutation;
+
+    MutationNotifyingEntry(Map.Entry<K, V> delegate, Consumer<String> onMutation) {
+        this.delegate = delegate;
+        this.onMutation = onMutation;
+    }
+
+    @Override
+    public K getKey() {
+        return delegate.getKey();
+    }
+
+    @Override
+    public V getValue() {
+        return delegate.getValue();
+    }
+
+    @Override
+    public V setValue(V value) {
+        onMutation.accept("Entry.setValue(Object)");
+        return delegate.setValue(value);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        // Map.Entry equality is defined value-wise across implementations, so delegating is symmetric.
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingEntrySet.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingEntrySet.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+/**
+ * A {@link Map#entrySet()} wrapper that, in addition to the mutators guarded by
+ * {@link MutationNotifyingSet}, guards {@link Map.Entry#setValue(Object)} on entries handed out
+ * via {@link #iterator()}, {@link #forEach(Consumer)} and {@link #spliterator()} (and therefore streams).
+ *
+ * <p>{@link #toArray()} intentionally returns the live entries unwrapped; mutating the backing map
+ * through {@code setValue} on an entry obtained from the array is not detected.
+ */
+class MutationNotifyingEntrySet<K, V> extends MutationNotifyingSet<Map.Entry<K, V>> {
+
+    MutationNotifyingEntrySet(Set<Map.Entry<K, V>> delegate, Consumer<String> onMutation) {
+        super(delegate, onMutation);
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+        // super.iterator() already notifies on remove(); wrap the entries it yields to guard setValue().
+        final Iterator<Map.Entry<K, V>> it = super.iterator();
+        return new Iterator<Map.Entry<K, V>>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public Map.Entry<K, V> next() {
+                return new MutationNotifyingEntry<K, V>(it.next(), onMutation);
+            }
+
+            @Override
+            public void remove() {
+                // notification already emitted by the iterator from super.iterator().
+                it.remove();
+            }
+        };
+    }
+
+    @Override
+    public void forEach(Consumer<? super Map.Entry<K, V>> action) {
+        delegate.forEach(entry -> action.accept(new MutationNotifyingEntry<K, V>(entry, onMutation)));
+    }
+
+    @Override
+    public Spliterator<Map.Entry<K, V>> spliterator() {
+        return Spliterators.spliterator(iterator(), size(), Spliterator.DISTINCT);
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingIterator.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingIterator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.Iterator;
+import java.util.function.Consumer;
+
+/**
+ * An {@link Iterator} wrapper that notifies a callback when {@link #remove()} is called.
+ */
+class MutationNotifyingIterator<E> implements Iterator<E> {
+
+    private final Iterator<E> delegate;
+    private final Consumer<String> onMutation;
+
+    MutationNotifyingIterator(Iterator<E> delegate, Consumer<String> onMutation) {
+        this.delegate = delegate;
+        this.onMutation = onMutation;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public E next() {
+        return delegate.next();
+    }
+
+    @Override
+    public void remove() {
+        onMutation.accept("iterator().remove()");
+        delegate.remove();
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingList.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingList.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+/**
+ * A {@link List} wrapper that notifies a callback when any mutating method is called,
+ * including mutation through {@link #iterator()}, {@link #listIterator()} and {@link #subList(int, int)}.
+ */
+public class MutationNotifyingList<E> extends MutationNotifyingCollection<E, List<E>> implements List<E> {
+
+    public MutationNotifyingList(List<E> delegate, Consumer<String> onMutation) {
+        super(delegate, onMutation);
+    }
+
+    @Override
+    public E get(int index) {
+        return delegate.get(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return delegate.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return delegate.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        return new MutationNotifyingListIterator<E>(delegate.listIterator(), onMutation);
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        return new MutationNotifyingListIterator<E>(delegate.listIterator(index), onMutation);
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        // A sublist is a live view; wrap recursively so its mutators, iterators and nested sublists notify too.
+        return new MutationNotifyingList<E>(delegate.subList(fromIndex, toIndex), name -> onMutation.accept("subList()." + name));
+    }
+
+    @Override
+    public void add(int index, E element) {
+        onMutation.accept("add(int, Object)");
+        delegate.add(index, element);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        onMutation.accept("addAll(int, Collection)");
+        return delegate.addAll(index, c);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        onMutation.accept("set(int, Object)");
+        return delegate.set(index, element);
+    }
+
+    @Override
+    public E remove(int index) {
+        onMutation.accept("remove(int)");
+        return delegate.remove(index);
+    }
+
+    @Override
+    public void replaceAll(UnaryOperator<E> operator) {
+        onMutation.accept("replaceAll(UnaryOperator)");
+        delegate.replaceAll(operator);
+    }
+
+    @Override
+    public void sort(@Nullable Comparator<? super E> c) {
+        onMutation.accept("sort(Comparator)");
+        delegate.sort(c);
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingListIterator.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingListIterator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.ListIterator;
+import java.util.function.Consumer;
+
+/**
+ * A {@link ListIterator} wrapper that notifies a callback when any mutating method is called.
+ */
+class MutationNotifyingListIterator<E> implements ListIterator<E> {
+
+    private final ListIterator<E> delegate;
+    private final Consumer<String> onMutation;
+
+    MutationNotifyingListIterator(ListIterator<E> delegate, Consumer<String> onMutation) {
+        this.delegate = delegate;
+        this.onMutation = onMutation;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public E next() {
+        return delegate.next();
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return delegate.hasPrevious();
+    }
+
+    @Override
+    public E previous() {
+        return delegate.previous();
+    }
+
+    @Override
+    public int nextIndex() {
+        return delegate.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+        return delegate.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+        onMutation.accept("listIterator().remove()");
+        delegate.remove();
+    }
+
+    @Override
+    public void set(E e) {
+        onMutation.accept("listIterator().set(Object)");
+        delegate.set(e);
+    }
+
+    @Override
+    public void add(E e) {
+        onMutation.accept("listIterator().add(Object)");
+        delegate.add(e);
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingMap.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingMap.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A {@link Map} wrapper that notifies a callback when any mutating method is called,
+ * including mutation through the {@link #keySet()}, {@link #values()} and {@link #entrySet()} views.
+ *
+ * <p>Serializes as its delegate: the notification callback is runtime-only wiring, and instances
+ * may be captured in task state and serialized to the configuration cache.
+ */
+public class MutationNotifyingMap<K, V> implements Map<K, V>, Serializable {
+
+    private final Map<K, V> delegate;
+    private final transient Consumer<String> onMutation;
+
+    public MutationNotifyingMap(Map<K, V> delegate, Consumer<String> onMutation) {
+        this.delegate = delegate;
+        this.onMutation = onMutation;
+    }
+
+    private Object writeReplace() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public @Nullable V get(Object key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public V getOrDefault(Object key, V defaultValue) {
+        return delegate.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        // Map views are live: removing from them removes the corresponding mappings from this map.
+        return new MutationNotifyingSet<>(delegate.keySet(), name -> onMutation.accept("keySet()." + name));
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new MutationNotifyingCollection<>(delegate.values(), name -> onMutation.accept("values()." + name));
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return new MutationNotifyingEntrySet<>(delegate.entrySet(), name -> onMutation.accept("entrySet()." + name));
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        delegate.forEach(action);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public @Nullable V put(K key, V value) {
+        onMutation.accept("put(Object, Object)");
+        return delegate.put(key, value);
+    }
+
+    @Override
+    public @Nullable V putIfAbsent(K key, V value) {
+        onMutation.accept("putIfAbsent(Object, Object)");
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        onMutation.accept("putAll(Map)");
+        delegate.putAll(m);
+    }
+
+    @Override
+    public V remove(@Nullable Object key) {
+        onMutation.accept("remove(Object)");
+        return delegate.remove(key);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        onMutation.accept("remove(Object, Object)");
+        return delegate.remove(key, value);
+    }
+
+    @Override
+    public @Nullable V replace(K key, V value) {
+        onMutation.accept("replace(Object, Object)");
+        return delegate.replace(key, value);
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        onMutation.accept("replace(Object, Object, Object)");
+        return delegate.replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        onMutation.accept("replaceAll(BiFunction)");
+        delegate.replaceAll(function);
+    }
+
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        onMutation.accept("merge(Object, Object, BiFunction)");
+        return delegate.merge(key, value, remappingFunction);
+    }
+
+    @Override
+    public @Nullable V compute(K key, BiFunction<? super K, ? super @Nullable V, ? extends V> remappingFunction) {
+        onMutation.accept("compute(Object, BiFunction)");
+        return delegate.compute(key, remappingFunction);
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        onMutation.accept("computeIfAbsent(Object, Function)");
+        return delegate.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public @Nullable V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        onMutation.accept("computeIfPresent(Object, BiFunction)");
+        return delegate.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public void clear() {
+        onMutation.accept("clear()");
+        delegate.clear();
+    }
+}

--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingSet.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/MutationNotifyingSet.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A {@link Set} wrapper that notifies a callback when any mutating method is called,
+ * including mutation through {@link #iterator()}.
+ */
+public class MutationNotifyingSet<E> extends MutationNotifyingCollection<E, Set<E>> implements Set<E> {
+
+    public MutationNotifyingSet(Set<E> delegate, Consumer<String> onMutation) {
+        super(delegate, onMutation);
+    }
+}

--- a/platforms/core-runtime/collections/src/test/groovy/org/gradle/internal/collect/MutationNotifyingCollectionsTest.groovy
+++ b/platforms/core-runtime/collections/src/test/groovy/org/gradle/internal/collect/MutationNotifyingCollectionsTest.groovy
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect
+
+import spock.lang.Specification
+
+class MutationNotifyingCollectionsTest extends Specification {
+
+    def "MutationNotifyingList notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def list = new MutationNotifyingList<>(new ArrayList(["a", "b"]), { mutations << it })
+
+        when:
+        operation(list)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage              | operation
+        "add(Object)"                | { l -> l.add("x") }
+        "add(int, Object)"           | { l -> l.add(0, "x") }
+        "addAll(Collection)"         | { l -> l.addAll(["x"]) }
+        "addAll(int, Collection)"    | { l -> l.addAll(0, ["x"]) }
+        "set(int, Object)"           | { l -> l.set(0, "x") }
+        "remove(int)"                | { l -> l.remove(0) }
+        "remove(Object)"             | { l -> l.remove("a") }
+        "removeAll(Collection)"      | { l -> l.removeAll(["a"]) }
+        "retainAll(Collection)"      | { l -> l.retainAll(["a"]) }
+        "removeIf(Predicate)"        | { l -> l.removeIf { it == "nope" } }
+        "replaceAll(UnaryOperator)"  | { l -> l.replaceAll { it.toUpperCase() } }
+        "sort(Comparator)"           | { l -> l.sort({ x, y -> x <=> y } as Comparator) }
+        "clear()"                    | { l -> l.clear() }
+    }
+
+    def "MutationNotifyingList does not notify on read operations"() {
+        List<String> mutations = []
+        def list = new MutationNotifyingList<>(["a", "b"], { mutations << it })
+
+        when:
+        list.size()
+        list.isEmpty()
+        list.contains("a")
+        list.get(0)
+        list.indexOf("a")
+        list.toArray()
+        list.iterator()
+
+        then:
+        mutations.empty
+    }
+
+    def "MutationNotifyingSet notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def set = new MutationNotifyingSet<>(new LinkedHashSet(["a", "b"]), { mutations << it })
+
+        when:
+        operation(set)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage         | operation
+        "add(Object)"           | { s -> s.add("x") }
+        "addAll(Collection)"    | { s -> s.addAll(["x"]) }
+        "remove(Object)"        | { s -> s.remove("a") }
+        "removeAll(Collection)" | { s -> s.removeAll(["a"]) }
+        "retainAll(Collection)" | { s -> s.retainAll(["a"]) }
+        "removeIf(Predicate)"   | { s -> s.removeIf { it == "nope" } }
+        "clear()"               | { s -> s.clear() }
+    }
+
+    def "MutationNotifyingSet does not notify on read operations"() {
+        List<String> mutations = []
+        def set = new MutationNotifyingSet<>(new LinkedHashSet(["a", "b"]), { mutations << it })
+
+        when:
+        set.size()
+        set.isEmpty()
+        set.contains("a")
+        set.containsAll(["a"])
+        set.toArray()
+        set.iterator()
+
+        then:
+        mutations.empty
+    }
+
+    def "MutationNotifyingMap notifies '#expectedMessage'"() {
+        given:
+        List<String> mutations = []
+        def map = new MutationNotifyingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        operation(map)
+
+        then:
+        mutations == [expectedMessage]
+
+        where:
+        expectedMessage                       | operation
+        "put(Object, Object)"                 | { m -> m.put("c", "3") }
+        "putIfAbsent(Object, Object)"         | { m -> m.putIfAbsent("c", "3") }
+        "putAll(Map)"                         | { m -> m.putAll(["c": "3"]) }
+        "remove(Object)"                      | { m -> m.remove("a") }
+        "remove(Object, Object)"              | { m -> m.remove("a", "1") }
+        "replace(Object, Object)"             | { m -> m.replace("a", "9") }
+        "replace(Object, Object, Object)"     | { m -> m.replace("a", "1", "9") }
+        "replaceAll(BiFunction)"              | { m -> m.replaceAll { k, v -> v } }
+        "merge(Object, Object, BiFunction)"   | { m -> m.merge("a", "9", { x, y -> y }) }
+        "compute(Object, BiFunction)"         | { m -> m.compute("a") { k, v -> "9" } }
+        "computeIfAbsent(Object, Function)"   | { m -> m.computeIfAbsent("c") { "9" } }
+        "computeIfPresent(Object, BiFunction)"| { m -> m.computeIfPresent("a") { k, v -> "9" } }
+        "clear()"                             | { m -> m.clear() }
+    }
+
+    def "MutationNotifyingMap does not notify on read operations"() {
+        List<String> mutations = []
+        def map = new MutationNotifyingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        map.size()
+        map.isEmpty()
+        map.containsKey("a")
+        map.containsValue("1")
+        map.get("a")
+        map.keySet()
+        map.values()
+        map.entrySet()
+
+        then:
+        mutations.empty
+    }
+
+    def "MutationNotifyingList notifies on mutation through iterators and sublists"() {
+        List<String> mutations = []
+        def backing = ["a", "b", "c"]
+        def list = new MutationNotifyingList<>(backing, { mutations << it })
+
+        when:
+        def it = list.iterator()
+        it.next()
+        it.remove()
+        then:
+        mutations == ["iterator().remove()"]
+        backing == ["b", "c"]
+
+        when:
+        mutations.clear()
+        def listIt = list.listIterator()
+        listIt.next()
+        listIt.set("x")
+        listIt.add("y")
+        listIt.previous()
+        listIt.remove()
+        then:
+        mutations == ["listIterator().set(Object)", "listIterator().add(Object)", "listIterator().remove()"]
+
+        when:
+        mutations.clear()
+        list.subList(0, 1).clear()
+        then:
+        mutations == ["subList().clear()"]
+
+        when:
+        mutations.clear()
+        list.subList(0, 1).iterator() // read-only use of a sublist
+        list.removeIf { it == "nope" }
+        then:
+        mutations == ["removeIf(Predicate)"]
+    }
+
+    def "MutationNotifyingSet notifies on mutation through iterator and removeIf"() {
+        List<String> mutations = []
+        def backing = new LinkedHashSet(["a", "b"])
+        def set = new MutationNotifyingSet<>(backing, { mutations << it })
+
+        when:
+        def it = set.iterator()
+        it.next()
+        it.remove()
+        then:
+        mutations == ["iterator().remove()"]
+        backing == ["b"] as Set
+
+        when:
+        mutations.clear()
+        set.removeIf { it == "nope" }
+        then:
+        mutations == ["removeIf(Predicate)"]
+    }
+
+    def "MutationNotifyingMap notifies on mutation through its views"() {
+        List<String> mutations = []
+        def backing = ["a": "1", "b": "2", "c": "3"]
+        def map = new MutationNotifyingMap<>(backing, { mutations << it })
+
+        when:
+        map.keySet().remove("a")
+        then:
+        mutations == ["keySet().remove(Object)"]
+        !backing.containsKey("a")
+
+        when:
+        mutations.clear()
+        def keyIt = map.keySet().iterator()
+        keyIt.next()
+        keyIt.remove()
+        then:
+        mutations == ["keySet().iterator().remove()"]
+        !backing.containsKey("b")
+
+        when:
+        mutations.clear()
+        map.values().remove("3")
+        then:
+        mutations == ["values().remove(Object)"]
+        backing.isEmpty()
+    }
+
+    def "MutationNotifyingMap notifies on mutation through its entry set"() {
+        List<String> mutations = []
+        def backing = ["a": "1", "b": "2"]
+        def map = new MutationNotifyingMap<>(backing, { mutations << it })
+
+        when:
+        def entryIt = map.entrySet().iterator()
+        def entry = entryIt.next()
+        entry.setValue("9")
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["a"] == "9"
+
+        when:
+        mutations.clear()
+        entryIt.remove()
+        then:
+        mutations == ["entrySet().iterator().remove()"]
+        !backing.containsKey("a")
+
+        when:
+        mutations.clear()
+        map.entrySet().forEach { it.setValue("7") }
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["b"] == "7"
+
+        when:
+        mutations.clear()
+        map.entrySet().stream().forEach { it.setValue("5") }
+        then:
+        mutations == ["entrySet().Entry.setValue(Object)"]
+        backing["b"] == "5"
+
+        when:
+        mutations.clear()
+        map.entrySet().removeIf { it.key == "b" }
+        then:
+        mutations == ["entrySet().removeIf(Predicate)"]
+        backing.isEmpty()
+    }
+
+    def "map view reads do not notify"() {
+        List<String> mutations = []
+        def map = new MutationNotifyingMap<>(["a": "1", "b": "2"], { mutations << it })
+
+        when:
+        map.keySet().contains("a")
+        map.keySet().each { }
+        map.values().contains("1")
+        map.entrySet().each { it.key; it.value }
+        map.entrySet().stream().map { it.value }.count()
+
+        then:
+        mutations.empty
+    }
+
+    def "wrappers serialize as their delegate"() {
+        // Wrappers may be captured in task state and serialized to the configuration cache;
+        // the notification callback is runtime-only and must not be dragged along.
+        given:
+        def list = new MutationNotifyingList<>(["a"], { })
+        def set = new MutationNotifyingSet<>(new LinkedHashSet(["a"]), { })
+        def map = new MutationNotifyingMap<>(["a": "1"], { })
+
+        expect:
+        javaRoundTrip(list) == ["a"]
+        javaRoundTrip(list) instanceof ArrayList
+        javaRoundTrip(set) == (["a"] as Set)
+        javaRoundTrip(set) instanceof LinkedHashSet
+        javaRoundTrip(map) == ["a": "1"]
+        javaRoundTrip(map) instanceof LinkedHashMap
+    }
+
+    private static Object javaRoundTrip(Object o) {
+        def bytes = new ByteArrayOutputStream()
+        new ObjectOutputStream(bytes).withCloseable { it.writeObject(o) }
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray())).withCloseable { it.readObject() }
+    }
+
+    def "MutationNotifyingList notifies on mutation through positioned list iterator"() {
+        given:
+        List<String> mutations = []
+        def list = new MutationNotifyingList<>(new ArrayList(["a", "b", "c"]), { mutations << it })
+
+        when:
+        def it = list.listIterator(1)
+        it.next()
+        it.remove()
+
+        then:
+        mutations == ["listIterator().remove()"]
+        !list.contains("b")
+    }
+
+    def "exotic map mutators delegate results and write through"() {
+        given:
+        List<String> mutations = []
+        def backing = ["a": "1"]
+        def map = new MutationNotifyingMap<>(backing, { mutations << it })
+
+        expect:
+        map.merge("a", "2", { x, y -> x + y }) == "12"
+        backing["a"] == "12"
+        map.compute("a") { k, v -> v + "!" } == "12!"
+        backing["a"] == "12!"
+        map.computeIfAbsent("b") { "9" } == "9"
+        backing["b"] == "9"
+        map.computeIfPresent("missing") { k, v -> "x" } == null
+        !backing.containsKey("missing")
+        mutations.size() == 4
+    }
+
+    def "entrySet toArray returns live entries that do not notify on setValue"() {
+        // Deliberate coverage boundary: wrapping toArray() results is not worth the complexity,
+        // see MutationNotifyingEntrySet. If this behavior changes, it is a design decision, not a bug.
+        given:
+        List<String> mutations = []
+        def backing = ["a": "1"]
+        def map = new MutationNotifyingMap<>(backing, { mutations << it })
+
+        when:
+        def entry = map.entrySet().toArray()[0] as Map.Entry
+        entry.setValue("9")
+
+        then:
+        backing["a"] == "9"
+        mutations.empty
+    }
+
+}

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -16,9 +16,9 @@
 
 package org.gradle.launcher.exec;
 
-import org.gradle.StartParameter;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -49,7 +49,7 @@ public class RootBuildLifecycleBuildActionExecutor {
     private final BuildTreeLifecycleListener lifecycleListener;
     private final ProblemsInternal problemsService;
     private final BuildOperationProgressEventEmitter eventEmitter;
-    private final StartParameter startParameter;
+    private final StartParameterInternal startParameter;
     private final ProblemStream problemsStream;
     private final BuildActionRunner buildActionRunner;
     private final BuildStateRegistry buildStateRegistry;
@@ -62,7 +62,7 @@ public class RootBuildLifecycleBuildActionExecutor {
         BuildTreeLifecycleListener lifecycleListener,
         ProblemsInternal problemsService,
         BuildOperationProgressEventEmitter eventEmitter,
-        StartParameter startParameter,
+        StartParameterInternal startParameter,
         ProblemStream problemsStream,
         BuildStateRegistry buildStateRegistry,
         BuildActionRunner buildActionRunner
@@ -98,6 +98,8 @@ public class RootBuildLifecycleBuildActionExecutor {
                 RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(action.getStartParameter(), null));
                 return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));
             } finally {
+                // Since continuous builds reuse the same StartParameter for multiple build trees.
+                startParameter.clearMutationListener();
                 lifecycleListener.beforeStop();
             }
         } finally {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -211,7 +211,7 @@ public class LauncherServices extends AbstractGradleModuleServices {
             List<ProblemReporter> problemReporters,
             BuildLoggerFactory buildLoggerFactory,
             InternalOptions options,
-            StartParameter startParameter,
+            StartParameterInternal startParameter,
             FailureFactory failureFactory,
             ProblemsInternal problemsService,
             ProblemStream problemStream,

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.launcher.exec
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.problems.internal.ProblemsInternal
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.RootBuildState
@@ -51,7 +51,7 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
             listener,
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),
-            Stub(StartParameter),
+            Stub(StartParameterInternal),
             Stub(ProblemStream),
             buildStateRegistry,
             buildActionRunner
@@ -77,7 +77,7 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
             Stub(BuildTreeLifecycleListener),
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),
-            Stub(StartParameter),
+            Stub(StartParameterInternal),
             Stub(ProblemStream),
             buildStateRegistry,
             Mock(BuildActionRunner)

--- a/platforms/core-runtime/start-parameter/build.gradle.kts
+++ b/platforms/core-runtime/start-parameter/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     api(libs.jspecify)
 
+    implementation(projects.collections)
     implementation(projects.logging)
     implementation(projects.inputTracking)
     implementation(projects.internalInstrumentationApi)

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -37,7 +37,11 @@ import org.gradle.initialization.DistributionInitScriptFinder;
 import org.gradle.initialization.UserHomeInitScriptFinder;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.RunDefaultTasksExecutionRequest;
+import org.gradle.internal.collect.MutationNotifyingList;
+import org.gradle.internal.collect.MutationNotifyingMap;
+import org.gradle.internal.collect.MutationNotifyingSet;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.deprecation.StartParameterDeprecations;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
@@ -52,6 +56,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.Collections.emptyList;
 
@@ -61,6 +66,7 @@ import static java.util.Collections.emptyList;
  *
  * <p>You can obtain an instance of a {@code StartParameter} by either creating a new one, or duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
  */
+@HasInternalProtocol
 public class StartParameter implements LoggingConfiguration, ParallelismConfiguration, Serializable {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = BuildLayoutParameters.GRADLE_USER_HOME_PROPERTY_KEY;
 
@@ -71,7 +77,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     private final DefaultLoggingConfiguration loggingConfiguration = new DefaultLoggingConfiguration();
     private final DefaultParallelismConfiguration parallelismConfiguration = new DefaultParallelismConfiguration();
-    private List<TaskExecutionRequest> taskRequests = new ArrayList<>();
+    private volatile List<TaskExecutionRequest> taskRequests = new CopyOnWriteArrayList<>();
     private Set<String> excludedTaskNames = new LinkedHashSet<>();
     private boolean buildProjectDependencies = true;
     private File currentDir;
@@ -106,6 +112,9 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean exportKeys;
     private WelcomeMessageConfiguration welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.ONCE);
 
+    protected void onMutableCall(String methodSignature) {
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -119,6 +128,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setLogLevel(LogLevel logLevel) {
+        onMutableCall("setLogLevel(LogLevel)");
         loggingConfiguration.setLogLevel(logLevel);
     }
 
@@ -135,6 +145,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setShowStacktrace(ShowStacktrace showStacktrace) {
+        onMutableCall("setShowStacktrace(ShowStacktrace)");
         loggingConfiguration.setShowStacktrace(showStacktrace);
     }
 
@@ -159,6 +170,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setConsoleOutput(ConsoleOutput consoleOutput) {
+        onMutableCall("setConsoleOutput(ConsoleOutput)");
         loggingConfiguration.setConsoleOutput(consoleOutput);
     }
 
@@ -167,6 +179,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setConsoleUnicodeSupport(ConsoleUnicodeSupport unicodeSupport) {
+        onMutableCall("setConsoleUnicodeSupport(ConsoleUnicodeSupport)");
         loggingConfiguration.setConsoleUnicodeSupport(unicodeSupport);
     }
 
@@ -191,6 +204,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setNonInteractive(boolean nonInteractive) {
+        onMutableCall("setNonInteractive(boolean)");
         this.loggingConfiguration.setNonInteractive(nonInteractive);
     }
 
@@ -199,6 +213,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setWarningMode(WarningMode warningMode) {
+        onMutableCall("setWarningMode(WarningMode)");
         loggingConfiguration.setWarningMode(warningMode);
     }
 
@@ -206,6 +221,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Sets the project's cache location. Set to null to use the default location.
      */
     public void setProjectCacheDir(@Nullable File projectCacheDir) {
+        onMutableCall("setProjectCacheDir(File)");
         this.projectCacheDir = projectCacheDir;
     }
 
@@ -257,7 +273,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;
-        p.taskRequests = new ArrayList<>(taskRequests);
+        p.taskRequests = new CopyOnWriteArrayList<>(taskRequests);
         p.excludedTaskNames = new LinkedHashSet<>(excludedTaskNames);
         p.buildProjectDependencies = buildProjectDependencies;
         p.currentDir = currentDir;
@@ -354,7 +370,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return the tasks to execute in this build. Never returns null.
      */
     public List<TaskExecutionRequest> getTaskRequests() {
-        return taskRequests;
+        return new MutationNotifyingList<>(taskRequests, name -> onMutableCall("getTaskRequests()." + name));
     }
 
     /**
@@ -364,7 +380,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param taskParameters the tasks to execute in this build.
      */
     public void setTaskRequests(Iterable<? extends TaskExecutionRequest> taskParameters) {
-        this.taskRequests = Lists.newArrayList(taskParameters);
+        this.taskRequests = new CopyOnWriteArrayList<>(Lists.newArrayList(taskParameters));
     }
 
     /**
@@ -373,7 +389,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return The names of the excluded tasks. Returns an empty set if there are no such tasks.
      */
     public Set<String> getExcludedTaskNames() {
-        return excludedTaskNames;
+        return new MutationNotifyingSet<>(excludedTaskNames, name -> onMutableCall("getExcludedTaskNames()." + name));
     }
 
     /**
@@ -382,6 +398,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param excludedTaskNames The task names.
      */
     public void setExcludedTaskNames(Iterable<String> excludedTaskNames) {
+        onMutableCall("setExcludedTaskNames(Iterable)");
         this.excludedTaskNames = Sets.newLinkedHashSet(excludedTaskNames);
     }
 
@@ -400,6 +417,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param currentDir The directory. Set to null to use the default.
      */
     public void setCurrentDir(@Nullable File currentDir) {
+        onMutableCall("setCurrentDir(File)");
         if (currentDir != null) {
             this.currentDir = FileUtils.canonicalize(currentDir);
         } else {
@@ -415,7 +433,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return map of properties
      */
     public Map<String, String> getProjectProperties() {
-        return projectProperties;
+        return new MutationNotifyingMap<>(projectProperties, name -> onMutableCall("getProjectProperties()." + name));
     }
 
     /**
@@ -426,6 +444,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param projectProperties new map of properties
      */
     public void setProjectProperties(Map<String, String> projectProperties) {
+        onMutableCall("setProjectProperties(Map)");
         this.projectProperties = projectProperties;
     }
 
@@ -438,7 +457,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return map of properties
      */
     public Map<String, String> getSystemPropertiesArgs() {
-        return systemPropertiesArgs;
+        return new MutationNotifyingMap<>(systemPropertiesArgs, name -> onMutableCall("getSystemPropertiesArgs()." + name));
     }
 
     /**
@@ -449,6 +468,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param systemPropertiesArgs new map of properties
      */
     public void setSystemPropertiesArgs(Map<String, String> systemPropertiesArgs) {
+        onMutableCall("setSystemPropertiesArgs(Map)");
         this.systemPropertiesArgs = systemPropertiesArgs;
     }
 
@@ -467,6 +487,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param gradleUserHomeDir The home directory. May be null.
      */
     public void setGradleUserHomeDir(@Nullable File gradleUserHomeDir) {
+        onMutableCall("setGradleUserHomeDir(File)");
         this.gradleUserHomeDir = gradleUserHomeDir == null ? new BuildLayoutParameters().getGradleUserHomeDir() : FileUtils.canonicalize(gradleUserHomeDir);
     }
 
@@ -483,6 +504,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return this
      */
     public StartParameter setBuildProjectDependencies(boolean build) {
+        onMutableCall("setBuildProjectDependencies(boolean)");
         this.buildProjectDependencies = build;
         return this;
     }
@@ -502,6 +524,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param dryRun true if the build should run as a dry-run
      */
     public void setDryRun(boolean dryRun) {
+        onMutableCall("setDryRun(boolean)");
         this.dryRun = dryRun;
     }
 
@@ -511,6 +534,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param initScriptFile The init scripts.
      */
     public void addInitScript(File initScriptFile) {
+        onMutableCall("addInitScript(File)");
         initScripts.add(initScriptFile);
     }
 
@@ -520,6 +544,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param initScripts The init scripts.
      */
     public void setInitScripts(List<File> initScripts) {
+        onMutableCall("setInitScripts(List)");
         this.initScripts = initScripts;
     }
 
@@ -555,6 +580,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param projectDir The project directory. May be null.
      */
     public void setProjectDir(@Nullable File projectDir) {
+        onMutableCall("setProjectDir(File)");
         if (projectDir == null) {
             setCurrentDir(null);
             this.projectDir = null;
@@ -583,6 +609,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @param profile true if a profile report should be generated
      */
     public void setProfile(boolean profile) {
+        onMutableCall("setProfile(boolean)");
         this.profile = profile;
     }
 
@@ -604,6 +631,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the build should continue on task failure. The default is false.
      */
     public void setContinueOnFailure(boolean continueOnFailure) {
+        onMutableCall("setContinueOnFailure(boolean)");
         this.continueOnFailure = continueOnFailure;
     }
 
@@ -618,6 +646,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the build should be performed offline (ie without network access).
      */
     public void setOffline(boolean offline) {
+        onMutableCall("setOffline(boolean)");
         this.offline = offline;
     }
 
@@ -632,6 +661,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the dependencies should be refreshed..
      */
     public void setRefreshDependencies(boolean refreshDependencies) {
+        onMutableCall("setRefreshDependencies(boolean)");
         this.refreshDependencies = refreshDependencies;
     }
 
@@ -646,6 +676,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether the cached task results should be ignored and each task should be forced to be executed.
      */
     public void setRerunTasks(boolean rerunTasks) {
+        onMutableCall("setRerunTasks(boolean)");
         this.rerunTasks = rerunTasks;
     }
 
@@ -664,6 +695,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 9.1.0
      */
     public void setTaskGraph(boolean taskGraph) {
+        onMutableCall("setTaskGraph(boolean)");
         this.taskGraph = taskGraph;
     }
 
@@ -680,6 +712,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setParallelProjectExecutionEnabled(boolean parallelProjectExecution) {
+        onMutableCall("setParallelProjectExecutionEnabled(boolean)");
         parallelismConfiguration.setParallelProjectExecutionEnabled(parallelProjectExecution);
     }
 
@@ -698,6 +731,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.5
      */
     public void setBuildCacheEnabled(boolean buildCacheEnabled) {
+        onMutableCall("setBuildCacheEnabled(boolean)");
         this.buildCacheEnabled = buildCacheEnabled;
     }
 
@@ -716,6 +750,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.6
      */
     public void setBuildCacheDebugLogging(boolean buildCacheDebugLogging) {
+        onMutableCall("setBuildCacheDebugLogging(boolean)");
         this.buildCacheDebugLogging = buildCacheDebugLogging;
     }
 
@@ -732,6 +767,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Override
     public void setMaxWorkerCount(int maxWorkerCount) {
+        onMutableCall("setMaxWorkerCount(int)");
         parallelismConfiguration.setMaxWorkerCount(maxWorkerCount);
     }
 
@@ -791,11 +827,13 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Package scope for testing purposes.
      */
     void setGradleHomeDir(File gradleHomeDir) {
+        onMutableCall("setGradleHomeDir(File)");
         this.gradleHomeDir = gradleHomeDir;
     }
 
     @Incubating
     public void setConfigureOnDemand(boolean configureOnDemand) {
+        onMutableCall("setConfigureOnDemand(boolean)");
         this.configureOnDemand = configureOnDemand;
     }
 
@@ -804,14 +842,17 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     }
 
     public void setContinuous(boolean enabled) {
+        onMutableCall("setContinuous(boolean)");
         this.continuous = enabled;
     }
 
     public void includeBuild(File includedBuild) {
+        onMutableCall("includeBuild(File)");
         includedBuilds.add(includedBuild);
     }
 
     public void setIncludedBuilds(List<File> includedBuilds) {
+        onMutableCall("setIncludedBuilds(List)");
         this.includedBuilds = includedBuilds;
     }
 
@@ -834,6 +875,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.4
      */
     public void setBuildScan(boolean buildScan) {
+        onMutableCall("setBuildScan(boolean)");
         this.buildScan = buildScan;
     }
 
@@ -852,6 +894,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 3.4
      */
     public void setNoBuildScan(boolean noBuildScan) {
+        onMutableCall("setNoBuildScan(boolean)");
         this.noBuildScan = noBuildScan;
     }
 
@@ -861,6 +904,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public void setWriteDependencyLocks(boolean writeDependencyLocks) {
+        onMutableCall("setWriteDependencyLocks(boolean)");
         this.writeDependencyLocks = writeDependencyLocks;
     }
 
@@ -882,6 +926,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public void setLockedDependenciesToUpdate(List<String> lockedDependenciesToUpdate) {
+        onMutableCall("setLockedDependenciesToUpdate(List)");
         this.lockedDependenciesToUpdate = Lists.newArrayList(lockedDependenciesToUpdate);
         this.writeDependencyLocks = true;
     }
@@ -895,7 +940,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.1
      */
     public List<String> getWriteDependencyVerifications() {
-        return writeDependencyVerifications;
+        return new MutationNotifyingList<>(writeDependencyVerifications, name -> onMutableCall("getWriteDependencyVerifications()." + name));
     }
 
     /**
@@ -906,6 +951,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.1
      */
     public void setWriteDependencyVerifications(List<String> checksums) {
+        onMutableCall("setWriteDependencyVerifications(List)");
         this.writeDependencyVerifications = checksums;
     }
 
@@ -916,7 +962,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 4.8
      */
     public List<String> getLockedDependenciesToUpdate() {
-        return lockedDependenciesToUpdate;
+        return new MutationNotifyingList<>(lockedDependenciesToUpdate, name -> onMutableCall("getLockedDependenciesToUpdate()." + name));
     }
 
     /**
@@ -932,6 +978,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setDependencyVerificationMode(DependencyVerificationMode verificationMode) {
+        onMutableCall("setDependencyVerificationMode(DependencyVerificationMode)");
         this.verificationMode = verificationMode;
     }
 
@@ -951,6 +998,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setRefreshKeys(boolean refresh) {
+        onMutableCall("setRefreshKeys(boolean)");
         refreshKeys = refresh;
     }
 
@@ -988,6 +1036,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @since 6.2
      */
     public void setExportKeys(boolean exportKeys) {
+        onMutableCall("setExportKeys(boolean)");
         this.exportKeys = exportKeys;
     }
 
@@ -1012,6 +1061,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Incubating
     public void setWelcomeMessageConfiguration(WelcomeMessageConfiguration welcomeMessageConfiguration) {
+        onMutableCall("setWelcomeMessageConfiguration(WelcomeMessageConfiguration)");
         this.welcomeMessageConfiguration = welcomeMessageConfiguration;
     }
 

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -30,6 +30,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class StartParameterInternal extends StartParameter {
     private WatchMode watchFileSystemMode = WatchMode.DEFAULT;
@@ -61,12 +62,34 @@ public class StartParameterInternal extends StartParameter {
     private Option.Value<Boolean> parallelToolingModelBuilding = Option.Value.defaultValue(false);
     private @Nullable String develocityUrl;
     private @Nullable String develocityPluginVersion;
+    // Runtime-only wiring, deliberately transient: a StartParameter captured in task state must be
+    // serializable to the configuration cache without dragging the listener (and its services) along.
+    private transient @Nullable Consumer<String> mutationListener;
 
     public StartParameterInternal() {
     }
 
     protected StartParameterInternal(BuildLayoutParameters layoutParameters) {
         super(layoutParameters);
+    }
+
+    public void setMutationListener(Consumer<String> mutationListener) {
+        if (this.mutationListener != null) {
+            throw new IllegalStateException("Mutation listener already set on StartParameterInternal");
+        }
+        this.mutationListener = mutationListener;
+    }
+
+    public void clearMutationListener() {
+        this.mutationListener = null;
+    }
+
+    @Override
+    protected void onMutableCall(String methodSignature) {
+        Consumer<String> listener = this.mutationListener;
+        if (listener != null) {
+            listener.accept(methodSignature);
+        }
     }
 
     @Override
@@ -130,6 +153,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setGradleHomeDir(File gradleHomeDir) {
+        onMutableCall("setGradleHomeDir(File)");
         this.gradleHomeDir = gradleHomeDir;
     }
 
@@ -138,6 +162,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void doNotSearchUpwards() {
+        onMutableCall("doNotSearchUpwards()");
         this.searchUpwards = false;
     }
 
@@ -146,6 +171,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void useEmptySettings() {
+        onMutableCall("useEmptySettings()");
         this.useEmptySettings = true;
     }
 
@@ -154,6 +180,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setWatchFileSystemMode(WatchMode watchFileSystemMode) {
+        onMutableCall("setWatchFileSystemMode(WatchMode)");
         this.watchFileSystemMode = watchFileSystemMode;
     }
 
@@ -162,6 +189,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setVfsVerboseLogging(boolean vfsVerboseLogging) {
+        onMutableCall("setVfsVerboseLogging(boolean)");
         this.vfsVerboseLogging = vfsVerboseLogging;
     }
 
@@ -175,6 +203,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCache(Option.Value<Boolean> configurationCache) {
+        onMutableCall("setConfigurationCache(Option.Value)");
         this.configurationCache = configurationCache;
     }
 
@@ -190,6 +219,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setIsolatedProjects(Option.Value<Boolean> isolatedProjects) {
+        onMutableCall("setIsolatedProjects(Option.Value)");
         this.isolatedProjects = isolatedProjects;
     }
 
@@ -198,6 +228,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value configurationCacheProblems) {
+        onMutableCall("setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value)");
         this.configurationCacheProblems = configurationCacheProblems;
     }
 
@@ -206,6 +237,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheDebug(boolean configurationCacheDebug) {
+        onMutableCall("setConfigurationCacheDebug(boolean)");
         this.configurationCacheDebug = configurationCacheDebug;
     }
 
@@ -214,10 +246,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheIgnoreInputsDuringStore(boolean ignoreInputsDuringStore) {
+        onMutableCall("setConfigurationCacheIgnoreInputsDuringStore(boolean)");
         configurationCacheIgnoreInputsDuringStore = ignoreInputsDuringStore;
     }
 
     public void setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(boolean configurationCacheIgnoreUnsupportedBuildEventsListeners) {
+        onMutableCall("setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(boolean)");
         this.configurationCacheIgnoreUnsupportedBuildEventsListeners = configurationCacheIgnoreUnsupportedBuildEventsListeners;
     }
 
@@ -230,6 +264,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheParallel(boolean parallel) {
+        onMutableCall("setConfigurationCacheParallel(boolean)");
         this.configurationCacheParallel = parallel;
     }
 
@@ -238,6 +273,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheReadOnly(boolean readOnly) {
+        onMutableCall("setConfigurationCacheReadOnly(boolean)");
         this.configurationCacheReadOnly = readOnly;
     }
 
@@ -246,6 +282,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheEntriesPerKey(int configurationCacheEntriesPerKey) {
+        onMutableCall("setConfigurationCacheEntriesPerKey(int)");
         this.configurationCacheEntriesPerKey = configurationCacheEntriesPerKey;
     }
 
@@ -254,6 +291,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheMaxProblems(int configurationCacheMaxProblems) {
+        onMutableCall("setConfigurationCacheMaxProblems(int)");
         this.configurationCacheMaxProblems = configurationCacheMaxProblems;
     }
 
@@ -263,6 +301,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheIgnoredFileSystemCheckInputs(@Nullable String configurationCacheIgnoredFileSystemCheckInputs) {
+        onMutableCall("setConfigurationCacheIgnoredFileSystemCheckInputs(String)");
         this.configurationCacheIgnoredFileSystemCheckInputs = configurationCacheIgnoredFileSystemCheckInputs;
     }
 
@@ -271,6 +310,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheRecreateCache(boolean configurationCacheRecreateCache) {
+        onMutableCall("setConfigurationCacheRecreateCache(boolean)");
         this.configurationCacheRecreateCache = configurationCacheRecreateCache;
     }
 
@@ -279,10 +319,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheQuiet(boolean configurationCacheQuiet) {
+        onMutableCall("setConfigurationCacheQuiet(boolean)");
         this.configurationCacheQuiet = configurationCacheQuiet;
     }
 
     public void setConfigurationCacheIntegrityCheckEnabled(boolean configurationCacheIntegrityCheck) {
+        onMutableCall("setConfigurationCacheIntegrityCheckEnabled(boolean)");
         this.configurationCacheIntegrityCheckEnabled = configurationCacheIntegrityCheck;
     }
 
@@ -291,6 +333,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheHeapDumpDir(@Nullable String configurationCacheHeapDumpDir) {
+        onMutableCall("setConfigurationCacheHeapDumpDir(String)");
         this.configurationCacheHeapDumpDir = configurationCacheHeapDumpDir;
     }
 
@@ -299,6 +342,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setConfigurationCacheFineGrainedPropertyTracking(boolean configurationCacheFineGrainedPropertyTracking) {
+        onMutableCall("setConfigurationCacheFineGrainedPropertyTracking(boolean)");
         this.configurationCacheFineGrainedPropertyTracking = configurationCacheFineGrainedPropertyTracking;
     }
 
@@ -311,10 +355,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setIsolatedProjectsDiagnostics(boolean isolatedProjectsDiagnostics) {
+        onMutableCall("setIsolatedProjectsDiagnostics(boolean)");
         this.isolatedProjectsDiagnostics = isolatedProjectsDiagnostics;
     }
 
     public void setContinuousBuildQuietPeriod(Duration continuousBuildQuietPeriod) {
+        onMutableCall("setContinuousBuildQuietPeriod(Duration)");
         this.continuousBuildQuietPeriod = continuousBuildQuietPeriod;
     }
 
@@ -327,10 +373,12 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setPropertyUpgradeReportEnabled(boolean propertyUpgradeReportEnabled) {
+        onMutableCall("setPropertyUpgradeReportEnabled(boolean)");
         this.propertyUpgradeReportEnabled = propertyUpgradeReportEnabled;
     }
 
     public void enableProblemReportGeneration(boolean enableProblemReportGeneration) {
+        onMutableCall("enableProblemReportGeneration(boolean)");
         this.enableProblemReportGeneration = enableProblemReportGeneration;
     }
 
@@ -343,6 +391,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDaemonJvmCriteriaConfigured(boolean daemonJvmCriteriaConfigured) {
+        onMutableCall("setDaemonJvmCriteriaConfigured(boolean)");
         this.daemonJvmCriteriaConfigured = daemonJvmCriteriaConfigured;
     }
 
@@ -351,6 +400,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setParallelToolingModelBuilding(Option.Value<Boolean> parallelToolingModelBuilding) {
+        onMutableCall("setParallelToolingModelBuilding(Option.Value)");
         this.parallelToolingModelBuilding = parallelToolingModelBuilding;
     }
 
@@ -360,6 +410,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDevelocityUrl(@Nullable String develocityUrl) {
+        onMutableCall("setDevelocityUrl(String)");
         this.develocityUrl = develocityUrl;
     }
 
@@ -369,6 +420,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public void setDevelocityPluginVersion(@Nullable String develocityPluginVersion) {
+        onMutableCall("setDevelocityPluginVersion(String)");
         this.develocityPluginVersion = develocityPluginVersion;
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -37,6 +37,7 @@ import org.gradle.plugin.management.internal.PluginRequests;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.Collections;
 
 import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
 
@@ -95,6 +96,12 @@ public class BuildStateFactory {
             publicBuildPath,
             true
         );
+        // The tasks of the buildSrc build are scheduled by BuildSrcBuildListenerFactory.Listener; clear the
+        // default-tasks request so that the default tasks do not also run. This must happen before the buildSrc
+        // build's settings are evaluated: after that, StartParameter mutation is reported as an IP violation.
+        // It must also happen on the BuildDefinition's own StartParameter: fromStartParameterForBuild() copies
+        // the parameter passed to it via newBuild(), which resets the task requests to the default-tasks request.
+        buildDefinition.getStartParameter().setTaskRequests(Collections.emptyList());
         return buildDefinition;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildTaskScheduler.java
@@ -15,13 +15,22 @@
  */
 package org.gradle.execution;
 
+import org.gradle.TaskExecutionRequest;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.execution.plan.ExecutionPlan;
 import org.jspecify.annotations.Nullable;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import java.util.List;
+
 @ServiceScope(Scope.Build.class)
 public interface BuildTaskScheduler {
-    void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan);
+    /**
+     * Schedules the given requested tasks. The task requests are passed explicitly rather than read from
+     * {@code gradle.getStartParameter()} so that implementations can refine them (e.g. resolve the
+     * default-tasks request) without mutating the StartParameter, which is reported as an Isolated Projects
+     * violation after settings evaluation.
+     */
+    void scheduleRequestedTasks(GradleInternal gradle, List<TaskExecutionRequest> taskRequests, @Nullable EntryTaskSelector selector, ExecutionPlan plan);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.execution;
 
-import org.gradle.StartParameter;
+import org.gradle.TaskExecutionRequest;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.execution.plan.ExecutionPlan;
+import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.RunDefaultTasksExecutionRequest;
 import org.gradle.util.internal.GUtil;
 import org.jspecify.annotations.Nullable;
@@ -28,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,10 +46,8 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
     }
 
     @Override
-    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
-        StartParameter startParameter = gradle.getStartParameter();
-
-        if (startParameter.getTaskRequests().size() == 1 && startParameter.getTaskRequests().get(0) instanceof RunDefaultTasksExecutionRequest) {
+    public void scheduleRequestedTasks(GradleInternal gradle, List<TaskExecutionRequest> taskRequests, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
+        if (taskRequests.size() == 1 && taskRequests.get(0) instanceof RunDefaultTasksExecutionRequest) {
             // Gather the default tasks from this first group project
             ProjectState defaultProjectState = gradle.getDefaultProjectState();
             // so that we don't miss out default tasks
@@ -63,9 +63,11 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
                 LOGGER.info("No tasks specified. Using project default tasks {}", GUtil.toString(defaultTasks));
             }
 
-            startParameter.setTaskNames(defaultTasks);
+            // Pass the resolved tasks on to the delegate instead of writing them back into the shared
+            // StartParameter: mutating it after settings evaluation is reported as an IP violation.
+            taskRequests = Collections.singletonList(DefaultTaskExecutionRequest.of(defaultTasks));
         }
 
-        delegate.scheduleRequestedTasks(gradle, selector, plan);
+        delegate.scheduleRequestedTasks(gradle, taskRequests, selector, plan);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
@@ -56,12 +56,11 @@ public class TaskNameResolvingBuildTaskScheduler implements BuildTaskScheduler {
     }
 
     @Override
-    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
+    public void scheduleRequestedTasks(GradleInternal gradle, List<TaskExecutionRequest> taskRequests, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
         if (selector != null) {
             selector.applyTasksTo(new EntryTaskSelectorContext(gradle), plan);
         }
-        List<TaskExecutionRequest> taskParameters = gradle.getStartParameter().getTaskRequests();
-        for (TaskExecutionRequest taskParameter : taskParameters) {
+        for (TaskExecutionRequest taskParameter : taskRequests) {
             List<TaskSelection> taskSelections = commandLineTaskParser.parseTasks(taskParameter);
             for (TaskSelection taskSelection : taskSelections) {
                 LOGGER.info("Selected primary task '{}' from project {}", taskSelection.getTaskName(), taskSelection.getProjectPath());

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
@@ -44,7 +44,7 @@ public class DefaultTaskExecutionPreparer implements TaskExecutionPreparer {
     @Override
     public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
         gradle.getOwner().getProjects().withMutableStateOfAllProjects(() -> {
-            buildTaskScheduler.scheduleRequestedTasks(gradle, selector, plan);
+            buildTaskScheduler.scheduleRequestedTasks(gradle, gradle.getStartParameter().getTaskRequests(), selector, plan);
 
             if (skipEvaluationDuringProjectPreparation(buildModelParameters, gradle)) {
                 new ProjectsEvaluatedNotifier(buildOperationRunner).notify(gradle);

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -16,17 +16,22 @@
 
 package org.gradle.initialization;
 
+import kotlin.Unit;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
 
 public class SettingsEvaluatedCallbackFiringSettingsProcessor implements SettingsProcessor {
 
     private final SettingsProcessor delegate;
+    private final IsolatedProjectsProblemsReporter problems;
 
-    public SettingsEvaluatedCallbackFiringSettingsProcessor(SettingsProcessor delegate) {
+    public SettingsEvaluatedCallbackFiringSettingsProcessor(SettingsProcessor delegate, IsolatedProjectsProblemsReporter problems) {
         this.delegate = delegate;
+        this.problems = problems;
     }
 
     @Override
@@ -35,6 +40,18 @@ public class SettingsEvaluatedCallbackFiringSettingsProcessor implements Setting
         SettingsInternal settings = state.getSettings();
         gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
         settings.preventFromFurtherMutation();
+        if (startParameter instanceof StartParameterInternal) {
+            ((StartParameterInternal) startParameter).setMutationListener(methodSignature ->
+                problems.report(factory ->
+                    factory.problem(null, messageBuilder -> {
+                        messageBuilder.text(
+                            "Cannot call '" + methodSignature + "' on StartParameter after settings have been evaluated when Isolated Projects is enabled."
+                        );
+                        return Unit.INSTANCE;
+                    }).exception().build()
+                )
+            );
+        }
         return state;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
@@ -31,7 +31,6 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import java.util.Collections;
 
 import static org.gradle.api.internal.tasks.TaskDependencyUtil.getDependenciesForInternalUse;
 
@@ -67,9 +66,11 @@ public class BuildSrcBuildListenerFactory {
 
         @Override
         public void projectsLoaded(Gradle gradle) {
+            // The task requests of the buildSrc build are cleared when its StartParameter is created,
+            // in BuildStateFactory.buildSrcStartParameterFor(), so that only the tasks scheduled by
+            // this selector run and not the default tasks. Mutating them here would be too late:
+            // after settings evaluation, StartParameter mutation is reported as an IP violation.
             GradleInternal gradleInternal = (GradleInternal) gradle;
-            // Run only those tasks scheduled by this selector and not the default tasks
-            gradleInternal.getStartParameter().setTaskRequests(Collections.emptyList());
             rootProjectState = gradleInternal.getOwner().getRootProject();
             rootProjectState.applyToMutableState(rootProjectConfiguration::execute);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -626,7 +626,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         GradleProperties gradleProperties,
         BuildOperationRunner buildOperationRunner,
         TextFileResourceLoader textFileResourceLoader,
-        BuildIncludeListener buildIncludeListener
+        BuildIncludeListener buildIncludeListener,
+        IsolatedProjectsProblemsReporter isolatedProjectsProblemsReporter
     ) {
         return new BuildOperationSettingsProcessor(
             new RootBuildCacheControllerSettingsProcessor(
@@ -642,7 +643,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
                             gradleProperties,
                             textFileResourceLoader,
                             buildIncludeListener
-                        )
+                        ),
+                        isolatedProjectsProblemsReporter
                     )
                 )
             ),

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
@@ -16,8 +16,8 @@
 package org.gradle.execution
 
 
+import org.gradle.TaskExecutionRequest
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.configuration.project.BuiltInCommand
@@ -32,7 +32,6 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
     final buildInCommand = Mock(BuiltInCommand)
     final delegate = Mock(BuildTaskScheduler)
     final action = new DefaultTasksBuildTaskScheduler([buildInCommand], delegate)
-    final startParameter = Mock(StartParameterInternal)
     final defaultProject = Mock(ProjectInternal)
     final defaultProjectState = Mock(ProjectState)
     final gradle = Mock(GradleInternal)
@@ -40,58 +39,57 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
     final plan = Mock(ExecutionPlan)
 
     def setup() {
-        _ * gradle.startParameter >> startParameter
         _ * gradle.defaultProjectState >> defaultProjectState
         _ * defaultProjectState.fromMutableState(_) >> { Function f -> f.apply(defaultProject) }
     }
 
-    def "proceeds when task request specified in StartParameter"() {
+    def "proceeds with given task requests"() {
         given:
-        _ * startParameter.taskRequests >> [new DefaultTaskExecutionRequest(['a'])]
+        def requests = [new DefaultTaskExecutionRequest(['a'])]
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, requests, selector, plan)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, requests, selector, plan)
     }
 
-    def "proceeds when no task requests specified in StartParameter"() {
+    def "proceeds when no task requests given"() {
         given:
-        _ * startParameter.taskRequests >> []
+        def requests = []
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, requests, selector, plan)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, requests, selector, plan)
     }
 
-    def "sets task names to project defaults when single task requests specified in StartParameter"() {
+    def "resolves default-tasks request to project defaults"() {
         given:
-        _ * startParameter.taskRequests >> [new RunDefaultTasksExecutionRequest()]
         _ * defaultProject.defaultTasks >> ['a', 'b']
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, [new RunDefaultTasksExecutionRequest()], selector, plan)
 
         then:
         1 * defaultProjectState.ensureConfigured()
-        1 * startParameter.setTaskNames(['a', 'b'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, { List<TaskExecutionRequest> requests ->
+            requests.size() == 1 && requests[0].args == ['a', 'b']
+        }, selector, plan)
     }
 
-    def "uses default build-in tasks if no tasks specified in StartParameter or project"() {
+    def "resolves default-tasks request to built-in tasks if project defines no default tasks"() {
         given:
-        _ * startParameter.taskRequests >> [new RunDefaultTasksExecutionRequest()]
         _ * defaultProject.defaultTasks >> []
         _ * buildInCommand.asDefaultTask() >> ['default1', 'default2']
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, [new RunDefaultTasksExecutionRequest()], selector, plan)
 
         then:
-        1 * startParameter.setTaskNames(['default1', 'default2'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, { List<TaskExecutionRequest> requests ->
+            requests.size() == 1 && requests[0].args == ['default1', 'default2']
+        }, selector, plan)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.execution
 import org.gradle.TaskExecutionRequest
 import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.StartParameterInternal
 import org.gradle.execution.commandline.CommandLineTaskParser
 import org.gradle.execution.plan.ExecutionPlan
 import org.gradle.execution.selection.BuildTaskSelector
@@ -41,23 +40,16 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         action = new TaskNameResolvingBuildTaskScheduler(parser, Stub(BuildTaskSelector.BuildSpecificSelector), [], TestUtil.problemsService())
     }
 
-    def "empty task parameters are no-op action"() {
-        given:
-        def startParameters = Mock(StartParameterInternal)
-
+    def "empty task requests are no-op action"() {
         when:
-        _ * gradle.getStartParameter() >> startParameters
-        _ * startParameters.getTaskRequests() >> []
-
-        action.scheduleRequestedTasks(gradle, null, executionPlan)
+        action.scheduleRequestedTasks(gradle, [], null, executionPlan)
 
         then:
         1 * executionPlan.getContents()
         0 * executionPlan._
     }
 
-    def "expand task parameters to tasks"() {
-        def startParameters = Mock(StartParameterInternal)
+    def "expand task requests to tasks"() {
         TaskExecutionRequest request1 = Stub(TaskExecutionRequest)
         TaskExecutionRequest request2 = Stub(TaskExecutionRequest)
         def task1 = Stub(Task)
@@ -67,9 +59,6 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         def selection2 = Stub(TaskSelection)
 
         given:
-        _ * gradle.startParameter >> startParameters
-        _ * startParameters.taskRequests >> [request1, request2]
-
         def tasks1 = [task1, task2] as Set
         _ * selection1.tasks >> tasks1
 
@@ -77,7 +66,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         _ * selection2.tasks >> tasks2
 
         when:
-        action.scheduleRequestedTasks(gradle, null, executionPlan)
+        action.scheduleRequestedTasks(gradle, [request1, request2], null, executionPlan)
 
         then:
         1 * parser.parseTasks(request1) >> [selection1]
@@ -87,14 +76,8 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
     }
 
     def "invokes given selector"() {
-        given:
-        def startParameters = Mock(StartParameterInternal)
-
         when:
-        _ * gradle.getStartParameter() >> startParameters
-        _ * startParameters.getTaskRequests() >> []
-
-        action.scheduleRequestedTasks(gradle, selector, executionPlan)
+        action.scheduleRequestedTasks(gradle, [], selector, executionPlan)
 
         then:
         1 * selector.applyTasksTo(_, executionPlan)

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.onMutableCall(java.lang.String)",
+            "acceptation": "We don't want to advertise this new API. It can only be used if you derive from it and the only accepted derived class is \"StartParameterInternal\"",
+            "changes": []
+        }
+    ]
 }


### PR DESCRIPTION
Part of 
- #37944.

### Context

Since 
- #38152, 

`StartParameter` is frozen after settings evaluation: later mutations are reported as Isolated Projects violations. Mutations of the **task requests** are exempt from that reporting for now, because Gradle itself still uses `setTaskNames()`/`setTaskRequests()` as a channel to communicate tasks to schedule while the build is already running. This PR removes two of those internal usages, working towards eventually lifting the exemption:

**buildSrc** — `BuildSrcBuildListenerFactory` cleared the default-tasks request from `projectsLoaded`, i.e. after the buildSrc build's settings were evaluated. The buildSrc build never acts on its own task requests: its classpath tasks are injected by an `EntryTaskSelector`, and an explicit `:buildSrc:<task>` invocation is resolved through the owning build's task addressing. An empty request list is therefore the correct value for the build's whole lifetime, and is now set once when the buildSrc `BuildDefinition` is created — before the freeze. Note that the clear must be applied to the `BuildDefinition`'s own `StartParameter`: `fromStartParameterForBuild()` re-copies the parameter passed to it via `newBuild()`, which does not retain task requests and re-installs the default-tasks request on the copy.

**Default tasks** — `DefaultTasksBuildTaskScheduler` resolved the default-tasks request at scheduling time and wrote the resolved task names back into the shared `StartParameter`, purely so that its delegate could read them out again one stack frame later. The task requests are now passed through `BuildTaskScheduler` explicitly: read once from the `StartParameter` by `DefaultTaskExecutionPreparer`, refined by the default-tasks scheduler, consumed by the delegate. The `StartParameter` remains untouched after settings evaluation and is identical between configuration cache store and load runs. The only observable difference is that `startParameter.taskNames` no longer reflects the resolved default tasks during execution; it keeps reporting what was actually requested.

Both scenarios are covered by new integration tests in `IsolatedProjectsStartParameterIntegrationTest`.

Known remaining users of the mutable channel, out of scope here and to be addressed before the exemption can be lifted: the Eclipse sync-task model builders (`RunEclipseTasksBuilder`, `RunBuildDependenciesTaskBuilder`) and IntelliJ's `KotlinDslScriptTaskModelBuilder`, which mutate task names during the projects-loaded phase of IDE sync and will likely need a public replacement API.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
