### PR TITLE
Polish IP/CC mode test annotations and allow linking related issues

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
-import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.startsWith
 
@@ -955,8 +954,10 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
         "incoming.artifactView({lenient(false)}).artifacts"           | _
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/24640")
-    @UnsupportedWithConfigurationCache(because = "Multiple failures are currently not all reported by the configuration cache, only the first is")
+    @UnsupportedWithConfigurationCache(
+        because = "Multiple failures are currently not all reported by the configuration cache, only the first is",
+        issue = "https://github.com/gradle/gradle/issues/24640"
+    )
     def "reports multiple failures to resolve artifacts when artifacts are queried"() {
         settingsFile << """
             include 'a'
@@ -1014,8 +1015,10 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
         "incoming.artifactView({lenient(false)}).artifacts"           | _
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/24640")
-    @UnsupportedWithConfigurationCache(because = "Multiple failures are currently not all reported by the configuration cache, only the first is")
+    @UnsupportedWithConfigurationCache(
+        because = "Multiple failures are currently not all reported by the configuration cache, only the first is",
+        issue = "https://github.com/gradle/gradle/issues/24640"
+    )
     def "lenient artifact view reports failure to resolve graph and artifacts"() {
         settingsFile << """
             include 'a'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedEntryCleanupIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedEntryCleanupIntegrationTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.resolve.JvmLibraryArtifactResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenModule
-import spock.lang.Issue
 
 import static java.util.concurrent.TimeUnit.DAYS
 import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES
@@ -364,8 +363,10 @@ class ArtifactCacheUnusedEntryCleanupIntegrationTest extends AbstractHttpDepende
     }
 
 
