### PR TITLE
Bring IP testing annotations to parity with CC

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
@@ -199,7 +198,6 @@ class KotlinApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
     }
 
     @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-    @ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
     def "initializes Kotlin application with JUnit Jupiter test framework with --split-project"() {
         when:
         run('init', '--type', 'kotlin-application', '--test-framework', 'junit-jupiter', "--split-project", '--java-version', JavaVersion.current().majorVersion)

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.test.preconditions.JdkVersionTestPreconditions
 import spock.lang.Issue
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects.Skip.FLAKY
 import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.not
@@ -200,7 +199,7 @@ class KotlinApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
     }
 
     @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-    @ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+    @ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
     def "initializes Kotlin application with JUnit Jupiter test framework with --split-project"() {
         when:
         run('init', '--type', 'kotlin-application', '--test-framework', 'junit-jupiter', "--split-project", '--java-version', JavaVersion.current().majorVersion)

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecution
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.Language
-import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
@@ -307,7 +306,6 @@ class GroovyDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -315,7 +313,6 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -323,7 +320,6 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -388,7 +384,6 @@ class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -396,7 +391,6 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -404,7 +398,6 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -33,7 +33,6 @@ import static org.gradle.buildinit.plugins.internal.modifiers.Language.GROOVY
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.JAVA
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.KOTLIN
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.SCALA
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects.Skip.FLAKY
 import static org.gradle.util.Matchers.containsLine
 import static org.gradle.util.Matchers.containsText
 import static org.hamcrest.core.AllOf.allOf
@@ -308,7 +307,7 @@ class GroovyDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -316,7 +315,7 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -324,7 +323,7 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -389,7 +388,7 @@ class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -397,7 +396,7 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -405,7 +404,7 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = JdkVersionTestPreconditions.KotlinSupportedJdk.class)
-@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
+@ToBeFixedForIsolatedProjects(because = "KGP modifies service parameter properties concurrently", skipBecause = "flaky")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryNamedTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryNamedTypeIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.model
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache.Skip.FLAKY
 import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.startsWith
@@ -103,7 +102,7 @@ class ObjectFactoryNamedTypeIntegrationTest extends AbstractIntegrationSpec {
         outputContains("thing1: thing1")
     }
 
