### PR TITLE
Enable remaining IP integ tests

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-core/build.gradle.kts
@@ -40,6 +40,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
@@ -72,6 +72,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-configuration/file-collections/build.gradle.kts
+++ b/platforms/core-configuration/file-collections/build.gradle.kts
@@ -65,6 +65,4 @@ packageCycles {
     // Some cycles have been inherited from the time these classes were in :core
     excludePatterns.add("org/gradle/api/internal/file/collections/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
 import static org.gradle.util.internal.TextUtil.escapeString
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs {
 
@@ -514,6 +515,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
     }
 
     @Issue('https://github.com/gradle/gradle/issues/29147')
+    @ToBeFixedForIsolatedProjects(because = "cross-project file access")
     def "can connect transformed incoming elements of a configuration to task input ListProperty"() {
         withZipArtifactProducingSubprojects 'p1', 'p2'
         withIdentityTransform()
@@ -561,6 +563,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
     }
 
     @Issue('https://github.com/gradle/gradle/issues/29147')
+    @ToBeFixedForIsolatedProjects(because = "cross-project file access")
     def "can connect transformed incoming files of a configuration to task input ListProperty"() {
         withZipArtifactProducingSubprojects 'p1', 'p2'
         withIdentityTransform()

--- a/platforms/core-configuration/flow-services/build.gradle.kts
+++ b/platforms/core-configuration/flow-services/build.gradle.kts
@@ -53,6 +53,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/build.gradle.kts
@@ -42,9 +42,7 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -44,6 +44,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
@@ -817,6 +818,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
         )
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `can cross configure buildscript`() {
 
@@ -965,6 +967,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
         build("help")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `can use kotlin java8 inline-only methods`() {
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
@@ -22,6 +22,7 @@ import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 class KotlinDslJvmDefaultIntegrationTest : AbstractKotlinIntegrationTest() {
@@ -97,6 +98,7 @@ class KotlinDslJvmDefaultIntegrationTest : AbstractKotlinIntegrationTest() {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `kotlin-dsl java and groovy consumers can use kotlin interface default methods directly`() {
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginAccessorsIntegrationTest.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.integration
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers.containsString
@@ -100,6 +101,7 @@ class PrecompiledScriptPluginAccessorsIntegrationTest : AbstractKotlinIntegratio
         build("clean", "--rerun-tasks")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `accessors are available after registering plugin`() {
         withSettings(
@@ -212,6 +214,7 @@ class PrecompiledScriptPluginAccessorsIntegrationTest : AbstractKotlinIntegratio
     private
     inline fun <reified T> nameOf() = T::class.qualifiedName
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     fun `accessors are available after renaming precompiled script plugin from project dependency`() {
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -30,6 +30,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
@@ -166,6 +167,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `applied precompiled script plugin is reloaded upon change`() {
         // given:

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorSettingEvaluationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorSettingEvaluationTest.kt
@@ -22,11 +22,13 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
 import org.junit.Test
 import java.io.File
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class PrecompiledScriptPluginAccessorSettingEvaluationTest : AbstractPrecompiledScriptPluginTest() {
 
+    @ToBeFixedForIsolatedProjects(because = "precompiled script plugins cross-project")
     @Test
     fun `settings and init scripts are not evaluated when generating accessors`() {
         // given:

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -53,11 +53,13 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import spock.lang.Issue
 import java.io.File
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest() {
 
+    @ToBeFixedForIsolatedProjects(because = "precompiled script plugins cross-project")
     @Test
     fun `cannot use type-safe accessors for extensions contributed in afterEvaluate`() {
         withFolders {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -26,6 +26,7 @@ import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.kotlin.dsl.fixtures.FoldersDslExpression
 import org.gradle.kotlin.dsl.fixtures.assertFailsWith
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
@@ -465,6 +466,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     fun `can apply plugin using ObjectConfigurationAction syntax`() {
 

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -240,9 +240,7 @@ testFilesCleanup.reportOnly = true
 strictCompile {
     ignoreDeprecations()
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 // Do not publish into the Gradle API ABI JAR
 configurations.remove(configurations.apiStubElements.get())

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -14,10 +14,12 @@ import org.junit.Assume.assumeThat
 import org.junit.Test
 import spock.lang.Issue
 import java.io.StringWriter
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
 
+    @ToBeFixedForIsolatedProjects(because = "Kotlin DSL cross-project configuration")
     @Test
     fun `can apply plugin using ObjectConfigurationAction syntax`() {
 

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslParentProjectPropertyLookupIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslParentProjectPropertyLookupIntegrationTest.kt
@@ -16,9 +16,8 @@
 
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -31,10 +30,6 @@ import org.junit.Test
  *
  * @see org.gradle.kotlin.dsl.PropertyDelegate
  */
-@Requires(
-    TestExecutionPreconditions.NotIsolatedProjects::class,
-    reason = "Under Isolated Projects, parent-project lookup is disabled entirely; no deprecation fires"
-)
 class KotlinDslParentProjectPropertyLookupIntegrationTest : AbstractKotlinIntegrationTest() {
 
     private
@@ -53,6 +48,7 @@ class KotlinDslParentProjectPropertyLookupIntegrationTest : AbstractKotlinIntegr
     }
 
     @Test
+    @UnsupportedWithIsolatedProjects(because = "Under Isolated Projects, parent-project lookup is disabled entirely; no deprecation fires")
     fun `val by project resolved from parent is deprecated with the Kotlin delegation caller context`() {
         withSettings(
             """

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -104,6 +104,4 @@ packageCycles {
     // (api.internal.provider -> ConfigureUtil, DeferredUtil -> api.internal.provider)
     excludePatterns.add("org/gradle/util/internal/*")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class PropertyIntegrationTest extends AbstractIntegrationSpec {
     def "can use property as task input"() {
@@ -598,6 +599,7 @@ assert custom.prop.get() == "value 4"
         reason = "--parallel is specified explicitly, no need to run with multiple executor types"
     )
     @Issue("https://github.com/gradle/gradle/issues/12811")
+    @ToBeFixedForIsolatedProjects(because = "cross-project property access")
     def "multiple tasks can have property values calculated from a shared finalize on read property instance with value derived from dependency resolution"() {
         createDirs("producer", "consumer")
         settingsFile << """
@@ -657,6 +659,7 @@ assert custom.prop.get() == "value 4"
         reason = "--parallel is specified explicitly, no need to run with multiple executor types"
     )
     @Issue("https://github.com/gradle/gradle/issues/12969")
+    @ToBeFixedForIsolatedProjects(because = "cross-project property access")
     def "task can have property value derived from dependency resolution result when another task has input files derived from same result"() {
         createDirs("producer", "consumer")
         settingsFile << """

--- a/platforms/core-configuration/model-groovy/build.gradle.kts
+++ b/platforms/core-configuration/model-groovy/build.gradle.kts
@@ -36,6 +36,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/build-cache-http/build.gradle.kts
+++ b/platforms/core-execution/build-cache-http/build.gradle.kts
@@ -48,6 +48,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/build-cache-local/build.gradle.kts
+++ b/platforms/core-execution/build-cache-local/build.gradle.kts
@@ -39,6 +39,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/build-cache-spi/build.gradle.kts
+++ b/platforms/core-execution/build-cache-spi/build.gradle.kts
@@ -21,9 +21,7 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/platforms/core-execution/build-cache/build.gradle.kts
+++ b/platforms/core-execution/build-cache/build.gradle.kts
@@ -52,6 +52,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/execution-e2e-tests/build.gradle.kts
+++ b/platforms/core-execution/execution-e2e-tests/build.gradle.kts
@@ -8,9 +8,7 @@ dependencies {
     integTestImplementation(projects.execution)
     integTestDistributionRuntimeOnly(projects.distributionsFull)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 errorprone {
     nullawayEnabled = true
 }

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/ParallelProjectExecutionIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/ParallelProjectExecutionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
@@ -51,6 +52,7 @@ allprojects {
         executer.withArgument('--info')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "executes dependency project targets concurrently"() {
         projectDependency from: 'a', to: ['b', 'c', 'd']
 
@@ -61,6 +63,7 @@ allprojects {
         run ':a:pingServer'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "executes dependency project targets concurrently where possible"() {
 
         projectDependency from: 'a', to: ['b', 'c']
@@ -75,6 +78,7 @@ allprojects {
         run ':a:pingServer'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->[b,c] and both b & c fail"() {
         projectDependency from: 'a', to: ['b', 'c']
         failingBuild 'b'
@@ -90,6 +94,7 @@ allprojects {
         failure.assertHasCause('c failed')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "tasks are executed when they are ready and not necessarily alphabetically"() {
         buildFile("b/build.gradle", """
             tasks.named("pingA") {
@@ -109,6 +114,7 @@ allprojects {
         run 'b:pingC'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "finalizer tasks are run in parallel"() {
         buildFile("c/build.gradle", """
             tasks.named("ping") {
@@ -129,6 +135,7 @@ allprojects {
         run 'd:ping'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     void 'tasks with should run after ordering rules are preferred when running over an idle worker thread'() {
         buildFile("a/build.gradle", """
             tasks.named("pingA") {

--- a/platforms/core-execution/execution/build.gradle.kts
+++ b/platforms/core-execution/execution/build.gradle.kts
@@ -70,6 +70,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/file-watching/build.gradle.kts
+++ b/platforms/core-execution/file-watching/build.gradle.kts
@@ -47,6 +47,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/persistent-cache/build.gradle.kts
+++ b/platforms/core-execution/persistent-cache/build.gradle.kts
@@ -50,6 +50,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/snapshots/build.gradle.kts
+++ b/platforms/core-execution/snapshots/build.gradle.kts
@@ -48,6 +48,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/workers/build.gradle.kts
+++ b/platforms/core-execution/workers/build.gradle.kts
@@ -73,6 +73,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
 @IntegrationTestTimeout(120)
 @Requires(value = TestExecutionPreconditions.NotEmbeddedExecutor, reason = "explicitly requests a daemon")
+@ToBeFixedForIsolatedProjects(because = "subprojects, cross-project task reference")
 class WorkerDaemonExpirationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -142,6 +143,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     @Issue("https://github.com/gradle/gradle/issues/12636")
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "can use work actions from multiple projects when running with --parallel"() {
         createDirs("project1", "project2", "project3", "project4", "project5")
         settingsFile << """

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -64,6 +65,7 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
         withMultipleActionTaskTypeInBuildScript()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, cross-project task reference")
     def "worker-based task completes as soon as work items are finished (while another task is executing in parallel)"() {
         when:
         createDirs("childProject")

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
@@ -554,6 +555,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("parallelWorkTask")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, cross-project task reference")
     def "starts dependent task in another project as soon as submitted work for current task is complete (with --parallel)"() {
         given:
         createDirs("childProject")
@@ -639,6 +641,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("allTasks")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, cross-project task reference")
     def "does not start task in another project when a task action is executing without --parallel"() {
         given:
         createDirs("childProject")
@@ -669,6 +672,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("allTasks")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, cross-project task reference")
     def "can start task in another project when a task submits async work without --parallel"() {
         given:
         createDirs("childProject")
@@ -776,6 +780,7 @@ See https://github.com/gradle/gradle/pull/25540 for details."""
         succeeds("allTasks")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, cross-project task reference")
     def "can start task in another project when a task awaits async work (with --parallel)"() {
         given:
         createDirs("childProject")

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.Project
 import org.gradle.api.file.ProjectLayout
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.reflect.Instantiator
 
 import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
@@ -86,6 +87,7 @@ class WorkerExecutorServicesIntegrationTest extends AbstractWorkerExecutorIntegr
         isolationMode << ISOLATION_MODES
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "workers with injected FileSystemOperations service always resolve files from the project directory using #isolationMode isolation"() {
         fixture.workActionThatCreatesFiles.extraFields += """
             org.gradle.api.file.FileSystemOperations fileOperations

--- a/platforms/core-runtime/base-services/build.gradle.kts
+++ b/platforms/core-runtime/base-services/build.gradle.kts
@@ -63,9 +63,7 @@ packageCycles {
 
 jmh.includes = listOf("HashingAlgorithmsBenchmark")
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 // TODO: Base services should not be responsible for generating the build receipt.
 //       Perhaps :api-metadata is a better fit

--- a/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/work/ResourceLockStatisticsIntegrationTest.groovy
+++ b/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/work/ResourceLockStatisticsIntegrationTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.internal.work
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.operations.DefaultBuildOperationsParameters
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ResourceLockStatisticsIntegrationTest extends AbstractIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "work resource tracking across projects")
     def "displays resource lock statistics after build finishes"() {
         createDirs("child")
         settingsFile << """

--- a/platforms/core-runtime/build-configuration/build.gradle.kts
+++ b/platforms/core-runtime/build-configuration/build.gradle.kts
@@ -42,6 +42,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/build-profile/build.gradle.kts
+++ b/platforms/core-runtime/build-profile/build.gradle.kts
@@ -39,6 +39,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/build-profile/src/integTest/groovy/org/gradle/profile/ProfilingIntegrationTest.groovy
+++ b/platforms/core-runtime/build-profile/src/integTest/groovy/org/gradle/profile/ProfilingIntegrationTest.groovy
@@ -24,9 +24,11 @@ import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ProfilingIntegrationTest extends AbstractIntegrationSpec {
 
+    @ToBeFixedForIsolatedProjects(because = "profiling aggregates across projects")
     def "can generate profiling report"() {
         given:
         createDirs("a", "b", "c")

--- a/platforms/core-runtime/instrumentation-agent-services/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-agent-services/build.gradle.kts
@@ -43,9 +43,7 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/platforms/core-runtime/instrumentation-reporting/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-reporting/build.gradle.kts
@@ -23,9 +23,7 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/platforms/core-runtime/launcher/build.gradle.kts
+++ b/platforms/core-runtime/launcher/build.gradle.kts
@@ -118,6 +118,4 @@ strictCompile {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/ConfigurationOnDemandIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/ConfigurationOnDemandIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.launcher
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ProjectLifecycleFixture
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
 
@@ -31,6 +32,7 @@ class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
         run()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "launcher cross-project configuration")
     def "can be enabled from command line and start parameter informs about it, too"() {
         file("gradle.properties") << "org.gradle.configureondemand=false"
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.test.precondition.TestPrecondition
 import org.gradle.test.preconditions.OsTestPreconditions
 
 import spock.lang.Ignore
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
@@ -54,6 +55,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "continuous build cross-project")
     def "changes to upstream project triggers build of downstream"() {
         expect:
         succeeds "build"
@@ -145,6 +147,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
     }
 
     // here to put more stress on parallel execution
+    @ToBeFixedForIsolatedProjects(because = "continuous build cross-project")
     def "reasonable sized multi-project"() {
         given:
         def extraProjectNames = (0..100).collect { "project$it" }

--- a/platforms/core-runtime/logging/build.gradle.kts
+++ b/platforms/core-runtime/logging/build.gradle.kts
@@ -76,6 +76,4 @@ packageCycles {
     excludePatterns.add("org/gradle/internal/featurelifecycle/**")
     excludePatterns.add("org/gradle/util/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.featurelifecycle.DeprecatedUsageProgressDetails
 
 import static org.gradle.problems.internal.services.DefaultProblemSummarizer.THRESHOLD_DEFAULT_VALUE
@@ -305,6 +306,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IP emits additional deprecation events that break count assertion")
     def "collects stack traces for deprecation usages at certain limit, regardless of whether the deprecation has been encountered before for warning mode #mode"() {
         file('settings.gradle') << "rootProject.name = 'root'"
 

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.logging.console
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.fixtures.flow.FlowActionsFixture
@@ -33,6 +35,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         server.start()
     }
 
+    @UnsupportedWithIsolatedProjects(because = "test verifies cross-project configuration ordering via HTTP-blocking checkpoints; BlockingHttpServer teardown failures escape ToBeFixed's catch")
     def "shows progress bar and percent phase completion"() {
         createDirs("a", "b", "c", "d")
         settingsFile << """
@@ -284,6 +287,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         waitForFinish()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "multi-project tests via BlockingHttpServer/parallel fail under IP")
     def "shows progress bar and percent phase completion with artifact transforms"() {
         given:
         setupTransformBuild()
@@ -326,6 +330,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
     }
 
     @Issue("https://github.com/gradle/gradle/issues/24370")
+    @ToBeFixedForIsolatedProjects(because = "multi-project tests via BlockingHttpServer/parallel fail under IP")
     def "shows progress bar and percent phase completion with non-planned planned artifact transforms"() {
         given:
         setupTransformBuild()

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestWorkerFunctionalTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.logging.console.jvm
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
@@ -85,6 +86,7 @@ abstract class AbstractConsoleJvmTestWorkerFunctionalTest extends AbstractIntegr
         JavaTestClass.SHORTENED_TEST1 | JavaTestClass.SHORTENED_TEST2 | 'shortened'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "console output depends on cross-project execution ordering")
     def "shows test class execution #description test class name in work-in-progress area of console for multi-project build"() {
         given:
         settingsFile << "include 'project1', 'project2'"

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.internal.logging.sink.GroupingProgressLogEventGenerator
@@ -31,6 +32,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
+    @ToBeFixedForIsolatedProjects(because = "multi-project tests via BlockingHttpServer/parallel fail under IP")
     def "multi-project build tasks logs are grouped"() {
         server.start()
 
@@ -144,6 +146,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
     }
 
     @Requires(TestExecutionPreconditions.NotParallelExecutor)
+    @ToBeFixedForIsolatedProjects(because = "multi-project tests via BlockingHttpServer/parallel fail under IP")
     def "long running task output correctly interleave with other tasks in parallel"() {
         given:
         server.start()

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.console.taskgrouping
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
@@ -45,6 +46,7 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
     }
 
     @Requires(TestExecutionPreconditions.NotParallelExecutor)
+    @ToBeFixedForIsolatedProjects(because = "console output depends on cross-project execution ordering")
     def "task headers for long running tasks are printed only once when there is no output"() {
         given:
         12.times { i ->

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.console.taskgrouping.rich
 
 import org.fusesource.jansi.Ansi
 import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.logging.console.taskgrouping.AbstractBasicGroupedTaskLoggingFunctionalTest
 import spock.lang.Issue
 
@@ -107,6 +108,7 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
         failure.assertHasFailures(2)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "multi-project tests via BlockingHttpServer/parallel fail under IP")
     def "tasks that complete without output do not break up other task output"() {
         server.start()
 

--- a/platforms/core-runtime/messaging/build.gradle.kts
+++ b/platforms/core-runtime/messaging/build.gradle.kts
@@ -43,6 +43,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/process-memory-services/build.gradle.kts
+++ b/platforms/core-runtime/process-memory-services/build.gradle.kts
@@ -36,6 +36,4 @@ gradleModule {
 packageCycles {
     excludePatterns.add("org/gradle/process/internal/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/wrapper-main/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-main/build.gradle.kts
@@ -144,6 +144,4 @@ tasks.jar {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/core-runtime/wrapper-shared/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-shared/build.gradle.kts
@@ -31,6 +31,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/extensibility/plugin-development/build.gradle.kts
+++ b/platforms/extensibility/plugin-development/build.gradle.kts
@@ -106,8 +106,6 @@ gradleModule {
 strictCompile {
     ignoreDeprecations()
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 testFilesCleanup.reportOnly = true

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
 
@@ -151,6 +152,7 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         outputContains("From MyPlugin")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "plugin uses allprojects/subprojects")
     def "build uses jars from multi-project buildSrc"() {
         writeBuildSrcPlugin("buildSrc", "MyPlugin")
         writeBuildSrcPlugin("buildSrc/subproject", "MyPluginSub")

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/compile/daemon/ParallelCompilerDaemonIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/compile/daemon/ParallelCompilerDaemonIntegrationTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.compile.daemon
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ParallelCompilerDaemonIntegrationTest extends AbstractIntegrationSpec {
     @Rule TestResources resources = new TestResources(temporaryFolder)
 
+    @ToBeFixedForIsolatedProjects(because = "compile daemon cross-project configuration")
     def "daemon compiler can handle --parallel"() {
         generateProjects(10, 10, 10)
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
@@ -80,6 +81,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("foo script plugin applied")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "can apply a precompiled script plugin by id to a multi-project build from root"() {
         given:
         enablePrecompiledPluginsInBuildSrc()

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.InputArtifactDependencies
 import org.gradle.api.problems.Severity
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implements ValidatePluginsTrait {
@@ -251,6 +252,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         assertValidationSucceeds()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "can validate task classes using types from other projects"() {
         settingsFile << """
             include 'lib'

--- a/platforms/extensibility/plugin-use/build.gradle.kts
+++ b/platforms/extensibility/plugin-use/build.gradle.kts
@@ -53,6 +53,4 @@ gradleModule {
 testFilesCleanup.reportOnly = true
 
 description = """Provides functionality for resolving and managing plugins during their application to projects."""
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.test.fixtures.maven.MavenRepository
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestEnvironmentPreconditions
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 @LeaksFileHandles
@@ -118,6 +119,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
         repoType << [IVY, MAVEN]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "plugin repository cross-project")
     def "can apply plugin from #repoType repo to subprojects"() {
         given:
         publishTestPlugin(repoType)

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.test.preconditions.TestEnvironmentPreconditions
 
 
 import static org.hamcrest.CoreMatchers.startsWith
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 //These tests depend on https://plugins.gradle.org
 @Requires(TestEnvironmentPreconditions.Online)
@@ -56,6 +57,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         fails("helloWorld")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "plugin use cross-project classloading")
     def "Can apply plugins to subprojects"() {
         when:
         createDirs("sub")

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseClassLoadingIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseClassLoadingIntegrationSpec.groovy
@@ -18,10 +18,12 @@ package org.gradle.plugin.use
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @LeaksFileHandles
 class PluginUseClassLoadingIntegrationSpec extends AbstractPluginSpec {
 
+    @ToBeFixedForIsolatedProjects(because = "plugin use cross-project classloading")
     def "plugin classes are reused if possible"() {
         given:
         publishPlugin()

--- a/platforms/extensibility/test-kit/build.gradle.kts
+++ b/platforms/extensibility/test-kit/build.gradle.kts
@@ -81,6 +81,4 @@ tasks.integMultiVersionTest {
     systemProperty("org.gradle.integtest.testkit.compatibility", "all")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/extensibility/unit-test-fixtures/build.gradle.kts
+++ b/platforms/extensibility/unit-test-fixtures/build.gradle.kts
@@ -76,6 +76,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/ide/ide-native/build.gradle.kts
+++ b/platforms/ide/ide-native/build.gradle.kts
@@ -78,6 +78,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCompositeBuildIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCompositeBuildIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.ide.visualstudio
 
 import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class VisualStudioCompositeBuildIntegrationTest extends AbstractVisualStudioIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "includes a visual studio project for every project in build with a C++ component"() {
         when:
         createDirs("one", "two", "three", "util", "other")

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioIncrementalIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioIncrementalIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 
 import static org.apache.commons.io.FileUtils.copyFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class VisualStudioIncrementalIntegrationTest extends AbstractVisualStudioIntegrationSpec {
     def app = new CppHelloWorldApp()
@@ -239,6 +240,7 @@ class VisualStudioIncrementalIntegrationTest extends AbstractVisualStudioIntegra
         skipped getComponentTasks("app")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "visual studio tasks re-execute when new component is added"() {
         app.writeSources(file("src/main"))
 

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.ide.visualstudio
 
 import groovy.test.NotYetImplemented
 import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrary
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
@@ -38,6 +39,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "create visual studio solution for build without any C++ components"() {
         when:
         createDirs("one", "two", "three")
@@ -57,6 +59,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         mainSolution.assertHasProjects()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "includes a visual studio project for every project with a C++ component"() {
         when:
         createDirs("one", "two", "three")
@@ -97,6 +100,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         mainSolution.assertReferencesProject(twoProject, projectConfigurations)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "create visual studio solution for executable that depends on a library in another project"() {
         when:
         app.executable.writeSources(file("exe/src/main"))
@@ -151,6 +155,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         mainSolution.assertReferencesProject(dllProject, projectConfigurations)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp build")
     def "visual studio solution does not reference the components of a project if it does not have visual studio plugin applied"() {
         when:
         app.executable.writeSources(file("exe/src/main"))
@@ -219,6 +224,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         file("other").listFiles().every { !(it.name.endsWith(".vcxproj") || it.name.endsWith(".vcxproj.filters")) }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp build")
     def "create visual studio solution for executable that transitively depends on multiple projects"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()
@@ -281,6 +287,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         greetLibProject.projectConfigurations['debug'].includePath == filePath("src/main/public", "src/main/headers")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Visual Studio uses allprojects/subprojects")
     def "create visual studio solution for executable with a transitive api dependency"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()

--- a/platforms/ide/ide-plugins/build.gradle.kts
+++ b/platforms/ide/ide-plugins/build.gradle.kts
@@ -114,6 +114,4 @@ packageCycles {
  */
 testFilesCleanup.reportOnly = true
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.custommonkey.xmlunit.XMLAssert
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
@@ -38,6 +39,7 @@ class EclipseIntegrationTest extends AbstractEclipseIntegrationTest {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void canCreateAndDeleteMetaData() {
         when:

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectDependencyWithoutTestCodeIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectDependencyWithoutTestCodeIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.plugins.ide.eclipse
 
 
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class EclipseProjectDependencyWithoutTestCodeIntegrationTest extends AbstractEclipseIntegrationSpec {
 
@@ -40,6 +41,7 @@ class EclipseProjectDependencyWithoutTestCodeIntegrationTest extends AbstractEcl
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "test code is not available by default"() {
         when:
         expectTaskDeprecations("eclipse", "eclipseClasspath", "eclipseJdt", "eclipseProject")
@@ -49,6 +51,7 @@ class EclipseProjectDependencyWithoutTestCodeIntegrationTest extends AbstractEcl
         classpath('b').project('a').assertHasAttribute(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_VALUE)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "test code is available if target project applies the java-test-fixtures plugin"() {
         file('a/build.gradle') << """
             plugins {
@@ -64,6 +67,7 @@ class EclipseProjectDependencyWithoutTestCodeIntegrationTest extends AbstractEcl
         classpath('b').project('a').assertHasNoAttribute(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_VALUE)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "test code is available if target project has the eclipse.classpath.containsTestFixtures=true configuration"() {
         file('a/build.gradle') << """
             eclipse {
@@ -81,6 +85,7 @@ class EclipseProjectDependencyWithoutTestCodeIntegrationTest extends AbstractEcl
         classpath('b').project('a').assertHasAttribute(EclipsePluginConstants.WITHOUT_TEST_CODE_ATTRIBUTE_KEY, 'false')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "eclipse.classpath.containsTestFixtures configuration has precedence over the applied java-test-fixtures plugin"() {
         file('a/build.gradle') << """
             plugins {

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
@@ -15,7 +15,10 @@
  */
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class EclipseWtpEarAndWebAndEjbProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "generates configuration files for an ear project and ejb and web projects it bundles"() {
         createDirs("ear", "web", "java")
         settingsFile << "include 'ear', 'web', 'java'"

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.junit.Test
 import spock.lang.Issue
 
@@ -43,6 +44,7 @@ class EclipseWtpIntegrationTest extends AbstractEclipseIntegrationTest {
         libEntriesInClasspathFileHaveFilenames("foo.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     @Issue("GRADLE-2526")
     void overwritesDependentModules() {
@@ -63,6 +65,7 @@ class EclipseWtpIntegrationTest extends AbstractEclipseIntegrationTest {
         classpath2.lib("myartifactdep-1.0.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "respects dependency substitution rules"() {
         // given:

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide.eclipse
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.junit.Rule
 import org.junit.Test
 import spock.lang.Issue
@@ -293,6 +294,7 @@ class EclipseWtpModelIntegrationTest extends AbstractEclipseIntegrationTest {
         classpath.lib('baz.txt').assertIsExcludedFromDeployment()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     @Issue("GRADLE-1881")
     void "uses eclipse project name for wtp module dependencies"() {
@@ -334,6 +336,7 @@ class EclipseWtpModelIntegrationTest extends AbstractEclipseIntegrationTest {
         assert contribComponent.deployName == 'cool-contrib'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     @Issue("GRADLE-1881")
     void "does not explode if dependent project does not have eclipse plugin"() {
@@ -451,6 +454,7 @@ class EclipseWtpModelIntegrationTest extends AbstractEclipseIntegrationTest {
         assert component.contains('coolAppDir')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     @Issue("GRADLE-1974")
     void "may use web libraries container"() {

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -16,8 +16,11 @@
 
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 
 class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "generates configuration files for web project and java project it depends on"() {
         settingsFile << "include 'web', 'java'"
 

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildIdeaProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildIdeaProjectIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.idea
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.plugins.ide.AbstractIdeIntegrationSpec
 import org.gradle.plugins.ide.fixtures.IdeaFixtures
@@ -56,6 +57,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         includeBuild(buildB)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -76,6 +78,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         notExecuted ":buildB:jar", ":buildB:b1:jar", ":buildB:b2:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted subproject dependencies"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -89,6 +92,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "b1", "b2"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted dependency from same build"() {
         given:
         dependency('org.test:buildB:1.0')
@@ -102,6 +106,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies(buildB, "b1")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted subproject dependency that has transitive dependencies"() {
         given:
         def transitive1 = mavenRepo.module("org.test", "transitive1").publish()
@@ -118,6 +123,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies(["buildB"], ["transitive1-1.0.jar", "transitive2-1.0.jar", ])
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted subproject dependency that has transitive project dependency"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -135,6 +141,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB", "b1"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with transitive substitutions"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -156,6 +163,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB", "buildC"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with substituted transitive dependency"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0').dependsOn("org.test", "buildB", "1.0").publish()
@@ -169,6 +177,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies(["buildB"], ["external-dep-1.0.jar"])
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with dependency cycle between substituted projects in a multiproject build"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -199,6 +208,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB", "b1", "b2"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata with dependency cycle between substituted participants in a composite build"() {
         given:
         dependency(buildA, "org.test:buildB:1.0")
@@ -220,6 +230,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata in composite containing participants with same root directory name"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -246,6 +257,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB", "buildC"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "generated IDEA project references modules for all projects in composite"() {
         given:
 
@@ -274,6 +286,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         notExecuted ":buildC:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "generated IDEA metadata respects idea plugin configuration"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -293,6 +306,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "b1-renamed", "b2"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA when one participant does not have IDEA plugin applied"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -314,6 +328,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB", "buildC"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "builds IDEA metadata when not all projects have IDEA plugin applied"() {
         given:
         dependency "org.test:b1:1.0"
@@ -345,6 +360,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "b1", "buildC", "c2"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "de-duplicates module names for included builds"() {
         given:
         dependency "org.test:b1:1.0"
@@ -386,6 +402,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
         imlHasDependencies "buildB-b1", "buildC-b1", "buildA-b1"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "de-duplicates module names between including and included builds"() {
         given:
         buildA.buildFile << """
@@ -438,6 +455,7 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIdeIntegrationSpe
 
     @ToBeImplemented
     @Issue("https://github.com/gradle/gradle/issues/2526")
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "de-duplicates module names when not all projects have IDEA plugin applied"() {
         given:
         dependency "org.test:b1:1.0"

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeMultiProjectBuildIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeMultiProjectBuildIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.plugins.ide.idea
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.AbstractIdeIntegrationSpec
 
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIml
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIpr
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root")
 class IdeMultiProjectBuildIntegrationTest extends AbstractIdeIntegrationSpec {
     def "includes module for each project in build"() {
         given:

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.custommonkey.xmlunit.XMLAssert
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
@@ -66,6 +67,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableCo
         assert moduleContent == moduleContentAfterMerge
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void canCreateAndDeleteMetaData() {
         expectTaskDeprecations("idea", "ideaModule", "ideaProject", "ideaWorkspace")
@@ -92,6 +94,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableCo
         assertHasExpectedContents('root.iml')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void worksWithASubProjectThatDoesNotHaveTheIdeaPluginApplied() {
         createDirs("a", "b")
@@ -101,6 +104,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableCo
         assertHasExpectedContents('root.ipr')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void worksWithNonStandardLayout() {
         createDirs("a child project")
@@ -120,6 +124,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableCo
         assertHasExpectedContents('root.iml')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void addsScalaSdkAndCompilerLibraries() {
         expectTaskDeprecations("idea", "ideaModule", "ideaProject", "ideaWorkspace")
@@ -146,6 +151,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableCo
         hasScalaSdk('project4/project4.iml', '3.0.1')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void addsScalaFacetAndCompilerLibraries() {
         expectTaskDeprecations("idea", "ideaModule", "ideaProject", "ideaWorkspace")

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.junit.Rule
 import org.junit.Test
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class IdeaModuleIntegrationTest extends AbstractIdeIntegrationTest {
     @Rule
@@ -442,6 +443,7 @@ class IdeaModuleIntegrationTest extends AbstractIdeIntegrationTest {
         content.contains 'hibernate-core.jar'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void doesNotBreakWhenSomeDependenciesCannotBeResolved() {
         //given

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiModuleIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiModuleIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.plugins.ide.idea
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.junit.Rule
 import org.junit.Test
@@ -24,6 +25,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void buildsCorrectModuleDependencies() {
         def settingsFile = file("settings.gradle")
@@ -80,6 +82,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void buildsCorrectModuleDependenciesForDependencyOnRoot() {
         createDirs("api")
@@ -114,6 +117,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert dependencies.modules.size() == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void respectsApiOfJavaLibraries() {
         def settingsFile = file("settings.gradle")
@@ -167,6 +171,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         dependencies.assertHasModule('TEST', "impl")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void buildsCorrectModuleDependenciesWhenRootProjectDoesNotApplyIdePlugin() {
         createDirs("api", "util", "other")
@@ -219,6 +224,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         utilDependencies.assertHasModule(['TEST'], "root-project-1")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void dealsWithDuplicatedModuleNames() {
       /*
@@ -321,6 +327,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void allowsFullyReconfiguredModuleNames() {
         //use case from the mailing list
@@ -367,6 +374,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert moduleFileNames.contains("master.iml")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void handlesModuleDependencyCycles() {
         def settingsFile = file("settings.gradle")
@@ -425,6 +433,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         dependencies.assertHasModule('COMPILE', "two")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void classpathContainsConflictResolvedDependencies() {
         def someLib1Jar = mavenRepo.module('someGroup', 'someLib', '1.0').publish().artifactFile
@@ -493,6 +502,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert dependencies.libraries*.jarName as Set == [someLib2Jar.name] as Set
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void cleansCorrectlyWhenModuleNamesAreChangedOrDeduplicated() {
         def settingsFile = file("settings.gradle")
@@ -530,6 +540,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert !getFile(project: 'contrib', "cool-contrib.iml").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void handlesInternalDependenciesToNonIdeaProjects() {
         def settingsFile = file("settings.gradle")
@@ -562,6 +573,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert getFile(project: 'api', 'api.iml').exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void doesNotCreateDuplicateEntriesInIpr() {
         def settingsFile = file("settings.gradle")
@@ -590,6 +602,7 @@ class IdeaMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert content.count('filepath="$PROJECT_DIR$/api/api.iml"') == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void buildsCorrectModuleDependenciesWithScopes() {
         def settingsFile = file("settings.gradle")

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaProjectIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.junit.Rule
 import org.junit.Test
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class IdeaProjectIntegrationTest extends AbstractIdeIntegrationTest {
     @Rule
@@ -44,6 +45,7 @@ class IdeaProjectIntegrationTest extends AbstractIdeIntegrationTest {
         assert ipr.contains('<mapping directory="" vcs="Git"/>')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void enablesCustomizationsOnNewModel() {
         //when

--- a/platforms/ide/ide/build.gradle.kts
+++ b/platforms/ide/ide/build.gradle.kts
@@ -93,6 +93,4 @@ packageCycles {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.plugins.ide
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectIntegrationTest {
     abstract String[] getGenerationTaskNames(String projectPath)
 
@@ -27,6 +29,7 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "lifecycle task is added and generates metadata"() {
         when:
         expectTaskDeprecations(deprecatedTaskNames)
@@ -44,6 +47,7 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
         projectName("foo/bar") == "bar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "clean tasks always run before generation tasks when specified on the command line"() {
         when:
         expectTaskDeprecations(deprecatedTaskNames + deprecatedCleanTaskNames)
@@ -60,6 +64,7 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
         assertGenerationTasksRunBeforeCleanTasks()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "clean tasks always run before generation tasks when modeled as a dependency"() {
         given:
         buildFile << """

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationSpec.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationSpec.groovy
@@ -16,12 +16,14 @@
 package org.gradle.plugins.ide.eclipse
 
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class EclipseClasspathIntegrationSpec extends AbstractEclipseIntegrationSpec {
 
     // TODO this should be part of EclipseClasspathIntegrationTest, but it uses a legacy superclass
 
     @Issue("https://github.com/gradle/gradle/issues/10393")
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def  "Does not contain duplicate project dependencies"() {
         setup:
         buildFile <<  """

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.eclipse
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.junit.Rule
 import org.junit.Test
@@ -156,6 +157,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         libraries[3].assertHasJar(anotherJar)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void includesTransitiveRepoFileDependencies() {
         //given
@@ -204,6 +206,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         libs[1].assertHasJar(someArtifactJar)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void includesTransitiveImplementationDependencies() {
         //given
@@ -254,6 +257,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         libs[1].assertHasJar(someArtifactJar)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void transitiveProjectDependenciesMappedAsDirectDependencies() {
         given:
@@ -288,6 +292,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         assert eclipseClasspath.projects.collect { it.name } == ['b', 'c']
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void transitiveFileDependenciesMappedAsDirectDependencies() {
         createDirs("a", "b", "c")
@@ -332,6 +337,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         eclipseClasspath.libs[2].assertHasJar(file("c/foo.jar"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void classpathContainsConflictResolvedDependencies() {
         def someLib1Jar = mavenRepo.module('someGroup', 'someLib', '1.0').publish().artifactFile
@@ -562,6 +568,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         libraries[1].assertHasJar(file("bar.txt"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void handlesPlusMinusConfigurationsForProjectDeps() {
         //when
@@ -942,6 +949,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
     }
 
     @Issue("GRADLE-1502")
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void createsLinkedResourcesForSourceDirectoriesWhichAreNotUnderTheProjectDirectory() {
         file('someGroovySrc').mkdirs()
@@ -1021,6 +1029,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         result.assertTasksScheduled(':generateForMain', ':generateForTest', ':eclipseClasspath', ':eclipseJdt', ':eclipseProject', ':eclipse')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void doesNotBreakWhenSomeDependenciesCannotBeResolved() {
         //given
@@ -1139,6 +1148,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         classpath.assertHasLibs('compileOnly-1.0.jar', 'testCompileOnly-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void compileOnlyDependenciesAreNotExported() {
         // given
@@ -1182,6 +1192,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
         classpathB.assertHasLibs('compile-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "test compile only dependencies mapped to classpath and not exported"() {
         // given
@@ -1230,6 +1241,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
      * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
      * use case or another.
      */
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "conflicting versions of the same library for compile and compile-only mapped to classpath"() {
         // given
@@ -1278,6 +1290,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
      * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
      * use case or another.
      */
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "conflicting versions of the same library for runtime and compile-only mapped to classpath"() {
         // given
@@ -1326,6 +1339,7 @@ Could not resolve: myGroup:missing-extra-artifact:1.0
      * put duplicate dependencies on the classpath. The order will always be arbitrary and break one
      * use case or another.
      */
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "conflicting versions of the same library for test-compile and testcompile-only mapped to classpath"() {
         // given

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.plugins.ide.eclipse
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
 import org.junit.Test
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class EclipseDependencySubstitutionIntegrationTest extends AbstractEclipseIntegrationTest {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "external dependency substituted with project dependency"() {
         createDirs("project1", "project2")
@@ -51,6 +53,7 @@ class EclipseDependencySubstitutionIntegrationTest extends AbstractEclipseIntegr
         assert classpath.libs == []
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "transitive external dependency substituted with project dependency"() {
         mavenRepo.module("org.gradle", "module1").dependsOnModules("module2").publish()
@@ -87,6 +90,7 @@ class EclipseDependencySubstitutionIntegrationTest extends AbstractEclipseIntegr
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void "project dependency substituted with external dependency"() {
         createDirs("project1", "project2")

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.plugins.ide.eclipse
 
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 
 @Requires(JdkVersionTestPreconditions.Jdk9OrLater)
 class EclipseJavaProjectModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "depend on modular project"() {
         setup:
         /*

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLinkedResourceIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLinkedResourceIntegrationTest.groovy
@@ -16,8 +16,11 @@
 
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class EclipseLinkedResourceIntegrationTest extends AbstractEclipseIntegrationSpec {
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "can reference linked resources as source folders"() {
         given:
         multiProjectWithSiblingSourceFolders()

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseMultiModuleIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseMultiModuleIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.plugins.ide.eclipse
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.junit.Rule
 import org.junit.Test
@@ -24,6 +25,7 @@ class EclipseMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void dealsWithDuplicatedModuleNames() {
       /*
@@ -107,6 +109,7 @@ class EclipseMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert deps.contains("/shared-api")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     @Test
     void shouldCreateCorrectClasspathEvenIfUserReconfiguresTheProjectName() {
         //use case from the mailing list
@@ -155,6 +158,7 @@ class EclipseMultiModuleIntegrationTest extends AbstractIdeIntegrationTest {
         assert deps.contains("/nonEclipse")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     void shouldCreateCorrectClasspathEvenIfUserReconfiguresTheProjectNameAndRootProjectDoesNotApplyEclipsePlugin() {
         createDirs("api", "shared", "shared/model")

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseTestConfigurationsWithProjectDependenciesIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseTestConfigurationsWithProjectDependenciesIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.plugins.ide.eclipse
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends AbstractEclipseTestSourcesIntegrationTest {
@@ -35,6 +36,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "dependencies in main source set dependency configurations are not marked with test classpath attribute"() {
         given:
         file('a/build.gradle') << """
@@ -51,6 +53,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyDoesNotHaveTestAttribute('a', 'b')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "dependencies in test source set dependency configurations are marked with test classpath attribute"() {
         given:
         file('a/build.gradle') << """
@@ -67,6 +70,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyHasTestAttribute('a', 'b')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "dependencies in jvm test suites are marked with test classpath attribute"() {
         file('a/build.gradle') << """
             plugins {
@@ -92,6 +96,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyHasTestAttribute('a', 'b')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "dependencies in custom source set dependency configurations are marked with test classpath attribute if the source set name contains the 'test' substring"() {
         given:
         file('a/build.gradle') << """
@@ -112,6 +117,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyHasTestAttribute('a', 'b')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "dependencies in custom source set dependency configurations are not marked with test classpath attribute if the source set name does not contain the 'test' substring"() {
         given:
         file('a/build.gradle') << """
@@ -132,6 +138,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyDoesNotHaveTestAttribute('a', 'b')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "can configure which source set dependency configurations contribute test dependencies to the classpath"() {
         given:
         settingsFile << "\ninclude 'c'"
@@ -168,6 +175,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
         assertProjectDependencyDoesNotHaveTestAttribute('a', 'c')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def "dependencies present in test and non-test configurations are not marked with test classpath attribute"() {
         given:
         file('a/build.gradle') << """
@@ -186,6 +194,7 @@ class EclipseTestConfigurationsWithProjectDependenciesIntegrationTest extends Ab
     }
 
     @Issue('https://github.com/gradle/gradle/issues/21968')
+    @ToBeFixedForIsolatedProjects(because = "Eclipse plugin uses allprojects/subprojects")
     def 'dependencies for different features present in test and non-test configurations are not marked with test classpath attribute'() {
         given:
         settingsFile << """

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaCompositeBuildIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaCompositeBuildIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.plugins.ide.idea
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.AbstractIdeIntegrationSpec
 
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIml
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIpr
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root")
 class IdeaCompositeBuildIntegrationTest extends AbstractIdeIntegrationSpec {
     def "includes module for each project in each build"() {
         given:

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
 import org.junit.Rule
 import org.junit.Test
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class IdeaDependencySubstitutionIntegrationTest extends AbstractIdeIntegrationTest {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void "external dependency substituted with project dependency"() {
         createDirs("project1", "project2")
@@ -54,6 +56,7 @@ class IdeaDependencySubstitutionIntegrationTest extends AbstractIdeIntegrationTe
         dependencies.assertHasModule(['COMPILE'], 'project1')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void "transitive external dependency substituted with project dependency"() {
         mavenRepo.module("org.gradle", "module1").dependsOnModules("module2").publish()
@@ -91,6 +94,7 @@ class IdeaDependencySubstitutionIntegrationTest extends AbstractIdeIntegrationTe
         dependencies.assertHasModule(['COMPILE'], 'project1')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     @Test
     void "project dependency substituted with external dependency"() {
         createDirs("project1", "project2")

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaJavaLanguageSettingsIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaJavaLanguageSettingsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.plugins.ide.AbstractIdeIntegrationSpec
 import org.gradle.plugins.ide.fixtures.IdeaFixtures
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec {
     @Rule
@@ -34,6 +35,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "global sourceCompatibility results in project language level"() {
         given:
         buildFile << """
@@ -56,6 +58,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         iml('child3').languageLevel == null
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "specific module languageLevel is exposed with derived language level"() {
         given:
         buildFile << """
@@ -90,6 +93,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         iml("child3").languageLevel == null
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "use project language level not source language level and target bytecode level when explicitly set"() {
         given:
         buildFile << """
@@ -171,6 +175,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         ipr.bytecodeTargetLevel.children().size() == 0
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "uses subproject sourceCompatibility even if root project does not apply java plugin"() {
         buildFile << """
             allprojects {
@@ -193,6 +198,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         iml('child3').languageLevel == null
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "module languageLevel always exposed when no idea root project found"() {
         buildFile << """
             subprojects {
@@ -213,6 +219,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "project bytecodeLevel set explicitly for same java versions"() {
         given:
         createDirs("subprojectA", "subprojectB", "subprojectC")
@@ -246,6 +253,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         ipr.bytecodeTargetLevel.@target == "1.6"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "explicit project target level when module version differs from project java sdk"() {
         given:
         createDirs("subprojectA", "subprojectB", "subprojectC")
@@ -279,6 +287,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         ipr.bytecodeTargetLevel.@target == "1.7"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "target bytecode version set if differs from calculated idea project bytecode version"() {
         given:
         createDirs("subprojectA")
@@ -311,6 +320,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         ipr.bytecodeTargetLevel.module.find { it.@name == "subprojectA" }.@target == "1.7"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "language level set if differs from calculated idea project language level"() {
         given:
         createDirs("child1")
@@ -342,6 +352,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         iml('child1').languageLevel == "JDK_1_7"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "language level set if root has no idea plugin applied"() {
         given:
         createDirs("child1")
@@ -369,6 +380,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         iml('child1').languageLevel == "JDK_1_7"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     def "can have module specific bytecode version"() {
         given:
         createDirs("subprojectA", "subprojectB", "subprojectC", "subprojectD")
@@ -422,6 +434,7 @@ class IdeaJavaLanguageSettingsIntegrationTest extends AbstractIdeIntegrationSpec
         ipr.bytecodeTargetLevel.module.find { it.@name == "subprojectB" }.@target == "1.7"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDEA plugin uses allprojects/subprojects")
     void "language levels specified in properties files are ignored"() {
         given:
         file('gradle.properties') << """

--- a/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/AbstractIdeDeduplicationIntegrationTest.groovy
+++ b/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/AbstractIdeDeduplicationIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.plugins.ide
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 
 abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjectIntegrationTest {
 
@@ -23,6 +25,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         return deprecatedTaskNames
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "unique project names are not deduplicated"() {
         given:
         project("root") {
@@ -46,6 +49,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("foobar/app") == "app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "deduplicates duplicate ide project names"() {
         given:
         project("root") {
@@ -69,6 +73,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("bar/app") == "bar-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "dedups child project with same name as parent project"() {
         given:
         project("root") {
@@ -88,6 +93,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
 
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "handles calculated name matches existing project name"() {
         given:
         project("root") {
@@ -114,6 +120,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("baz/bar") == "baz-bar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "dedups projects with different nested level"() {
         given:
         project("root") {
@@ -137,6 +144,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("services/bar/app") == "bar-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "dedups root project name"() {
         given:
         project("app") {
@@ -152,6 +160,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("app") == "app-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "deduplication works on deduplicated parent module name"() {
         given:
         project("root") {
@@ -179,6 +188,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("foo/services/rest") == "foo-services-rest"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "allows deduplication with parent not part of the target list"() {
         given:
         project("root") {
@@ -206,6 +216,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("foo/services/rest") == "foo-services-rest"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "allows deduplication when root project does not apply IDE plugin"() {
         given:
         project("root", false) {
@@ -228,6 +239,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("bar/app") == "bar-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "removes duplicate words from project dedup prefix"() {
         given:
         project("root"){
@@ -265,6 +277,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("impl/myproject/myproject-foo/app") == "impl-myproject-foo-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root, IDE plugin aggregates subprojects")
     def "will use configured module name"() {
         given:
         project("root") {
@@ -289,6 +302,7 @@ abstract class AbstractIdeDeduplicationIntegrationTest extends AbstractIdeProjec
         projectName("bar/app") == "bar-app"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin cross-project configuration")
     def "will not de-duplicate module that conflicts with configured module name"() {
         given:
         project("root") {

--- a/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/AbstractMultiBuildIdeIntegrationTest.groovy
+++ b/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/AbstractMultiBuildIdeIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.fixtures
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.plugins.ide.AbstractIdeIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Issue
@@ -50,6 +51,7 @@ abstract class AbstractMultiBuildIdeIntegrationTest extends AbstractIdeIntegrati
         } // else, unspecified
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin uses allprojects/subprojects across included builds")
     def "workspace includes projects from included builds"() {
         buildTestFixture.withBuildInSubDir()
         def buildA = singleProjectBuild("buildA") {
@@ -87,6 +89,7 @@ abstract class AbstractMultiBuildIdeIntegrationTest extends AbstractIdeIntegrati
         workspace.assertContains(project(buildB.file("p2"), "p2"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IDE plugin uses allprojects/subprojects across included builds")
     def "workspace includes projects from nested included builds"() {
         buildTestFixture.withBuildInSubDir()
         def buildA = singleProjectBuild("buildA") {

--- a/platforms/ide/problems-api/build.gradle.kts
+++ b/platforms/ide/problems-api/build.gradle.kts
@@ -70,9 +70,7 @@ jvmCompile {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 packageCycles {
     excludePatterns.add("org/gradle/api/problems/**") // ProblemId.create() and ProblemGroup.create() return internal types

--- a/platforms/ide/problems/build.gradle.kts
+++ b/platforms/ide/problems/build.gradle.kts
@@ -76,9 +76,7 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 // Problems should not be part of the public API, this only contains internal types
 // TODO Find a way to not register this and the task instead

--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -135,9 +135,7 @@ packageCycles {
 testFilesCleanup.reportOnly = true
 
 apply(from = "buildship.gradle")
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 // AutoTestedSamplesToolingApiTest includes customized test logic, so automatic auto testing samples generation is not needed (and would fail) in this project
 integTest.generateDefaultAutoTestedSamplesTest = false

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.OtherGradleVersionFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApi
@@ -143,6 +144,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec implements Other
         notThrown(Throwable)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects { task ... } in generated root script")
     def "tooling api searches up from the project directory to find the wrapper properties"() {
         settingsFile << "include 'child'"
         buildFile << """

--- a/platforms/jvm/code-quality/build.gradle.kts
+++ b/platforms/jvm/code-quality/build.gradle.kts
@@ -80,6 +80,4 @@ gradleModule {
 packageCycles {
     excludePatterns.add("org/gradle/api/plugins/quality/internal/*")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.quality
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.GitUtility
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
@@ -119,6 +120,7 @@ class AntWorkerMemoryLeakIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/22172')
+    @ToBeFixedForIsolatedProjects(because = "subprojects, applies CodeNarc/Checkstyle to subprojects")
     void 'CodeNarc/Checkstyle do not fail with PermGen space error'() {
         given:
         withCheckstyle()

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginClasspathIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginClasspathIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.quality.integtest.fixtures.CheckstyleCoverage
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @Issue("gradle/gradle#855")
 @TargetCoverage({ CheckstyleCoverage.getSupportedVersionsByJdk() })
@@ -29,6 +30,7 @@ class CheckstylePluginClasspathIntegrationTest extends MultiVersionIntegrationSp
         goodCode()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "checkstyle plugin uses cross-project configuration")
     def "accepts throwing exception from other project"() {
         expect:
         succeeds("checkstyleMain")

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.junit.Assume
 import static org.gradle.util.Matchers.containsLine
 import static org.gradle.util.Matchers.containsText
 import static org.hamcrest.CoreMatchers.containsString
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionIntegrationTest {
     private static final String ASSERTJ_STR = "'org.assertj:assertj-core:3.23.1'" // Some arbitrary dependency which is not already on the worker classpath.
@@ -97,6 +98,7 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
         """.stripIndent()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath configured for rule-using project"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -111,6 +113,7 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
             assertContents(containsText("auxclasspath configured"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath configured for test sourceset of rule-using project"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -127,6 +130,7 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
             assertContents(containsText("auxclasspath configured"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath not configured properly for rule-using project"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -149,6 +153,7 @@ project("rule-using") {
             assertContents(containsText("auxclasspath not configured"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath contains transitive implementation dependencies"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -163,6 +168,7 @@ project("rule-using") {
             assertContents(containsText("auxclasspath configured"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath does not contain transitive compileOnly dependencies"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -177,6 +183,7 @@ project("rule-using") {
             assertContents(containsText("auxclasspath not configured"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "pmd plugin uses cross-project configuration")
     def "auxclasspath contains pmdAux dependencies"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 

--- a/platforms/jvm/ear/build.gradle.kts
+++ b/platforms/jvm/ear/build.gradle.kts
@@ -58,6 +58,4 @@ strictCompile {
 packageCycles {
     excludePatterns.add("org/gradle/plugins/ear/internal/*")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/ear/src/integTest/groovy/org/gradle/integtests/MixedWarAndEjbProjectIntegrationTest.groovy
+++ b/platforms/jvm/ear/src/integTest/groovy/org/gradle/integtests/MixedWarAndEjbProjectIntegrationTest.groovy
@@ -16,8 +16,10 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MixedWarAndEjbProjectIntegrationTest extends AbstractIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project can use compiled classes from an EAR project"() {
         given:
         file("settings.gradle") << 'include "a", "b"'

--- a/platforms/jvm/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/platforms/jvm/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugins.ear
 import groovy.xml.XmlSlurper
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.archives.TestFileSystemSensitiveArchives
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.hamcrest.CoreMatchers
@@ -459,6 +460,7 @@ ear {
         ear.assertContainsFile("META-INF/application.xml")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "ear contains runtime classpath of upstream java project"() {
         given:
         createDirs("a", "b", "c", "d", "e")
@@ -506,6 +508,7 @@ ear {
         ear.assertNotContainsFile("lib/e.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "ear plugin cross-project configuration")
     def "ear contains runtime classpath of upstream java-library project"() {
         given:
         createDirs("a", "b", "c", "d", "e")

--- a/platforms/jvm/jacoco/build.gradle.kts
+++ b/platforms/jvm/jacoco/build.gradle.kts
@@ -72,6 +72,4 @@ packageCycles {
     excludePatterns.add("org/gradle/testing/jacoco/plugins/*")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoCoverage
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
 import spock.lang.Issue
@@ -151,6 +152,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "can aggregate jacoco execution data from dependent projects"() {
         given:
         file("application/build.gradle") << """
@@ -173,6 +175,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassCoverage("transitive.Powerize")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "aggregated report does not contain external dependencies"() {
         given:
         file("application/build.gradle") << """
@@ -192,6 +195,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "aggregated report resolves sources variant of project dependencies"() {
         given:
         file("application/build.gradle") << """
@@ -222,6 +226,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         outputContains(file('transitive/src/main/resources').absolutePath)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "aggregated report resolves classes variant of project dependencies"() {
         given:
         file("application/build.gradle") << """
@@ -252,6 +257,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         outputDoesNotContain(file('transitive/build/libs/transitive-1.0.jar').absolutePath)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def 'aggregated report infers dependency versions from platform'() {
         given:
         file("application/build.gradle") << """
@@ -274,6 +280,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertDoesNotContainClass("org.codehaus.janino.Parser")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def 'multiple test suites create multiple aggregation tasks'() {
         given:
         file("transitive/build.gradle") << """
@@ -373,6 +380,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         integTestReport.assertHasClassCoverage("transitive.Divisor")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def "can aggregate jacoco reports from root project"() {
         given:
         buildFile << """
@@ -409,6 +417,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/25618")
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "can aggregate jacoco reports when dependency publishes test fixtures"() {
         given:
         buildFile << """
@@ -456,6 +465,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassCoverage("transitive.Powerize")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def "can aggregate jacoco reports from root project when subproject doesn't have tests"() {
         given:
         buildFile << """
@@ -494,6 +504,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassButNoCoverage("transitive.Powerize")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "can aggregate jacoco reports from root project with platform"() {
         given:
         file("transitive/build.gradle") << """
@@ -542,6 +553,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertDoesNotContainClass("org.codehaus.janino.Parser")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def 'test verification failure prevents creation of aggregated report'() {
         given:
         file("application/build.gradle") << """
@@ -577,6 +589,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").assertDoesNotExist()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def 'test verification failure creates aggregated report with --continue flag'() {
         given:
         file("application/build.gradle") << """
@@ -618,6 +631,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassCoverage("transitive.Powerize")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def 'catastrophic failure of single test prevents creation of aggregated report'() {
         given:
         file("application/build.gradle") << """
@@ -697,6 +711,7 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/29916")
+    @ToBeFixedForIsolatedProjects(because = "jacoco aggregation resolves subproject artifacts at config time")
     def "can create jacoco report while report tasks are realized early"() {
         buildFile << """
             apply plugin: 'org.gradle.jacoco-report-aggregation'

--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoKotlinJvmPluginAggregationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoKotlinJvmPluginAggregationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoCoverage
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
@@ -32,6 +33,7 @@ import spock.lang.Issue
  * all files to be added to the jacoco report to ensure none are zip), this test will fail.
  */
 @Issue("https://github.com/gradle/gradle/issues/20532")
+@ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
 class JacocoKotlinJvmPluginAggregationTest extends AbstractIntegrationSpec {
 
     def kotlinVersion = new KotlinGradlePluginVersions().latestStableOrRC

--- a/platforms/jvm/jvm-services/build.gradle.kts
+++ b/platforms/jvm/jvm-services/build.gradle.kts
@@ -66,9 +66,7 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 packageCycles {
     // Needed for the factory methods in the interface since the implementation is in an internal package

--- a/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
+++ b/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
 
@@ -134,6 +135,7 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
         outputContains(otherJvm)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "toolchain registry queries cross-project state")
     def "relative file paths are resolved relative to root dir"() {
         def javaHome = AvailableJavaHomes.availableJvms[0].javaHome.absolutePath
 

--- a/platforms/jvm/language-groovy/build.gradle.kts
+++ b/platforms/jvm/language-groovy/build.gradle.kts
@@ -84,6 +84,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/tasks/javadoc/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -119,6 +119,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/tasks/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.fixtures.AnnotationProcessorFixture
 import org.gradle.language.fixtures.CompileJavaBuildOperationsFixture
 import org.gradle.test.fixtures.file.TestFile
@@ -94,6 +95,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         out
     }
 
+    @ToBeFixedForIsolatedProjects(because = "annotation processing across projects")
     def "explicit -processor option overrides automatic detection"() {
         buildFile << """
             compileJava.options.compilerArgs << "-processor" << "unknown.Processor"
@@ -105,6 +107,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         failure.assertHasCause("Annotation processor 'unknown.Processor' not found")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "recompiles when a resource changes"() {
         given:
         buildFile << """
@@ -125,6 +128,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         outputs.recompiledClasses("A", "B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "recompiles when a resource is removed"() {
         given:
         buildFile << """
@@ -145,6 +149,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         outputs.recompiledClasses("A", "B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "annotation processing across projects")
     def "compilation is incremental when an empty directory is added"() {
         given:
         def a = java("class A {}")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.fixtures.AnnotatedGeneratedClassProcessorFixture
 import org.gradle.language.fixtures.AnnotationProcessorFixture
 import org.gradle.language.fixtures.HelperProcessorFixture
@@ -45,6 +46,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         withProcessor(writingResourcesTo(StandardLocation.CLASS_OUTPUT.toString()))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are recompiled when any annotated file changes"() {
         def a = java "@Service class A {}"
         java "@Service class B {}"
@@ -61,6 +63,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         serviceRegistryReferences("A", "B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "incremental processing works on subsequent incremental compilations after failure"() {
         def a = java "@Service class A {}"
         java "@Service class B {}"
@@ -93,6 +96,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "incremental processing works when new aggregating type is added on subsequent incremental compilations after failure"() {
         def a = java "@Service class A {}"
         java "@Service class B {}"
@@ -123,6 +127,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         serviceRegistryReferences("A", "B", "C")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "unrelated files are not recompiled when annotated file changes"() {
         def a = java "@Service class A {}"
         java "class Unrelated {}"
@@ -137,6 +142,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.recompiledFiles("A", "ServiceRegistry", "ServiceRegistryResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "annotated files are reprocessed when an unrelated file changes"() {
         java "@Service class A {}"
         def unrelated = java "class Unrelated {}"
@@ -151,6 +157,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.recompiledFiles("Unrelated", "ServiceRegistry", "ServiceRegistryResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "annotated files are reprocessed when a new file is added"() {
         java "@Service class A {}"
         java "class Unrelated {}"
@@ -166,6 +173,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         serviceRegistryReferences("A", "B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "annotated files are reprocessed when a file is deleted"() {
         def a = java "@Service class A {}"
         java "@Service class B {}"
@@ -185,6 +193,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Issue("https://github.com/gradle/gradle/issues/13767")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files with annotations are not reprocessed when a file is added (#label)"() {
         def fixture = new AnnotatedGeneratedClassProcessorFixture()
         if (generateClass) {
@@ -220,6 +229,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Issue("https://github.com/gradle/gradle/issues/17572")
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "can have an aggregating annotation processor for package info"() {
         def fixture = new PackageInfoGeneratedClassProcessorFixture()
         withProcessor(fixture)
@@ -266,6 +276,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files with annotations are reprocessed when a file is deleted (#label)"() {
         def fixture = new AnnotatedGeneratedClassProcessorFixture()
         if (generateClass) {
@@ -303,6 +314,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         true          | "generate class files"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes depending on generated file are recompiled when source file changes"() {
         given:
         def a = java "@Service class A {}"
@@ -321,6 +333,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.recompiledFiles("A", "ServiceRegistry", "ServiceRegistryResource.txt", "Dependent")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes files of generated sources are deleted when annotated file is deleted"() {
         given:
         def a = java "@Service class A {}"
@@ -336,6 +349,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.deletedFiles("A", "ServiceRegistry", "ServiceRegistryResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are deleted when annotated file is deleted"() {
         given:
         withProcessor(writingResourcesTo(StandardLocation.SOURCE_OUTPUT.toString()))
@@ -358,6 +372,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         !file("build/generated/sources/annotationProcessor/java/main/ServiceRegistryResource.txt").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files and classes are deleted when processor is removed"() {
         given:
         withProcessor(writingResourcesTo(StandardLocation.SOURCE_OUTPUT.toString()))
@@ -382,6 +397,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.deletedClasses("ServiceRegistry")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors can generate identical resources in different locations"() {
         given:
         def locations = [StandardLocation.SOURCE_OUTPUT.toString(), StandardLocation.NATIVE_HEADER_OUTPUT.toString(), StandardLocation.CLASS_OUTPUT.toString()]
@@ -408,6 +424,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         !file("build/classes/java/main/A.txt").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "an isolating processor is also a valid aggregating processor"() {
         given:
         withProcessor(new HelperProcessorFixture().withDeclaredType(IncrementalAnnotationProcessorType.AGGREGATING))
@@ -417,6 +434,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         succeeds "compileJava"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors can provide multiple originating elements"() {
         given:
         java "@Service class A {}"
@@ -426,6 +444,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         succeeds "compileJava"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "aggregating processor do not work with source retention"() {
         given:
         annotationProjectDir.file("src/main/java/Service.java").text = """
@@ -449,6 +468,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputContains("Full recompilation is required because '@Service' has source retention. Aggregating annotation processors require class or runtime retention.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "reports aggregating processor in build operation"() {
         java "class Irrelevant {}"
 
@@ -463,6 +483,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "annotation processing across projects")
     def "updating an unrelated file doesn't delete generated resources built by an aggregating processor"() {
         def locations = [StandardLocation.SOURCE_OUTPUT.toString(), StandardLocation.NATIVE_HEADER_OUTPUT.toString(), StandardLocation.CLASS_OUTPUT.toString()]
         withProcessor(new ResourceGeneratingProcessorFixture().withOutputLocations(locations).withDeclaredType(IncrementalAnnotationProcessorType.AGGREGATING))
@@ -489,6 +510,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Issue("https://github.com/gradle/gradle/issues/18840")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "a class can be aggregated with a type that it generated"() {
         given:
         withProcessor(new AnnotatedGeneratedClassProcessorFixture())
@@ -503,6 +525,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "does not reprocess if nothing in the current sourceSet changed"() {
         given:
         withProcessor(new AnnotatedGeneratedClassProcessorFixture())
@@ -520,6 +543,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Requires(JdkVersionTestPreconditions.Jdk9OrLater)
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "module-info.java does not cause exception in annotation processor handling"() {
         given:
         withProcessor(new AnnotationProcessorFixture("foo", "FooAnnotation", true).withDeclaredType(IncrementalAnnotationProcessorType.AGGREGATING))

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.compile
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.fixtures.AnnotationProcessorFixture
 import org.gradle.language.fixtures.HelperProcessorFixture
 import org.gradle.language.fixtures.NonIncrementalProcessorFixture
@@ -46,6 +47,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         withProcessor(helperProcessor)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are recompiled when annotated file changes"() {
         given:
         def a = java "@Helper class A {}"
@@ -62,6 +64,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "remembers generated files across multiple compilations"() {
         given:
         def a = java "@Helper class A {}"
@@ -80,6 +83,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are recompiled when annotated file is affected by a change"() {
         given:
         def util = java "class Util {}"
@@ -100,6 +104,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21203")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are recompiled when annotated file is affected by a change through method return type parameter"() {
         given:
         def util = java "class Util {}"
@@ -122,6 +127,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("Util", "A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "classes depending on generated files are recompiled when annotated file's ABI is affected by a change"() {
         given:
         def util = java "class Util {}"
@@ -146,6 +152,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("Util", "A", "AHelper", "AHelperResource.txt", "Dependent")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "annotation processing across projects")
     def "classes depending on generated files are not recompiled when annotated file's implementation is affected by a change"() {
         given:
         def util = java "class Util {}"
@@ -170,6 +177,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("Util", "A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "incremental processing works on subsequent incremental compilations"() {
         given:
         def a = java "@Helper class A {}"
@@ -186,6 +194,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "incremental processing works on subsequent incremental compilations after failure"() {
         given:
         def a = java "@Helper class A {}"
@@ -219,6 +228,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "annotated files are not recompiled on unrelated changes"() {
         given:
         java "@Helper class A {}"
@@ -234,6 +244,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledClasses("Unrelated")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "annotated files are not recompiled on unrelated changes even after failure"() {
         given:
         java "@Helper class A {}"
@@ -258,6 +269,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledClasses("Unrelated")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes depending on generated file are recompiled when source file changes"() {
         given:
         def a = java "@Helper class A {}"
@@ -276,6 +288,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt", "Dependent")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "source file is reprocessed when dependency of generated file changes"() {
         given:
         withProcessor(new OpaqueDependencyProcessor())
@@ -293,6 +306,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledClasses("AThingy", "Dependency")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes files of generated sources are deleted when annotated file is deleted"() {
         given:
         def a = java "@Helper class A {}"
@@ -308,6 +322,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.deletedFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files are deleted when annotated file is deleted"() {
         given:
         withProcessor(writingResourcesTo(StandardLocation.SOURCE_OUTPUT.toString()))
@@ -330,6 +345,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         !file("build/generated/sources/annotationProcessor/java/main/AHelperResource.txt").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files and classes are deleted when processor is removed"() {
         given:
         withProcessor(writingResourcesTo(StandardLocation.SOURCE_OUTPUT.toString()))
@@ -354,6 +370,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.deletedFiles("AHelper")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "all files are recompiled when processor changes"() {
         given:
         java "@Helper class A {}"
@@ -368,6 +385,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "all files are recompiled if compiler does not support incremental annotation processing"() {
         given:
         buildFile << """
@@ -392,6 +410,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputContains("the chosen compiler did not support incremental annotation processing")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "all files are recompiled if a generated source file is deleted"() {
         given:
         java "@Helper class A {}"
@@ -407,6 +426,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles('A', "AHelper", "AHelperResource.txt", "Unrelated")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "all files are recompiled if a generated class is deleted"() {
         given:
         java "@Helper class A {}"
@@ -422,6 +442,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles('A', "AHelper", "AHelperResource.txt", "Unrelated")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "all files are recompiled if a generated resource is deleted"() {
         given:
         java "@Helper class A {}"
@@ -437,6 +458,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles('A', "AHelper", "AHelperResource.txt", "Unrelated")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors must provide an originating element for each source element"() {
         given:
         withProcessor(new NonIncrementalProcessorFixture().providingNoOriginatingElements().withDeclaredType(IncrementalAnnotationProcessorType.ISOLATING))
@@ -453,6 +475,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputContains("Full recompilation is required because the generated type 'AThing' must have exactly one originating element, but had 0.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors must provide an originating element for each resource"() {
         given:
         withProcessor(new ResourceGeneratingProcessorFixture().providingNoOriginatingElements().withDeclaredType(IncrementalAnnotationProcessorType.ISOLATING))
@@ -469,6 +492,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputContains("Full recompilation is required because the generated resource 'A.txt in SOURCE_OUTPUT' must have exactly one originating element, but had 0.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "processors cannot provide multiple originating elements for types"() {
         given:
         helperProcessor.withMultipleOriginatingElements = true
@@ -490,6 +514,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputContains(" must have exactly one originating element, but had 2.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors cannot provide multiple originating elements for resources"() {
         given:
         helperProcessor.withMultipleOriginatingElements = true
@@ -510,6 +535,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputContains(" must have exactly one originating element, but had 2.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "processors can generate identical resources in different locations"() {
         given:
         def locations = [StandardLocation.SOURCE_OUTPUT.toString(), StandardLocation.NATIVE_HEADER_OUTPUT.toString(), StandardLocation.CLASS_OUTPUT.toString()]
@@ -537,6 +563,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
     }
 
     @Issue(["https://github.com/gradle/gradle/issues/8128", "https://bugs.openjdk.java.net/browse/JDK-8162455"])
+    @ToBeFixedForIsolatedProjects(because = "annotation processing across projects")
     def "incremental processing doesn't trigger unmatched processor option warning"() {
         buildFile << """
             dependencies {
@@ -557,6 +584,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledClasses("B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "reports isolating processor in build operation"() {
         java "class Irrelevant {}"
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingCompileAvoidanceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingCompileAvoidanceIntegrationTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
+@ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
 class JavaAnnotationProcessingCompileAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         settingsFile << "include 'a', 'b'"

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
@@ -27,12 +27,14 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.junit.Rule
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     @Rule
     HttpServer server
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes from cache are used when dependent class is changed in ABI compatible way"() {
         given:
         project_a_depends_on_project_b()
@@ -54,6 +56,7 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
         skipped ':a:compileJava'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "classes from cache are not used when dependent class is changed in ABI breaking way"() {
         given:
         project_a_depends_on_project_b()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
@@ -115,6 +116,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         javaClassFile("Foo.class").exists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "don't implicitly compile source files from classpath"() {
         settingsFile << "include 'a', 'b'"
         buildFile << """
@@ -277,6 +279,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         javaClassFile("com/example/Foo.class").assertDoesNotExist()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "implementation dependencies should not leak into compile classpath of consumer"() {
         mavenRepo.module('org.gradle.test', 'shared', '1.0').publish()
         mavenRepo.module('org.gradle.test', 'other', '1.0').publish()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -25,11 +25,13 @@ import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.util.internal.TextUtil
 import org.junit.Assume
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @Requires([TestExecutionPreconditions.NotParallelExecutor])
 class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3029")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "system property java.home is not modified across compile task boundaries"() {
         def projectNames = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.compile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.language.fixtures.HelperProcessorFixture
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class JavaCompileTaskOperationResultIntegTest extends AbstractIntegrationSpec {
     def setup() {
@@ -45,6 +46,7 @@ class JavaCompileTaskOperationResultIntegTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/22999")
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "listener added during doFirst of JavaCompile can subscribe to task completion events but does not get a callback"() {
         buildFile << """
             import javax.inject.Inject

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.compile.CompileJavaBuildOperationType
 import org.gradle.language.fixtures.NonIncrementalProcessorFixture
 
 import static org.gradle.api.internal.tasks.compile.CompileJavaBuildOperationType.Result.AnnotationProcessorDetails.Type.UNKNOWN
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncrementalAnnotationProcessingIntegrationTest {
 
@@ -28,6 +29,7 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         withProcessor(new NonIncrementalProcessorFixture())
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "all sources are recompiled when any class changes"() {
         def a = java "@Thing class A {}"
         java "class B {}"
@@ -42,6 +44,7 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         outputs.recompiledClasses("A", "AThing", "B")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "the user is informed about non-incremental processors"() {
         def a = java "@Thing class A {}"
 
@@ -59,6 +62,7 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "compilation is incremental if the non-incremental processor is not used"() {
         def a = java "class A {}"
         java "class B {}"
@@ -72,6 +76,7 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         outputs.recompiledClasses("A")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "incremental compilation across projects")
     def "generated files and classes are deleted when processor is removed"() {
         given:
         java "@Thing class A {}"

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
 class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
@@ -58,6 +59,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         '''
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project task configuration")
     def "does not regenerate javadoc when the upstream jar is just rebuilt without changes"() {
         given:
         succeeds(":a:javadoc")
@@ -75,6 +77,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksSkipped(":a:compileJava", ":a:processResources", ":a:classes", ":a:javadoc")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project task configuration")
     def "order of upstream jar entries does not matter"() {
         given:
         file("a/build.gradle") << '''
@@ -119,6 +122,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             ":a:compileJava", ":a:processResources", ":a:classes", ":a:javadoc")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project task configuration")
     def "timestamp of upstream jar entries does not matter"() {
         given:
         file("a/build.gradle") << '''
@@ -154,6 +158,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             ":a:compileJava", ":a:processResources", ":a:classes", ":a:javadoc")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project task configuration")
     def "duplicates in an upstream jar are not ignored"() {
         given:
         file("a/build.gradle") << '''
@@ -215,6 +220,7 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6168")
+    @ToBeFixedForIsolatedProjects(because = "cross-project task configuration")
     def "removes stale outputs from last execution"() {
         def aaJava = file('a/src/main/java/AA.java')
         aaJava << '''

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.java.compile.incremental
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class AbstractCompileAvoidanceWithIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
     def setup() {
         buildFile << """

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskConstantChangesIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskConstantChangesIncrementalCompilationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.java.compile.incremental
 
 import groovy.test.NotYetImplemented
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 abstract class AbstractCrossTaskConstantChangesIncrementalCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationSupport {
 
@@ -35,6 +36,7 @@ abstract class AbstractCrossTaskConstantChangesIncrementalCompilationIntegration
         impl.recompiledClasses('Y')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects { } used by AbstractCrossTaskIncrementalCompilationSupport")
     def "change in an upstream transitive class with non-private constant does not cause full rebuild"() {
         source api: ["class A { final static int x = 1; }", "class B extends A {}"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -47,6 +49,7 @@ abstract class AbstractCrossTaskConstantChangesIncrementalCompilationIntegration
         impl.recompiledClasses('ImplB')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects { } used by AbstractCrossTaskIncrementalCompilationSupport")
     def "private constant in upstream project does not trigger full rebuild"() {
         source api: ["class A {}", "class B { private final static int x = 1; }"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -59,6 +62,7 @@ abstract class AbstractCrossTaskConstantChangesIncrementalCompilationIntegration
         impl.noneRecompiled()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects { } used by AbstractCrossTaskIncrementalCompilationSupport")
     def "detects that changed class still has the same constants so no recompile is necessary"() {
         source api: ["class A { public static final int FOO = 123;}"],
             impl: ["class B { void foo() { int x = 123; }}"]

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
@@ -18,8 +18,10 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationSupport {
 
     def "detects change to dependency and ensures class dependency info refreshed"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskClassChangesIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskClassChangesIncrementalCompilationIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class CrossTaskClassChangesIncrementalCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationSupport {
 
     def "detects changed class in an upstream project"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskConstantChangesIncrementalGroovyCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskConstantChangesIncrementalGroovyCompilationIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class CrossTaskConstantChangesIncrementalGroovyCompilationIntegrationTest extends AbstractCrossTaskConstantChangesIncrementalCompilationIntegrationTest {
     CompiledLanguage language = CompiledLanguage.GROOVY
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskConstantChangesIncrementalJavaCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskConstantChangesIncrementalJavaCompilationIntegrationTest.groovy
@@ -18,10 +18,13 @@ package org.gradle.java.compile.incremental
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class CrossTaskConstantChangesIncrementalJavaCompilationIntegrationTest extends AbstractCrossTaskConstantChangesIncrementalCompilationIntegrationTest {
     CompiledLanguage language = CompiledLanguage.JAVA
 
@@ -277,6 +280,7 @@ abstract class CrossTaskConstantChangesIncrementalJavaCompilationIntegrationTest
     }
 
     @NotYetImplemented
+    @UnsupportedWithIsolatedProjects(because = "@NotYetImplemented test does not throw, so class-level ToBeFixedForIsolatedProjects sees unexpected success")
     // This would be possible but it's not yet implemented since we would have
     // to track every constants as (symbol, value) pair and this is expensive, so there is no solution yet
     def "ignores irrelevant changes to constant values in annotations"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationSupport {
@@ -28,6 +29,7 @@ class CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest extends Abst
     }
 
     @Issue("https://github.com/gradle/gradle/issues/22531")
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def 'incremental compilation does not fail on api change referenced via static property when affected class is #bCompileStatic#bSuffix'() {
         given:
         // A is a private dependency of B1 and B1 is referenced in E1.isCacheEnabled through inheritance.
@@ -63,6 +65,7 @@ class CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest extends Abst
         "groovy" | "@groovy.transform.CompileStatic " | ["B1", "E1", "E2"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project incremental compilation")
     def 'incremental compilation does not fail when some deleted class with Java source is private referenced in class that is loaded by Groovy'() {
         given:
         // A is a private dependency of B1 and B1 is referenced in E1.isCacheEnabled through inheritance.
@@ -118,6 +121,7 @@ class CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest extends Abst
         impl.recompiledClasses("B1", "C1", "D1", "E1", "E2")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project incremental compilation")
     def 'incremental compilation does not fail on api change when we compile only groovy in the dependent project and affected class is #bCompileStatic#bSuffix'() {
         given:
         // A is a private dependency of B and B is referenced in E.isCacheEnabled through inheritance.
@@ -145,6 +149,7 @@ class CrossTaskGroovyJavaJointIncrementalCompilationIntegrationTest extends Abst
         "groovy" | "@groovy.transform.CompileStatic " | ["B", "E"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project incremental compilation")
     def 'incremental compilation after a failure works on api dependency change'() {
         given:
         File aClass = sourceForLanguageForProject(CompiledLanguage.JAVA, "api", "class A { void m1() {}; }")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.java.compile.incremental
 
 
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 import spock.lang.Issue
 
+@ToBeFixedForIsolatedProjects(because = "subprojects/allprojects, configure projects from root")
 abstract class CrossTaskIncrementalJavaCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationIntegrationTest {
     CompiledLanguage language = CompiledLanguage.JAVA
 

--- a/platforms/jvm/language-jvm/build.gradle.kts
+++ b/platforms/jvm/language-jvm/build.gradle.kts
@@ -56,6 +56,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/platform-jvm/build.gradle.kts
+++ b/platforms/jvm/platform-jvm/build.gradle.kts
@@ -60,6 +60,4 @@ strictCompile {
     ignoreDeprecations() // most of this project has been deprecated
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/plugins-groovy/build.gradle.kts
+++ b/platforms/jvm/plugins-groovy/build.gradle.kts
@@ -61,6 +61,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.archive.JarTestFixture
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyResolutionTest {
 
@@ -119,6 +120,7 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
         'java'         | 'implementation' | false             | true                      | "jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Groovy plugin cross-project configuration")
     def "selects classes when #consumerPlugin plugin adds a project dependency to #consumerConf and producer has java-library=#groovyWithJavaLib (runtime classes variant)"() {
         given:
         multiProjectBuild('issue7398', ['groovyLib', 'javaLib']) {

--- a/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyLibraryIntegrationTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyLibraryIntegrationTest.groovy
@@ -17,10 +17,12 @@ package org.gradle.groovy
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class GroovyLibraryIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("gradle/gradle#9872")
+    @ToBeFixedForIsolatedProjects(because = "Groovy plugin cross-project configuration")
     def "extension methods should be visible to Groovy library consumers (consumer java lib=#consumerIsJavaLib, producer java library=#producerIsJavaLib, CompileStatic=#cs)"() {
         settingsFile << """
             include 'groovy-lib'

--- a/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/java/compile/AbstractGroovyCompileAvoidanceIntegrationSpec.groovy
+++ b/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/java/compile/AbstractGroovyCompileAvoidanceIntegrationSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.java.compile
 
 import org.gradle.api.internal.tasks.compile.CompilationFailedException
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJavaGroovyCompileAvoidanceIntegrationSpec {
     CompiledLanguage language = CompiledLanguage.GROOVY
@@ -100,6 +101,7 @@ abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJav
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project Groovy compilation")
     def 'always recompile if compilation avoidance is not enabled'() {
         given:
         settingsFile.text = settingsFile.text.readLines().findAll { !it.contains("enableFeaturePreview") }.join('\n')
@@ -141,6 +143,7 @@ abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJav
         executedAndNotSkipped ":b:compileGroovy"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project Groovy compilation")
     def "recompile with change of local ast transformation"() {
         given:
         executer.beforeExecute {
@@ -182,6 +185,7 @@ abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJav
         failure.assertHasCause('Bad AST transformation!')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "recompile with change of global ast transformation"() {
         given:
         executer.beforeExecute {

--- a/platforms/jvm/plugins-jvm-test-fixtures/build.gradle.kts
+++ b/platforms/jvm/plugins-jvm-test-fixtures/build.gradle.kts
@@ -54,6 +54,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/plugins-jvm-test-fixtures/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-fixtures/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.java.fixtures
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaProjectTestFixturesIntegrationTest {
     @Override
     String getPluginName() {
@@ -27,6 +29,7 @@ class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaProjectTestFixt
         compileClasspathPackaging ? [] : [':jar', ':testFixturesJar']
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Java test fixtures cross-project")
     def "can consume test fixtures of subproject written in Groovy"() {
         settingsFile << """
             include 'sub'

--- a/platforms/jvm/plugins-jvm-test-suite/build.gradle.kts
+++ b/platforms/jvm/plugins-jvm-test-suite/build.gradle.kts
@@ -53,6 +53,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.testing.toolchains.internal.TestNGTestToolchain
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
     def "new test suites adds appropriate test tasks"() {
@@ -1088,6 +1089,7 @@ This method is only meant to be called on configurations which allow the (non-de
     }
 
     @Issue("https://github.com/gradle/gradle/issues/36428")
+    @ToBeFixedForIsolatedProjects(because = "test suites cross-project")
     def "cross-project dependency manipulation with allDependencies.configureEach does not break test suite creation"() {
         given: "a multi-project build with cross-project configuration accessing allDependencies"
         settingsFile << """

--- a/platforms/jvm/plugins-test-report-aggregation/build.gradle.kts
+++ b/platforms/jvm/plugins-test-report-aggregation/build.gradle.kts
@@ -50,6 +50,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/plugins-test-report-aggregation/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-test-report-aggregation/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins
 import org.gradle.api.internal.tasks.testing.report.VerifiesGenericTestReportResults
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.startsWith
@@ -146,6 +147,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'can aggregate unit test results from dependent projects'() {
         given:
         file('application/build.gradle') << '''
@@ -174,6 +176,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedResults.assertAtLeastTestPathsExecuted("application.AdderTest", "direct.MultiplierTest", "transitive.PowerizeTest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'multiple test suites create multiple aggregation tasks'() {
         given:
         file("transitive/build.gradle") << """
@@ -280,6 +283,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedIntegTestResults.assertAtLeastTestPathsExecuted('transitive.ModTest', 'application.DivTest')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'can aggregate tests from root project'() {
         given:
         buildFile << '''
@@ -317,6 +321,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
     }
 
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'can aggregate tests from root project with different overall statuses'() {
         given:
         buildFile << '''
@@ -410,6 +415,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'can aggregate tests from root project when subproject does not have tests'() {
         given:
         buildFile << '''
@@ -439,6 +445,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedTestResults.assertAtLeastTestPathsExecuted('application.AdderTest', 'direct.MultiplierTest')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'test verification failure prevents creation of aggregated report'() {
         given:file("application/build.gradle") << """
             apply plugin: 'org.gradle.test-report-aggregation'
@@ -468,6 +475,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         file("application/build/reports/tests/test/aggregated-results").assertDoesNotExist()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'test verification failure creates aggregated report with --continue flag'() {
         given:file("application/build.gradle") << """
             apply plugin: 'org.gradle.test-report-aggregation'
@@ -508,6 +516,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedResults.assertAtLeastTestPathsExecuted("application.AdderTest", "direct.MultiplierTest", "transitive.PowerizeTest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'test aggregated report can be put into a custom location'() {
         given:
         // Reordering the plugins so that Java is applied later
@@ -535,6 +544,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedResults.assertTestClassesExecuted("application.AdderTest", "direct.MultiplierTest", "transitive.PowerizeTest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def 'catastrophic failure of single test prevents creation of aggregated report'() {
         given:
         file("application/build.gradle") << """
@@ -604,6 +614,7 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
     }
 
     @Issue("https://github.com/gradle/gradle/issues/29820")
+    @ToBeFixedForIsolatedProjects(because = "aggregation plugin resolves subproject artifacts at config time")
     def "can aggregate when a jar file dependency is used"() {
         buildFile("application/build.gradle", """
             apply plugin: 'org.gradle.test-report-aggregation'

--- a/platforms/jvm/scala/build.gradle.kts
+++ b/platforms/jvm/scala/build.gradle.kts
@@ -85,6 +85,4 @@ packageCycles {
     excludePatterns.add("org/gradle/language/scala/tasks/*")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.plugins.scala.ScalaBasePlugin
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.ScalaCoverage
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
@@ -45,6 +46,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6558")
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "can build in parallel with lazy tasks"() {
         createDirs("a", "b", "c", "d")
         settingsFile << """
@@ -89,6 +91,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6735")
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "can depend on the source set of another Java project"() {
         createDirs("java", "scala")
         settingsFile << """
@@ -122,6 +125,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6750")
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "can depend on Scala project from other project"() {
         createDirs("other", "scala")
         settingsFile << """
@@ -164,6 +168,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/7014")
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "can use Scala with war and ear plugins"() {
         createDirs("war", "ear")
         settingsFile << """
@@ -273,6 +278,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6854")
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "dependencies task does not show FAILED entries for incremental Scala analysis configurations"() {
         given:
         createDirs("producer", "consumer")

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileMultiProjectTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileMultiProjectTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.scala.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ScalaCoverage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 
+@ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
 class ScalaCompileMultiProjectTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
     def setup() {
         buildFile << """

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.scala.compile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ScalaCoverage
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
@@ -32,6 +33,7 @@ class ScalaCompileWithJavaLibraryIntegrationTest extends AbstractIntegrationSpec
         executer.withRepositoryMirrors()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "multi-project test fixture configures from root")
     def javaLibraryCanDependOnScalaLibraryProject() {
         when:
         run ":compileJava"

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.scala.compile
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ScalaCoverage
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
 import org.junit.Assume
@@ -143,6 +144,7 @@ class ZincScalaCompilerIntegrationTest extends BasicZincScalaCompilerIntegration
         other.lastModified() == old(other.lastModified())
     }
 
+    @ToBeFixedForIsolatedProjects(because = "subprojects, configure projects from root")
     def "compiles Scala incrementally across project boundaries"() {
         file("settings.gradle") << """include 'a', 'b'"""
         // overwrite the build file from setup

--- a/platforms/jvm/testing-jvm/build.gradle.kts
+++ b/platforms/jvm/testing-jvm/build.gradle.kts
@@ -92,6 +92,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/internal/tasks/testing/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing
 import com.google.common.base.Utf8
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.SafeFileLocationUtils
 import org.gradle.internal.jvm.SupportedJavaVersions
 import org.gradle.test.fixtures.file.TestFile
@@ -187,6 +188,7 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
     }
 
     @Requires(TestEnvironmentPreconditions.Online)
+    @ToBeFixedForIsolatedProjects(because = "include 'dependency' without a per-subproject build script")
     def "re-runs tests when resources are renamed in a jar"() {
         given:
         buildFile << """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.testsuites.dependencies
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegrationSpec {
     // region basic functionality
@@ -211,6 +212,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
         succeeds 'checkConfiguration'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def 'can add dependencies to other projects to #suiteDesc'() {
         given:
         multiProjectBuild('root', ['consumer', 'util']) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing.testsuites.dependencies
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.dsl.GradleDsl
 
 class TestSuitesKotlinDSLDependenciesIntegrationTest extends AbstractIntegrationSpec {
@@ -223,6 +224,7 @@ class TestSuitesKotlinDSLDependenciesIntegrationTest extends AbstractIntegration
         succeeds 'checkConfiguration'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def 'can add dependencies to other projects to #suiteDesc'() {
         given:
         settingsKotlinFile << """

--- a/platforms/jvm/toolchains-jvm/build.gradle.kts
+++ b/platforms/jvm/toolchains-jvm/build.gradle.kts
@@ -91,6 +91,4 @@ packageCycles {
     excludePatterns.add("org/gradle/jvm/toolchain/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/war/build.gradle.kts
+++ b/platforms/jvm/war/build.gradle.kts
@@ -66,6 +66,4 @@ gradleModule {
 packageCycles {
     excludePatterns.add("org/gradle/api/plugins/internal/*")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/jvm/war/src/integTest/groovy/org/gradle/integtests/MixedJavaAndWebProjectIntegrationTest.groovy
+++ b/platforms/jvm/war/src/integTest/groovy/org/gradle/integtests/MixedJavaAndWebProjectIntegrationTest.groovy
@@ -16,7 +16,9 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root")
 class MixedJavaAndWebProjectIntegrationTest extends AbstractIntegrationSpec {
     def "project can use classes from WAR project"() {
         given:

--- a/platforms/native/language-native/build.gradle.kts
+++ b/platforms/native/language-native/build.gradle.kts
@@ -87,6 +87,4 @@ packageCycles {
     excludePatterns.add("org/gradle/language/nativeplatform/internal/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
@@ -16,7 +16,10 @@
 
 package org.gradle.language
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 abstract class AbstractNativeLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "C++/Swift cross-project native component config")
     def "can define api dependencies on component"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppApp
@@ -365,6 +366,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/some-app").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a library"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -398,6 +400,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against a library when specifying multiple target machines"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -435,6 +438,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "fails when dependency library does not specify the same target machines"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -469,6 +473,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         failure.assertHasCause("No matching variant of project ':greeter' was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName.toLowerCase()}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "fails when dependency library does not specify the same target architecture"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -544,6 +549,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         succeeds "compileDebug"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against a library with explicit target machine defined"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -581,6 +587,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "fails compile and link against a library with different operating system family support"() {
         createDirs("app", "hello")
         settingsFile << """
@@ -623,6 +630,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
           - Doesn't say anything about org.gradle.native.optimized (required 'false')"""
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against a static library"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -658,6 +666,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against a library with both linkages defined"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -693,6 +702,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a library with debug and release variants"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -742,6 +752,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("app/build/install/main/debug").exec().out == app.withFeatureDisabled().expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against library with api and implementation dependencies"() {
         createDirs("app", "deck", "card", "shuffle")
         settingsFile << "include 'app', 'deck', 'card', 'shuffle'"
@@ -791,6 +802,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against a static library with api and implementation dependencies"() {
         createDirs("app", "deck", "card", "shuffle")
         settingsFile << "include 'app', 'deck', 'card', 'shuffle'"
@@ -843,6 +855,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "honors changes to library buildDir"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -889,6 +902,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         sharedLibrary("app/build/install/main/debug/lib/lib2").file.assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "honors changes to library output locations"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -941,6 +955,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         file("app/build/install/main/debug/lib/lib1_debug.dll").assertIsFile()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "honors changes to library public header location"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -992,6 +1007,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         sharedLibrary("app/build/install/main/debug/lib/lib2").file.assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "multiple components can share the same source directory"() {
         createDirs("app", "greeter", "logger")
         settingsFile << "include 'app', 'greeter', 'logger'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.VariantContext
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -160,6 +161,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
         installation.exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish an executable and library to a Maven repository"() {
         def app = new CppAppWithLibrary()
 
@@ -243,6 +245,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
         installation.exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish an executable and a binary-specific dependency to a Maven repository"() {
         def app = new CppAppWithLibrary()
         def logger = new CppLogger().asLib()
@@ -337,6 +340,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
         installation.exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "uses the basename to calculate the coordinates"() {
         def app = new CppAppWithLibrary()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBinariesRelocationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBinariesRelocationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppBinariesRelocationIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
     def setup() {
@@ -72,6 +73,7 @@ class CppBinariesRelocationIntegrationTest extends AbstractInstalledToolChainInt
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can execute application with dependencies when relocated"() {
         def installDir = file("build/install/main/debug")
         def relocatedInstallDir = file("relocated-install")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCachingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCachingIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements DirectoryBuildCacheFixture, CppTaskNames {
     CppAppWithLibraries app = new CppAppWithLibraries()
@@ -50,6 +51,7 @@ class CppCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpe
         app.main.writeToProject(project)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def 'compilation can be cached (#buildType)'() {
         setupProject()
 
@@ -79,6 +81,7 @@ class CppCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpe
         buildType << [debug, release]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "compilation task is relocatable for release"() {
 
         def originalLocation = file('original-location')

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -22,12 +22,14 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.gradle.vcs.git.GitVersionControlSpec
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def app = new CppAppWithLibraries()
     @Rule
     GitFileRepository repo = new GitFileRepository(testDirectory)
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can combine C++ builds in a composite"() {
         given:
         createDirs("app", "hello", "log")
@@ -56,6 +58,7 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
 
     // NOTE: This method is named in a short way because of the maximum path length
     // on Windows.
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def app = new CppAppWithLibraries()
@@ -33,6 +34,7 @@ class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChai
     }
 
     @Issue("https://github.com/gradle/gradle-native/issues/994")
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can depends on library with generated headers"() {
         given:
         writeHelloLibrary { TestFile libraryPath ->
@@ -59,6 +61,7 @@ class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChai
     }
 
     @Issue("https://github.com/gradle/gradle-native/issues/994")
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can transitively depends on library with generated headers"() {
         given:
         writeHelloLibrary()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
@@ -24,6 +25,7 @@ import org.gradle.test.fixtures.file.TestFile
 
 import static org.junit.Assume.assumeFalse
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
 class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
     private static final String LIBRARY = ':library'

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleLinkOutputApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleLinkOutputAppWithLib
 import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleLinkOutputLib
 import org.gradle.nativeplatform.fixtures.app.SourceElement
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
@@ -78,6 +79,7 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "removes stale installed executable and library file when all source files for executable are removed"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.hamcrest.CoreMatchers
 
 import static org.gradle.util.Matchers.containsText
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements CppTaskNames {
 
@@ -348,6 +349,7 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against implementation and api libraries"() {
         createDirs("lib1", "lib2", "lib3")
         settingsFile << "include 'lib1', 'lib2', 'lib3'"
@@ -393,6 +395,7 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("lib3/build/lib/main/release/lib3").strippedRuntimeFile.assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can compile and link against static implementation and api libraries"() {
         createDirs("lib1", "lib2", "lib3")
         settingsFile << "include 'lib1', 'lib2', 'lib3'"
@@ -438,6 +441,7 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("lib1/build/lib/main/release/lib1").strippedRuntimeFile.assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "private headers are not visible to consumer"() {
         def lib = new CppLib()
 
@@ -478,6 +482,7 @@ project(':greeter') {
         succeeds(":consumer:compileDebugCpp")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "implementation dependencies are not visible to consumer"() {
         def app = new CppAppWithLibraries()
 
@@ -515,6 +520,7 @@ project(':greeter') {
         succeeds(":consumer:compileDebugCpp")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can change default base name and successfully link against library"() {
         createDirs("lib1", "lib2")
         settingsFile << "include 'lib1', 'lib2'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -35,6 +35,7 @@ import static org.gradle.nativeplatform.MachineArchitecture.X86_64
 import static org.gradle.nativeplatform.OperatingSystemFamily.LINUX
 import static org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import static org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrationTest implements CppTaskNames {
 
@@ -147,6 +148,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         releaseRuntime.files[0].url == withSharedLibrarySuffix("test_release-1.2")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish a library and its dependencies to a Maven repository"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -267,6 +269,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish a library with external dependencies to a Maven repository"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -381,6 +384,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "uses base name of library to calculate coordinates"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -576,6 +580,7 @@ library.publicHeaders.from 'src/main/public', 'src/main/headers'
         succeeds("compileDebugCpp")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "implementation dependencies are not visible to consumer"() {
         def app = new CppAppWithLibraries()
         def repoDir = file("repo")
@@ -693,6 +698,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6766")
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     void "configuration exclusions are published in generated POM and Gradle metadata"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -744,6 +750,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish a library and its dependencies to a Maven repository when multiple target operating systems are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(WINDOWS, currentArchitecture), machine(LINUX, currentArchitecture), machine(MACOS, currentArchitecture)]
@@ -814,6 +821,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]
@@ -884,6 +892,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "fails when a dependency is published without a matching target architecture"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.cpp
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.VariantContext
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -29,6 +30,7 @@ import static org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import static org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
 
 class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "can publish a library and its dependencies to a Maven repository when multiple target operating systems are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(WINDOWS, currentArchitecture), machine(LINUX, currentArchitecture), machine(MACOS, currentArchitecture)]
@@ -97,6 +99,7 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.AvailableToolChains.InstalledToolChain
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.opentest4j.TestAbortedException
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CppToolChainChangesIntegrationTest extends AbstractIntegrationSpec {
 
@@ -54,6 +55,7 @@ class CppToolChainChangesIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "C++ uses allprojects/subprojects (software model)")
     def "recompiles binary when toolchain changes from #toolChainBefore to #toolChainAfter"() {
         buildFile.text = buildScriptForToolChains(toolChainBefore, toolChainAfter)
         def useAlternateToolChain = false

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunction
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLogger
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLoggerApi
@@ -30,6 +31,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "Swift/C++ interop uses allprojects/subprojects (software model)")
     def "can compile and link against a #linkage.toLowerCase() c++ library"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"
@@ -71,6 +73,7 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a c++ library with both static and shared linkages"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"
@@ -102,6 +105,7 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         installation("app/build/install/main/debug").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift/C++ interop uses allprojects/subprojects (software model)")
     def "can compile and link against a library with a dependency on a #linkage.toLowerCase() c++ library"() {
         createDirs("app", "greeter", "cppGreeter")
         settingsFile << "include 'app', 'greeter', 'cppGreeter'"
@@ -159,6 +163,7 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift/C++ interop uses allprojects/subprojects (software model)")
     def "can compile and link against a #linkage.toLowerCase() c++ library with a dependency on another c++ library"() {
         createDirs("app", "greeter", "cppGreeter", "logger")
         settingsFile << "include 'app', 'greeter', 'cppGreeter', ':logger'"
@@ -210,6 +215,7 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against a c++ library with an api dependency on another c++ library"() {
         createDirs("app", "greeter", "cppGreeter", "logger")
         settingsFile << "include 'app', 'greeter', 'cppGreeter', ':logger'"
@@ -250,6 +256,7 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         installation("app/build/install/main/debug").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "declaring a dependency on a c++ library without public headers does not fail"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.swift
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
@@ -62,6 +63,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         return "application"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "relinks when an upstream dependency changes in ABI compatible way"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -97,6 +99,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("app/build/install/main/debug").exec().out == app.expectedOutput.replace("Hello", "Goodbye")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "recompiles when an upstream dependency changes in non-ABI compatible way"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -390,6 +393,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("build/some-app").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against a library"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -421,6 +425,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation.assertIncludesLibraries("Greeter")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against a library specifying target machines"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -458,6 +463,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation.assertIncludesLibraries("Greeter")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "fails when dependency library does not specify the same target machines"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -493,6 +499,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
                                "  - No variants exist.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a static library"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -526,6 +533,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation.assertIncludesLibraries()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a library with both linkage defined"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -559,6 +567,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation.assertIncludesLibraries("Greeter")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against library with API dependencies"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"
@@ -611,6 +620,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("app/build/install/main/release").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against static library with API dependencies"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"
@@ -666,6 +676,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("app/build/install/main/release").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against static library with API dependencies to shared library"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"
@@ -721,6 +732,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("app/build/install/main/release").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can compile and link against shared library with API dependencies to static library"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"
@@ -776,6 +788,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("app/build/install/main/release").exec().out == app.expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a library with debug and release variants"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -823,6 +836,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         executable("app/build/exe/main/debug/App").exec().out == app.withFeatureDisabled().expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against a static library with debug and release variants"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -869,6 +883,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         executable("app/build/exe/main/debug/App").exec().out == app.withFeatureDisabled().expectedOutput
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "honors changes to library buildDir"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"
@@ -910,6 +925,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         sharedLibrary("app/build/install/main/debug/lib/Log").file.assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "multiple components can share the same source directory"() {
         createDirs("app", "hello", "log")
         settingsFile << "include 'app', 'hello', 'log'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftCachingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftCachingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.swift
 
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -26,6 +27,7 @@ import org.gradle.test.fixtures.file.TestFile
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
+@ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
 class SwiftCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements DirectoryBuildCacheFixture {
 
     def app = new SwiftAppWithLibraries()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
@@ -19,11 +19,13 @@ package org.gradle.language.swift
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithCppLibrary
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.vcs.fixtures.GitFileRepository
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 class SwiftDependenciesCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
     def app = new SwiftAppWithCppLibrary()
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can depend on both swift and cpp libraries from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -28,6 +29,7 @@ import org.gradle.vcs.fixtures.GitFileRepository
 class SwiftDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def app = new SwiftAppWithLibraries()
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can combine swift builds in a composite"() {
         given:
         createDirs("app", "hello", "log")
@@ -54,6 +56,7 @@ class SwiftDependenciesIntegrationTest extends AbstractInstalledToolChainIntegra
         assertAppHasOutputFor("release")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can depend on swift libraries from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.language.swift
 
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -78,6 +79,7 @@ class SwiftIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInt
         result.assertTasksSkipped(assembleAppTasks)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "rebuilds application when a single source file in library changes"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCppInteroperabilityIntegrationTest.groovy
@@ -19,8 +19,10 @@ package org.gradle.language.swift
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepHeadersApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepModuleMapApp
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "relinks but does not recompile when c++ sources change"() {
         def app = new IncrementalSwiftModifyCppDepApp()
         createDirs("app", "cppGreeter")
@@ -70,6 +72,7 @@ class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         result.assertTasksSkipped(":cppGreeter:compileDebugCpp", ":cppGreeter:linkDebug", ":app:compileDebugSwift", ":app:linkDebug", ":app:installDebug", ":app:assemble")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "recompiles when c++ headers change"() {
         def app = new IncrementalSwiftModifyCppDepHeadersApp()
         createDirs("app", "cppGreeter")
@@ -119,6 +122,7 @@ class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         result.assertTasksSkipped(":cppGreeter:compileDebugCpp", ":cppGreeter:linkDebug", ":app:compileDebugSwift", ":app:linkDebug", ":app:installDebug", ":app:assemble")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "regenerates module map and recompiles swift app when headers change"() {
         def app = new IncrementalSwiftModifyCppDepModuleMapApp()
         createDirs("app", "cppGreeter")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunction
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLogger
@@ -24,6 +25,7 @@ import org.gradle.nativeplatform.fixtures.app.SwiftGreeterUsingCppFunction
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
+@ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
 class SwiftLibraryCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
 
     def "can compile and link against a #linkage.toLowerCase() c++ library"() {

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.swift
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.AbstractNativeLibraryDependenciesIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -25,6 +26,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDependenciesIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile against a library with implementation dependencies"() {
         createDirs("lib1", "lib2")
         settingsFile << """
@@ -70,6 +72,7 @@ class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDepen
         result.assertTasksScheduled([":lib1:compileDebugSwift", ":lib1:linkDebug", ":lib2:compileDebugSwift", ":lib2:linkDebug"], assembleDevBinaryTasks, assembleDevBinaryTask)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile against a library with binary-specific implementation dependencies"() {
         createDirs("lib1", "lib2")
         settingsFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.swift
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -266,6 +267,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
     def "can compile and link against another library"() {
         createDirs("hello", "log")
         settingsFile << "include 'hello', 'log'"
@@ -302,6 +304,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         sharedLibrary("log/build/lib/main/release/Log").assertHasDebugSymbolsFor(app.logLibrary.sourceFileNames)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift uses allprojects/subprojects (software model)")
     def "can change default module name and successfully link against library"() {
         createDirs("lib1", "lib2")
         settingsFile << "include 'lib1', 'lib2'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerCppBuildExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerCppBuildExportIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.swiftpm
 
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppLib
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SwiftPackageManagerCppBuildExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
     def "produces manifest for single project C++ library that defines only the production targets"() {
@@ -66,6 +67,7 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "produces manifest for multi project C++ build"() {
         given:
         createDirs("lib1", "lib2")
@@ -197,6 +199,7 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "honors customization of component basename"() {
         given:
         createDirs("lib1", "lib2")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.swiftpm
 
 import org.gradle.util.internal.VersionNumber
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SwiftPackageManagerExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "produces manifest for build with no native components"() {
         given:
         createDirs("lib1", "lib2")
@@ -75,6 +77,7 @@ let package = Package(
         file("Package.swift").assertDoesNotExist()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "can exclude certain products from the generated file"() {
         given:
         createDirs("lib1", "lib2", "app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerIncrementalExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerIncrementalExportIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.swiftpm
 
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
     def swiftBuild() {
@@ -107,6 +108,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "regenerates manifest when Swift components added or removed"() {
         given:
         swiftBuild()
@@ -155,6 +157,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "regenerates manifest when Swift dependencies added or removed"() {
         given:
         settingsFile << """
@@ -216,6 +219,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "ignores irrelevant changes to Swift source"() {
         given:
         swiftBuild()
@@ -235,6 +239,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "ignores irrelevant changes to Swift build"() {
         given:
         swiftBuild()
@@ -298,6 +303,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         !file("Package.swift").text.contains('main.cpp')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "regenerates manifest when C++ components added or removed"() {
         given:
         swiftBuild()
@@ -346,6 +352,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "ignores irrelevant changes to C++ source"() {
         given:
         cppBuild()
@@ -368,6 +375,7 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "ignores irrelevant changes to C++ build"() {
         given:
         cppBuild()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SwiftPackageManagerSwiftBuildExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
 
@@ -67,6 +68,7 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "produces manifest for multi-project Swift build"() {
         given:
         createDirs("hello", "log")
@@ -240,6 +242,7 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "Swift Package Manager export uses allprojects")
     def "honors customizations to Swift module name"() {
         given:
         createDirs("lib1", "lib2")

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.language
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
 abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def setup() {
         settingsFile << """

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
@@ -16,7 +16,10 @@
 
 package org.gradle.language
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 abstract class AbstractNativeProductionComponentDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "C++/Swift cross-project native component config")
     def "can define different implementation dependencies on each binary"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeUnitTestComponentDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeUnitTestComponentDependenciesIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.language
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
+@ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Cpp/Swift build")
 abstract class AbstractNativeUnitTestComponentDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec  {
     def setup() {
         settingsFile << """

--- a/platforms/native/platform-native/build.gradle.kts
+++ b/platforms/native/platform-native/build.gradle.kts
@@ -89,6 +89,4 @@ packageCycles {
     excludePatterns.add("org/gradle/nativeplatform/toolchain/internal/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -30,6 +30,7 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPAT
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32_AND_64
 import static org.junit.Assume.assumeTrue
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 
 @Requires(TestEnvironmentPreconditions.CanInstallExecutable)
 class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -172,6 +173,7 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executable(toolChains.dir.file("build/exe/main/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def multiProject() {
         given:
         sample multiProject

--- a/platforms/native/plugins-model-native/build.gradle.kts
+++ b/platforms/native/plugins-model-native/build.gradle.kts
@@ -78,6 +78,4 @@ packageCycles {
     excludePatterns.add("org/gradle/nativeplatform/internal/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelMultiProjectIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelMultiProjectIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
 import org.gradle.ide.visualstudio.fixtures.MSBuildExecutor
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
@@ -26,6 +27,7 @@ import org.gradle.plugins.ide.internal.IdePlugin
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
+@UnsupportedWithIsolatedProjects(because = "software model")
 class VisualStudioSoftwareModelMultiProjectIntegrationTest extends AbstractVisualStudioIntegrationSpec {
     Set<String> projectConfigurations = ['debug', 'release'] as Set
 

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryBinariesIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryBinariesIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.nativeplatform
 
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.test.precondition.Requires
@@ -104,6 +105,7 @@ model {
             .exec().out == "Hello staticHello shared"
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "executable can use a combination of libraries from the same and other projects"() {
         given:
         settingsFile << """

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryDependenciesIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.nativeplatform
 
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.ExeWithDiamondDependencyHelloWorldApp
@@ -44,6 +45,7 @@ class LibraryDependenciesIntegrationTest extends AbstractInstalledToolChainInteg
 """
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "produces reasonable error message when referenced library #label"() {
         given:
         def app = new CppHelloWorldApp()
@@ -180,6 +182,7 @@ model {
         executable("build/exe/main/main").exec().out == app.englishOutput
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "can use map notation to reference library in different project"() {
         given:
         def app = new CppHelloWorldApp()
@@ -217,6 +220,7 @@ project(":lib") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "can use map notation to reference library in different project with configure-on-demand"() {
         given:
         def app = new CppHelloWorldApp()
@@ -255,6 +259,7 @@ project(":lib") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "can use map notation to transitively reference libraries in different projects"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()
@@ -302,6 +307,7 @@ project(":greet") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "can have component graph with project dependency cycle"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 
@@ -200,6 +201,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         output.contains('Some non-buildable components were not shown, use --non-buildable or --all to show them.')
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "displays dependents across projects in a build"() {
         given:
         settingsFile.text = multiProjectSettings()
@@ -236,6 +238,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     }
 
     @Requires(TestExecutionPreconditions.NotParallelExecutor)
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "can show dependent components in parallel"() {
         given: 'a multiproject build'
         settingsFile.text = multiProjectSettings()
@@ -418,6 +421,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
             '''.stripIndent().trim()
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "circular dependencies across projects are handled gracefully"() {
         given:
         settingsFile.text = multiProjectSettings()

--- a/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
+++ b/platforms/native/plugins-model-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.nativeplatform
 
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjects
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativePlatformsTestFixture
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
@@ -189,6 +190,7 @@ model {
         installation("build/install/main").exec().out == app.frenchOutput
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "locates prebuilt library in another project"() {
         given:
         app.executable.writeSources(file("projectA/src/main"))
@@ -330,6 +332,7 @@ model {
         failure.assertHasCause("Could not locate library 'other' required by 'main' in project ':'.")
     }
 
+    @UnsupportedWithIsolatedProjects(because = "software model")
     def "produces reasonable error message when prebuilt library does not exist in a different project"() {
         given:
         settingsFile.text = "include ':projectA', ':projectB'"

--- a/platforms/native/testing-native/build.gradle.kts
+++ b/platforms/native/testing-native/build.gradle.kts
@@ -55,6 +55,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestCppInteroperabilityIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.xctest
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.language.swift.AbstractSwiftMixedLanguageIntegrationTest
 import org.gradle.language.swift.SwiftTaskNames
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
@@ -33,6 +34,7 @@ import static org.gradle.test.preconditions.TestEnvironmentPreconditions.HasXCTe
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 @Requires(HasXCTest)
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@ToBeFixedForIsolatedProjects(because = "configure projects from root")
 class SwiftXCTestCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest implements XCTestExecutionResult, SwiftTaskNames {
     @Override
     def getSwiftToolChain() {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.test.xctest
 
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.internal.tasks.testing.report.VerifiesGenericTestReportResults
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -37,6 +38,7 @@ import static org.gradle.util.Matchers.containsText
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
 @Requires(TestEnvironmentPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
+@ToBeFixedForIsolatedProjects(because = "downstream of multi-project build abort due to configure projects from root")
 class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements VerifiesGenericTestReportResults {
     def "fails when working directory is invalid"() {
         buildWithApplicationAndDependencies()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.test.xctest
 
 import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.swift.SwiftTaskNames
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
@@ -163,6 +164,7 @@ apply plugin: 'xctest'
         lib.assertTestCasesRan(testExecutionResult)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Swift build")
     def "can specify a test dependency on another library"() {
         def lib = new SwiftLib()
         def test = new SwiftLibTest(lib, lib.greeter, lib.sum, lib.multiply)
@@ -419,6 +421,7 @@ apply plugin: 'swift-library'
         test.assertTestCasesRan(testExecutionResult)
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Swift build")
     def 'can build xctest bundle which transitively depends on other Swift libraries'() {
         given:
         def app = new SwiftAppWithLibraries()
@@ -459,6 +462,7 @@ apply plugin: 'swift-library'
             tasks.debug.compile, tasks.test.relocate, tasks.test.allToInstall, ':xcTest', ':test')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root in multi-project Swift build")
     def 'can run xctest in swift package manager layout'() {
         given:
         def app = new SwiftAppWithLibraries()

--- a/platforms/software/ivy/build.gradle.kts
+++ b/platforms/software/ivy/build.gradle.kts
@@ -82,6 +82,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy
 
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class IvyGradleModuleMetadataPublishIntegrationTest extends AbstractIvyPublishIntegTest {
     def setup() {
@@ -415,6 +416,7 @@ class TestCapability implements Capability {
         module.parsedModuleMetadata.attributes['org.gradle.status'] == 'milestone'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "maps project dependencies"() {
         given:
         createDirs("a", "b")

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
@@ -17,6 +17,8 @@
 
 package org.gradle.api.publish.ivy
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
 
     def "can publish single jar with specified coordinates"() {
@@ -189,6 +191,7 @@ class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
         outputContains("Multiple publications with coordinates 'org.example:duplicate-publications:1.0' are published to repository 'ivy'. The publications 'main' in root project 'duplicate-publications' and 'other' in root project 'duplicate-publications' will overwrite each other!")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "warns when publications in different projects share the same coordinates"() {
         given:
         createDirs("projectA", "projectB")

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -16,11 +16,14 @@
 
 package org.gradle.api.publish.ivy
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class IvyPublishMultiProjectIntegTest extends AbstractIvyPublishIntegTest {
     def project1 = javaLibrary(ivyRepo.module("org.gradle.test", "project1", "1.0"))
     def project2 = javaLibrary(ivyRepo.module("org.gradle.test", "project2", "2.0"))
     def project3 = javaLibrary(ivyRepo.module("org.gradle.test", "project3", "3.0"))
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "project dependencies are correctly bound to published project"() {
         createBuildScripts("")
 
@@ -41,6 +44,7 @@ class IvyPublishMultiProjectIntegTest extends AbstractIvyPublishIntegTest {
         resolveArtifacts(project1) { expectFiles 'project1-1.0.jar', 'project2-2.0.jar', 'project3-3.0.jar' }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "project dependencies reference publication identity of dependent project"() {
         def project3 = javaLibrary(ivyRepo.module("changed.org", "changed-module", "changed"))
 
@@ -73,6 +77,7 @@ project(":project3") {
         resolveArtifacts(project1) { expectFiles 'changed-module-changed.jar', 'project1-1.0.jar', 'project2-2.0.jar' }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "reports failure when project dependency references a project with multiple conflicting publications"() {
         createBuildScripts("""
 project(":project2") {
@@ -105,6 +110,7 @@ Found the following publications in project ':project2':
   - Ivy publication 'extra' with coordinates extra.org:extra-module-2:extra"""
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "referenced project can have additional non-component publications"() {
         createBuildScripts("""
 project(":project3") {
@@ -124,6 +130,7 @@ project(":project3") {
         succeeds "publish"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "referenced project can have multiple additional publications that contain a child of some other publication"() {
         createBuildScripts("""
 // TODO - replace this with a public API when available
@@ -163,6 +170,7 @@ project(":project3") {
         project1.assertApiDependencies("org.gradle.test:project2:2.0", "custom:custom3:456")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "ivy-publish plugin does not take archivesBaseName into account"() {
         createBuildScripts("""
 project(":project2") {

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SamplesIvyPublishIntegrationTest extends AbstractSampleIntegrationTest {
     @Rule
@@ -46,6 +47,7 @@ class SamplesIvyPublishIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("integration-tests/ivy-publish/java-multi-project")
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "java-multi-project sample with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)

--- a/platforms/software/maven/build.gradle.kts
+++ b/platforms/software/maven/build.gradle.kts
@@ -89,6 +89,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/artifacts/maven/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MavenGradleModuleMetadataPublishIntegrationTest extends AbstractMavenPublishIntegTest {
     def setup() {
@@ -424,6 +425,7 @@ class TestCapability implements Capability {
         true    | true
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "maps project dependencies"() {
         given:
         createDirs("a", "b")

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCoordinatesIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCoordinatesIntegTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.publish.maven
 
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MavenPublishCoordinatesIntegTest extends AbstractMavenPublishIntegTest {
 
@@ -195,6 +196,7 @@ class MavenPublishCoordinatesIntegTest extends AbstractMavenPublishIntegTest {
         outputContains("Multiple publications with coordinates 'org.example:duplicate-publications:1.0' are published to repository 'mavenLocal'. The publications 'main' in root project 'duplicate-publications' and 'other' in root project 'duplicate-publications' will overwrite each other!")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "warns when publications in different projects share the same coordinates"() {
         given:
         createDirs("projectA", "projectB")

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -25,6 +25,7 @@ import org.spockframework.util.TextUtil
 import spock.lang.Issue
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 /**
  * Tests for bugfixes to maven publishing scenarios
@@ -112,6 +113,7 @@ publishing {
     }
 
     @Issue("GRADLE-2837")
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "project is properly configured when it is the target of a project dependency"() {
         given:
         mavenRepo.module("org.gradle", "dep", "1.1").publish()
@@ -218,6 +220,7 @@ subprojects {
     }
 
     @Issue("GRADLE-3318")
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "can reference rule-source tasks from sub-projects"() {
         given:
         using m2

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenJavaPlatformModule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
     MavenJavaPlatformModule javaPlatform = javaPlatform(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
@@ -88,6 +89,7 @@ class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "can define a platform with local projects"() {
         given:
         settingsFile << """
@@ -149,6 +151,7 @@ class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "can define a platform with local projects with customized artifacts"() {
         given:
         createDirs("core", "utils")

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MavenPublishMultiProjectIntegTest extends AbstractMavenPublishIntegTest {
     def project1 = javaLibrary(mavenRepo.module("org.gradle.test", "project1", "1.0"))
     def project2 = javaLibrary(mavenRepo.module("org.gradle.test", "project2", "2.0"))
     def project3 = javaLibrary(mavenRepo.module("org.gradle.test", "project3", "3.0"))
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "project dependency correctly reflected in POM"() {
         createBuildScripts()
 
@@ -34,6 +36,7 @@ class MavenPublishMultiProjectIntegTest extends AbstractMavenPublishIntegTest {
         projectsCorrectlyPublished()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "project dependencies reference publication identity of dependent project (version mapping: #mapping)"() {
         def project3 = javaLibrary(mavenRepo.module("changed.group", "changed-artifact-id", "changed"))
 
@@ -87,6 +90,7 @@ project(":project1") {
         mapping << [false, true]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "reports failure when project dependency references a project with multiple conflicting publications"() {
         createBuildScripts("""
 project(":project2") {
@@ -119,6 +123,7 @@ Found the following publications in project ':project2':
   - Maven publication 'extra' with coordinates extra.group:extra:extra"""
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "referenced project can have additional non-component publications"() {
         createBuildScripts("""
 project(":project3") {
@@ -138,6 +143,7 @@ project(":project3") {
         succeeds "publish"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "referenced project can have multiple additional publications that contain a child of some other publication"() {
         createBuildScripts("""
 // TODO - replace this with a public API when available
@@ -176,6 +182,7 @@ project(":project3") {
         project1.assertApiDependencies("org.gradle.test:project2:2.0", "custom:custom3:456")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "maven-publish plugin does not take archivesBaseName into account when publishing"() {
         createBuildScripts("""
 project(":project2") {
@@ -294,6 +301,7 @@ project(":project2") {
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "publish and resolve java-library with dependency on java-platform (named #platformName)"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishWarProjectIntegTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class MavenPublishWarProjectIntegTest extends AbstractMavenPublishIntegTest {
     void "publishes war and meta-data for web component with external dependencies"() {
@@ -70,6 +71,7 @@ class MavenPublishWarProjectIntegTest extends AbstractMavenPublishIntegTest {
         resolveArtifacts(webModule) { expectFiles "project1-1.9.war" }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     void "publishes war and meta-data for web component with project dependencies"() {
         given:
         createDirs("projectWeb", "depProject1", "depProject2")

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
     @Rule
@@ -103,6 +104,7 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("integration-tests/maven-publish/customize-identity")
+    @ToBeFixedForIsolatedProjects(because = "publishing plugin accesses subproject state at config time")
     def "customize publication identity with #dsl dsl"() {
         given:
         def sampleDir = sampleProject.dir.file(dsl)

--- a/platforms/software/platform-base/build.gradle.kts
+++ b/platforms/software/platform-base/build.gradle.kts
@@ -54,6 +54,4 @@ packageCycles {
 }
 
 description = """Provides general purpose base types and interfaces for modeling projects, and provides runtime and language support."""
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/plugins-distribution/build.gradle.kts
+++ b/platforms/software/plugins-distribution/build.gradle.kts
@@ -54,6 +54,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/plugins-version-catalog/build.gradle.kts
+++ b/platforms/software/plugins-version-catalog/build.gradle.kts
@@ -59,6 +59,4 @@ gradleModule {
 packageCycles {
     excludePatterns.add("org/gradle/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/publish/build.gradle.kts
+++ b/platforms/software/publish/build.gradle.kts
@@ -46,6 +46,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/reporting/build.gradle.kts
+++ b/platforms/software/reporting/build.gradle.kts
@@ -52,6 +52,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/reporting/internal/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/platforms/software/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -330,6 +331,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         unavailableReports.empty
     }
 
+    @ToBeFixedForIsolatedProjects(because = "reporting plugin uses cross-project configuration")
     void 'reports from subprojects are aggregated'() {
         given:
         goodCode()

--- a/platforms/software/resources-gcs/build.gradle.kts
+++ b/platforms/software/resources-gcs/build.gradle.kts
@@ -54,6 +54,4 @@ gradleModule {
 strictCompile {
     ignoreDeprecations()
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/resources-http/build.gradle.kts
+++ b/platforms/software/resources-http/build.gradle.kts
@@ -51,6 +51,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/resources-s3/build.gradle.kts
+++ b/platforms/software/resources-s3/build.gradle.kts
@@ -64,6 +64,4 @@ dependencyAnalysis {
         }
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/resources-sftp/build.gradle.kts
+++ b/platforms/software/resources-sftp/build.gradle.kts
@@ -47,6 +47,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/resources/build.gradle.kts
+++ b/platforms/software/resources/build.gradle.kts
@@ -38,6 +38,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/signing/build.gradle.kts
+++ b/platforms/software/signing/build.gradle.kts
@@ -68,9 +68,7 @@ packageCycles {
     excludePatterns.add("org/gradle/plugins/signing/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 tasks.withType<Test>().configureEach {
     // increase the amount of memory available as the sample key from https://www.rfc-editor.org/rfc/rfc9580.html#name-sample-locked-version-6-sec

--- a/platforms/software/software-diagnostics/build.gradle.kts
+++ b/platforms/software/software-diagnostics/build.gradle.kts
@@ -100,6 +100,4 @@ sourceSets.main {
     output.dir(layout.buildDirectory.file("generated-resources/report-resources"))
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.reporting.dependencies
 
 import groovy.json.JsonSlurper
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.TestFile
 import org.jsoup.Jsoup
 import spock.lang.Issue
@@ -196,6 +197,7 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         json.project.configurations[0].dependencies[1].name == "foo:bar:2.0"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "generates report for multiple projects"() {
         given:
         createDirs("a", "b")
@@ -245,6 +247,7 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         file("build/reports/project/dependencies/root.js").assertExists();
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "generates index.html file"() {
         given:
         createDirs("a", "b")
@@ -393,6 +396,7 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-2979")
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "renders a mix of project and external dependencies"() {
         given:
         mavenRepo.module("foo", "bar", "1.0").publish()

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTaskIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.diagnostics
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
@@ -32,6 +33,7 @@ class BuildEnvironmentReportTaskIntegrationTest extends AbstractIntegrationSpec 
     }
 
     @LeaksFileHandles("Putting an generated Jar on the classpath of the buildscript")
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "reports external dependency name and version change"() {
         mavenRepo.module("org", "leaf1").publish()
         mavenRepo.module("org", "leaf2").publish()

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.resolve.locking.LockfileFixture
 import org.gradle.util.GradleVersion
 
@@ -1443,6 +1444,7 @@ org:leaf:[1.5,2.0] FAILED
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     void "marks project dependencies that cannot be resolved as 'FAILED'"() {
         given:
         createDirs("A", "B", "C")
@@ -1539,6 +1541,7 @@ org:leaf2:1.0
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "deals with dependency cycle to root"() {
         given:
         createDirs("impl")
@@ -1599,6 +1602,7 @@ root project 'root'
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "selects a module component dependency with a given name"() {
         given:
         mavenRepo.module("org", "leaf1").dependsOnModules("leaf2").publish()
@@ -1656,6 +1660,7 @@ org:leaf2:1.0
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "selects a project component dependency with a given project path"() {
         given:
         mavenRepo.module("org", "leaf1").dependsOnModules("leaf2").publish()
@@ -1710,6 +1715,7 @@ project ':impl'
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "selects a module component dependency with a given name with dependency command line option"() {
         given:
         mavenRepo.module("org", "leaf1").dependsOnModules("leaf2").publish()
@@ -1827,6 +1833,7 @@ org:leaf2:1.0
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "selects a project component dependency with a given name with dependency command line option"() {
         given:
         mavenRepo.module("org", "leaf1").dependsOnModules("leaf2").publish()
@@ -1930,6 +1937,7 @@ project ':some:deeply:nested'
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
     def "renders tree with a mix of project and external dependencies"() {
         given:
         mavenRepo.module("org", "leaf1").dependsOnModules("leaf2").publish()

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -16,8 +16,10 @@
 package org.gradle.api.tasks.diagnostics
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class DependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "omits repeated dependencies in case of circular dependencies"() {
         given:
         createDirs("client", "a", "b", "c")
@@ -62,6 +64,7 @@ compile
         output.contains '(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "marks project dependency that can't be resolved as 'FAILED'"() {
         given:
         createDirs("A", "B", "C")
@@ -252,6 +255,7 @@ config
         output.contains "foo:bar:1.0 -> 2.0"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "renders selected versions in case of a conflict"() {
         given:
         mavenRepo.module("foo", "bar", "1.0").publish()
@@ -577,6 +581,7 @@ No dependencies
         output.contains "No configurations"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "dependencies report does not run for subprojects by default"() {
         given:
         createDirs("a")
@@ -669,6 +674,7 @@ conf
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "renders a mix of project and external dependencies"() {
         given:
         mavenRepo.module("foo", "bar", "1.0").publish()
@@ -741,6 +747,7 @@ compileClasspath - Compile classpath for source set 'main'.
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "reports external dependency replaced with project dependency"() {
         mavenRepo.module("org.utils", "api",  '1.3').publish()
 
@@ -788,6 +795,7 @@ compile
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "reports external dependency with version updated by resolve rule"() {
         mavenRepo.module("org.utils", "api", '0.1').publish()
 
@@ -831,6 +839,7 @@ compile
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "reports external dependency substituted with another"() {
         mavenRepo.module("org.utils", "api", '0.1').publish()
         mavenRepo.module("org.other", "another", '0.1').publish()
@@ -1039,6 +1048,7 @@ compileClasspath - Compile classpath for source set 'main'.
 """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "adding declarations to deprecated configurations for declaration will warn"() {
         given:
         createDirs("a", "b")
@@ -1064,6 +1074,7 @@ compileClasspath - Compile classpath for source set 'main'.
         succeeds ':a:dependencies'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects/subprojects, configure projects from root")
     def "adding declarations to invalid configurations for declaration will fail"() {
         given:
         createDirs("a", "b")

--- a/platforms/software/testing-base-infrastructure/build.gradle.kts
+++ b/platforms/software/testing-base-infrastructure/build.gradle.kts
@@ -49,6 +49,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/internal/tasks/testing/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/testing-base/build.gradle.kts
+++ b/platforms/software/testing-base/build.gradle.kts
@@ -88,6 +88,4 @@ packageCycles {
     excludePatterns.add("org/gradle/api/internal/tasks/testing/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/version-control/build.gradle.kts
+++ b/platforms/software/version-control/build.gradle.kts
@@ -59,6 +59,4 @@ gradleModule {
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyMultiprojectIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule
 
+@ToBeFixedForIsolatedProjects(because = "included build uses allprojects { apply plugin: 'java' }")
 abstract class AbstractSourceDependencyMultiprojectIntegrationTest extends AbstractIntegrationSpec implements SourceDependencies {
     @Rule
     BlockingHttpServer httpServer = new BlockingHttpServer()

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/DeclarativeSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/DeclarativeSourceDependencyMultiprojectIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.vcs.internal
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
+@ToBeFixedForIsolatedProjects(because = "included build uses allprojects { apply plugin: 'java' }")
 class DeclarativeSourceDependencyMultiprojectIntegrationTest extends AbstractSourceDependencyMultiprojectIntegrationTest {
     @Override
     void mappingFor(String gitRepo, String coords, String repoDef) {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -333,6 +334,7 @@ The following types/formats are supported:
         deeperCheckout.file('.git').assertExists()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects in included build, BlockingHttpServer timeout downstream")
     def 'can resolve the same version for latest.integration within the same build session'() {
         given:
         BlockingHttpServer server = new BlockingHttpServer()

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.vcs.internal
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.git.GitVersionControlSpec
 
 class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceDependencyMultiprojectIntegrationTest {
@@ -35,6 +36,7 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "included build uses allprojects { apply plugin: 'java' }")
     def "can map all modules in group to repo using all {}"() {
         settingsFile << """
             sourceControl {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 
@@ -134,6 +135,7 @@ Required by:
         "rootProject.name='someLib'" | "buildC"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects in nested included build")
     def "includes build identifier in dependency resolution results with #display"() {
         repoC.file("a/.gitkeepdir").touch()
         repoC.file("settings.gradle") << """

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule
 
+@ToBeFixedForIsolatedProjects(because = "allprojects in included build")
 class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     BlockingHttpServer httpServer = new BlockingHttpServer()

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 
@@ -110,6 +111,7 @@ Required by:
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "allprojects { apply plugin: 'java-library' } in included build")
     def "includes build identifier in dependency resolution results with #display"() {
         repo.file("a/.gitkeepdir").touch()
         repo.file("settings.gradle") << """

--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -59,6 +59,4 @@ gradleModule {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildArtifactTransformIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildArtifactTransformIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+
 class CompositeBuildArtifactTransformIntegrationTest extends AbstractCompositeBuildIntegrationTest {
 
     def "can apply a transform to the outputs of included builds"() {
@@ -80,6 +82,7 @@ class CompositeBuildArtifactTransformIntegrationTest extends AbstractCompositeBu
         output.count("Transforming") == 2
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "cross-build dependency with transform in another build"() {
         given:
         def buildB = multiProjectBuild('buildB', ['app', 'lib'])

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.composite
 
 import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.build.BuildTestFixture
 import org.gradle.internal.build.BuildStateRegistry
@@ -27,6 +28,7 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
 
     BuildOperationsFixture fixture = new BuildOperationsFixture(executer, temporaryFolder)
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can have buildLogic build and include build with buildLogic build"() {
         def builds = nestedBuilds {
             includedBuild {
@@ -57,6 +59,7 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "build paths are selected based on the directory hierarchy"() {
         def builds = nestedBuilds {
             includedBuild {
@@ -103,6 +106,7 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "buildSrc is relative to its including build"() {
         def builds = nestedBuilds {
             includedBuild {
@@ -142,6 +146,7 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "uses the directory hierarchy to determine the build path when the builds are not nested"() {
         def builds = nestedBuilds {
             includedBuildA {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
@@ -45,6 +46,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "generates configure, task graph and run tasks operations for buildSrc of included builds with #display"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -131,6 +133,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         "rootProject.name='someLib'" | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates configure, task graph and run tasks operations when all builds have buildSrc with #display"() {
         given:
         dependency 'org.test:buildB:1.0'

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBuildIntegrationTest {
     BuildTestFile buildB
@@ -33,6 +34,7 @@ class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBui
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in logging output with #display"() {
         dependency "org.test:buildB:1.0"
 
@@ -57,6 +59,7 @@ class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBui
         "rootProject.name='someLib'" | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in dependency report with #display"() {
         dependency "org.test:buildB:1.0"
 
@@ -134,6 +137,7 @@ Required by:
         "rootProject.name='someLib'" | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in dependency resolution results with #display"() {
         dependency "org.test:buildB:1.0"
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
@@ -44,6 +45,7 @@ class CompositeBuildCommandLineArgsIntegrationTest extends AbstractCompositeBuil
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configures included build subprojects from root")
     def "passes project properties to included build"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -64,6 +66,7 @@ class CompositeBuildCommandLineArgsIntegrationTest extends AbstractCompositeBuil
         assertTaskExecuted(":buildB", ":jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configures included build subprojects from root")
     def "passes system property arguments to included build"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -84,6 +87,7 @@ class CompositeBuildCommandLineArgsIntegrationTest extends AbstractCompositeBuil
         assertTaskExecuted(":buildB", ":jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configures included build subprojects from root")
     def "can include same build multiple times using --include-build and settings.gradle"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -103,6 +107,7 @@ includeBuild '${buildB.toURI()}'
         assertTaskExecuted(":buildB", ":jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configures included build subprojects from root")
     def "does not exclude tasks when building artifact for included build"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -114,6 +119,7 @@ includeBuild '${buildB.toURI()}'
         assertTaskExecuted(":buildB", ":jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configures included build subprojects from root")
     def "does not execute task actions when dry run specified on composite build"() {
         given:
         dependency 'org.test:buildB:1.0'

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.util.internal.ToBeImplemented
 
@@ -30,6 +31,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         using m2
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "context travels to transitive dependencies"() {
         given:
         createDirs("a", "b", "includedBuild")
@@ -132,6 +134,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "context travels to transitive dependencies via external components (Maven)"() {
         given:
         mavenRepo.module('com.acme.external', 'external', '1.2')
@@ -244,6 +247,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "context travels to transitive dependencies via external components (Ivy)"() {
         given:
         ivyRepo.module('com.acme.external', 'external', '1.2')
@@ -356,6 +360,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "attribute values are matched across builds - #type"() {
         given:
         createDirs("a", "b", "includedBuild")
@@ -695,6 +700,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
 //        }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "reports failure to resolve due to incompatible attribute values"() {
         given:
         createDirs("a", "b", "includedBuild")
@@ -801,6 +807,7 @@ All of them match the consumer attributes:
   - Variant 'foo' capability 'com.acme.external:external:2.0-SNAPSHOT' declares attribute 'flavor' with value 'red'""")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration")
     def "context travels down to transitive dependencies with typed attributes using plugin"() {
         def resolve = new ResolveTestFixture(testDirectory)
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenModule
@@ -67,6 +68,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
 
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "references but does not build substituted dependency resolved at configuration time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
 
@@ -81,6 +83,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "uses substituted dependency when same root build dependency is resolved at both configuration and execution time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
         dependency 'org.test:buildB:1.0'
@@ -95,6 +98,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "references substituted dependencies when root build dependencies are resolved at both configuration and execution time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
         dependency 'org.test:b1:1.0'
@@ -112,6 +116,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "included build references substituted dependency from preceding included build"() {
         dependency 'org.test:buildC:1.0'
         configurationTimeDependency buildC, 'org.test:buildB:1.0'
@@ -127,6 +132,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "included build does not use substituted dependency from subsequent included build"() {
         dependency 'org.test:buildB:1.0'
         configurationTimeDependency buildB, 'org.test:buildC:1.0'

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnMultipleFailuresIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnMultipleFailuresIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.composite
 
 import org.gradle.initialization.StartParameterBuildOptions.ContinueOption
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 /**
  * Tests for composite build delegating to tasks in an included build that produce more than one failure.
@@ -54,6 +55,7 @@ class CompositeBuildContinueOnMultipleFailuresIntegrationTest extends AbstractCo
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can collect build failures from multiple included builds"() {
         when:
         includedBuilds << buildB << buildC << buildD
@@ -81,6 +83,7 @@ class CompositeBuildContinueOnMultipleFailuresIntegrationTest extends AbstractCo
         failure.assertHasDescription("Execution failed for task ':buildD:test'.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can collect build failure in root and included build"() {
         when:
         includedBuilds << buildC

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
@@ -58,6 +59,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "will only make declared substitutions when defined for included build"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -83,6 +85,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "can combine included builds with declared and discovered substitutions"() {
         given:
         dependency "org.test:b1:1.0"
@@ -106,6 +109,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can inject substitutions into other builds"() {
         given:
         mavenRepo.module("org.test", "plugin", "1.0").publish()
@@ -132,6 +136,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5871")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can inject substitutions into other builds when root build does not reference included builds via a dependency and included build has non-empty script classpath"() {
         mavenRepo.module("org.test", "plugin", "1.0").publish()
 
@@ -162,6 +167,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         result.assertTaskScheduled(":buildC:jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can substitute arbitrary coordinates for included build"() {
         given:
         dependency "org.test:buildX:1.0"
@@ -209,6 +215,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependency with project dependency from same participant build"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -301,6 +308,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
         'module("org.test:platform")'           | 'project(":")'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "preserves the requested capabilities when performing a composite substitution"() {
         buildA.buildFile << """
             dependencies {
@@ -332,6 +340,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
 
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "preserves the requested capabilities when performing a composite substitution using mapping"() {
         buildA.buildFile << """
             dependencies {
@@ -372,6 +381,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15659")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "resolves dependencies of included build with dependency substitution when substitution build contains buildSrc"() {
         given:
         includeBuild(buildB, """
@@ -393,6 +403,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15659")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds included build with dependency substitution when substitution build contains buildSrc"() {
         given:
         includeBuild(buildB, """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -46,6 +47,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds single artifact for substituted dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -58,6 +60,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "builds multiple artifacts for substituted dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -81,6 +84,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file('build/libs/buildB-1.0-my.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds artifacts for dependencies on multiple subprojects in the same build"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -94,6 +98,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('b1/build/libs/b1-1.0.jar'), buildB.file('b2/build/libs/b2-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "builds substituted dependency with transitive external dependencies"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -116,6 +121,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), moduleC.artifactFile
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "builds substituted dependency with transitive external dependency that is substituted"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -141,6 +147,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildC.file('build/libs/buildC-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds dependency once when included directly and as a transitive dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -167,6 +174,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildC.file('build/libs/buildC-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds substituted dependency with transitive external dependency that is substituted in the same build"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -185,6 +193,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file('b1/build/libs/b1-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds substituted dependency with transitive project dependencies"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -217,6 +226,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file('b1/build/libs/b1-1.0.jar'), buildB.file('b2/build/libs/b2-1.0-my.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds substituted dependency with file dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -238,6 +248,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file("build/libs/buildB-1.0-1.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "builds substituted dependency with non-default configuration"() {
         given:
         buildA.buildFile << """
@@ -272,6 +283,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0-my.jar'), moduleC.artifactFile
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds substituted dependency with non-default artifactType"() {
         given:
         buildA.buildFile << """
@@ -298,6 +310,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/distributions/buildB-1.0.zip')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds substituted dependency with defined artifacts"() {
         given:
         buildA.buildFile << """
@@ -333,6 +346,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0-my.jar'), buildB.file('build/libs/another-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds multiple configurations for the same substituted dependency"() {
         given:
         buildA.buildFile << """
@@ -364,6 +378,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file('build/libs/buildB-1.0-my.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "does not attempt to build dependency artifacts more than once"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -384,6 +399,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('b1/build/libs/b1-1.0.jar'), buildB.file('b2/build/libs/b2-1.0.jar')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "build dependency artifacts only once when depended on by multiple subprojects"() {
         given:
         def buildC = singleProjectBuild("buildC") {
@@ -420,6 +436,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executedInOrder ":buildC:compileJava", ":buildC:jar", ":b2:compileJava", ":b2:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds multiple configurations for the same project via separate dependency paths"() {
         given:
         buildA.buildFile << """
@@ -461,6 +478,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         assertResolved buildB.file('build/libs/buildB-1.0.jar'), buildB.file('build/libs/buildB-1.0-my.jar'), buildC.file("build/libs/buildC-1.0.jar")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds artifacts for different subprojects from the same build included via separate dependency paths"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -485,6 +503,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executed ":buildB:b1:compileJava", ":buildB:b2:compileJava", ":buildC:compileJava"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes and builds compileOnly dependency"() {
         given:
         buildA.buildFile << """
@@ -499,6 +518,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executedInOrder ":buildB:compileJava", ":buildB:classes", ":compileJava", ":jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes and builds transitive compileOnly dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -523,6 +543,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executedInOrder ":buildC:jar", ":buildB:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "only builds dependency once when included as transitive compile and compileOnly dependency"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -545,6 +566,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executedInOrder ":buildB:compileJava", ":buildB:jar", ":buildC:compileJava", ":buildC:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "handles compileOnly dependencies for different subprojects from the same build included via separate dependency paths"() {
         given:
         dependency 'org.test:b1:1.0'
@@ -569,6 +591,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executed ":buildB:b1:compileJava", ":buildB:b2:compileJava", ":buildC:compileJava"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "handles separate implementation and compileOnly dependencies on different subprojects"() {
         given:
         dependency 'org.test:buildC:1.0'
@@ -598,6 +621,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         executedInOrder ":buildB:b2:jar", ":buildC:compileJava", ":buildC:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to build dependent artifact"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -616,6 +640,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
             .assertHasCause("jar task failed")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to build transitive dependent artifact"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -647,6 +672,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "builds artifacts and reports failures for dependency on multiple subprojects where one fails"() {
         given:
         server.start()
@@ -685,6 +711,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         notExecuted(":resolveCompile")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "new substitutions can be discovered while building the task graph for the first level included builds"() {
         given:
         def firstLevel = (1..2).collect { "firstLevel$it" }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -58,6 +59,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to configure one participant build"() {
         given:
         def buildC = singleProjectBuild("buildC") {
@@ -75,6 +77,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
             .assertHasCause("exception thrown on configure")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "does no substitution when no project matches external dependencies"() {
         given:
         mavenRepo.module("org.different", "buildB", "1.0").publish()
@@ -97,6 +100,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependency with root project dependency"() {
         given:
         buildA.buildFile << """
@@ -120,6 +124,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         executed ":buildB:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "substitutes external dependencies with project dependencies using --include-build"() {
         given:
         singleProjectBuild("buildC") {
@@ -152,6 +157,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependencies with subproject dependencies"() {
         given:
         buildA.buildFile << """
@@ -177,6 +183,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependency with project dependency from same participant build"() {
         given:
         buildA.buildFile << """
@@ -206,6 +213,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependency with subproject dependency that has transitive dependencies"() {
         given:
         def transitive1 = mavenRepo.module("org.test", "transitive1").publish()
@@ -236,6 +244,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes external dependency with subproject dependency that has transitive project dependencies"() {
         given:
         buildA.buildFile << """
@@ -274,6 +283,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "honours excludes defined in substituted subproject dependency that has transitive dependencies"() {
         given:
         def transitive1 = mavenRepo.module("org.test", "transitive1").publish()
@@ -304,6 +314,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes transitive dependency of substituted project dependency"() {
         given:
         buildA.buildFile << """
@@ -339,6 +350,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes transitive dependency of non-substituted external dependency"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0').dependsOn("org.test", "buildB", "1.0").publish()
@@ -362,6 +374,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "substitutes transitive dependency with forced version"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0').dependsOn("org.test", "buildB", "1.0").publish()
@@ -387,6 +400,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes transitive dependency based on result of resolution rules"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0')
@@ -428,6 +442,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "evaluates subprojects when substituting external dependencies with #name"() {
         given:
         buildA.buildFile << """
@@ -461,6 +476,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         "parallel"            | ["--parallel"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes dependency in composite containing participants with same root directory name"() {
         given:
         buildA.buildFile << """
@@ -498,6 +514,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can substitute dependencies in composite with duplicate publication if not involved in resolution"() {
         given:
         def buildC = multiProjectBuild("buildC", ['a2', 'b2', 'c1']) {
@@ -532,6 +549,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to resolve dependencies when substitution is ambiguous"() {
         given:
         def buildC = multiProjectBuild("buildC", ['a1', 'b1']) {
@@ -557,6 +575,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         failure.assertHasCause("Module version 'org.test:b1:1.0' is not unique in composite: can be provided by [project ':buildB:b1', project ':buildC:b1'].")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to resolve dependencies when substitution is ambiguous within single participant"() {
         given:
         buildB
@@ -585,6 +604,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         failure.assertHasCause("Module version 'org.test:c1:1.0' is not unique in composite: can be provided by [project ':buildC:c1', project ':buildC:nested:c1'].")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure to resolve dependencies when transitive dependency substitution is ambiguous"() {
         given:
         transitiveDependencyIsAmbiguous("'org.test:b1:2.0'")
@@ -596,6 +616,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         failure.assertHasCause("Module version 'org.test:b1:2.0' is not unique in composite: can be provided by [project ':buildB:b1', project ':buildC:b1'].")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "resolve transitive project dependency that is ambiguous in the composite"() {
         given:
         transitiveDependencyIsAmbiguous("project(':b1')")
@@ -637,6 +658,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "handles unused participant with no defined configurations"() {
         given:
         def buildC = singleProjectBuild("buildC")
@@ -660,6 +682,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure when substituted project does not have requested configuration"() {
         given:
         def buildC = singleProjectBuild("buildC")
@@ -680,6 +703,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
     }
 
     public static final REPOSITORY_HINT = repositoryHint("Maven POM")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in error message on failure to resolve dependencies of included build"() {
         def m = mavenRepo.module("org.test", "test", "1.2")
 
@@ -757,6 +781,7 @@ Required by:
         failure.assertHasCause("Could not find test-1.2.jar (org.test:test:1.2).")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "substitutes external dependency for a subproject of the root build - #rootIsIncluded"() {
         given:
         def empty = file('empty').tap {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.problems.Severity
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.flow.FlowActionsFixture
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.internal.exceptions.LocationAwareException
 
@@ -104,6 +105,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "fires build listener events on included builds"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -122,6 +124,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "fires build listener events for unused included builds"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -142,6 +145,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "fires build listener events for included build that provides buildscript and compile dependencies"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -169,6 +173,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -194,6 +199,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "buildFinished for root build is guaranteed to complete after included builds"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -302,6 +308,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "fires build finished events for all builds when build script for child build fails"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -354,6 +361,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "fires build finished events for all builds when build finished event for other builds fail"() {
         given:
         setupInitScript(buildFinishedCallbackType)
@@ -404,6 +412,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = [".*CallbackType: BUILD_.*"], because = "gradle.buildFinished or BuildListener")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "fires build finished events for all builds when other builds fail"() {
         given:
         setupInitScript(buildFinishedCallbackType)

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 
 class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegrationTest {
@@ -32,6 +33,7 @@ class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegr
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "includes build identifier in logging output with #display"() {
         dependency "org.test:${dependencyName}:1.0"
 
@@ -56,6 +58,7 @@ class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegr
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in dependency report with #display"() {
         dependency "org.test:${dependencyName}:1.0"
 
@@ -80,6 +83,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in error message on failure to resolve dependencies of build with #display"() {
         dependency "org.test:${dependencyName}:1.0"
 
@@ -104,6 +108,7 @@ Required by:
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "includes build identifier in task failure error message with #display"() {
         dependency "org.test:${dependencyName}:1.0"
 
@@ -127,6 +132,7 @@ Required by:
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "includes build identifier in dependency resolution results with #display"() {
         dependency "org.test:${dependencyName}:1.0"
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludeCycleIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
@@ -175,6 +176,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         canRunFromCache(buildA, 'task1')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "can depend back on root build"() {
         given:
         def rootBuild = multiProjectBuild('rootBuild', ['root1', 'root2']) {
@@ -208,6 +210,7 @@ class CompositeBuildIncludeCycleIntegrationTest extends AbstractCompositeBuildIn
         canRunFromCache(rootBuild, ':root1:compileJava')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can depend back on root build and back on an included build"() {
         given:
         def rootBuild = multiProjectBuild('rootBuild', ['root1', 'root2', 'x3']) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
@@ -50,6 +51,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "does not configure build with declared substitutions that is not required for dependency substitution"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -73,6 +75,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "build with discovered substitutions that is not required for dependency substitution is configured only once"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -96,6 +99,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         output.count('Configured buildC') == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "configures included build only once when building artifacts"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -130,6 +134,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         output.count('Configured buildC') == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "configures included build only once when not building artifacts"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -164,6 +169,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         output.count('Configured buildC') == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "when configuration fails included build with #name substitutions is configured only once "() {
         given:
         dependency "org.test:buildB:1.0"
@@ -197,6 +203,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         name << ["discovered", "declared"]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "configures included build only once when building multiple artifacts"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -224,6 +231,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
         output.count('Configured buildB') == 1
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "configures included build only once when building multiple artifacts for a dependency of a referenced task"() {
         given:
         includeBuild buildB

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
@@ -47,6 +48,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates build operations for tasks in included builds"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -68,6 +70,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "generates build lifecycle operations for included builds with #display"() {
         given:
         dependency "org.test:${dependencyName}:1.0"
@@ -142,6 +145,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         "rootProject.name='someLib'" | "someLib"      | "configured root project name"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates build lifecycle operations for multiple included builds"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -197,6 +201,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates build lifecycle operations for multiple included builds used as buildscript dependencies"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -260,6 +265,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "generates build lifecycle operations for included build used as buildscript and production dependency"() {
         given:
         buildA.buildFile.prepend("""
@@ -344,6 +350,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         ]
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates finish build tree lifecycle operation for included builds without build finished operations"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -375,6 +382,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
     }
 
     @UnsupportedWithConfigurationCache(because = "buildFinished", iterationMatchers = ".*with buildFinished.*")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "generates finish build tree lifecycle operation for included builds with #description"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -414,6 +422,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         "flow actions"  | CompositeBuildOperationsIntegrationTest.&flowActionRegistrationFor    | "flowAction from"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "build tree finished operation happens even when configuration fails"() {
         buildA.buildFile.text = """
             buildscript {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildParallelIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildParallelIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.junit.Rule
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @Requires(TestExecutionPreconditions.NotParallelExecutor)
 class CompositeBuildParallelIntegrationTest extends AbstractCompositeBuildIntegrationTest {
@@ -94,6 +95,7 @@ class CompositeBuildParallelIntegrationTest extends AbstractCompositeBuildIntegr
         execute(buildA, "jar", "--max-workers=4")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "constructs included build artifacts in parallel with multi-project included build"() {
         given:
         def maxWorkers = 4

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.composite
 
 import org.gradle.api.problems.LineInFileLocation
 import org.gradle.api.problems.Severity
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
@@ -364,6 +365,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         executed ":pluginDependencyA:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "can use an included build that provides both a buildscript dependency and a compile dependency"() {
         given:
         def buildB = multiProjectBuild("buildB", ['b1', 'b2']) {
@@ -711,6 +713,7 @@ tasks.register("resolve") {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15068")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can develop plugin whose build requires dependency resolution using configure-on-demand"() {
         given:
         buildA = multiProjectBuild("cod", ["consumer"]) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildRootProjectIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 
 class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildIntegrationTest {
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "root of a composite build cannot refer to own subprojects by GA coordinates by default"() {
         given:
         def buildB = multiProjectBuild("buildB", ['c1', 'c2', 'c3']) {
@@ -44,6 +46,7 @@ class CompositeBuildRootProjectIntegrationTest extends AbstractCompositeBuildInt
         failure.assertHasCause("Cannot resolve external dependency org.test:buildB because no repositories are defined.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "root of a composite build can refer to own subprojects by GA coordinates when including itself"() {
         given:
         def buildB = multiProjectBuild("buildB", ['c1', 'c2', 'c3']) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 
 /**
@@ -41,6 +42,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         includedBuilds << buildB
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "can depend on task in root project of included build"() {
         when:
         buildA.buildFile << """
@@ -56,6 +58,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildB' project ':' task ':logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can depend on task in subproject of included build"() {
         when:
         buildA.buildFile << """
@@ -71,6 +74,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildB' project ':b1' task ':b1:logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can depend on multiple tasks of included build"() {
         when:
         buildA.buildFile << """
@@ -97,6 +101,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildB' project ':b1' task ':b1:logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "executes tasks only once for included build"() {
         when:
         buildA.buildFile << """
@@ -120,6 +125,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildB' project ':b1' task ':b1:logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can depend on task from subproject of composing build"() {
         given:
         createDirs("buildA", "buildA/a1")
@@ -153,6 +159,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildB' project ':' task ':logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can depend on task with name in all included builds"() {
         when:
         BuildTestFile buildC = singleProjectBuild("buildC") {
@@ -174,6 +181,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         output.contains("Executing build 'buildC' project ':' task ':logProject'")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "substitutes dependency of included build when executed via task dependency"() {
         given:
         buildA.buildFile << """
@@ -198,6 +206,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         executed ":buildB:b1:jar", ":buildB:jar"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "reports failure when included build does not exist for composite"() {
         when:
         buildA.buildFile << """
@@ -214,6 +223,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         failure.assertHasCause("Included build 'does-not-exist' not found in build ':'.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "reports failure when task does not exist for included build"() {
         when:
         buildA.buildFile << """
@@ -230,6 +240,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         failure.assertHasCause("Task with name 'does-not-exist' not found in project ':buildB'.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure when task path is not qualified for included build"() {
         when:
         buildA.buildFile << """
@@ -246,6 +257,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         failure.assertHasCause("Task path 'logProject' is not a qualified task path (e.g. ':task' or ':project:task')")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure when task path is substring of task in included build"() {
         given:
         buildA.buildFile << """
@@ -272,6 +284,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         failure.assertHasCause("Task with name 'logP' not found in project ':buildB:b1'.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "reports failure when attempting to access included build when build is not a composite"() {
         when:
         buildB.buildFile << """
@@ -288,6 +301,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
         failure.assertHasCause("Included build 'does-not-exist' not found in build ':'.")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "included build cannot reference tasks in #scenario"() {
         when:
         BuildTestFile buildC = singleProjectBuild("buildC") {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import spock.lang.Issue
 
 class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTaskExecutionIntegrationTest {
@@ -91,6 +92,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         """
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude tasks from an included build"() {
         expect:
         2.times {
@@ -105,6 +107,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude tasks using pattern matching"() {
         expect:
         2.times {
@@ -119,6 +122,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "excluding a task from a root project does not affect included task with same path"() {
         when:
         succeeds("build", "-x", ":sub:test")
@@ -128,6 +132,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         result.assertTasksNotScheduled(":sub:test")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "cannot use unqualified task paths to exclude tasks from included build roots"() {
         when:
         run("build", "-x", "test")
@@ -138,6 +143,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         result.assertTasksNotScheduled(":sub:test")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "cannot use unqualified task paths to exclude tasks from included build subproject"() {
         when:
         run("build", "-x", "sub:test")
@@ -147,6 +153,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         result.assertTasksNotScheduled(":sub:test")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude task from main build when root build uses project plugin from included build"() {
         setup:
         settingsFile << "includeBuild('build-logic')"
@@ -191,6 +198,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude task from included build that produces a project plugin used from root build"() {
         setup:
         settingsFile << "includeBuild('build-logic')"
@@ -211,6 +219,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude task from included build that is a dependency of the root build and also produces a project plugin used from root build"() {
         setup:
         settingsFile << "includeBuild('build-logic')"
@@ -236,6 +245,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21708")
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "can exclude task from included build that requires a project plugin from another build"() {
         setup:
         settingsFile << """
@@ -259,6 +269,7 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
     }
 
     @Issue("https://github.com/gradle/gradle/issues/24341")
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "can exclude task with included build that in turn includes a build for convention plugins"() {
         setup:
         file('included/settings.gradle').text = """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrationTest {
     def setup() {
@@ -182,6 +183,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         stopGradle()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-build configuration in composite build")
     def "will rebuild on change for build included into a multi-project build"() {
         def includedLibrary = singleProjectBuild("library") {
             buildFile << """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import spock.lang.Ignore
 
@@ -110,6 +111,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         execute(buildA, "help")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "allows to rename included build that conflicts with subproject name"() {
         given:
         createDirs("buildA", "buildA/buildB")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite.plugins
 
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.resolve.ResolveFailureTestFixture
 
 class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
@@ -350,6 +351,7 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         build.assertProjectPluginApplied()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project / cross-build configuration")
     def "Including a build as both plugin build and regular build does not lead to an error in the presence of include cycles"() {
         given:
         def commonsPluginBuild = pluginBuild("commons-plugin-build", dsl == 'Kotlin')
@@ -573,6 +575,7 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         projectPluginBuild.assertProjectPluginApplied()
     }
 
+    @ToBeFixedForIsolatedProjects(because = "plugin composite-build configuration")
     def "plugin builds can include each other without consequences"() {
         given:
         def settingsPluginBuild = pluginBuild("settings-plugin", dsl == 'Kotlin')

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -73,6 +73,4 @@ strictCompile {
 // AutoTestedSamplesCoreApiIntegrationTest includes customized test logic, so automatic auto testing samples generation is not needed (and would fail) in this project
 integTest.generateDefaultAutoTestedSamplesTest = false
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/testing/distributions-integ-tests/build.gradle.kts
+++ b/testing/distributions-integ-tests/build.gradle.kts
@@ -31,9 +31,7 @@ tasks.forkingIntegTest {
     systemProperty("gradleBuildBranch", lazy(buildBranch::get))
     systemProperty("gradleBuildCommitId", lazy(buildCommitId::get))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/testing/integ-test/build.gradle.kts
+++ b/testing/integ-test/build.gradle.kts
@@ -59,9 +59,7 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest {
@@ -174,6 +175,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
         inTestDirectory().withTasks("hello").run();
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     @Test
     public void inheritsClassPathOfParentProject() {
         ArtifactBuilder builder = artifactBuilder();

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
@@ -18,9 +18,11 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ClosureScopeIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "check scope when closure in ext"() {
         given:
         buildFile("closure_in_ext.gradle", """

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ConfigurationOnDemandPluginsIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ConfigurationOnDemandPluginsIntegrationTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ProjectLifecycleFixture
 import org.junit.Rule
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 class ConfigurationOnDemandPluginsIntegrationTest extends AbstractIntegrationSpec {
     @Rule ProjectLifecycleFixture fixture = new ProjectLifecycleFixture(executer, temporaryFolder)
 
     @Issue('GRADLE-3534')
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "configures only requested projects when the #plugin plugin is applied"() {
         given:
         multiProjectBuild('multi', ['a', 'b']) {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/MultiProjectDependencyIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/MultiProjectDependencyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.hamcrest.CoreMatchers
@@ -41,6 +42,7 @@ allprojects {
         executer.withArgument('--info')
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "project dependency c->[a,b]"() {
         projectDependency from: 'c', to: ['a', 'b']
         when:
@@ -53,6 +55,7 @@ allprojects {
         depsCopied 'c', ['a', 'b']
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "project dependency c->b->a"() {
 
         projectDependency from: 'c', to: ['b']
@@ -68,6 +71,7 @@ allprojects {
         depsCopied 'a', []
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->[b,c] and b->c"() {
 
         projectDependency from: 'a', to: ['b', 'c']
@@ -83,6 +87,7 @@ allprojects {
         depsCopied 'c', []
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "project dependency a->[b,d] and b->c->d"() {
 
         projectDependency from: 'a', to: ['b', 'd']
@@ -100,6 +105,7 @@ allprojects {
         depsCopied 'd', []
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def "project dependency a->[b,c] and b->d and c->d"() {
 
         projectDependency from: 'a', to: ['b', 'c']
@@ -117,6 +123,7 @@ allprojects {
         depsCopied 'd', []
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "circular project dependency without task cycle a->b->c->a:2"() {
 
         projectDependency from: 'a', to: ['b']
@@ -152,6 +159,7 @@ project(':c') {
         file('a/build/output.txt').text == "$outputValue"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency cycle a->b->c->a"() {
         projectDependency from: 'a', to: ['b']
         projectDependency from: 'b', to: ['c']
@@ -165,6 +173,7 @@ project(':c') {
         failure.assertThatDescription(CoreMatchers.startsWith("Circular dependency between the following tasks:"))
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->b->c->d and c fails"() {
         projectDependency from: 'a', to: ['b']
         projectDependency from: 'b', to: ['c']
@@ -185,6 +194,7 @@ project(':c') {
     // 'c' + 'd' _may_ be built with parallel executer
     // test can't handle parallel task execution
     @Requires(TestExecutionPreconditions.NotParallelOrConfigCacheExecutor)
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->[b,c] and c->d and b fails"() {
         projectDependency from: 'a', to: ['b', 'c']
         projectDependency from: 'c', to: ['d']
@@ -200,6 +210,7 @@ project(':c') {
         jarsNotBuilt 'a', 'b', 'c', 'd'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->[b,c] and c->d and b fails with run with --continue"() {
         projectDependency from: 'a', to: ['b', 'c']
         projectDependency from: 'c', to: ['d']
@@ -217,6 +228,7 @@ project(':c') {
         jarsNotBuilt 'a', 'b'
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "project dependency a->[b,c] and both b & c fail with --continue"() {
         projectDependency from: 'a', to: ['b', 'c']
         failingBuild 'b'

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/MultiprojectIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/MultiprojectIntegrationTest.groovy
@@ -16,9 +16,11 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.junit.Test
 
 class MultiprojectIntegrationTest extends AbstractIntegrationTest {
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     @Test
     public void canInjectConfigurationFromParentProject() {
         createDirs("a", "b")

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
@@ -20,9 +20,11 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.GradleVersion
 import org.gradle.util.Matchers
 import spock.lang.Issue
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 
 @Issue(["https://github.com/gradle/gradle/issues/17812", "https://github.com/gradle/gradle/issues/22090"])
 class ParallelStaleOutputIntegrationTest extends AbstractIntegrationSpec {
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "fails when configuring tasks which do dependency resolution from non-project context in constructor"() {
         buildFile << """
             abstract class BadTask extends DefaultTask {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects;
 
 public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
 
@@ -231,6 +232,7 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         inTestDirectory().withTasks("do-stuff").run().assertTasksScheduled(":child1:do-stuff", ":child2:do-stuff");
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     @Test
     public void multiProjectBuildCanHaveAllProjectsAsChildrenOfSettingsDir() {
         TestFile settingsFile = testFile("settings.gradle");
@@ -247,6 +249,7 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         inTestDirectory().withTasks(":sub:thing").run().assertTasksScheduled(":sub:thing");
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     @Test
     public void usesRootProjectAsDefaultProjectWhenInSettingsDir() {
         TestFile settingsDir = testFile("gradle");

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests
 import org.gradle.api.problems.Severity
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.test.fixtures.file.TestFile
 
@@ -99,6 +100,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         failure.assertHasCause("broken action")
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "reports task injected by other project fails with runtime exception"() {
         createDirs("a", "b")
         file("settings.gradle") << "include 'a', 'b'"
@@ -171,6 +173,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "reports unknown task"() {
         enableProblemsApiCheck()
         createDirs("a", "b")
@@ -240,6 +243,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         )
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "reports ambiguous task"() {
         enableProblemsApiCheck()
         createDirs("a", "b")
@@ -291,6 +295,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "IP changes error message")
     def "reports unknown project"() {
         enableProblemsApiCheck()
         createDirs("projA", "projB")
@@ -324,6 +329,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "reports ambiguous project"() {
         enableProblemsApiCheck()
         createDirs("projA", "projB")

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import spock.lang.Issue
 import spock.lang.Timeout
@@ -116,6 +117,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def executesMultiProjectsTasksInASingleBuildAndEachTaskAtMostOnce() {
         createDirs("child1", "child2", "child1-2", "child1-2-2")
         settingsFile << "include 'child1', 'child2', 'child1-2', 'child1-2-2'"
@@ -134,6 +136,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
         }
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure projects from root")
     def executesMultiProjectDefaultTasksInASingleBuildAndEachTaskAtMostOnce() {
         createDirs("child1", "child2")
         settingsFile << "include 'child1', 'child2'"
@@ -344,6 +347,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21962")
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "honours mustRunAfter task ordering declared via dependency resolution"() {
         createDirs("a", "b")
         settingsFile << """
@@ -615,6 +619,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
     }
 
     @Issue("gradle/gradle#783")
+    @ToBeFixedForIsolatedProjects(because = "cross-project configuration / project loading")
     def "executes finalizer task as soon as possible after finalized task"() {
         buildFile << """
             project(":a") {

--- a/testing/internal-distribution-testing/build.gradle.kts
+++ b/testing/internal-distribution-testing/build.gradle.kts
@@ -146,6 +146,4 @@ packageCycles {
     excludePatterns.add("org/gradle/**")
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/ResettableExpectations.java
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/ResettableExpectations.java
@@ -17,7 +17,7 @@
 package org.gradle.test.fixtures;
 
 /**
- * Allows {@link org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension} to verify
+ * Allows {@link org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCacheExtension} to verify
  * test expectations before cleanup so they can be silenced if necessary.
  */
 public interface ResettableExpectations {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -27,6 +27,7 @@ import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistributio
 import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCacheRule;
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjectsRule;
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCacheRule;
+import org.gradle.integtests.fixtures.modes.UnsupportedWithIsolatedProjectsRule;
 import org.gradle.test.fixtures.IntegrationTest;
 import org.gradle.test.fixtures.dsl.GradleDsl;
 import org.gradle.test.fixtures.file.TestFile;
@@ -57,6 +58,9 @@ public abstract class AbstractIntegrationTest implements HasGradleExecutor {
 
     @Rule
     public final ToBeFixedForConfigurationCacheRule toBeFixedForConfigurationCache = new ToBeFixedForConfigurationCacheRule();
+
+    @Rule
+    public final UnsupportedWithIsolatedProjectsRule unsupportedForIsolatedProjects = new UnsupportedWithIsolatedProjectsRule();
 
     @Rule
     public final ToBeFixedForIsolatedProjectsRule toBeFixedForIsolatedProjects = new ToBeFixedForIsolatedProjectsRule();

--- a/testing/internal-performance-testing/build.gradle.kts
+++ b/testing/internal-performance-testing/build.gradle.kts
@@ -91,6 +91,4 @@ tasks.jar {
 
     from(files(provider{ flamegraph.map { zipTree(it) } }))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+

--- a/testing/precondition-tester/build.gradle.kts
+++ b/testing/precondition-tester/build.gradle.kts
@@ -95,9 +95,7 @@ fun Test.setupPreconditionTesting() {
     // These tests should always run
     outputs.upToDateWhen { false }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/testing/public-api-tests/build.gradle.kts
+++ b/testing/public-api-tests/build.gradle.kts
@@ -57,9 +57,7 @@ tasks.withType<IntegrationTest>() {
     }
     jvmArgumentProviders.add(argument)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true

--- a/testing/soak/build.gradle.kts
+++ b/testing/soak/build.gradle.kts
@@ -36,9 +36,7 @@ tasks.register("soakTest") {
     group = "CI Lifecycle"
     dependsOn(":soak:forkingIntegTest")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
+
 
 errorprone {
     nullawayEnabled = true


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/34266

Integration tests in all projects are now running with IP executor as well. The only exception for now is `configuration-cache` project where tests control CC/IP directly.

Many tests are not compatible though, so we mark test cases and classes with a to-be-fixed annotation to tackle them later.

The changeset is large, but trivial:
1. We remove the disablement of the IP executor from the build scripts
2. We add `@ToBeFixedForIsolatedProjects` or `@UnsupportedWithIsolatedProjects` annotations to the tests that failed.

FTR, the `because` of the annotations might not be 100% accurate, since it was suggested by an agent. We accept this trade-off, which is better than having an empty reason.

---

Better online review experience: https://diffshub.com/gradle/gradle/pull/38203/changes