### PR TITLE
Resolve distribution sources only once per build

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
@@ -10,6 +10,8 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.util.GradleVersion
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.io.File
@@ -384,6 +386,47 @@ class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest(
             } finally {
                 primaryServer.stop()
                 fallbackServer.stop()
+            }
+        }
+    }
+
+    @Test
+    @LeaksFileHandles
+    @Requires(TestExecutionPreconditions.NotEmbeddedExecutor::class, reason = "srcDistribution is only available in forked mode")
+    fun `warning about unresolvable distribution sources is logged only once per build`() {
+        val gradleVersion = distribution.version
+        val repositoryName = gradleVersion.repositoryName
+        val artifactFileName = gradleVersion.artifactFileName
+
+        withOwnGradleUserHomeDir("need fresh cache for artifact resolution") {
+            val primaryServer = HttpServer().apply { start() }
+            val fallbackServer = HttpServer().apply { start() }
+            try {
+                withCustomGradleProperties("${primaryServer.uri}/$repositoryName/gradle-${gradleVersion.version}-bin.zip")
+
+                // Both repositories permanently fail to serve the sources, any number of attempts
+                primaryServer.allowGetOrHeadMissing("/$repositoryName/$artifactFileName")
+                fallbackServer.allowGetOrHeadMissing("/$repositoryName/$artifactFileName")
+
+                // The IDE builds one Kotlin DSL model per script, each with its own resolver instance.
+                // Resolving twice in one build must still warn only once and resolve only once.
+                withBuildScript(
+                    """
+                    ${SourceDistributionResolver::class.qualifiedName}(project).sourceDirs()
+                    ${SourceDistributionResolver::class.qualifiedName}(project).sourceDirs()
+                    """
+                )
+
+                val result = build("-Dorg.gradle.kotlin.dsl.resolver.defaultGradleDistRepoBaseUrl=${fallbackServer.uri}")
+
+                val warning = "Could not resolve Gradle distribution sources. See debug logs for details."
+                val warningCount = result.output.split(warning).size - 1
+                assertThat(warningCount, equalTo(1))
+            } finally {
+                primaryServer.stop()
+                fallbackServer.stop()
+                primaryServer.resetExpectations()
+                fallbackServer.resetExpectations()
             }
         }
     }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -28,6 +28,8 @@ import org.gradle.internal.Try
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.resolver.internal.GradleDistRepoDescriptor
 import org.gradle.kotlin.dsl.resolver.internal.GradleDistRepoDescriptorLocator
+import org.gradle.kotlin.dsl.resolver.internal.SourceDistributionResolutionCache
+import org.gradle.kotlin.dsl.support.serviceOf
 import java.io.File
 import kotlin.jvm.optionals.getOrNull
 
@@ -47,18 +49,16 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
     private val repoLocator = GradleDistRepoDescriptorLocator(project)
 
     override fun sourceDirs(): Collection<File> =
-        try {
-            sourceDirs
-        } catch (ex: Exception) {
-            project.logger.warn("Could not resolve Gradle distribution sources. See debug logs for details.")
-            project.logger.debug("Gradle distribution sources resolution failure", ex)
-            emptyList()
+        // Cached for the duration of the build so the resolution, and its failure warning, happen at most once
+        project.serviceOf<SourceDistributionResolutionCache>().computeIfAbsent {
+            try {
+                resolveSourceDirsFromRepositories(candidateRepositories())
+            } catch (ex: Exception) {
+                project.logger.warn("Could not resolve Gradle distribution sources. See debug logs for details.")
+                project.logger.debug("Gradle distribution sources resolution failure", ex)
+                emptyList()
+            }
         }
-
-    private
-    val sourceDirs by lazy {
-        resolveSourceDirsFromRepositories(candidateRepositories())
-    }
 
     private
     fun candidateRepositories() =

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/internal/SourceDistributionResolutionCache.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/internal/SourceDistributionResolutionCache.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.resolver.internal
+
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+import java.io.File
+
+
+/**
+ * Memoizes Gradle distribution source resolution, which is invariant across the build tree.
+ *
+ * The IDE creates a fresh resolver per script model, so without this the network-bound resolution, and its
+ * failure warning, would repeat for every script. Build-tree scoped, so a later build retries.
+ */
+@ServiceScope(Scope.BuildTree::class)
+internal class SourceDistributionResolutionCache {
+
+    @Volatile
+    private var cachedSourceDirs: Collection<File>? = null
+
+    fun computeIfAbsent(resolve: () -> Collection<File>): Collection<File> =
+        cachedSourceDirs ?: synchronized(this) {
+            cachedSourceDirs ?: resolve().also { cachedSourceDirs = it }
+        }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
@@ -32,6 +32,7 @@ class KotlinScriptServices : AbstractGradleModuleServices() {
     override fun registerBuildTreeServices(registration: ServiceRegistration) {
         registration.addProvider(org.gradle.kotlin.dsl.accessors.BuildTreeServices)
         registration.addProvider(org.gradle.kotlin.dsl.support.BuildTreeServices)
+        registration.add(org.gradle.kotlin.dsl.resolver.internal.SourceDistributionResolutionCache::class.java)
     }
 
     override fun registerGlobalServices(registration: ServiceRegistration) {


### PR DESCRIPTION
When a distribution's sources cannot be resolved (snapshot or nightly builds, locally built distributions, or no network), IDE syncs logged a warning and repeated the expensive resolution once per script model. The inputs are identical across the whole build, so this is wasted work and the repeated warning is just noise.

Cache the outcome so the resolution, and its warning, happen at most once per build. The cache is scoped to the build tree and discarded afterwards, so a later build retries once connectivity is restored.

* Fixes #38160

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
