### PR TITLE
Don't clear real system properties in UndeclaredSystemPropertiesIntegrationTest

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/UndeclaredSystemPropertiesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/UndeclaredSystemPropertiesIntegrationTest.groovy
@@ -196,10 +196,21 @@ class UndeclaredSystemPropertiesIntegrationTest extends AbstractConfigurationCac
         outputContains("foo = null")
 
         where:
-        source << PropertySource.values()
-
-        combined:
-        mutation << ['remove("foo")', 'clear()']
+        // Clearing the REAL System.getProperties() is deliberately excluded.
+        // Config-time system-property mutations are replayed onto the live System.getProperties()
+        // while the fingerprint is verified on a cache hit and, unlike on a cache miss, they are NOT
+        // rolled back afterwards (see ConfigurationCacheFingerprintChecker and
+        // DefaultConfigurationCache.checkFingerprint). Replaying a full clear() therefore wipes
+        // JVM-essential properties (java.specification.version, file.encoding, ...) and breaks the
+        // runtime mid-load — e.g. Groovy's VMPluginFactory fails to initialize — which makes this case
+        // fail under --no-daemon with parallel configuration cache (seen on Linux JDK 17 and Windows
+        // JDK 25). Surgical removal of a single real key is safe to replay
+        // (covered by remove("foo")), and clearing a clone never touches the real properties (covered
+        // by the dedicated clone tests below). Tests that genuinely clear the real properties restore
+        // them immediately and run on the daemon executor only — see UndeclaredBuildInputsIntegrationTest.
+        [source, mutation] << [(PropertySource.values() as List), ['remove("foo")', 'clear()']]
+            .combinations()
+            .findAll { src, mut -> !(src == PropertySource.REAL && mut == 'clear()') }
     }
 
     @Issue("https://github.com/gradle/gradle/pull/37526")


### PR DESCRIPTION
### Context

`UndeclaredSystemPropertiesIntegrationTest` (added in #37526) fails on the no-daemon + parallel-CC test configurations, deterministically and independently of platform/JDK:

- `Gradle_Master_Check_NoDaemon_12_bucket2` — Linux JDK 17 ([build 113926772](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_12_bucket2/113926772))
- `Gradle_Master_Check_NoDaemon_13_bucket2_virtual_Batch_5_1` — Windows JDK 25 ([build 113926966](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_13_bucket2_virtual_Batch_5_1/113926966))

Both fail the same iteration with the same error (and failed all 3 retries):

```
clear() then getProperty on real source returns null and hits cache
> Could not create an instance of type org.gradle.api.internal.project.DefaultProject.
  > Could not initialize class org.codehaus.groovy.vmplugin.VMPluginFactory
```

**Root cause.** For the `clear()` × `real` combination the build runs `System.getProperties().clear()`, clearing the *real* JVM system properties; this is recorded as `SystemPropertiesCleared` in the configuration cache fingerprint. On a cache **hit**, `ConfigurationCacheFingerprintChecker` *replays* the recorded mutations onto the live `System.getProperties()` (so later `UndeclaredSystemProperty` read-checks observe the post-mutation values), and on a valid hit those mutations are deliberately **not** rolled back (`DefaultConfigurationCache.checkFingerprint` only restores the snapshot when the fingerprint is invalid). Replaying a full `clear()` thus leaves the JVM stripped of essential properties (`java.specification.version`, `file.encoding`, …); parallel CC then creates `DefaultProject`, Groovy's `VMPluginFactory` static-init reads a now-missing property and fails.

This production behavior predates #37526 (the replay was added in `2f11990a5c0`); the PR only added a test that exercises it. Faithfully reproducing "all real system properties cleared" on a cache hit is fundamentally incompatible with keeping the JVM runnable, so the scenario cannot be supported.

### Fix

Restrict the parameterized test to the supported combinations:

- keep `remove("foo")` for both the **real** and **clone** sources — removing a single key is safe to replay;
- keep `clear()` for the **clone** source — clone mutations never touch the real properties;
- exclude only **real** + `clear()`.

The genuine full-clear-of-real-properties case adds no coverage beyond `remove("foo")` (the only safe way to clear-then-read-null on real properties is to restore every key except `foo`, which *is* `remove("foo")`). This mirrors `UndeclaredBuildInputsIntegrationTest`, which restores the properties it clears and is annotated `@Requires(NotNoDaemonExecutor)`.

### Verification

Reproduced and verified locally on JDK 17 with the exact CI task (`:configuration-cache:noDaemonIntegTest`):

- before the fix (only `real + clear()` enabled): `Could not initialize class ...VMPluginFactory` → `CONFIGURE FAILED`, matching CI;
- with the fix: `BUILD SUCCESSFUL`, 27 tests, 0 failures.

Also triggered `Gradle_Master_Check_NoDaemon_12_bucket2` on this branch to confirm on CI.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things