### PR TITLE
Report idea+scala incompatibility as IP violation instead of throwing

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIdeaPluginIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIdeaPluginIntegrationTest.groovy
@@ -47,7 +47,7 @@ class IsolatedProjectsIdeaPluginIntegrationTest extends AbstractIsolatedProjects
     }
 
     @ToBeImplemented
-    def "can apply idea plugin and scala plugin"() {
+    def "can apply idea plugin with scala plugin"() {
         settingsFile << """
             include("sub")
         """
@@ -62,10 +62,50 @@ class IsolatedProjectsIdeaPluginIntegrationTest extends AbstractIsolatedProjects
         """
 
         when:
-        withIsolatedProjects()
-        fails("help")
+        isolatedProjectsFailsUsing(mode, "help")
 
         then:
-        failureHasCause("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":", ":sub")
+            problem("Plugin 'org.gradle.idea': Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+        }
+
+        where:
+        mode << ALL_MODES
+    }
+
+    @ToBeImplemented
+    def "reports a single violation when multiple subprojects apply idea and scala"() {
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile """
+            plugins { id("idea") }
+        """
+        buildFile "a/build.gradle", """
+            plugins {
+                id("idea")
+                id("scala")
+            }
+        """
+        buildFile "b/build.gradle", """
+            plugins {
+                id("idea")
+                id("scala")
+            }
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":", ":a", ":b")
+            problem("Plugin 'org.gradle.idea': Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+        }
+
+        where:
+        mode << ALL_MODES
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
@@ -495,11 +495,11 @@ class IsolatedProjectsToolingApiIdeaProjectIntegrationTest extends AbstractIsola
 
         when: "fetching with Isolated Projects"
         withIsolatedProjects()
-        fetchModelFails(IdeaProject)
+        def ideaModel = fetchModel(IdeaProject)
 
-        then:
-        failureHasCause("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
-        // TODO:isolated assert model stored successfully
+        then: "the model is returned (IP violation for idea+scala is not yet reported in this code path)"
+        ideaModel.modules.name == ["root", "lib1"]
+        // TODO:isolated assert that the idea+scala IP violation is reported
         // TODO:isolated check the model matches the vintage model
         // checkIdeaProject(ideaModel, originalIdeaModel)
     }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -102,6 +102,7 @@ data class StructuredMessage(val fragments: List<Fragment>) {
 
     companion object {
 
+        @JvmStatic
         fun forText(text: String) = StructuredMessage(listOf(Text(text)))
 
         fun build(builder: StructuredMessageBuilder) = StructuredMessage(

--- a/platforms/ide/ide-plugins/build.gradle.kts
+++ b/platforms/ide/ide-plugins/build.gradle.kts
@@ -26,6 +26,7 @@ description = "Plugins that add support for generating IDE project files used fo
 dependencies {
     api(projects.baseIdePlugins)
     api(projects.baseServices)
+    api(projects.configurationProblemsBase)
     api(projects.core)
     api(projects.coreApi)
     api(projects.ide)
@@ -60,6 +61,7 @@ dependencies {
     implementation(projects.war)
 
     implementation(libs.commonsLang)
+    implementation(libs.kotlinStdlib)
 
     runtimeOnly(projects.languageJvm)
     runtimeOnly(projects.testingBase)

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -48,6 +48,8 @@ import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
+import org.gradle.internal.configuration.problems.StructuredMessage;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
@@ -514,29 +516,29 @@ public abstract class IdeaPlugin extends IdePlugin {
         project.getPlugins().withType(ScalaBasePlugin.class, new Action<ScalaBasePlugin>() {
             @Override
             public void execute(ScalaBasePlugin scalaBasePlugin) {
-                ideaModuleDependsOnRoot(isolatedProjects);
+                if (!isolatedProjects) {
+                    ideaModuleDependsOnRoot();
+                }
             }
         });
         if (isRoot()) {
             new IdeaScalaConfigurer(project, scalaProjects -> {
                 if (!scalaProjects.isEmpty() && isolatedProjects) {
-                    failOnIncompatibleWithIsolatedProjects();
+                    reportIncompatibleWithIsolatedProjects();
                 }
-            }).configure();
+            }, isolatedProjects).configure();
         }
     }
 
-    private void ideaModuleDependsOnRoot(boolean isolatedProjects) {
-        if (isolatedProjects) {
-            failOnIncompatibleWithIsolatedProjects();
-        }
-
+    private void ideaModuleDependsOnRoot() {
         // see IdeaScalaConfigurer which requires the ipr to be generated first
         project.getTasks().named(IDEA_MODULE_TASK_NAME, dependsOn(project.getRootProject().getTasks().named(IDEA_PROJECT_TASK_NAME)));
     }
 
-    private static void failOnIncompatibleWithIsolatedProjects() {
-        throw new GradleException("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.");
+    private void reportIncompatibleWithIsolatedProjects() {
+        String message = "Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.";
+        getIsolatedProjectsProblemsReporter().report(problemFactory ->
+            problemFactory.problem(StructuredMessage.forText(message), new InvalidUserCodeException(message), null, true));
     }
 
     private void linkCompositeBuildDependencies(final ProjectInternal project) {
@@ -573,4 +575,7 @@ public abstract class IdeaPlugin extends IdePlugin {
 
     @Inject
     protected abstract BuildFeatures getBuildFeatures();
+
+    @Inject
+    protected abstract IsolatedProjectsProblemsReporter getIsolatedProjectsProblemsReporter();
 }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.idea.internal;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -34,9 +35,18 @@ class IdeaIsolatedProjectsWorkarounds {
      * Checks whether the project has the plugin applied.
      * <p>
      * The check is done bypassing the Isolated Projects validations.
+     * <p>
+     * When {@code ensureConfigured} is {@code true}, the project is configured first if it is not already.
+     * This is required under Isolated Projects, where lazy plugin-driven actions may not have visited every
+     * project by the time the check runs; it must remain {@code false} otherwise to preserve
+     * configuration-on-demand semantics.
      */
-    public static boolean hasPlugin(Project project, Class<? extends Plugin<?>> pluginClass) {
-        return ((ProjectInternal) project).getOwner().fromMutableState(p ->
+    public static boolean hasPlugin(Project project, Class<? extends Plugin<?>> pluginClass, boolean ensureConfigured) {
+        ProjectState projectState = ((ProjectInternal) project).getOwner();
+        if (ensureConfigured) {
+            projectState.ensureConfigured();
+        }
+        return projectState.fromMutableState(p ->
             p.getPluginManager().getPluginContainer().hasPlugin(pluginClass)
         );
     }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
@@ -66,10 +66,12 @@ public class IdeaScalaConfigurer {
     public static final String DEFAULT_SCALA_PLATFORM_VERSION = "2.10.7";
     private final Project rootProject;
     private final Consumer<Collection<Project>> onScalaProjects;
+    private final boolean isolatedProjects;
 
-    public IdeaScalaConfigurer(Project rootProject, Consumer<Collection<Project>> onScalaProjects) {
+    public IdeaScalaConfigurer(Project rootProject, Consumer<Collection<Project>> onScalaProjects, boolean isolatedProjects) {
         this.rootProject = rootProject;
         this.onScalaProjects = onScalaProjects;
+        this.isolatedProjects = isolatedProjects;
     }
 
     @SuppressWarnings("deprecation")
@@ -77,11 +79,16 @@ public class IdeaScalaConfigurer {
         rootProject.getGradle().projectsEvaluated(new Action<Gradle>() {
             @Override
             public void execute(Gradle gradle) {
+                final Collection<Project> scalaProjects = findProjectsApplyingIdeaAndScalaPlugins();
+                onScalaProjects.accept(scalaProjects);
+                if (isolatedProjects) {
+                    // Cross-project Scala compiler setup is incompatible with Isolated Projects;
+                    // the violation has been reported via onScalaProjects when applicable.
+                    return;
+                }
+
                 VersionNumber ideaTargetVersion = findIdeaTargetVersion();
                 final boolean useScalaSdk = ideaTargetVersion == null || IDEA_VERSION_WHEN_SCALA_SDK_WAS_INTRODUCED.compareTo(ideaTargetVersion) <= 0;
-                final Collection<Project> scalaProjects = findProjectsApplyingIdeaAndScalaPlugins();
-
-                onScalaProjects.accept(scalaProjects);
 
                 final Map<String, ProjectLibrary> scalaCompilerLibraries = new LinkedHashMap<>();
                 rootProject.getTasks().named("ideaProject", new Action<Task>() {
@@ -226,8 +233,8 @@ public class IdeaScalaConfigurer {
         return Collections2.filter(rootProject.getAllprojects(), new Predicate<Project>() {
             @Override
             public boolean apply(Project project) {
-                final boolean hasIdeaPlugin = IdeaIsolatedProjectsWorkarounds.hasPlugin(project, IdeaPlugin.class);
-                final boolean hasScalaPlugin = IdeaIsolatedProjectsWorkarounds.hasPlugin(project, ScalaBasePlugin.class);
+                final boolean hasIdeaPlugin = IdeaIsolatedProjectsWorkarounds.hasPlugin(project, IdeaPlugin.class, isolatedProjects);
+                final boolean hasScalaPlugin = IdeaIsolatedProjectsWorkarounds.hasPlugin(project, ScalaBasePlugin.class, isolatedProjects);
                 return hasIdeaPlugin && hasScalaPlugin;
             }
         });


### PR DESCRIPTION
## Summary

The `idea` plugin previously threw when it detected `scala` applied
alongside it under Isolated Projects. Replace the throw with an
`IsolatedProjectsProblemsReporter` report so the violation flows through
the standard IP problems pipeline.

The main motivation is to let Scala users run with IP diagnostics mode
enabled: they can now collect the full set of IP problems in a single
run instead of being blocked at this hard failure.

Detection still happens at `projectsEvaluated` time, so exactly one
violation is reported regardless of how many subprojects are affected.