-    @ToBeFixedForConfigurationCache(because = "re-download of deleted artifacts requires dependency resolution, which is skipped when configuration cache entry is reused")
-    @Issue("https://github.com/gradle/gradle/issues/16179")
+    @ToBeFixedForConfigurationCache(
+        because = "re-download of deleted artifacts requires dependency resolution, which is skipped when configuration cache entry is reused",
+        issue = "https://github.com/gradle/gradle/issues/16179"
+    )
     def "redownloads deleted artifacts for artifact query"() {
         given:
         def module = mavenHttpRepo.module('org.example', 'example', '1.0')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptErrorIntegrationTest.groovy
@@ -89,8 +89,10 @@ class BuildScriptErrorIntegrationTest extends AbstractIntegrationSpec {
                 .assertHasLineNumber(2)
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/29159")
-    @ToBeFixedForIsolatedProjects(because = "evaluationDependsOn is not IP compatible")
+    @ToBeFixedForIsolatedProjects(
+        because = "evaluationDependsOn is not IP compatible",
+        issue = "https://github.com/gradle/gradle/issues/29159"
+    )
     def "produces reasonable error message when nested buildFile evaluation fails"() {
         createDirs("child")
         settingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -507,8 +507,10 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":a", ":b")
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/29154")
-    @ToBeFixedForIsolatedProjects(because = "-x is not IP compatible")
+    @ToBeFixedForIsolatedProjects(
+        because = "-x is not IP compatible",
+        issue = "https://github.com/gradle/gradle/issues/29154"
+    )
     def "does not configure all projects when excluded task path is not qualified and an exact match for task has already been seen in some sub-project of default project"() {
         createDirs("a", "b", "c", "c/child")
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
@@ -548,8 +550,10 @@ project(':b') {
         }
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/29154")
-    @ToBeFixedForIsolatedProjects(because = "-x is not IP compatible")
+    @ToBeFixedForIsolatedProjects(
+        because = "-x is not IP compatible",
+        issue = "https://github.com/gradle/gradle/issues/29154"
+    )
     def "configures all subprojects of default project when excluded task path is not qualified and an exact match not found in default project"() {
         createDirs("a", "b", "c", "c/child")
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
@@ -587,8 +591,10 @@ allprojects {
         }
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/29154")
-    @ToBeFixedForIsolatedProjects(because = "-x is not IP compatible")
+    @ToBeFixedForIsolatedProjects(
+        because = "-x is not IP compatible",
+        issue = "https://github.com/gradle/gradle/issues/29154"
+    )
     def "configures all subprojects of default projects when excluded task path is not qualified and uses camel case matching"() {
         createDirs("a", "b", "b/child", "c")
         settingsFile << "include 'a', 'b', 'b:child', 'c'"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -175,7 +175,7 @@ project(':api') {
         fixture.assertProjectsConfigured(":", ":api", ':impl')
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Property dynamic lookup")
+    @ToBeFixedForIsolatedProjects(because = "configure-on-demand is not supported in IP mode")
     def "follows project dependencies when run in subproject"() {
         createDirs("api", "impl", "util")
         settingsFile << "include 'api', 'impl', 'util'"
@@ -507,10 +507,7 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":a", ":b")
     }
 
-    @ToBeFixedForIsolatedProjects(
-        because = "-x is not IP compatible",
-        issue = "https://github.com/gradle/gradle/issues/29154"
-    )
+    @ToBeFixedForIsolatedProjects(because = "allprojects")
     def "does not configure all projects when excluded task path is not qualified and an exact match for task has already been seen in some sub-project of default project"() {
         createDirs("a", "b", "c", "c/child")
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
@@ -550,10 +547,7 @@ project(':b') {
         }
     }
 
-    @ToBeFixedForIsolatedProjects(
-        because = "-x is not IP compatible",
-        issue = "https://github.com/gradle/gradle/issues/29154"
-    )
+    @ToBeFixedForIsolatedProjects(because = "allprojects")
     def "configures all subprojects of default project when excluded task path is not qualified and an exact match not found in default project"() {
         createDirs("a", "b", "c", "c/child")
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
@@ -591,10 +585,7 @@ allprojects {
         }
     }
 
-    @ToBeFixedForIsolatedProjects(
-        because = "-x is not IP compatible",
-        issue = "https://github.com/gradle/gradle/issues/29154"
-    )
+    @ToBeFixedForIsolatedProjects(because = "allprojects")
     def "configures all subprojects of default projects when excluded task path is not qualified and uses camel case matching"() {
         createDirs("a", "b", "b/child", "c")
         settingsFile << "include 'a', 'b', 'b:child', 'c'"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -102,8 +102,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'broken'
     }
 
-    @Issue("https://github.com/gradle/configuration-cache/issues/97")
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/31128")
+    @ToBeFixedForConfigurationCache(
+        because = "https://github.com/gradle/gradle/issues/31128",
+        issue = "https://github.com/gradle/configuration-cache/issues/97"
+    )
     def "does nag when service is used indirectly via another service even if task declares service reference and feature preview is enabled"() {
         given:
         serviceImplementation()
@@ -151,8 +153,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'broken'
     }
 
-    @Issue("https://github.com/gradle/configuration-cache/issues/156")
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/31128")
+    @ToBeFixedForConfigurationCache(
+        because = "https://github.com/gradle/gradle/issues/31128",
+        issue = "https://github.com/gradle/configuration-cache/issues/156"
+    )
     def "does nag when service is used by artifact transform parameters and feature preview is enabled"() {
         given:
         serviceImplementation()

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
@@ -48,6 +48,14 @@ public @interface ToBeFixedForConfigurationCache {
      */
     Skip skip() default Skip.DO_NOT_SKIP;
 
+    String because() default "";
+
+    /**
+     * Link to the issue tracking the incompatibility addressed by this annotation.
+     * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
+     */
+    String issue() default "";
+
     /**
      * Declare to which bottom spec this annotation should be applied.
      * Defaults to an empty array, meaning this annotation applies to all bottom specs.
@@ -59,14 +67,6 @@ public @interface ToBeFixedForConfigurationCache {
      * Defaults to an empty array, meaning this annotation applies to all iterations of the annotated feature.
      */
     String[] iterationMatchers() default {};
-
-    String because() default "";
-
-    /**
-     * Link to the issue tracking the incompatibility addressed by this annotation.
-     * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
-     */
-    String issue() default "";
 
     /**
      * Reason for skipping a test with configuration cache.

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
@@ -52,6 +52,12 @@ public @interface ToBeFixedForConfigurationCache {
     String because() default "";
 
     /**
+     * Link to the issue tracking the incompatibility addressed by this annotation.
+     * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
+     */
+    String issue() default "";
+
+    /**
      * Reason for skipping a test with configuration cache.
      */
     enum Skip {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCache.java
@@ -25,7 +25,18 @@ import java.lang.annotation.Target;
 
 
 /**
- * Assert that this test fails when run with configuration cache enabled.
+ * Expect the test to fail or skip it when running with Configuration Cache executor.
+ * <p>
+ * Use this annotation when the intention is to fix either the test itself or the underlying feature,
+ * making it compatible with Configuration Cache. If the intention is to not support the tested feature
+ * with Configuration Cache, use {@link UnsupportedWithConfigurationCache} instead.
+ * <p>
+ * The expectation of failure essentially flips the test result.
+ * A specific failure is not verified, and we only confirm that the test is not passing.
+ * <p>
+ * Instead of expecting failure, you can skip the test in case the test doesn't fail consistently
+ * or has other undesirable effects, such as timeouts.
+ * Set {@link #skip()} into any other value apart from {@link Skip#DO_NOT_SKIP DO_NOT_SKIP} to skip the test.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.java
@@ -41,6 +41,12 @@ public @interface ToBeFixedForIsolatedProjects {
     String because() default "";
 
     /**
+     * Link to the issue tracking the incompatibility addressed by this annotation.
+     * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
+     */
+    String issue() default "";
+
+    /**
      * Reason for skipping a test with isolated projects.
      */
     enum Skip {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.java
@@ -14,19 +14,25 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.fixtures
+package org.gradle.integtests.fixtures;
 
-import org.spockframework.runtime.extension.ExtensionAnnotation
+import org.spockframework.runtime.extension.ExtensionAnnotation;
 
-import java.lang.annotation.ElementType
-import java.lang.annotation.Retention
-import java.lang.annotation.RetentionPolicy
-import java.lang.annotation.Target
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
+/**
+ * Assert that this test fails when run with Isolated Projects enabled.
+ * <p>
+ * In case the {@link #skip()} reason is anything but {@link Skip#DO_NOT_SKIP DO_NOT_SKIP}, the test will be skipped.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target([ElementType.METHOD, ElementType.TYPE])
+@Target({ElementType.METHOD, ElementType.TYPE})
 @ExtensionAnnotation(ToBeFixedForIsolatedProjectsExtension.class)
-@interface ToBeFixedForIsolatedProjects {
+public @interface ToBeFixedForIsolatedProjects {
+
     /**
      * Set to some {@link Skip} to skip the annotated test.
      */
@@ -43,16 +49,22 @@ import java.lang.annotation.Target
          * Do not skip this test, this is the default.
          */
         DO_NOT_SKIP {
-            @Override String getReason() { throw new UnsupportedOperationException("Must not be skipped") }
+            @Override
+            public String getReason() {
+                throw new UnsupportedOperationException("Must not be skipped");
+            }
         },
 
         /**
          * Use this reason on tests that intermittently fail with isolated projects.
          */
         FLAKY {
-            @Override String getReason() { "flaky" }
+            @Override
+            public String getReason() {
+                return "flaky";
+            }
         };
 
-        abstract String getReason();
+        public abstract String getReason();
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCache.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCache.java
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures;
 
-import org.gradle.integtests.fixtures.executer.ConfigurationCacheGradleExecuter;
 import org.spockframework.runtime.extension.ExtensionAnnotation;
 
 import java.lang.annotation.ElementType;
@@ -26,10 +25,13 @@ import java.lang.annotation.Target;
 
 
 /**
- * Denotes a test for a feature that is unsupported with configuration cache.
- * Do not use this for tests for features that are supported by configuration cache but where the test happens to be incompatible.
- *
- * <p>The annotated test will be skipped by the {@link ConfigurationCacheGradleExecuter}.
+ * Skip the test when running with Configuration Cache executor.
+ * <p>
+ * Use this annotation when the tested feature is fundamentally incompatible with Configuration Cache
+ * and there is no intention to support it. If the intention is to eventually fix either the test
+ * or the underlying feature, use {@link ToBeFixedForConfigurationCache} instead.
+ * <p>
+ * The annotated test is skipped entirely; no assertion is made about its behavior under Configuration Cache.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
@@ -38,6 +40,16 @@ public @interface UnsupportedWithConfigurationCache {
 
     String because() default "";
 
+    /**
+     * Link to the issue documenting why the tested feature is not supported.
+     * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
+     */
+    String issue() default "";
+
+    /**
+     * Declare to which bottom spec this annotation should be applied.
+     * Defaults to an empty array, meaning this annotation applies to all bottom specs.
+     */
     String[] bottomSpecs() default {};
 
     /**


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/38185, preparation for https://github.com/gradle/gradle/pull/38142

## Summary
- Rewrite `ToBeFixedForIsolatedProjects` in Java for consistency with the other mode annotations and to play nicely with the Kotlin/IntelliJ tooling.
- Add an `issue()` attribute to `ToBeFixedForConfigurationCache`, `ToBeFixedForIsolatedProjects`, and `UnsupportedWithConfigurationCache` so the issue tracking the incompatibility can be linked separately from `@spock.lang.Issue` (which links the test itself).
- Expand and sharpen the Javadoc on all three annotations to clarify when to use which (intent to fix vs. fundamentally unsupported) and the semantics of `skip()` / expected-failure behavior.
- Apply the new `issue()` attribute to existing usages, combining Gradle-mode annotations with their respective tracking issues, and remove a few test-control annotations that had no effect.