### PR TITLE
Add `accessorHeavyJavaMultiProjectKotlinDsl` performance testbed

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -56,9 +56,24 @@ performanceTest.registerTestProject("largeEmptyMultiProjectDeclarativeDsl", Java
 
 
 // === Java ===
-['largeMonolithicJavaProject', 'largeJavaMultiProject', 'smallJavaMultiProjectManyExternalDependencies', 'largeJavaMultiProjectHierarchy', 'largeMonolithicGroovyProject', 'largeGroovyMultiProject', 'largeJavaMultiProjectNoBuildSrc', 'largeJavaMultiProjectKotlinDsl',
- 'mediumMonolithicJavaProject', 'mediumJavaMultiProject', 'mediumJavaMultiProjectWithTestNG', 'mediumJavaCompositeBuild', 'mediumJavaPredefinedCompositeBuild',
- 'smallJavaMultiProject', 'smallJavaMultiProjectNoBuildSrc'].each { template ->
+[
+    'smallJavaMultiProject',
+    'smallJavaMultiProjectManyExternalDependencies',
+    'smallJavaMultiProjectNoBuildSrc',
+    'mediumJavaCompositeBuild',
+    'mediumJavaMultiProject',
+    'mediumJavaMultiProjectWithTestNG',
+    'mediumJavaPredefinedCompositeBuild',
+    'mediumMonolithicJavaProject',
+    'largeAccessorHeavyJavaMultiProjectKotlinDsl',
+    'largeGroovyMultiProject',
+    'largeJavaMultiProject',
+    'largeJavaMultiProjectHierarchy',
+    'largeJavaMultiProjectKotlinDsl',
+    'largeJavaMultiProjectNoBuildSrc',
+    'largeMonolithicGroovyProject',
+    'largeMonolithicJavaProject'
+].each { template ->
     performanceTest.registerTestProject(template, JavaExecProjectGeneratorTask) {
         outputs.dir new File(buildDir, template)
         outputs.cacheIf { true }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -71,6 +71,7 @@ abstract class FileContentGenerator {
         return """
         plugins {
             ${config.plugins.collect { decideOnJavaPlugin(it, dependencyTree.hasParentProject(subProjectNumber)) }.join("\n        ")}
+            ${config.accessorHeavy ? pluginBlockApply("accessor-variant") : ""}
         }
 
         group = "org.gradle.test.performance"

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
@@ -94,6 +94,17 @@ enum JavaTestProjectGenerator {
         .withDsl(KOTLIN)
         .create()),
 
+    LARGE_ACCESSOR_HEAVY_JAVA_MULTI_PROJECT_KOTLIN_DSL(new TestProjectGeneratorConfigurationBuilder("largeAccessorHeavyJavaMultiProjectKotlinDsl", "largeJavaMultiProject")
+        .withSourceFiles(100)
+        .withSubProjects(500)
+        .withDaemonMemory('1536m')
+        .withCompilerMemory('256m')
+        .assembleChangeFile()
+        .testChangeFile(450, 2250, 45000)
+        .withDsl(KOTLIN)
+        .withAccessorHeavy(true)
+        .create()),
+
     LARGE_EMPTY_MULTI_PROJECT_DECLARATIVE_DSL(new TestProjectGeneratorConfigurationBuilder("largeEmptyMultiProjectDeclarativeDsl", "largeEmptyMultiProject")
         .withSubProjects(500)
         .withDsl(DECLARATIVE)

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -103,10 +103,32 @@ class TestProjectGenerator extends AbstractTestProjectGenerator {
 
     /**
      * This is just to ensure we test the overhead of having a buildSrc project, e.g. snapshotting the Gradle API.
+     *
+     * For the accessor-heavy testbed, the buildSrc is upgraded to a Kotlin DSL project
+     * containing a precompiled script plugin that registers a uniquely-named extension
+     * based on {@code project.name} at apply time. Each subproject's TypedProjectSchema
+     * then differs, so {@code GenerateProjectAccessors} fires once per subproject
+     * instead of being deduped by {@code IdentityCacheStep}.
      */
     private addDummyBuildSrcProject(File projectDir) {
-        file projectDir, "buildSrc/src/main/${config.language.name}/Thing.${config.language.name}", "public class Thing {}"
-        file projectDir, "buildSrc/build.gradle", "compileJava.options.incremental = true"
+        if (config.accessorHeavy) {
+            file projectDir, "buildSrc/settings.gradle.kts", ""
+            file projectDir, "buildSrc/build.gradle.kts", """
+                plugins { `kotlin-dsl` }
+                repositories { mavenCentral() }
+            """.stripIndent()
+            file projectDir, "buildSrc/src/main/kotlin/AccessorVariantExtension.kt", """
+                abstract class AccessorVariantExtension {
+                    var value: String = ""
+                }
+            """.stripIndent()
+            file projectDir, "buildSrc/src/main/kotlin/accessor-variant.gradle.kts", """
+                extensions.create<AccessorVariantExtension>("ext_\${project.name.replace('-', '_')}")
+            """.stripIndent()
+        } else {
+            file projectDir, "buildSrc/src/main/${config.language.name}/Thing.${config.language.name}", "public class Thing {}"
+            file projectDir, "buildSrc/build.gradle", "compileJava.options.incremental = true"
+        }
     }
 
     static void main(String[] args) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
@@ -56,6 +56,15 @@ class TestProjectGeneratorConfiguration {
     int testForkEvery
     boolean useTestNG
     Map<String, String> fileToChangeByScenario
+
+    /**
+     * When true, each subproject's build script declares a uniquely-named
+     * configuration. This makes every project's accessor schema distinct,
+     * so {@code GenerateProjectAccessors} fires once per subproject instead
+     * of being deduped down to a handful of schemas by {@code IdentityCacheStep}.
+     * Used by the {@code accessorHeavyJavaMultiProjectKotlinDsl} testbed.
+     */
+    boolean accessorHeavy
 }
 
 @Builder(prefix = "with",
@@ -151,6 +160,7 @@ class TestProjectGeneratorConfigurationBuilder {
         config.testForkEvery = 1000
         config.useTestNG = this.useTestNG
         config.fileToChangeByScenario = this.fileToChangeByScenario
+        config.accessorHeavy = this.accessorHeavy
         return config
     }
 }

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -24,7 +24,7 @@ import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "largeJavaMultiProjectKotlinDsl"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "largeJavaMultiProjectKotlinDsl", "largeAccessorHeavyJavaMultiProjectKotlinDsl"])
 )
 class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTest {
 


### PR DESCRIPTION
Secondary results of implementing https://github.com/gradle/gradle/issues/37278

---

Adds a large multi-project Kotlin DSL performance testbed, `largeAccessorHeavyJavaMultiProjectKotlinDsl`, in which each subproject has a **distinct** accessor schema.

The normal `largeJavaMultiProjectKotlinDsl` scenario is too uniform, and only generates 2 units of work, regardless of how many projects are generated.

## What it does

- New `largeAccessorHeavyJavaMultiProjectKotlinDsl` test project: 500 Kotlin DSL subprojects, each applying a buildSrc precompiled script plugin that registers a uniquely-named extension (`ext_<projectName>`). This will make the schema unique and will trigger a whole accessor generation pipeline.
- The `accessorHeavy` flag is plumbed through the generator config/builder so the buildSrc is upgraded to a `kotlin-dsl` project only for this testbed; all other testbeds are unchanged.
