### PR TITLE
Disable Kotlin DSL accessor build caching by default

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinDslBuildCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/groovy/org/gradle/kotlin/dsl/KotlinDslBuildCacheIntegrationTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.operations.execution.ExecuteWorkBuildOperationType
+import spock.lang.Issue
+
+class KotlinDslBuildCacheIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final String ACCESSOR_GENERATION_TYPE = "GENERATE_PROJECT_ACCESSORS"
+
+    // Values are copied to make sure no accidental drift in property names and messages can happen
+    private static final String ACCESSOR_CACHING_DISABLED_PROPERTY = "org.gradle.internal.kotlin-script-accessors-caching-disabled"
+    private static final String SCRIPT_CACHING_DISABLED_PROPERTY = "org.gradle.internal.kotlin-script-caching-disabled"
+    private static final String ACCESSOR_CACHING_DISABLED_MESSAGE = "Build caching of Kotlin script accessor generation disabled by property"
+    private static final String SCRIPT_CACHING_DISABLED_MESSAGE = "Caching of Kotlin script compilation and Kotlin DSL accessors generation disabled by property"
+
+    def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)
+
+    def setup() {
+        // Own Gradle user home so the local build cache is writable and the immutable workspace is fresh
+        requireOwnGradleUserHomeDir("Kotlin DSL accessor generation must run fresh, not be shared between tests")
+
+        file("settings.gradle.kts") << '''
+            rootProject.name = "accessor-cache"
+        '''
+        // Accessing the generated accessors (the `java { }` block) is what forces accessor generation;
+        // a plugins-only script stays static and generates none.
+        file("build.gradle.kts") << '''
+            plugins {
+                java
+            }
+
+            java {
+            }
+        '''
+    }
+
+    @Issue("37278")
+    def "Kotlin DSL accessor generation is not build-cached by default"() {
+        when:
+        withBuildCache().run "help"
+
+        then:
+        def accessors = accessorBuildOperations()
+        accessors.size() == 1
+        accessors.first().result.cachingDisabledReasonCategory == "NOT_CACHEABLE"
+        accessors.first().result.cachingDisabledReasonMessage == ACCESSOR_CACHING_DISABLED_MESSAGE
+    }
+
+    @Issue("37278")
+    def "Kotlin DSL accessor generation caching can be re-enabled via the internal property"() {
+        when:
+        withBuildCache().run "-D${ACCESSOR_CACHING_DISABLED_PROPERTY}=false", "help"
+
+        then:
+        def accessors = accessorBuildOperations()
+        accessors.size() == 1
+        accessors.first().result.cachingDisabledReasonCategory == null
+        accessors.first().result.cachingDisabledReasonMessage == null
+    }
+
+    @Issue("37278")
+    def "disabling Kotlin script caching also disables accessor generation caching, for the shared reason"() {
+        when: "the global script-caching switch is on while the accessor-specific switch is off"
+        withBuildCache().run "-D${SCRIPT_CACHING_DISABLED_PROPERTY}=true", "-D${ACCESSOR_CACHING_DISABLED_PROPERTY}=false", "help"
+
+        then: "accessor generation is disabled for the shared script-caching reason, not the accessor-specific one"
+        def accessor = accessorBuildOperations().first()
+        accessor.result.cachingDisabledReasonCategory == "NOT_CACHEABLE"
+        accessor.result.cachingDisabledReasonMessage == SCRIPT_CACHING_DISABLED_MESSAGE
+    }
+
+    private accessorBuildOperations() {
+        buildOperations.all(ExecuteWorkBuildOperationType).findAll { it.details.workType == ACCESSOR_GENERATION_TYPE }
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -97,8 +97,7 @@ class ProjectAccessorsClassPathGenerator @Inject internal constructor(
     private
     val classPathCache = ConcurrentHashMap<ClassLoaderScope, AccessorsClassPath>()
 
-    private val cachingDisabled: Boolean =
-        internalOptions.getBoolean(KotlinDslInternalOptions.CACHING_DISABLED_PROPERTY)
+    private val accessorCachingDisabledReason = KotlinDslInternalOptions.accessorCachingDisabledReason(internalOptions)
 
     fun projectAccessorsClassPath(scriptTarget: ExtensionAware, classPath: ClassPath): AccessorsClassPath {
         val classLoaderScope = classLoaderScopeOf(scriptTarget)
@@ -127,7 +126,7 @@ class ProjectAccessorsClassPathGenerator @Inject internal constructor(
                     inputFingerprinter,
                     workspaceProvider,
                     isDclEnabledForScriptTarget(scriptTarget),
-                    cachingDisabled,
+                    accessorCachingDisabledReason,
                 )
                 executionEngine.createRequest(work)
                     .execute()
@@ -174,7 +173,7 @@ class GenerateProjectAccessors(
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider,
     private val isDclEnabled: Boolean,
-    private val cachingDisabled: Boolean,
+    private val cachingDisabledReason: CachingDisabledReason? = null
 ) : ImmutableUnitOfWork {
 
     companion object {
@@ -189,11 +188,10 @@ class GenerateProjectAccessors(
         return Optional.of("GENERATE_PROJECT_ACCESSORS")
     }
 
-    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> {
-        if (cachingDisabled) {
-            return Optional.of(KotlinDslInternalOptions.CACHING_DISABLED_REASON)
-        }
-        return super.shouldDisableCaching(detectedOverlappingOutputs)
+    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> = if (cachingDisabledReason != null) {
+        Optional.of(cachingDisabledReason)
+    } else {
+        super.shouldDisableCaching(detectedOverlappingOutputs)
     }
 
     override fun execute(executionContext: ExecutionContext): WorkOutput {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GeneratePluginSpecBuilderAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GeneratePluginSpecBuilderAccessors.kt
@@ -25,6 +25,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.execution.ExecutionContext
 import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.execution.WorkOutput
+import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.hash.HashCode
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
 import org.gradle.kotlin.dsl.concurrent.IO
@@ -103,9 +104,9 @@ class GeneratePluginSpecBuilderAccessors(
     fileCollectionFactory: FileCollectionFactory,
     inputFingerprinter: InputFingerprinter,
     workspaceProvider: KotlinDslWorkspaceProvider,
-    cachingDisabled: Boolean,
+    cachingDisabledReason: CachingDisabledReason?
 ) : AbstractStage1BlockAccessorsUnitOfWork(
-    rootProject, buildSrcClassLoaderScope, classLoaderHash, fileCollectionFactory, inputFingerprinter, workspaceProvider, cachingDisabled
+    rootProject, buildSrcClassLoaderScope, classLoaderHash, fileCollectionFactory, inputFingerprinter, workspaceProvider, cachingDisabledReason
 ) {
 
     override fun getDisplayName(): String = "Kotlin DSL plugin specs accessors for classpath '$classLoaderHash'"

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GenerateVersionCatalogAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GenerateVersionCatalogAccessors.kt
@@ -26,6 +26,7 @@ import org.gradle.initialization.DependenciesAccessors.IN_PLUGINS_BLOCK_FACTORIE
 import org.gradle.internal.execution.ExecutionContext
 import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.execution.WorkOutput
+import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.hash.HashCode
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
@@ -70,9 +71,9 @@ class GenerateVersionCatalogAccessors(
     fileCollectionFactory: FileCollectionFactory,
     inputFingerprinter: InputFingerprinter,
     workspaceProvider: KotlinDslWorkspaceProvider,
-    cachingDisabled: Boolean,
+    cachingDisabledReason: CachingDisabledReason?,
 ) : AbstractStage1BlockAccessorsUnitOfWork(
-    rootProject, buildSrcClassLoaderScope, classLoaderHash, fileCollectionFactory, inputFingerprinter, workspaceProvider, cachingDisabled
+    rootProject, buildSrcClassLoaderScope, classLoaderHash, fileCollectionFactory, inputFingerprinter, workspaceProvider, cachingDisabledReason
 ) {
 
     override fun getDisplayName(): String = "Kotlin DSL version catalog plugin accessors for classpath '$classLoaderHash'"

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Stage1BlocksAccessorClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Stage1BlocksAccessorClassPath.kt
@@ -72,8 +72,7 @@ class Stage1BlocksAccessorClassPathGenerator @Inject internal constructor(
     internalOptions: InternalOptions,
 ) {
 
-    private val cachingDisabled: Boolean =
-        internalOptions.getBoolean(KotlinDslInternalOptions.CACHING_DISABLED_PROPERTY)
+    private val scriptDisabledReason = KotlinDslInternalOptions.accessorCachingDisabledReason(internalOptions)
 
     private
     val stage1BlocksAccessorClassPath by lazy {
@@ -123,7 +122,7 @@ class Stage1BlocksAccessorClassPathGenerator @Inject internal constructor(
                     fileCollectionFactory,
                     inputFingerprinter,
                     workspaceProvider,
-                    cachingDisabled,
+                    scriptDisabledReason
                 )
                 executionEngine.createRequest(work)
                     .execute()
@@ -148,7 +147,7 @@ class Stage1BlocksAccessorClassPathGenerator @Inject internal constructor(
             fileCollectionFactory,
             inputFingerprinter,
             workspaceProvider,
-            cachingDisabled,
+            scriptDisabledReason
         )
         return executionEngine.createRequest(work)
             .execute()
@@ -166,7 +165,7 @@ abstract class AbstractStage1BlockAccessorsUnitOfWork(
     private val fileCollectionFactory: FileCollectionFactory,
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider,
-    private val cachingDisabled: Boolean,
+    private val cachingDisabledReason: CachingDisabledReason?
 ) : ImmutableUnitOfWork {
 
     companion object {
@@ -175,12 +174,7 @@ abstract class AbstractStage1BlockAccessorsUnitOfWork(
         const val CLASSES_OUTPUT_PROPERTY = "classes"
     }
 
-    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> {
-        if (cachingDisabled) {
-            return Optional.of(KotlinDslInternalOptions.CACHING_DISABLED_REASON)
-        }
-        return super.shouldDisableCaching(detectedOverlappingOutputs)
-    }
+    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> = Optional.ofNullable(cachingDisabledReason)
 
     override fun identify(scalarInputs: MutableMap<String, ValueSnapshot>, fileInputs: MutableMap<String, CurrentFileCollectionFingerprint>) =
         Identity { "$classLoaderHash-$identitySuffix" }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslInternalOptions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslInternalOptions.kt
@@ -22,8 +22,30 @@ import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 
 internal object KotlinDslInternalOptions {
-    val CACHING_DISABLED_PROPERTY: InternalOption<Boolean> =
+    // Disables build caching for both Kotlin script compilation AND accessor generation
+    private val CACHING_DISABLED_PROPERTY: InternalOption<Boolean> =
         InternalOptions.ofBoolean("org.gradle.internal.kotlin-script-caching-disabled", false)
-    val CACHING_DISABLED_REASON: CachingDisabledReason =
+    private val CACHING_DISABLED_REASON: CachingDisabledReason =
         CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Caching of Kotlin script compilation and Kotlin DSL accessors generation disabled by property")
+
+    // Disables build caching only for accessor generation (overridden by CACHING_DISABLED_PROPERTY)
+    private val ACCESSOR_CACHING_DISABLED_PROPERTY: InternalOption<Boolean> =
+        InternalOptions.ofBoolean("org.gradle.internal.kotlin-script-accessors-caching-disabled", true)
+    private val ACCESSOR_CACHING_DISABLED_REASON: CachingDisabledReason =
+        CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Build caching of Kotlin script accessor generation disabled by property")
+
+    /**
+     * Returns a reason why the script and accessor generation caching is disabled, or `null` if there is none
+     */
+    fun cachingDisabledReason(internalOptions: InternalOptions): CachingDisabledReason? =
+        if (internalOptions.getBoolean(CACHING_DISABLED_PROPERTY)) CACHING_DISABLED_REASON else null
+
+    /**
+     * Returns a reason why specifically the accessor generation is disabled, or `null` if there is none
+     */
+    fun accessorCachingDisabledReason(internalOptions: InternalOptions): CachingDisabledReason? = when {
+        internalOptions.getBoolean(CACHING_DISABLED_PROPERTY) -> CACHING_DISABLED_REASON
+        internalOptions.getBoolean(ACCESSOR_CACHING_DISABLED_PROPERTY) -> ACCESSOR_CACHING_DISABLED_REASON
+        else -> null
+    }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -411,8 +411,7 @@ class StandardKotlinScriptEvaluator(
             const val ACCESSORS_CLASS_PATH = "accessorsClassPath"
         }
 
-        private val cachingDisabledByProperty: Boolean =
-            internalOptions.getBoolean(KotlinDslInternalOptions.CACHING_DISABLED_PROPERTY)
+        private val cachingDisabledReason = KotlinDslInternalOptions.cachingDisabledReason(internalOptions)
 
         override fun getDisplayName(): String =
             "Kotlin DSL script compilation (${programId.templateId})"
@@ -422,8 +421,8 @@ class StandardKotlinScriptEvaluator(
         }
 
         override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> {
-            if (cachingDisabledByProperty) {
-                return Optional.of(KotlinDslInternalOptions.CACHING_DISABLED_REASON)
+            if (cachingDisabledReason != null) {
+                return Optional.of(cachingDisabledReason)
             }
 
             return super.shouldDisableCaching(detectedOverlappingOutputs)

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslInternalOptionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslInternalOptionsTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.provider
+
+import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.InternalOptions
+import org.gradle.internal.execution.caching.CachingDisabledReason
+import org.gradle.internal.execution.caching.CachingDisabledReasonCategory.NOT_CACHEABLE
+import org.gradle.kotlin.dsl.provider.KotlinDslInternalOptions.accessorCachingDisabledReason
+import org.gradle.kotlin.dsl.provider.KotlinDslInternalOptions.cachingDisabledReason
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class KotlinDslInternalOptionsTest {
+
+    // Values are copied to make sure no accidental drift in property names and messages can happen
+    private val cachingDisabledProperty = "org.gradle.internal.kotlin-script-caching-disabled"
+    private val cachingDisabledMessage = "Caching of Kotlin script compilation and Kotlin DSL accessors generation disabled by property"
+    private val accessorCachingDisabledProperty = "org.gradle.internal.kotlin-script-accessors-caching-disabled"
+    private val accessorCachingDisabledMessage = "Build caching of Kotlin script accessor generation disabled by property"
+
+    @Test
+    fun `script caching is enabled by default`() {
+        assertThat(
+            cachingDisabledReason(optionsWith(cachingDisabledProperty to false)),
+            nullValue()
+        )
+    }
+
+    @Test
+    fun `script caching can be disabled`() {
+        assertReason(
+            cachingDisabledReason(optionsWith(cachingDisabledProperty to true)),
+            cachingDisabledMessage
+        )
+    }
+
+    @Test
+    fun `accessor caching is disabled by default`() {
+        assertReason(
+            accessorCachingDisabledReason(optionsWith(cachingDisabledProperty to false)),
+            accessorCachingDisabledMessage
+        )
+    }
+
+    @Test
+    fun `accessor caching can be enabled`() {
+        assertThat(
+            accessorCachingDisabledReason(optionsWith(cachingDisabledProperty to false, accessorCachingDisabledProperty to false)),
+            nullValue()
+        )
+    }
+
+    @Test
+    fun `disabling script caching also disables accessor caching`() {
+        assertReason(
+            accessorCachingDisabledReason(optionsWith(cachingDisabledProperty to true, accessorCachingDisabledProperty to false)),
+            cachingDisabledMessage
+        )
+    }
+
+    @Test
+    fun `script caching disabled takes precedence over accessor caching`() {
+        assertReason(
+            accessorCachingDisabledReason(optionsWith(cachingDisabledProperty to true, accessorCachingDisabledProperty to true)),
+            cachingDisabledMessage
+        )
+    }
+
+    private
+    fun optionsWith(vararg settings: Pair<String, Boolean>): InternalOptions =
+        DefaultInternalOptions(settings.associate { (name, disabled) -> name to disabled.toString() })
+
+    private
+    fun assertReason(reason: CachingDisabledReason?, expectedMessage: String) {
+        assertThat(reason?.category, equalTo(NOT_CACHEABLE))
+        assertThat(reason?.message, equalTo(expectedMessage))
+    }
+}

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -153,6 +153,20 @@ Gradle provides [Tooling APIs](userguide/third_party_integration.html) that faci
 ### General improvements
 Gradle provides various incremental updates and performance optimizations to ensure the continued reliability of the build ecosystem.
 
+#### Kotlin DSL accessor generation is no longer stored in the build cache
+
+Generating the [type-safe Kotlin DSL accessors](userguide/kotlin_dsl.html#type-safe-accessors) for a project produces Kotlin source files.
+For some projects those files can be sizeable, but their generation is fast.
+
+Storing and fetching those files adds its own overhead when the [Build Cache](userguide/build_cache.html#build_cache) is in use.
+That overhead alone is comparable to or higher than the cost of just regenerating the accessors.
+Gradle therefore no longer stores Kotlin DSL accessor generation in the Build Cache by default.
+
+Builds that use a remote Build Cache will regenerate accessors locally instead of downloading them; in-build deduplication of accessor generation is unaffected.
+Kotlin DSL script compilation continues to be cached as before.
+
+See the [Type-safe model accessors](userguide/kotlin_dsl.html#type-safe-accessors) section in the Gradle User Manual for more details.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ========================================================== -->


### PR DESCRIPTION
Implementation of the decision made in https://github.com/gradle/gradle/issues/37278

The analysis of the issue showed that the payoff, especially for accessor generation artifacts, is only applicable in a thin zone.

For accessor generation, we established that a 19ms RTT[^1] to the cache server already zeroes out the benefits.
Also, we identified that the cache-related operations (snapshotting, packing, unpacking) is significant vs. the script compilation artifacts. Therefore, we decided to disable accessor generation caching.

[^1]: This is measured on one specific machine; numbers might vary depending on how fast a given machine is. Slower machines push this number up, faster ones down.