### PR TITLE
Improve error message when signing task has no signatory 

### DIFF
--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
@@ -30,6 +30,7 @@ public abstract class GradleCoreProblemGroup {
     private static final ProblemGroup CONFIGURATION_USAGE_PROBLEM_GROUP = ProblemGroup.create("configuration-usage", "Configuration usage");
     private static final DaemonToolchainProblemGroup DAEMON_TOOLCHAIN_PROBLEM_GROUP = new DefaultDaemonToolchainProblemGroup();
     private static final ProblemGroup SCRIPTS_PROBLEM_GROUP = ProblemGroup.create("scripts", "Scripts");
+    private static final DefaultPackagingProblemGroup PACKAGING_PROBLEM_GROUP = new DefaultPackagingProblemGroup();
 
     public static CompilationProblemGroup compilation() {
         return COMPILATION_PROBLEM_GROUP;
@@ -71,6 +72,10 @@ public abstract class GradleCoreProblemGroup {
         return SCRIPTS_PROBLEM_GROUP;
     }
 
+    public static PackagingProblemGroup packaging() {
+        return PACKAGING_PROBLEM_GROUP;
+    }
+
     public interface CompilationProblemGroup {
         ProblemGroup thisGroup();
         ProblemGroup java();
@@ -87,6 +92,11 @@ public abstract class GradleCoreProblemGroup {
     public interface DaemonToolchainProblemGroup {
         ProblemGroup thisGroup();
         ProblemGroup configurationGeneration();
+    }
+
+    public interface PackagingProblemGroup {
+        ProblemGroup thisGroup();
+        ProblemGroup signing();
     }
 
     private static class DefaultCompilationProblemGroup implements CompilationProblemGroup {
@@ -158,6 +168,22 @@ public abstract class GradleCoreProblemGroup {
         @Override
         public ProblemGroup configurationGeneration() {
             return configurationGeneration;
+        }
+    }
+
+    private static class DefaultPackagingProblemGroup implements PackagingProblemGroup {
+
+        private final ProblemGroup thisGroup = ProblemGroup.create("packaging", "Packaging");
+        private final ProblemGroup signing = ProblemGroup.create("signing", "Signing", thisGroup);
+
+        @Override
+        public ProblemGroup thisGroup() {
+            return thisGroup;
+        }
+
+        @Override
+        public ProblemGroup signing() {
+            return signing;
         }
     }
 

--- a/platforms/software/signing/build.gradle.kts
+++ b/platforms/software/signing/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     api(projects.coreApi)
     api(projects.domainObjectCollections)
     api(projects.fileCollections)
+    api(projects.logging)
+    api(projects.problemsApi)
     api(projects.publish)
     api(projects.stdlibJavaExtensions)
 

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
@@ -20,6 +20,7 @@ class NoSigningCredentialsIntegrationSpec extends SigningIntegrationSpec {
     def setup() {
         using m2
         executer.withArguments("-info")
+        enableProblemsApiCheck()
     }
 
     def "trying to perform a signing operation without a signatory produces reasonable error"() {
@@ -34,8 +35,12 @@ class NoSigningCredentialsIntegrationSpec extends SigningIntegrationSpec {
         fails ":signJar"
 
         and:
-        failure.assertHasDocumentedCause("Cannot perform signing task ':signJar' because it has no configured signatory. " +
-            "A signatory holds the PGP key used to sign artifacts and must be configured in the 'signing {}' block. " +
-            "For more information on configuring signing, please refer to https://docs.gradle.org/current/userguide/signing_plugin.html in the Gradle documentation.")
+        verifyAll(receivedProblem) {
+            definition.id.fqid == 'packaging:signing:no-configured-signatory'
+            definition.id.displayName == 'No configured signatory'
+            contextualLabel == "Cannot perform signing task ':signJar' because it has no configured signatory"
+            solutions == ["Configure a signatory in the 'signing {}' block."]
+            definition.documentationLink.url.contains('userguide/signing_plugin.html')
+        }
     }
 }

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
@@ -34,6 +34,8 @@ class NoSigningCredentialsIntegrationSpec extends SigningIntegrationSpec {
         fails ":signJar"
 
         and:
-        failureHasCause "Cannot perform signing task ':signJar' because it has no configured signatory"
+        failure.assertHasDocumentedCause("Cannot perform signing task ':signJar' because it has no configured signatory. " +
+            "A signatory holds the PGP key used to sign artifacts and must be configured in the 'signing {}' block. " +
+            "For more information on configuring signing, please refer to https://docs.gradle.org/current/userguide/signing_plugin.html in the Gradle documentation.")
     }
 }

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -31,6 +31,9 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.Problems;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
@@ -101,6 +104,9 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf("Signing is required, or signatory is set", spec(task -> isRequired() || getSignatory() != null));
     }
+
+    @Inject
+    protected abstract Problems getProblems();
 
     @Inject
     protected abstract DocumentationRegistry getDocumentationRegistry();
@@ -232,9 +238,21 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @TaskAction
     public void generate() {
         if (getSignatory() == null) {
-            throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory. "
-                + "A signatory holds the PGP key used to sign artifacts and must be configured in the \'signing {}\' block. "
-                + getDocumentationRegistry().getDocumentationRecommendationFor("information on configuring signing", "signing_plugin"));
+            ProblemId problemId = ProblemId.create(
+                "no-configured-signatory",
+                "No configured signatory",
+                GradleCoreProblemGroup.packaging().signing()
+            );
+            throw getProblems().getReporter().throwing(
+                new InvalidUserDataException(),
+                problemId,
+                spec -> spec
+                    .contextualLabel("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory")
+                    .details("A signatory holds the PGP key used to sign artifacts. "
+                        + "It must be configured in the \'signing {}\' block before signing tasks can run.")
+                    .solution("Configure a signatory in the \'signing {}\' block.")
+                    .documentedAt(getDocumentationRegistry().getDocumentationFor("signing_plugin"))
+            );
         }
 
         for (Signature.Generator signature : sanitizedGenerators().values()) {

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -228,7 +228,9 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @TaskAction
     public void generate() {
         if (getSignatory() == null) {
-            throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory");
+            throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory. "
+                + "A signatory holds the PGP key used to sign artifacts and must be configured in the \'signing {}\' block. "
+                + "See https://docs.gradle.org/current/userguide/signing_plugin.html for details.");
         }
 
         for (Signature.Generator signature : sanitizedGenerators().values()) {

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.Publication;
@@ -100,6 +101,9 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf("Signing is required, or signatory is set", spec(task -> isRequired() || getSignatory() != null));
     }
+
+    @Inject
+    protected abstract DocumentationRegistry getDocumentationRegistry();
 
     /**
      * Configures the task to sign the archive produced for each of the given tasks (which must be archive tasks).
@@ -230,7 +234,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
         if (getSignatory() == null) {
             throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory. "
                 + "A signatory holds the PGP key used to sign artifacts and must be configured in the \'signing {}\' block. "
-                + "See https://docs.gradle.org/current/userguide/signing_plugin.html for details.");
+                + getDocumentationRegistry().getDocumentationRecommendationFor("information on configuring signing", "signing_plugin"));
         }
 
         for (Signature.Generator signature : sanitizedGenerators().values()) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -59,10 +59,12 @@ class KnownProblemIds {
         'daemon-toolchain' : 'Daemon toolchain',
         'dependency-version-catalog': 'Version catalog',
         'deprecation': 'Deprecation',
+        'packaging': 'Packaging',
         'plugin-application': 'Plugin application',
         'task-selection': 'Task selection',
 
         // Sub-groups
+        'packaging:signing': 'Signing',
         'compilation:groovy-dsl': 'Groovy DSL script compilation',
         'compilation:java': 'Java compilation',
         'daemon-toolchain:configuration-generation' : 'Gradle configuration generation',
@@ -132,6 +134,7 @@ class KnownProblemIds {
         'validation:configuration-cache:registration-of-listener-on-gradle-buildfinished-is-unsupported': ['registration of listener on \'Gradle.buildFinished\' is unsupported'],
         'validation:configuration-cache:invocation-of-task-project-at-execution-time-is-unsupported-with-the-configuration-cache': ['invocation of \'Task.project\' at execution time is unsupported with the configuration cache.'],
         'validation:configuration-cache:isolated-projects-dangerously-ignoring-problems': ['Isolated Projects problems are dangerously ignored'],
+        'packaging:signing:no-configured-signatory': ['No configured signatory'],
         'plugin-application:target-type-mismatch': ['Unexpected plugin type'],
         'task-selection:ambiguous-matches': ['Ambiguous matches'],
         'task-selection:selection-failed': ['Selection failed'],


### PR DESCRIPTION
Fixes #19417

Context

The current error thrown when a signing task runs without a signatory — "Cannot perform signing task ':X' because it has no configured signatory" — gives users no indication of what a "signatory" is or how to resolve the problem. Users who hit it (often just by running a build that signs artifacts) are left with a dead end, and "no configured signatory" is a common, unresolved search online.

In practice the fix is simply to configure a signatory in the signing {} block, but the message never says so.

This change extends the message to explain that a signatory holds the PGP key used to sign artifacts and must be configured in the signing {} block, and adds a link to the Signing Plugin documentation. The original leading sentence is left unchanged, so the existing NoSigningCredentialsIntegrationSpec assertion (a substring match on the cause) remains compatible.
