### PR TITLE
Report Isolated Projects problem when a project plugin registers shared model defaults

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsSharedModelDefaultsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsSharedModelDefaultsIntegrationTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import spock.lang.Issue
+
+class IsolatedProjectsSharedModelDefaultsIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    @Issue("https://github.com/gradle/gradle/issues/38028")
+    def "reports problem when a project plugin registers shared model defaults"() {
+        given:
+        buildFile """
+            import org.gradle.api.initialization.SharedModelDefaults
+            import javax.inject.Inject
+
+            abstract class DefaultsRegisteringPlugin implements Plugin<Project> {
+                @Inject
+                abstract SharedModelDefaults getSharedModelDefaults()
+
+                void apply(Project project) {
+                    sharedModelDefaults.add("myProjectType", String, {})
+                }
+            }
+            apply plugin: DefaultsRegisteringPlugin
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":")
+            problem("Build file 'build.gradle': line 10: Project ':' cannot register shared model defaults. Shared model defaults can only be registered in a settings script, using the 'defaults' block.", 1)
+        }
+
+        where:
+        mode << ALL_MODES
+    }
+
+    def "without isolated projects, a project plugin registering shared model defaults fails with the late IllegalStateException"() {
+        given:
+        buildFile """
+            import org.gradle.api.initialization.SharedModelDefaults
+            import javax.inject.Inject
+
+            abstract class DefaultsRegisteringPlugin implements Plugin<Project> {
+                @Inject
+                abstract SharedModelDefaults getSharedModelDefaults()
+
+                void apply(Project project) {
+                    sharedModelDefaults.add("myProjectType", String, {})
+                }
+            }
+            apply plugin: DefaultsRegisteringPlugin
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Cannot add shared model defaults after processing.")
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Formatter;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
@@ -65,7 +66,7 @@ import static org.gradle.util.internal.CollectionUtils.join;
  * be registered as a listener of that type. Alternatively, service implementations can be annotated with {@link org.gradle.internal.service.scopes.ListenerService} to indicate that the should be
  * registered as a listener.</p>
  */
-public class DefaultServiceRegistry extends AbstractServiceRegistry implements CloseableServiceRegistry {
+public class DefaultServiceRegistry extends AbstractServiceRegistry implements CloseableServiceRegistry, ServiceRegistryIntrospection {
     private enum State {INIT, STARTED, CLOSED}
 
     private final static ServiceRegistry[] NO_PARENTS = new ServiceRegistry[0];
@@ -137,6 +138,15 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
     @Override
     ServiceProvider asServiceProvider() {
         return thisAsServiceProvider;
+    }
+
+    @Override
+    public Set<Class<?>> getAllServiceTypes() {
+        // thisAsServiceProvider composes this registry's own services with the parent chain,
+        // so this walks every reachable scope. Reads type metadata only; no service is realized.
+        Set<Class<?>> types = new HashSet<Class<?>>();
+        thisAsServiceProvider.collectServiceTypes(types);
+        return types;
     }
 
     private static ServiceProvider toParentServices(ServiceRegistry serviceRegistry) {
@@ -461,6 +471,17 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
                 visitor = serviceProvider.getAll(serviceType, token, visitor);
             }
             return visitor;
+        }
+
+        @Override
+        public void collectServiceTypes(Set<Class<?>> dest) {
+            // providersByType is keyed by every type each registered service can be resolved as
+            // (declared types plus their supertypes/interfaces). Read the current snapshot once.
+            @SuppressWarnings("NullAway") // TODO(https://github.com/uber/NullAway/issues/681) Can't infer that AtomicReference holds non-nullable type
+            PersistentMap<Class<?>, PersistentArray<ServiceProvider>> providersByType = services.get().providersByType;
+            for (Map.Entry<Class<?>, PersistentArray<ServiceProvider>> entry : providersByType) {
+                dest.add(entry.getKey());
+            }
         }
 
         @Override
@@ -1076,6 +1097,13 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
         }
 
         @Override
+        public void collectServiceTypes(Set<Class<?>> dest) {
+            for (ServiceProvider serviceProvider : serviceProviders) {
+                serviceProvider.collectServiceTypes(dest);
+            }
+        }
+
+        @Override
         public void stop() {
             try {
                 CompositeStoppable.stoppable(Arrays.asList(serviceProviders)).stop();
@@ -1108,6 +1136,11 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
         @Override
         public Visitor getAll(Class<?> serviceType, @Nullable ServiceAccessToken token, Visitor visitor) {
             return parent.getAll(serviceType, token, visitor);
+        }
+
+        @Override
+        public void collectServiceTypes(Set<Class<?>> dest) {
+            parent.collectServiceTypes(dest);
         }
 
         @Override

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -149,6 +149,15 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
         return types;
     }
 
+    @Override
+    public Set<Class<?>> getOwnServiceTypes() {
+        // Only this registry's own services - no parent traversal. For a project-scoped registry this
+        // is exactly the project-scoped services. Reads type metadata only; no service is realized.
+        Set<Class<?>> types = new HashSet<Class<?>>();
+        ownServices.collectServiceTypes(types);
+        return types;
+    }
+
     private static ServiceProvider toParentServices(ServiceRegistry serviceRegistry) {
         if (serviceRegistry instanceof AbstractServiceRegistry) {
             return new ParentServices(((AbstractServiceRegistry) serviceRegistry).asServiceProvider());

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
@@ -20,6 +20,7 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
+import java.util.Set;
 
 /**
  * Provides a set of zero or more services. The get-methods may be called concurrently. {@link #stop()} is guaranteed to be only called once,
@@ -38,6 +39,15 @@ interface ServiceProvider extends Stoppable {
      * @return A visitor that should be used for all subsequent services.
      */
     Visitor getAll(Class<?> serviceType, @Nullable ServiceAccessToken token, Visitor visitor);
+
+    /**
+     * Adds to {@code dest} every type by which a service from this provider can be resolved, for introspection
+     * (see {@link ServiceRegistryIntrospection}). Implemented by the structural providers that hold the registry
+     * contents and the parent chain; per-service providers contribute their types via the owning registry's
+     * type index, so the default is a no-op. Must not realize any service.
+     */
+    default void collectServiceTypes(Set<Class<?>> dest) {
+    }
 
     interface Visitor {
         void visit(Service service);

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceRegistryIntrospection.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceRegistryIntrospection.java
@@ -39,4 +39,15 @@ public interface ServiceRegistryIntrospection {
      * Only type metadata is read; no service instances are realized.
      */
     Set<Class<?>> getAllServiceTypes();
+
+    /**
+     * Returns the types provided by <em>this</em> registry's own services only, excluding anything inherited
+     * from ancestor registries. For the per-project registry returned by {@code ProjectInternal.getServices()},
+     * this is the set of <em>project-scoped</em> services (including services declared at multiple scopes that
+     * have a project-scoped registration, e.g. {@code {Build, Project}} ones); {@link #getAllServiceTypes()}
+     * minus this set is what is inherited from build/global scope.
+     * <p>
+     * Only type metadata is read; no service instances are realized.
+     */
+    Set<Class<?>> getOwnServiceTypes();
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceRegistryIntrospection.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceRegistryIntrospection.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import java.util.Set;
+
+/**
+ * Introspection over a {@link ServiceRegistry}, allowing the set of resolvable service types to be
+ * enumerated without instantiating any service.
+ * <p>
+ * Implemented by {@link DefaultServiceRegistry}, so it is available on the scoped registries built from it
+ * (e.g. the per-project registry returned by {@code ProjectInternal.getServices()}).
+ * <p>
+ * This is internal tooling — primarily for auditing which services are injectable into user code (a service
+ * is injectable by any type it can be resolved as) and reconciling that against the documented set.
+ */
+public interface ServiceRegistryIntrospection {
+
+    /**
+     * Returns every type by which a service can be resolved from this registry <em>and all of its ancestor
+     * registries</em> — that is, each registered service's declared types together with their supertypes and
+     * interfaces. This is the set of types that {@link ServiceRegistry#find(java.lang.reflect.Type)} could
+     * satisfy, and therefore the set of types injectable from this scope.
+     * <p>
+     * Only type metadata is read; no service instances are realized.
+     */
+    Set<Class<?>> getAllServiceTypes();
+}

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/ServiceRegistryIntrospectionTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/ServiceRegistryIntrospectionTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import spock.lang.Specification
+
+class ServiceRegistryIntrospectionTest extends Specification implements ServiceRegistryFixture {
+
+    interface ParentService {}
+
+    static class ParentServiceImpl implements ParentService {}
+
+    interface ChildService {}
+
+    static class ChildServiceImpl implements ChildService {}
+
+    def "enumerates service types from this registry and all ancestors, including their interfaces"() {
+        given:
+        def parent = newRegistry()
+        parent.add(ParentServiceImpl, new ParentServiceImpl())
+        def registry = newRegistry(parent)
+        registry.add(ChildServiceImpl, new ChildServiceImpl())
+
+        when:
+        def types = registry.allServiceTypes
+
+        then:
+        // own service: declared type and the interface it implements
+        types.contains(ChildServiceImpl)
+        types.contains(ChildService)
+
+        and:
+        // ancestor service is reachable too
+        types.contains(ParentServiceImpl)
+        types.contains(ParentService)
+
+        and:
+        // the registry always provides itself as a service
+        types.contains(ServiceRegistry)
+
+        and:
+        // the shared hierarchy root is not reported as a service type
+        !types.contains(Object)
+    }
+
+    def "enumeration does not realize any service"() {
+        given:
+        def realized = false
+        def registry = newRegistry()
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ChildService createChild() {
+                realized = true
+                return new ChildServiceImpl()
+            }
+        })
+
+        when:
+        def types = registry.allServiceTypes
+
+        then:
+        types.contains(ChildService)
+        !realized
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/SharedModelDefaults.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/SharedModelDefaults.java
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 8.10
  */
 @Incubating
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface SharedModelDefaults {
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/service/InjectableServicesEnumerationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/service/InjectableServicesEnumerationIntegrationTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * Demonstrates programmatically listing the services injectable from a project's service registry,
+ * filtered to the public ones (no {@code internal} package segment). This exercises
+ * {@link ServiceRegistryIntrospection#getAllServiceTypes()} against a real project, to produce an
+ * up-to-date list to reconcile against the documented injectable services.
+ */
+@Issue("https://github.com/gradle/gradle/issues/38028")
+class InjectableServicesEnumerationIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can list the public services injectable from a project's service registry"() {
+        given:
+        buildFile """
+            // Enumerate at configuration time and capture only Strings, so the task stays
+            // configuration-cache compatible (no live service/registry held by the task).
+            def publicServiceTypes = (project.services as ${ServiceRegistryIntrospection.name})
+                .allServiceTypes
+                .collect { it.name }
+                .findAll { it.startsWith("org.gradle.") && !it.contains(".internal.") }
+                .unique()
+                .sort()
+
+            tasks.register("listInjectableServices") {
+                doLast {
+                    publicServiceTypes.each { println "INJECTABLE_SERVICE: \$it" }
+                    println "INJECTABLE_SERVICE_COUNT: \${publicServiceTypes.size()}"
+                }
+            }
+        """
+
+        when:
+        run "listInjectableServices"
+
+        then:
+        // documented project-injectable services that resolve from project scope or an ancestor
+        outputContains("INJECTABLE_SERVICE: org.gradle.api.model.ObjectFactory")
+        outputContains("INJECTABLE_SERVICE: org.gradle.api.provider.ProviderFactory")
+        outputContains("INJECTABLE_SERVICE: org.gradle.api.file.FileSystemOperations")
+        outputContains("INJECTABLE_SERVICE: org.gradle.api.file.ProjectLayout")
+
+        and:
+        def listed = output.readLines()
+            .findAll { it.startsWith("INJECTABLE_SERVICE: ") }
+            .collect { it.substring("INJECTABLE_SERVICE: ".length()) }
+        // the filter actually filtered: every entry is a public org.gradle type
+        listed.every { it.startsWith("org.gradle.") && !it.contains(".internal.") }
+        // and there is a meaningful number of them
+        listed.size() >= 5
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/service/InjectableServicesEnumerationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/service/InjectableServicesEnumerationIntegrationTest.groovy
@@ -20,30 +20,79 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
 /**
- * Demonstrates programmatically listing the services injectable from a project's service registry,
- * filtered to the public ones (no {@code internal} package segment). This exercises
- * {@link ServiceRegistryIntrospection#getAllServiceTypes()} against a real project, to produce an
- * up-to-date list to reconcile against the documented injectable services.
+ * Demonstrates programmatically listing the services injectable from a project's service registry, via
+ * {@link ServiceRegistryIntrospection#getAllServiceTypes()}. Produces three views to compare:
+ * <ul>
+ *     <li>{@code INJECTABLE_SERVICE} - heuristic "public": {@code org.gradle.*} with no {@code internal} package segment.</li>
+ *     <li>{@code ALL_SERVICE} - everything under {@code org.gradle.*}, including internal services.</li>
+ *     <li>{@code PUBLIC_API_SERVICE} - only types matching the authoritative Gradle public API definition
+ *         (PublicApi.kt / PublicKotlinDslApi.kt includes minus excludes).</li>
+ * </ul>
  */
 @Issue("https://github.com/gradle/gradle/issues/38028")
 class InjectableServicesEnumerationIntegrationTest extends AbstractIntegrationSpec {
 
-    def "can list the public services injectable from a project's service registry"() {
+    def "can list injectable services as heuristic-public, all (incl. internal), and strict public-API"() {
         given:
         buildFile """
             // Enumerate at configuration time and capture only Strings, so the task stays
             // configuration-cache compatible (no live service/registry held by the task).
-            def publicServiceTypes = (project.services as ${ServiceRegistryIntrospection.name})
+            def names = (project.services as ${ServiceRegistryIntrospection.name})
                 .allServiceTypes
                 .collect { it.name }
-                .findAll { it.startsWith("org.gradle.") && !it.contains(".internal.") }
                 .unique()
                 .sort()
 
+            // Authoritative Gradle public API definition, mirrored from
+            // build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/PublicApi.kt and PublicKotlinDslApi.kt.
+            // These are Ant-style path globs matched against the FQCN's slash-path.
+            def apiIncludes = [
+                "org/gradle/*", "org/gradle/api/**", "org/gradle/authentication/**", "org/gradle/build/**",
+                "org/gradle/buildconfiguration/**", "org/gradle/buildinit/**", "org/gradle/caching/**",
+                "org/gradle/concurrent/**", "org/gradle/deployment/**", "org/gradle/external/javadoc/**",
+                "org/gradle/ide/**", "org/gradle/ivy/**", "org/gradle/jvm/**", "org/gradle/language/**",
+                "org/gradle/maven/**", "org/gradle/nativeplatform/**", "org/gradle/normalization/**",
+                "org/gradle/platform/**", "org/gradle/plugin/devel/**", "org/gradle/plugin/use/*",
+                "org/gradle/plugin/management/*", "org/gradle/plugins/**", "org/gradle/process/**",
+                "org/gradle/testfixtures/**", "org/gradle/testing/jacoco/**", "org/gradle/tooling/**",
+                "org/gradle/swiftpm/**", "org/gradle/model/**", "org/gradle/testkit/**", "org/gradle/testing/**",
+                "org/gradle/vcs/**", "org/gradle/work/**", "org/gradle/workers/**", "org/gradle/util/**",
+            ]
+            def dslIncludes = ["org/gradle/kotlin/dsl/*", "org/gradle/kotlin/dsl/precompile/*"]
+            // PublicApi.excludes; PublicKotlinDslApi.excludes only filters synthetic inlined-lambda classes,
+            // which are never registered as services, so it is omitted here.
+            def excludes = ["**/internal/**"]
+
+            def antToRegex = { String glob ->
+                def out = new StringBuilder()
+                int i = 0
+                while (i < glob.length()) {
+                    if (glob.startsWith("**", i)) { out.append(".*"); i += 2 }
+                    else if (glob.charAt(i) == ("*" as char)) { out.append("[^/]*"); i += 1 }
+                    else { out.append(glob.charAt(i)); i += 1 }
+                }
+                out.toString()
+            }
+            def includeRe = (apiIncludes + dslIncludes).collect { antToRegex(it) }
+            def excludeRe = excludes.collect { antToRegex(it) }
+            def isPublicApi = { String fqcn ->
+                def path = fqcn.replace(".", "/")
+                includeRe.any { path ==~ it } && !excludeRe.any { path ==~ it }
+            }
+
+            def gradleServices    = names.findAll { it.startsWith("org.gradle.") }
+            def publicHeuristic   = gradleServices.findAll { !it.contains(".internal.") }
+            def allServices       = gradleServices              // includes internal
+            def publicApiServices = names.findAll { isPublicApi(it) }
+
             tasks.register("listInjectableServices") {
                 doLast {
-                    publicServiceTypes.each { println "INJECTABLE_SERVICE: \$it" }
-                    println "INJECTABLE_SERVICE_COUNT: \${publicServiceTypes.size()}"
+                    publicHeuristic.each { println "INJECTABLE_SERVICE: \$it" }
+                    println "INJECTABLE_SERVICE_COUNT: \${publicHeuristic.size()}"
+                    allServices.each { println "ALL_SERVICE: \$it" }
+                    println "ALL_SERVICE_COUNT: \${allServices.size()}"
+                    publicApiServices.each { println "PUBLIC_API_SERVICE: \$it" }
+                    println "PUBLIC_API_SERVICE_COUNT: \${publicApiServices.size()}"
                 }
             }
         """
@@ -52,19 +101,402 @@ class InjectableServicesEnumerationIntegrationTest extends AbstractIntegrationSp
         run "listInjectableServices"
 
         then:
-        // documented project-injectable services that resolve from project scope or an ancestor
-        outputContains("INJECTABLE_SERVICE: org.gradle.api.model.ObjectFactory")
-        outputContains("INJECTABLE_SERVICE: org.gradle.api.provider.ProviderFactory")
-        outputContains("INJECTABLE_SERVICE: org.gradle.api.file.FileSystemOperations")
-        outputContains("INJECTABLE_SERVICE: org.gradle.api.file.ProjectLayout")
+        def lines = output.readLines()
+        def extract = { String prefix ->
+            lines.findAll { it.startsWith(prefix) }.collect { it.substring(prefix.length()) }
+        }
+        def heuristic = extract("INJECTABLE_SERVICE: ")
+        def all = extract("ALL_SERVICE: ")
+        def api = extract("PUBLIC_API_SERVICE: ")
 
-        and:
-        def listed = output.readLines()
-            .findAll { it.startsWith("INJECTABLE_SERVICE: ") }
-            .collect { it.substring("INJECTABLE_SERVICE: ".length()) }
-        // the filter actually filtered: every entry is a public org.gradle type
-        listed.every { it.startsWith("org.gradle.") && !it.contains(".internal.") }
-        // and there is a meaningful number of them
-        listed.size() >= 5
+        and: "documented public services appear in the heuristic and strict public-API lists"
+        ["org.gradle.api.model.ObjectFactory",
+         "org.gradle.api.provider.ProviderFactory",
+         "org.gradle.api.file.FileSystemOperations",
+         "org.gradle.api.file.ProjectLayout"].each {
+            assert heuristic.contains(it)
+            assert api.contains(it)
+        }
+
+        and: "the all-services list includes internal services that the other lists omit"
+        all.any { it.contains(".internal.") }
+        heuristic.every { !it.contains(".internal.") }
+        api.every { !it.contains(".internal.") }
+
+        and: "the strict public-API list excludes non-public packages (e.g. launcher/daemon, execution.plan) that the heuristic lets through"
+        !api.contains("org.gradle.launcher.daemon.server.Daemon")
+        !api.any { it.startsWith("org.gradle.execution.plan.") }
+        heuristic.contains("org.gradle.launcher.daemon.server.Daemon")
+
+        and: "lists narrow from all -> heuristic-public -> strict public-API, and public-API is a subset of the heuristic"
+        all.size() > heuristic.size()
+        heuristic.size() > api.size()
+        api.every { heuristic.contains(it) }
+    }
+
+    def "can determine which services actually resolve for injection without failure"() {
+        given:
+        buildFile """
+            // Injection ultimately does serviceLookup.find(type): it returns the instance, returns null
+            // ("no service of type X"), or throws (e.g. ambiguous - multiple services match a supertype).
+            // Probe each candidate the same way and classify. Done at configuration time; only Strings are
+            // captured into the task, so it stays configuration-cache compatible.
+            def intro = project.services as ${ServiceRegistryIntrospection.name}
+            def candidates = intro.allServiceTypes
+                .findAll { it.name.startsWith("org.gradle.") && !it.name.contains(".internal.") }
+                .sort { it.name }
+
+            def ok = []
+            def fails = []
+            candidates.each { c ->
+                try {
+                    def svc = project.services.find(c)
+                    if (svc != null) {
+                        ok << c.name
+                    } else {
+                        fails << (c.name + " | null (no service of this type)")
+                    }
+                } catch (Throwable t) {
+                    fails << (c.name + " | " + t.getClass().simpleName)
+                }
+            }
+
+            tasks.register("probeInjectableServices") {
+                doLast {
+                    ok.each { println "INJECTS_OK: \$it" }
+                    println "INJECTS_OK_COUNT: \${ok.size()}"
+                    fails.each { println "INJECTS_FAILS: \$it" }
+                    println "INJECTS_FAILS_COUNT: \${fails.size()}"
+                }
+            }
+        """
+
+        when:
+        run "probeInjectableServices"
+
+        then:
+        def lines = output.readLines()
+        def ok = lines.findAll { it.startsWith("INJECTS_OK: ") }.collect { it.substring("INJECTS_OK: ".length()) }
+        def fails = lines.findAll { it.startsWith("INJECTS_FAILS: ") }.collect { it.substring("INJECTS_FAILS: ".length()) }
+
+        and: "documented injectable services resolve cleanly"
+        ["org.gradle.api.model.ObjectFactory",
+         "org.gradle.api.provider.ProviderFactory",
+         "org.gradle.api.file.FileSystemOperations",
+         "org.gradle.api.file.ProjectLayout"].each { assert ok.contains(it) }
+
+        and: "not everything in the enumerated list resolves - some fail (e.g. ambiguous supertypes that match multiple services)"
+        !fails.isEmpty()
+        ok.every { it.startsWith("org.gradle.") && !it.contains(".internal.") }
+
+        and: "ubiquitous supertypes like Action are ambiguous (multiple services match) and so are NOT injectable"
+        !ok.contains("org.gradle.api.Action")
+        fails.any { it.startsWith("org.gradle.api.Action |") }
+    }
+
+    def "the injectable service set is the same under vintage, configuration cache, and isolated projects"() {
+        given:
+        buildFile """
+            def names = (project.services as ${ServiceRegistryIntrospection.name})
+                .allServiceTypes
+                .collect { it.name }
+                .findAll { it.startsWith("org.gradle.") && !it.contains(".internal.") }
+                .unique()
+                .sort()
+            tasks.register("listInjectableServices") {
+                doLast { names.each { println "INJECTABLE_SERVICE: \$it" } }
+            }
+        """
+        def servicesFrom = { result ->
+            result.output.readLines()
+                .findAll { it.startsWith("INJECTABLE_SERVICE: ") }
+                .collect { it.substring("INJECTABLE_SERVICE: ".length()) } as Set
+        }
+
+        when:
+        def vintage = servicesFrom(run("listInjectableServices"))
+        def configCache = servicesFrom(run("-Dorg.gradle.configuration-cache=true", "listInjectableServices"))
+        def isolatedProjects = servicesFrom(run("-Dorg.gradle.unsafe.isolated-projects=true", "listInjectableServices"))
+
+        then: "the publicly-injectable (org.gradle.api.*) surface is identical across all three modes"
+        def apiOnly = { Set s -> s.findAll { it.startsWith("org.gradle.api.") } as Set }
+        apiOnly(vintage) == apiOnly(configCache)
+        apiOnly(vintage) == apiOnly(isolatedProjects)
+
+        and: "configuration cache and isolated projects only ever ADD services, never remove them"
+        (vintage - configCache).isEmpty()
+        (vintage - isolatedProjects).isEmpty()
+
+        and: "and the only additions are mode-specific infrastructure services, not public API"
+        // empirically CC/IP register e.g. org.gradle.initialization.ClassLoaderScopeRegistryListener
+        (configCache - vintage).every { !it.startsWith("org.gradle.api.") }
+        (isolatedProjects - vintage).every { !it.startsWith("org.gradle.api.") }
+    }
+
+    def "can list the project-scoped public-API services (own scope vs inherited from build/global)"() {
+        given:
+        buildFile """
+            def intro = project.services as ${ServiceRegistryIntrospection.name}
+            def ownTypes = intro.ownServiceTypes                                 // project-scoped only (Class objects)
+            def allTypes = intro.allServiceTypes                                 // project + all ancestors (Class objects)
+
+            // Public API definition mirrored from PublicApi.kt / PublicKotlinDslApi.kt (Ant-style path globs).
+            def apiIncludes = [
+                "org/gradle/*", "org/gradle/api/**", "org/gradle/authentication/**", "org/gradle/build/**",
+                "org/gradle/buildconfiguration/**", "org/gradle/buildinit/**", "org/gradle/caching/**",
+                "org/gradle/concurrent/**", "org/gradle/deployment/**", "org/gradle/external/javadoc/**",
+                "org/gradle/ide/**", "org/gradle/ivy/**", "org/gradle/jvm/**", "org/gradle/language/**",
+                "org/gradle/maven/**", "org/gradle/nativeplatform/**", "org/gradle/normalization/**",
+                "org/gradle/platform/**", "org/gradle/plugin/devel/**", "org/gradle/plugin/use/*",
+                "org/gradle/plugin/management/*", "org/gradle/plugins/**", "org/gradle/process/**",
+                "org/gradle/testfixtures/**", "org/gradle/testing/jacoco/**", "org/gradle/tooling/**",
+                "org/gradle/swiftpm/**", "org/gradle/model/**", "org/gradle/testkit/**", "org/gradle/testing/**",
+                "org/gradle/vcs/**", "org/gradle/work/**", "org/gradle/workers/**", "org/gradle/util/**",
+                "org/gradle/kotlin/dsl/*", "org/gradle/kotlin/dsl/precompile/*",
+            ]
+            def excludes = ["**/internal/**"]
+            def antToRegex = { String glob ->
+                def out = new StringBuilder(); int i = 0
+                while (i < glob.length()) {
+                    if (glob.startsWith("**", i)) { out.append(".*"); i += 2 }
+                    else if (glob.charAt(i) == ("*" as char)) { out.append("[^/]*"); i += 1 }
+                    else { out.append(glob.charAt(i)); i += 1 }
+                }
+                out.toString()
+            }
+            def incRe = apiIncludes.collect { antToRegex(it) }
+            def excRe = excludes.collect { antToRegex(it) }
+            def isPublicApi = { String fqcn ->
+                def path = fqcn.replace(".", "/")
+                incRe.any { path ==~ it } && !excRe.any { path ==~ it }
+            }
+
+            // Project-scoped = registered in this (project) registry's own services.
+            // Inherited (non-project) = resolvable only via the parent chain (build/buildTree/.../global).
+            def projectScopedTypes = ownTypes.findAll { isPublicApi(it.name) }.sort { it.name }
+            def inheritedTypes = (allTypes - ownTypes).findAll { isPublicApi(it.name) }.sort { it.name }
+            def projectScopedPublicApi = projectScopedTypes.collect { it.name }
+            def inheritedPublicApi = inheritedTypes.collect { it.name }
+
+            // "Injectable" = actually resolves via find() (the same call @Inject makes). This drops types
+            // that match MULTIPLE services (e.g. Action) and so fail with a not-unique ServiceLookupException.
+            // Maps each injectable service type to the concrete class of the resolved instance.
+            def probe = { types ->
+                def out = new TreeMap()
+                types.each { c ->
+                    try { def svc = project.services.find(c); if (svc != null) out[c.name] = svc.getClass().name } catch (Throwable ignored) { }
+                }
+                out
+            }
+            def projectScopedInjectable = probe(projectScopedTypes)
+            def inheritedInjectable = probe(inheritedTypes)
+
+            tasks.register("listProjectScopedServices") {
+                doLast {
+                    projectScopedPublicApi.each { println "PROJECT_SCOPED_PUBLIC_API: \$it" }
+                    println "PROJECT_SCOPED_PUBLIC_API_COUNT: \${projectScopedPublicApi.size()}"
+                    inheritedPublicApi.each { println "INHERITED_PUBLIC_API: \$it" }
+                    println "INHERITED_PUBLIC_API_COUNT: \${inheritedPublicApi.size()}"
+                    projectScopedInjectable.each { k, v -> println "PROJECT_SCOPED_INJECTABLE: \$k -> \$v" }
+                    println "PROJECT_SCOPED_INJECTABLE_COUNT: \${projectScopedInjectable.size()}"
+                    inheritedInjectable.each { k, v -> println "INHERITED_INJECTABLE: \$k -> \$v" }
+                    println "INHERITED_INJECTABLE_COUNT: \${inheritedInjectable.size()}"
+                }
+            }
+        """
+
+        when:
+        run "listProjectScopedServices"
+
+        then:
+        def lines = output.readLines()
+        def extract = { String prefix -> lines.findAll { it.startsWith(prefix) }.collect { it.substring(prefix.length()) } }
+        def projectScoped = extract("PROJECT_SCOPED_PUBLIC_API: ")
+        def inherited = extract("INHERITED_PUBLIC_API: ")
+        // entries are "type -> implClass"; take the type for the assertions below
+        def injectable = extract("PROJECT_SCOPED_INJECTABLE: ").collect { it.split(" -> ", 2)[0] }
+        def inheritedInjectable = extract("INHERITED_INJECTABLE: ").collect { it.split(" -> ", 2)[0] }
+
+        and: "Project-scoped public services are present in the project-scoped list"
+        projectScoped.contains("org.gradle.api.file.ProjectLayout")
+        projectScoped.contains("org.gradle.workers.WorkerExecutor")
+        projectScoped.contains("org.gradle.api.model.ObjectFactory")
+
+        and: "services scoped to build/parent are inherited, NOT project-scoped"
+        !projectScoped.contains("org.gradle.api.provider.ProviderFactory")   // Build scope
+        !projectScoped.contains("org.gradle.api.invocation.Gradle")          // Build scope
+        inherited.contains("org.gradle.api.provider.ProviderFactory")
+
+        and: "the two sets are disjoint and both non-trivial"
+        projectScoped.intersect(inherited).isEmpty()
+        projectScoped.size() >= 3
+
+        and: "the definitive list (project-scoped AND public-API AND actually injectable) keeps the real targets"
+        injectable.contains("org.gradle.api.file.ProjectLayout")
+        injectable.contains("org.gradle.workers.WorkerExecutor")
+        injectable.contains("org.gradle.api.model.ObjectFactory")
+        injectable.contains("org.gradle.api.artifacts.dsl.DependencyFactory")
+
+        and: "and drops the ambiguous supertypes that match multiple project services"
+        injectable.every { projectScoped.contains(it) }            // subset of project-scoped public-API
+        !injectable.contains("org.gradle.api.DomainObjectCollection")
+        !injectable.contains("org.gradle.api.NamedDomainObjectContainer")
+        injectable.size() < projectScoped.size()                  // some were dropped
+
+        and: "the inherited (non-project) public-API services that are actually injectable"
+        inheritedInjectable.every { inherited.contains(it) }       // subset of inherited public-API
+        inheritedInjectable.contains("org.gradle.api.provider.ProviderFactory")   // Build scope, uniquely resolvable
+        inheritedInjectable.contains("org.gradle.api.problems.Problems")          // BuildTree scope
+        // Action is inherited but matches MULTIPLE services, so it is NOT uniquely injectable
+        inherited.contains("org.gradle.api.Action")
+        !inheritedInjectable.contains("org.gradle.api.Action")
+        inheritedInjectable.size() < inherited.size()             // ambiguous ones dropped
+    }
+
+    def "verifies the scope classification by instance identity across two projects"() {
+        given:
+        file("a").createDir()
+        file("b").createDir()
+        settingsFile << "include('a', 'b')\n"
+        buildFile """
+            // For each candidate, classify via the introspection (own = project-scoped) and capture the
+            // identity of the resolved instance. Run in two projects: a project-scoped service yields a
+            // DISTINCT instance per project; an inherited (build/global) service yields the SAME shared instance.
+            subprojects { sp ->
+                def intro = sp.services as ${ServiceRegistryIntrospection.name}
+                def ownNames = intro.ownServiceTypes.collect { it.name } as Set
+                def candidates = [
+                    "org.gradle.api.model.ObjectFactory", "org.gradle.api.file.ProjectLayout",
+                    "org.gradle.workers.WorkerExecutor", "org.gradle.api.tasks.TaskContainer",
+                    "org.gradle.api.artifacts.dsl.RepositoryHandler", "org.gradle.api.artifacts.dsl.DependencyHandler",
+                    "org.gradle.api.invocation.Gradle", "org.gradle.api.provider.ProviderFactory",
+                    "org.gradle.api.problems.Problems", "org.gradle.api.services.BuildServiceRegistry",
+                    "org.gradle.api.configuration.BuildFeatures",
+                ]
+                def rows = []
+                candidates.each { n ->
+                    def scope = ownNames.contains(n) ? "OWN" : "INHERITED"
+                    def id = "null"
+                    try { def svc = sp.services.find(Class.forName(n)); if (svc != null) id = System.identityHashCode(svc).toString() }
+                    catch (Throwable ignored) { }
+                    rows << "SCOPE_IDENTITY: \${sp.path}|\$n|\$scope|\$id"
+                }
+                sp.tasks.register("scopeIdentity") { doLast { rows.each { println it } } }
+            }
+        """
+
+        when:
+        run ":a:scopeIdentity", ":b:scopeIdentity"
+
+        then:
+        def rows = output.readLines()
+            .findAll { it.startsWith("SCOPE_IDENTITY: ") }
+            .collect { it.substring("SCOPE_IDENTITY: ".length()).split("\\|") }   // [path, name, scope, id]
+        def scopeOf = { n -> rows.find { it[1] == n && it[0] == ":a" }[2] }
+
+        and: "the introspection classification matches known scopes"
+        scopeOf("org.gradle.api.model.ObjectFactory") == "OWN"
+        scopeOf("org.gradle.api.file.ProjectLayout") == "OWN"
+        scopeOf("org.gradle.api.tasks.TaskContainer") == "OWN"
+        scopeOf("org.gradle.api.provider.ProviderFactory") == "INHERITED"
+        scopeOf("org.gradle.api.invocation.Gradle") == "INHERITED"
+        scopeOf("org.gradle.api.problems.Problems") == "INHERITED"
+
+        and: "identity proves it: project-scoped => distinct per project; inherited => the same shared instance"
+        rows.groupBy { it[1] }.each { name, list ->
+            def a = list.find { it[0] == ":a" }; def b = list.find { it[0] == ":b" }
+            assert a && b && a[2] == b[2]                          // present in both, same classification
+            if (a[3] != "null" && b[3] != "null") {
+                if (a[2] == "OWN") {
+                    assert a[3] != b[3] : "project-scoped ${name} should be a distinct instance per project"
+                } else {
+                    assert a[3] == b[3] : "inherited ${name} should be one shared instance across projects"
+                }
+            }
+        }
+    }
+
+    def "screens project-scoped public-API services for references to inherited (build/global) services"() {
+        given:
+        buildFile """
+            import java.lang.reflect.Modifier
+            def intro = project.services as ${ServiceRegistryIntrospection.name}
+            def ownNames = intro.ownServiceTypes.collect { it.name } as Set
+            def allNames = intro.allServiceTypes.collect { it.name } as Set
+
+            // public API filter, mirrored from PublicApi.kt / PublicKotlinDslApi.kt
+            def apiIncludes = [
+                "org/gradle/*", "org/gradle/api/**", "org/gradle/authentication/**", "org/gradle/build/**",
+                "org/gradle/buildconfiguration/**", "org/gradle/buildinit/**", "org/gradle/caching/**",
+                "org/gradle/concurrent/**", "org/gradle/deployment/**", "org/gradle/external/javadoc/**",
+                "org/gradle/ide/**", "org/gradle/ivy/**", "org/gradle/jvm/**", "org/gradle/language/**",
+                "org/gradle/maven/**", "org/gradle/nativeplatform/**", "org/gradle/normalization/**",
+                "org/gradle/platform/**", "org/gradle/plugin/devel/**", "org/gradle/plugin/use/*",
+                "org/gradle/plugin/management/*", "org/gradle/plugins/**", "org/gradle/process/**",
+                "org/gradle/testfixtures/**", "org/gradle/testing/jacoco/**", "org/gradle/tooling/**",
+                "org/gradle/swiftpm/**", "org/gradle/model/**", "org/gradle/testkit/**", "org/gradle/testing/**",
+                "org/gradle/vcs/**", "org/gradle/work/**", "org/gradle/workers/**", "org/gradle/util/**",
+                "org/gradle/kotlin/dsl/*", "org/gradle/kotlin/dsl/precompile/*",
+            ]
+            def antToRegex = { String glob ->
+                def out = new StringBuilder(); int i = 0
+                while (i < glob.length()) {
+                    if (glob.startsWith("**", i)) { out.append(".*"); i += 2 }
+                    else if (glob.charAt(i) == ("*" as char)) { out.append("[^/]*"); i += 1 }
+                    else { out.append(glob.charAt(i)); i += 1 }
+                }
+                out.toString()
+            }
+            def incRe = apiIncludes.collect { antToRegex(it) }
+            def isPublicApi = { String fqcn ->
+                def path = fqcn.replace(".", "/")
+                incRe.any { path ==~ it } && !path.contains("/internal/")
+            }
+            // A dependency is "inherited" (shared, build/global) if it is a registered service type that
+            // is NOT in the project's own services.
+            def classify = { String n -> ownNames.contains(n) ? "OWN" : (allNames.contains(n) ? "INHERITED" : null) }
+
+            def projectScoped = intro.ownServiceTypes.findAll { isPublicApi(it.name) }.sort { it.name }
+            def report = []
+            projectScoped.each { svcType ->
+                def inst
+                try { inst = project.services.find(svcType) } catch (Throwable ignored) { return }
+                if (inst == null) return
+                def seen = [] as Set
+                def k = inst.getClass()
+                while (k != null && k != Object) {
+                    try {
+                        k.declaredFields.each { f ->
+                            def depName = f.type.name
+                            if (classify(depName) == "INHERITED" && seen.add(depName)) {
+                                report << (svcType.name + " -> " + depName)
+                            }
+                        }
+                    } catch (Throwable ignored) { }
+                    k = k.getSuperclass()
+                }
+            }
+            report = report.sort().unique()
+
+            tasks.register("screenProjectScopedDeps") {
+                doLast {
+                    report.each { println "PS_REACHES_SHARED: \$it" }
+                    println "PS_REACHES_SHARED_COUNT: \${report.size()}"
+                    println "PS_REACHES_SHARED_SERVICES: \${report.collect { it.split(' -> ')[0] }.unique().size()}"
+                }
+            }
+        """
+
+        when:
+        run "screenProjectScopedDeps"
+
+        then: "the screen produces well-formed 'projectScopedService -> inheritedService' pairs"
+        def deps = output.readLines().findAll { it.startsWith("PS_REACHES_SHARED: ") }.collect { it.substring("PS_REACHES_SHARED: ".length()) }
+        deps.every { it.contains(" -> ") }
+
+        and: "it is only a screen: some project-scoped services do reference shared services (to be reviewed against the freeze/immutable/sink criterion)"
+        // the build script only emits pairs whose right-hand side is classified INHERITED, so a non-empty,
+        // well-formed result is the signal; safety of each reference is a per-service judgement.
+        !deps.isEmpty()
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ProblemReportingSharedModelDefaults.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ProblemReportingSharedModelDefaults.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization;
+
+import kotlin.Unit;
+import org.gradle.api.Action;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.initialization.SharedModelDefaults;
+import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
+import org.gradle.internal.metaobject.DynamicInvokeResult;
+import org.gradle.internal.metaobject.MethodAccess;
+import org.gradle.internal.metaobject.MethodMixIn;
+import org.gradle.util.Path;
+
+/**
+ * The project-scoped view of the build-scoped {@link SharedModelDefaults} service, used when
+ * Isolated Projects is enabled.
+ *
+ * <p>Shared model defaults can only be registered in settings scripts, inside the {@code defaults} block.
+ * By the time a project is configured, the registrations have already been processed, and under Isolated
+ * Projects the service is additionally a shared mutable resource accessed from parallel project
+ * configuration. This view reports an Isolated Projects problem on registration attempts, so that the
+ * violation is surfaced with proper location information instead of only the late
+ * {@code IllegalStateException} of the underlying service. The registration is skipped, as it could
+ * never take effect anyway.
+ */
+public class ProblemReportingSharedModelDefaults implements SharedModelDefaultsInternal, MethodMixIn {
+
+    private final SharedModelDefaultsInternal delegate;
+    private final IsolatedProjectsProblemsReporter problems;
+    private final Path projectIdentityPath;
+
+    public ProblemReportingSharedModelDefaults(
+        SharedModelDefaults delegate,
+        IsolatedProjectsProblemsReporter problems,
+        Path projectIdentityPath
+    ) {
+        this.delegate = (SharedModelDefaultsInternal) delegate;
+        this.problems = problems;
+        this.projectIdentityPath = projectIdentityPath;
+    }
+
+    @Override
+    public ProjectLayout getLayout() {
+        return delegate.getLayout();
+    }
+
+    @Override
+    public void withProjectLayout(ProjectLayout projectLayout, Runnable action) {
+        delegate.withProjectLayout(projectLayout, action);
+    }
+
+    @Override
+    public void processRegistrations() {
+        delegate.processRegistrations();
+    }
+
+    @Override
+    public <T> void add(String name, Class<T> publicType, Action<? super T> configureAction) {
+        // The reporter throws in fail-fast mode. In diagnostics mode the problem is recorded and the
+        // registration is skipped: it could never take effect, as registrations have already been processed.
+        reportProjectScopeViolation();
+    }
+
+    @Override
+    public MethodAccess getAdditionalMethods() {
+        if (delegate instanceof MethodMixIn) {
+            return new ProblemReportingMethodAccess(((MethodMixIn) delegate).getAdditionalMethods());
+        }
+        return NO_METHODS;
+    }
+
+    private static final MethodAccess NO_METHODS = new MethodAccess() {
+        @Override
+        public boolean hasMethod(String name, Object... arguments) {
+            return false;
+        }
+
+        @Override
+        public DynamicInvokeResult tryInvokeMethod(String name, Object... arguments) {
+            return DynamicInvokeResult.notFound();
+        }
+    };
+
+    private void reportProjectScopeViolation() {
+        problems.report(factory ->
+            factory.problem(null, messageBuilder -> {
+                messageBuilder.text(
+                    "Project '" + projectIdentityPath + "' cannot register shared model defaults. " +
+                        "Shared model defaults can only be registered in a settings script, using the 'defaults' block."
+                );
+                return Unit.INSTANCE;
+            }).exception().build()
+        );
+    }
+
+    private class ProblemReportingMethodAccess implements MethodAccess {
+        private final MethodAccess delegate;
+
+        ProblemReportingMethodAccess(MethodAccess delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasMethod(String name, Object... arguments) {
+            return delegate.hasMethod(name, arguments);
+        }
+
+        @Override
+        public DynamicInvokeResult tryInvokeMethod(String name, Object... arguments) {
+            if (delegate.hasMethod(name, arguments)) {
+                reportProjectScopeViolation();
+                return DynamicInvokeResult.found();
+            }
+            return delegate.tryInvokeMethod(name, arguments);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -33,8 +33,10 @@ import org.gradle.api.internal.file.TaskFileVarFactory;
 import org.gradle.api.internal.file.collections.ManagedFactories;
 import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
+import org.gradle.api.initialization.SharedModelDefaults;
 import org.gradle.api.internal.initialization.BuildLogicBuilder;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
+import org.gradle.api.internal.initialization.ProblemReportingSharedModelDefaults;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
@@ -75,7 +77,9 @@ import org.gradle.configuration.project.DefaultProjectConfigurationActionContain
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.code.UserCodeApplicationContext;
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.LoggingManagerFactory;
@@ -200,6 +204,18 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         boolean isRootProject = project.getParent() == null;
         toolingModelBuilderRegistrants.forEach(provider -> provider.registerForProject(registry, isRootProject));
         return registry;
+    }
+
+    @Provides
+    protected SharedModelDefaults decorateSharedModelDefaults(
+        SharedModelDefaults buildScopedSharedModelDefaults,
+        IsolatedProjectsProblemsReporter isolatedProjectsProblemsReporter,
+        BuildModelParameters buildModelParameters
+    ) {
+        if (buildModelParameters.isIsolatedProjects()) {
+            return new ProblemReportingSharedModelDefaults(buildScopedSharedModelDefaults, isolatedProjectsProblemsReporter, project.getIdentityPath());
+        }
+        return buildScopedSharedModelDefaults;
     }
 
     @Provides


### PR DESCRIPTION
Part of #38028.

### What

`SharedModelDefaults` is a build-scoped public service that is conceptually settings-only (the `defaults { }` block), but it is injectable into project plugins. Calling `add()` from a project today fails with a late `IllegalStateException` ("Cannot add shared model defaults after processing.") that gives the plugin author no hint about what they did wrong, and under Isolated Projects diagnostics mode it hard-stops configuration instead of being collected as a problem.

With this change, when Isolated Projects is enabled, project scope resolves a problem-reporting view of the service:

```
> Configure project :
Problem found: Project ':' cannot register shared model defaults. Shared model defaults
can only be registered in a settings script, using the 'defaults' block.
    Location: build file 'build.gradle' line 10
```

- **FAIL_FAST** (default IP): the problem is thrown immediately with build script location.
- **DIAGNOSTICS**: the problem is recorded in the configuration cache report and configuration continues; the registration is skipped (it could never take effect, since registrations are processed at the end of settings evaluation).
- **Without Isolated Projects**: the decorator is not installed; projects resolve the build-scoped service directly and behavior is unchanged (verified by test).

### How

- `ProjectScopeServices.decorateSharedModelDefaults()` shadows the build-scoped service for project-scope lookups under IP (same pattern as the tooling model builder registry and the build services registry IP guard).
- `ProblemReportingSharedModelDefaults` reports via `IsolatedProjectsProblemsReporter` on `add()` and on the Groovy dynamic-method registration path, and delegates the internal lifecycle (`getLayout`, `withProjectLayout`, `processRegistrations`) untouched — the declarative DSL machinery resolves the service at project scope and relies on these.
- The `@ServiceScope` of `SharedModelDefaults` is extended to `{Build, Project}` to permit the project-scope registration. Annotation-value changes are not binary-incompatible.

This also removes a dependence on a theoretical data race: the existing protection relies on a non-volatile `processed` flag read from parallel project configuration threads, while the new view never touches the shared mutable state.

### Test coverage

`IsolatedProjectsSharedModelDefaultsIntegrationTest`:
- violation reported in both DIAGNOSTICS and FAIL_FAST modes
- non-IP baseline asserting the pre-existing `IllegalStateException` is preserved

Regression: `ProjectTypeModelDefaultsIntegrationTest` (62 tests) passes, covering legitimate settings-side `defaults { }` usage.