### PR TITLE
Automate tested Kotlin version updates

### DIFF
--- a/.github/actions/open-pr/action.yml
+++ b/.github/actions/open-pr/action.yml
@@ -1,0 +1,82 @@
+name: "Open a bot PR"
+description: "Commit the current working-tree changes onto a branch, push it, and open a PR as bot-gradle (optionally asking the merge bot to test and merge)."
+
+inputs:
+  branch:
+    description: "Branch to create the changes on and open the PR from"
+    required: true
+  title:
+    description: "PR title (also used as the PR body)"
+    required: true
+  message:
+    description: "Commit message"
+    required: true
+  reviewer:
+    description: "Reviewer to request on the PR"
+    required: true
+  labels:
+    description: "Comma-separated labels to apply to the PR"
+    required: false
+  bot-command:
+    description: "@bot-gradle comment to post: 'test and merge' tests then auto-merges, 'test <pipeline>' tests only, empty posts nothing"
+    required: false
+    default: "test and merge"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::992382829881:role/GHASecrets_gradle_all
+        aws-region: "eu-central-1"
+    - name: Get bot token
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
+      with:
+        secret-ids: |
+          BOT_GRADLE_GITHUB_TOKEN, gha/gradle/_all/BOT_GRADLE_GITHUB_TOKEN
+    - name: Commit, push, and open PR
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ env.BOT_GRADLE_GITHUB_TOKEN }}
+        BRANCH: ${{ inputs.branch }}
+        PR_TITLE: ${{ inputs.title }}
+        COMMIT_MSG: ${{ inputs.message }}
+        REVIEWER: ${{ inputs.reviewer }}
+        LABELS: ${{ inputs.labels }}
+        BOT_COMMAND: ${{ inputs.bot-command }}
+      run: |
+        set -euo pipefail
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "No changes."
+          exit 0
+        fi
+
+        # Don't touch the branch if a PR is already open: someone may be working on it.
+        if [ -n "$(gh pr list --state open --head "$BRANCH" --json number --jq '.[].number')" ]; then
+          echo "An open PR for $BRANCH already exists; skipping."
+          exit 0
+        fi
+
+        git config user.name  "bot-gradle"
+        git config user.email "bot-gradle@gradle.com"
+        git checkout -B "$BRANCH"
+        git add -A
+        git commit -s -m "$COMMIT_MSG"
+
+        # Replace any stale branch left behind by a previously-closed PR.
+        git push origin --delete "$BRANCH" 2>/dev/null || true
+        git push origin "$BRANCH"
+
+        label_arg=()
+        [ -n "$LABELS" ] && label_arg=(--label "$LABELS")
+        gh pr create \
+          --base master \
+          --title "$PR_TITLE" \
+          --body "$PR_TITLE" \
+          --reviewer "$REVIEWER" \
+          "${label_arg[@]}"
+
+        if [ -n "$BOT_COMMAND" ]; then
+          gh pr comment "$BRANCH" --body "@bot-gradle $BOT_COMMAND"
+        fi

--- a/.github/workflows/update-kotlin-versions.yml
+++ b/.github/workflows/update-kotlin-versions.yml
@@ -1,15 +1,15 @@
-name: Update tested AGP versions
+name: Update tested Kotlin versions
 
 on:
   workflow_dispatch:
   schedule:
-    # Every Saturday at 22:00 UTC
-    - cron: '0 22 * * 6'
+    # Every Saturday at 20:00 UTC
+    - cron: '0 20 * * 6'
 
 permissions: {}
 
 jobs:
-  update-agp-versions:
+  update-kotlin-versions:
     if: github.repository == 'gradle/gradle'
     permissions:
       contents: write
@@ -26,13 +26,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Update AGP versions
-        run: ./gradlew updateAgpVersions
+      - name: Update Kotlin versions
+        run: ./gradlew updateKotlinVersions
       - name: Open bot PR
         uses: ./.github/actions/open-pr
         with:
-          branch: tide/update-agp
-          title: Update tested AGP versions
-          message: Update AGP versions
+          branch: tide/update-kotlin
+          title: Update tested Kotlin versions
+          message: Update Kotlin versions
           reviewer: gradle/bt-tide
-          labels: a:chore,re:android,in:performance-test,in:smoke-test,to-triage
+          labels: a:chore,in:performance-test,in:smoke-test,to-triage


### PR DESCRIPTION
### Context

Tested-Kotlin-version bumps have been done manually (e.g. #35363, #35252, #34480), whereas the equivalent AGP bumps are automated by a scheduled workflow. This adds the same automation for Kotlin and factors out the shared plumbing both share.

The flow is very similar to the previous AGP automation:
 - run the `updateKotlinVersions` task
 - commit / push / create a PR
 - send the PR to the merge queue

An added interesting thing is a new abstraction, the `open-pr` action that takes care of doing the (quite involved) process of managing git and GitHub.