-    @ToBeFixedForConfigurationCache(skip = FLAKY, because = "https://github.com/gradle/gradle/issues/36718")
+    @ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36718", skipBecause = "flaky")
     def "named instance can be used as task input property"() {
         buildFile << """
             interface Thing extends Named { }
@@ -154,7 +153,7 @@ class ObjectFactoryNamedTypeIntegrationTest extends AbstractIntegrationSpec {
         result.assertTaskSkipped(":a")
     }
 
-    @ToBeFixedForConfigurationCache(skip = FLAKY, because = "https://github.com/gradle/gradle/issues/36718")
+    @ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36718", skipBecause = "flaky")
     def "cannot mutate named instance from groovy"() {
         buildFile << """
             interface Thing extends Named { }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -31,7 +31,6 @@ import org.gradle.util.internal.ToBeImplemented
 import org.junit.Rule
 import spock.lang.Issue
 
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache.Skip.FLAKY
 
 class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
@@ -2250,7 +2249,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     @ToBeFixedForConfigurationCache(
         because = "eachFile, expand, filter and rename",
-        skip = FLAKY
+        skipBecause = "flaky"
     )
     def "task output caching is disabled when #description is used"() {
         file("src.txt").createFile()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.hamcrest.Matchers
 import org.junit.Rule
 import spock.lang.Issue
 
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache.Skip.FLAKY
 
 class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
 
@@ -305,8 +304,9 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
     }
 
     @ToBeFixedForConfigurationCache(
-        skip = FLAKY,
-        because = "Due to extra parallelism with cc missing dependencies detection can be flaky. See https://github.com/gradle/gradle/issues/27576"
+        because = "Due to extra parallelism with cc missing dependencies detection can be flaky",
+        issue = "https://github.com/gradle/gradle/issues/27576",
+        skipBecause = "flaky"
     )
     def "fails when missing dependencies using filtered inputs"() {
         file("src/main/java/MyClass.java").createFile()

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     api(libs.jgit) {
         because("Some tests require a git reportitory - see AbstractIntegrationSpec.initGitDir(")
     }
-    api(libs.jspecify)
     api(libs.jsr305)
     api(testLibs.junit) {
         because("Part of the public API, used by spock AST transformer")
@@ -130,6 +129,7 @@ dependencies {
     implementation(libs.sshdSftp)
     implementation(platform(libs.sshdSftp))
 
+    compileOnly(libs.jspecify)
     compileOnly(libs.kotlinStdlib) {
         because("""Fixes:
             compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.21, {1}, {2}, {3}, {4}, {5}, {6}, {7}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCache.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCache.java
@@ -36,19 +36,20 @@ import java.lang.annotation.Target;
  * <p>
  * Instead of expecting failure, you can skip the test in case the test doesn't fail consistently
  * or has other undesirable effects, such as timeouts.
- * Set {@link #skip()} into any other value apart from {@link Skip#DO_NOT_SKIP DO_NOT_SKIP} to skip the test.
+ * Set {@link #skipBecause()} to a non-empty reason to skip the test.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @ExtensionAnnotation(ToBeFixedForConfigurationCacheExtension.class)
 public @interface ToBeFixedForConfigurationCache {
 
-    /**
-     * Set to some {@link Skip} to skip the annotated test.
-     */
-    Skip skip() default Skip.DO_NOT_SKIP;
-
     String because() default "";
+
+    /**
+     * Reason for skipping the annotated test instead of expecting it to fail.
+     * Empty (the default) means expect-failure; any non-empty value skips the test with that reason.
+     */
+    String skipBecause() default "";
 
     /**
      * Link to the issue tracking the incompatibility addressed by this annotation.
@@ -67,37 +68,4 @@ public @interface ToBeFixedForConfigurationCache {
      * Defaults to an empty array, meaning this annotation applies to all iterations of the annotated feature.
      */
     String[] iterationMatchers() default {};
-
-    /**
-     * Reason for skipping a test with configuration cache.
-     */
-    enum Skip {
-
-        /**
-         * Do not skip this test, this is the default.
-         */
-        DO_NOT_SKIP,
-
-        /**
-         * Use this reason on unrolled tests in super classes that fail on some subclasses.
-         * Spock doesn't allow to override test methods and annotate them.
-         */
-        UNROLLED_FAILS_IN_SUBCLASS,
-
-        /**
-         * Use this reason on tests that intermittently fail with configuration cache.
-         */
-        FLAKY,
-
-        /**
-         * Use this reason on tests that take a long time to fail, slowing down the CI feedback.
-         * Use sparingly, only in dramatic cases.
-         */
-        LONG_TIMEOUT,
-
-        /**
-         * This test has been seen failing, but we did not have time to investigate the reason yet.
-         */
-        INVESTIGATE
-    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheExtension.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.fixtures.modes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
 
 import java.util.function.Predicate
 
@@ -27,13 +28,30 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
     private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Configuration Cache")
 
     @Override
-    void visitFeatureAnnotation(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {
-
+    void visitSpecAnnotation(ToBeFixedForConfigurationCache annotation, SpecInfo spec) {
         if (GradleContextualExecuter.isNotConfigCache()) {
             return
         }
 
-        if (!isEnabledSpec(annotation, feature)) {
+        if (!isEnabledBottomSpec(annotation.bottomSpecs(), { spec.bottomSpec.name == it })) {
+            return
+        }
+
+        if (!annotation.skipBecause().isEmpty()) {
+            spec.skipped = true
+            return
+        }
+
+        toBeFixedSpecInterceptor.intercept(spec, annotation.iterationMatchers())
+    }
+
+    @Override
+    void visitFeatureAnnotation(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {
+        if (GradleContextualExecuter.isNotConfigCache()) {
+            return
+        }
+
+        if (!isEnabledBottomSpec(annotation.bottomSpecs(), { feature.spec.bottomSpec.name == it })) {
             return
         }
 
@@ -43,10 +61,6 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
         }
 
         toBeFixedSpecInterceptor.intercept(feature, annotation.iterationMatchers())
-    }
-
-    private static boolean isEnabledSpec(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {
-        isEnabledBottomSpec(annotation.bottomSpecs(), { it == feature.spec.bottomSpec.name })
     }
 
     static boolean isEnabledBottomSpec(String[] bottomSpecs, Predicate<String> specNamePredicate) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheExtension.groovy
@@ -22,8 +22,6 @@ import org.spockframework.runtime.model.FeatureInfo
 
 import java.util.function.Predicate
 
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache.Skip.DO_NOT_SKIP
-
 class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtension<ToBeFixedForConfigurationCache> {
 
     private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Configuration Cache")
@@ -39,7 +37,7 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
             return
         }
 
-        if (annotation.skip() != DO_NOT_SKIP) {
+        if (!annotation.skipBecause().isEmpty()) {
             feature.skipped = true
             return
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheRule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForConfigurationCacheRule.groovy
@@ -39,8 +39,7 @@ class ToBeFixedForConfigurationCacheRule implements TestRule {
         def enabledBottomSpec = isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })
         def enabledIteration = iterationMatches(annotation.iterationMatchers(), description.methodName)
         if (enabledBottomSpec && enabledIteration) {
-            ToBeFixedForConfigurationCache.Skip skip = annotation.skip()
-            if (skip == ToBeFixedForConfigurationCache.Skip.DO_NOT_SKIP) {
+            if (annotation.skipBecause().isEmpty()) {
                 return new ExpectingFailureRuleStatement(base, "Configuration Cache")
             } else {
                 return new UnsupportedWithConfigurationCacheRule.SkippingRuleStatement(base)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjects.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjects.java
@@ -23,10 +23,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+
 /**
- * Assert that this test fails when run with Isolated Projects enabled.
+ * Expect the test to fail or skip it when running with Isolated Projects enabled.
  * <p>
- * Set {@link #skipBecause()} to a non-empty reason to skip the test instead of expecting it to fail.
+ * Use this annotation when the intention is to fix either the test itself or the underlying feature,
+ * making it compatible with Isolated Projects. If the intention is to not support the tested feature
+ * with Isolated Projects, use {@link UnsupportedWithIsolatedProjects} instead.
+ * <p>
+ * The expectation of failure essentially flips the test result.
+ * A specific failure is not verified, and we only confirm that the test is not passing.
+ * <p>
+ * Instead of expecting failure, you can skip the test in case the test doesn't fail consistently
+ * or has other undesirable effects, such as timeouts.
+ * Set {@link #skipBecause()} to a non-empty reason to skip the test.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -46,4 +56,16 @@ public @interface ToBeFixedForIsolatedProjects {
      * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
      */
     String issue() default "";
+
+    /**
+     * Declare to which bottom spec this annotation should be applied.
+     * Defaults to an empty array, meaning this annotation applies to all bottom specs.
+     */
+    String[] bottomSpecs() default {};
+
+    /**
+     * Declare regular expressions matching the iteration name.
+     * Defaults to an empty array, meaning this annotation applies to all iterations of the annotated feature.
+     */
+    String[] iterationMatchers() default {};
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjects.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjects.java
@@ -26,51 +26,24 @@ import java.lang.annotation.Target;
 /**
  * Assert that this test fails when run with Isolated Projects enabled.
  * <p>
- * In case the {@link #skip()} reason is anything but {@link Skip#DO_NOT_SKIP DO_NOT_SKIP}, the test will be skipped.
+ * Set {@link #skipBecause()} to a non-empty reason to skip the test instead of expecting it to fail.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @ExtensionAnnotation(ToBeFixedForIsolatedProjectsExtension.class)
 public @interface ToBeFixedForIsolatedProjects {
 
-    /**
-     * Set to some {@link Skip} to skip the annotated test.
-     */
-    Skip skip() default Skip.DO_NOT_SKIP;
-
     String because() default "";
+
+    /**
+     * Reason for skipping the annotated test instead of expecting it to fail.
+     * Empty (the default) means expect-failure; any non-empty value skips the test with that reason.
+     */
+    String skipBecause() default "";
 
     /**
      * Link to the issue tracking the incompatibility addressed by this annotation.
      * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
      */
     String issue() default "";
-
-    /**
-     * Reason for skipping a test with isolated projects.
-     */
-    enum Skip {
-
-        /**
-         * Do not skip this test, this is the default.
-         */
-        DO_NOT_SKIP {
-            @Override
-            public String getReason() {
-                throw new UnsupportedOperationException("Must not be skipped");
-            }
-        },
-
-        /**
-         * Use this reason on tests that intermittently fail with isolated projects.
-         */
-        FLAKY {
-            @Override
-            public String getReason() {
-                return "flaky";
-            }
-        };
-
-        public abstract String getReason();
-    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjectsExtension.groovy
@@ -22,8 +22,6 @@ import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecElementInfo
 import org.spockframework.runtime.model.SpecInfo
 
-import static org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects.Skip.DO_NOT_SKIP
-
 class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtension<ToBeFixedForIsolatedProjects> {
 
     private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Isolated Projects")
@@ -43,8 +41,8 @@ class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtensio
             return
         }
 
-        if (annotation.skip() != DO_NOT_SKIP) {
-            specElementInfo.skip(annotation.skip().reason)
+        if (!annotation.skipBecause().isEmpty()) {
+            specElementInfo.skip(annotation.skipBecause())
             return
         }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/ToBeFixedForIsolatedProjectsExtension.groovy
@@ -19,8 +19,9 @@ package org.gradle.integtests.fixtures.modes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.spockframework.runtime.extension.IAnnotationDrivenExtension
 import org.spockframework.runtime.model.FeatureInfo
-import org.spockframework.runtime.model.SpecElementInfo
 import org.spockframework.runtime.model.SpecInfo
+
+import static ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
 
 class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtension<ToBeFixedForIsolatedProjects> {
 
@@ -28,24 +29,37 @@ class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtensio
 
     @Override
     void visitSpecAnnotation(ToBeFixedForIsolatedProjects annotation, SpecInfo spec) {
-        visitAnnotation(annotation, spec)
-    }
-
-    @Override
-    void visitFeatureAnnotation(ToBeFixedForIsolatedProjects annotation, FeatureInfo feature) {
-        visitAnnotation(annotation, feature)
-    }
-
-    private void visitAnnotation(ToBeFixedForIsolatedProjects annotation, SpecElementInfo specElementInfo) {
         if (GradleContextualExecuter.isNotIsolatedProjects()) {
             return
         }
 
-        if (!annotation.skipBecause().isEmpty()) {
-            specElementInfo.skip(annotation.skipBecause())
+        if (!isEnabledBottomSpec(annotation.bottomSpecs(), { spec.bottomSpec.name == it })) {
             return
         }
 
-        toBeFixedSpecInterceptor.intercept(specElementInfo, new String[0])
+        if (!annotation.skipBecause().isEmpty()) {
+            spec.skipped = true
+            return
+        }
+
+        toBeFixedSpecInterceptor.intercept(spec, annotation.iterationMatchers())
+    }
+
+    @Override
+    void visitFeatureAnnotation(ToBeFixedForIsolatedProjects annotation, FeatureInfo feature) {
+        if (GradleContextualExecuter.isNotIsolatedProjects()) {
+            return
+        }
+
+        if (!isEnabledBottomSpec(annotation.bottomSpecs(), { feature.spec.bottomSpec.name == it })) {
+            return
+        }
+
+        if (!annotation.skipBecause().isEmpty()) {
+            feature.skipped = true
+            return
+        }
+
+        toBeFixedSpecInterceptor.intercept(feature, annotation.iterationMatchers())
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjects.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjects.java
@@ -25,34 +25,23 @@ import java.lang.annotation.Target;
 
 
 /**
- * Expect the test to fail or skip it when running with Configuration Cache executor.
+ * Skip the test when running with Isolated Projects enabled.
  * <p>
- * Use this annotation when the intention is to fix either the test itself or the underlying feature,
- * making it compatible with Configuration Cache. If the intention is to not support the tested feature
- * with Configuration Cache, use {@link UnsupportedWithConfigurationCache} instead.
+ * Use this annotation when the tested feature is fundamentally incompatible with Isolated Projects
+ * and there is no intention to support it. If the intention is to eventually fix either the test
+ * or the underlying feature, use {@link ToBeFixedForIsolatedProjects} instead.
  * <p>
- * The expectation of failure essentially flips the test result.
- * A specific failure is not verified, and we only confirm that the test is not passing.
- * <p>
- * Instead of expecting failure, you can skip the test in case the test doesn't fail consistently
- * or has other undesirable effects, such as timeouts.
- * Set {@link #skipBecause()} to a non-empty reason to skip the test.
+ * The annotated test is skipped entirely; no assertion is made about its behavior under Isolated Projects.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
-@ExtensionAnnotation(ToBeFixedForConfigurationCacheExtension.class)
-public @interface ToBeFixedForConfigurationCache {
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(UnsupportedWithIsolatedProjectsExtension.class)
+public @interface UnsupportedWithIsolatedProjects {
 
     String because() default "";
 
     /**
-     * Reason for skipping the annotated test instead of expecting it to fail.
-     * Empty (the default) means expect-failure; any non-empty value skips the test with that reason.
-     */
-    String skipBecause() default "";
-
-    /**
-     * Link to the issue tracking the incompatibility addressed by this annotation.
+     * Link to the issue documenting why the tested feature is not supported.
      * Distinct from {@code @spock.lang.Issue}, which links the test itself to its tracking issue.
      */
     String issue() default "";

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjectsExtension.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.modes
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.opentest4j.TestAbortedException
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
+
+import static ToBeFixedSpecInterceptor.isAllIterations
+import static ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
+import static ToBeFixedSpecInterceptor.iterationMatches
+
+class UnsupportedWithIsolatedProjectsExtension implements IAnnotationDrivenExtension<UnsupportedWithIsolatedProjects> {
+
+    @Override
+    void visitSpecAnnotation(UnsupportedWithIsolatedProjects annotation, SpecInfo spec) {
+        if (GradleContextualExecuter.isIsolatedProjects()) {
+            if (isAllIterations(annotation.iterationMatchers()) && isEnabledBottomSpec(annotation.bottomSpecs(), { spec.bottomSpec.name == it })) {
+                spec.skipped = true
+            } else {
+                spec.features.each { feature ->
+                    feature.getFeatureMethod().addInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                }
+            }
+        }
+    }
+
+    @Override
+    void visitFeatureAnnotation(UnsupportedWithIsolatedProjects annotation, FeatureInfo feature) {
+        if (GradleContextualExecuter.isIsolatedProjects()) {
+            if (isAllIterations(annotation.iterationMatchers()) && isEnabledBottomSpec(annotation.bottomSpecs(), { feature.parent.bottomSpec.name == it })) {
+                feature.skipped = true
+            } else {
+                feature.getFeatureMethod().addInterceptor(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+            }
+        }
+    }
+
+    private static class IterationMatchingMethodInterceptor implements IMethodInterceptor {
+
+        private final String[] iterationMatchers
+
+        IterationMatchingMethodInterceptor(String[] iterationMatchers) {
+            this.iterationMatchers = iterationMatchers
+        }
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            if (iterationMatches(iterationMatchers, invocation.iteration.displayName)) {
+                throw new TestAbortedException("Unsupported with isolated projects")
+            }
+            invocation.proceed()
+        }
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjectsRule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/modes/UnsupportedWithIsolatedProjectsRule.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures.modes
 
-
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -24,27 +23,35 @@ import org.junit.runners.model.Statement
 
 import static ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
 import static ToBeFixedSpecInterceptor.iterationMatches
+import static org.junit.Assume.assumeTrue
 
-/**
- * JUnit Rule supporting the {@link ToBeFixedForIsolatedProjects} annotation.
- */
-class ToBeFixedForIsolatedProjectsRule implements TestRule {
+class UnsupportedWithIsolatedProjectsRule implements TestRule {
 
     @Override
     Statement apply(Statement base, Description description) {
-        def annotation = description.getAnnotation(ToBeFixedForIsolatedProjects.class)
+        def annotation = description.getAnnotation(UnsupportedWithIsolatedProjects.class)
         if (GradleContextualExecuter.isNotIsolatedProjects() || annotation == null) {
             return base
         }
         def enabledBottomSpec = isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })
         def enabledIteration = iterationMatches(annotation.iterationMatchers(), description.methodName)
         if (enabledBottomSpec && enabledIteration) {
-            if (annotation.skipBecause().isEmpty()) {
-                return new ExpectingFailureRuleStatement(base, "Isolated Projects")
-            } else {
-                return new UnsupportedWithIsolatedProjectsRule.SkippingRuleStatement(base)
-            }
+            return new SkippingRuleStatement(annotation.because())
         }
         return base
+    }
+
+    static class SkippingRuleStatement extends Statement {
+
+        private final String reason
+
+        SkippingRuleStatement(String reason) {
+            this.reason = reason
+        }
+
+        @Override
+        void evaluate() throws Throwable {
+            assumeTrue("Test does not support isolated projects: $reason", false)
+        }
     }
 }


### PR DESCRIPTION
Part of #38185.

Gradle integration tests run in three modes: Vintage (baseline), Configuration Cache (CC), and Isolated Projects (IP). Per-mode expectations are expressed via annotations: `@ToBeFixedFor*` (expect failure, or skip with a reason) and `@UnsupportedWith*` (skip). CC has a richer surface than IP today — this PR closes the gap.

These changes intentionally introduce duplication to unblock using IP annotations. The unification and a refactor will follow later.

## What changes

**`Skip` enum → free-form `String skipBecause()`** on `@ToBeFixedForConfigurationCache` and `@ToBeFixedForIsolatedProjects`. Empty = expect failure (unchanged default), non-empty = skip with that reason. Placed after `because` so call sites read naturally: `(because = "…", skipBecause = "…")`. Of the enum's possible reasons only `FLAKY` was ever used in practice (~5 call sites); the rest are dropped along with the enum, and the `FLAKY` sites become `skipBecause = "flaky"`.

**IP gains CC's capability set:**
- `@ToBeFixedForIsolatedProjects` gains `bottomSpecs` and `iterationMatchers` — narrowing a base-class annotation to specific concrete subclasses / specific Spock iterations.
- New `@UnsupportedWithIsolatedProjects` (annotation + Spock extension + JUnit rule), modeled on `@UnsupportedWithConfigurationCache`. Previously IP could express "expect failure" but not "skip".
- IP Spock extension and JUnit rule aligned with their CC counterparts (spec- and feature-level dispatch, bottom-spec gating, iteration matching).
- `@ToBeFixedForConfigurationCache`'s `@Target` extended from `METHOD` to `{METHOD, TYPE}` so both families allow class-level placement.

The IP Spock extension / JUnit rule / `@UnsupportedWithIsolatedProjects` are intentional near-mechanical mirrors of their CC counterparts. The duplication is temporary — a unified dispatch layer will collapse it once both families have the same shape.

Additive at call sites — existing usages keep working.