### PR TITLE
Restore GradleInternal.getRootProject override for binary compatibility

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -19,6 +19,7 @@ import org.gradle.BuildListener;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.invocation.Gradle;
@@ -159,4 +160,9 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      * Resets the lifecycle for this Gradle object.
      */
     void resetState();
+
+    // We technically don't need this overload, but some plugins using GradleInternal break at runtime if we remove it
+    // E.g. see https://github.com/quarkusio/quarkus/issues/54851
+    @Override
+    ProjectInternal getRootProject() throws IllegalStateException;
 }


### PR DESCRIPTION
Some plugins break at runtime without this covariant override.
See https://github.com/quarkusio/quarkus/issues/54851

---

The change was verified manually on the reproducer in the Quarkus issue