### PR TITLE
Use shared intTestHome dir for smoke tests and leverage artifact cache to speed up smoke tests

### DIFF
--- a/.teamcity/hooks/hooks.sh
+++ b/.teamcity/hooks/hooks.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Repository build hook for the integration-test Gradle user home (intTestHomeDir).
+# Restores (pre) or stores (post) each distribution home via the artifact-cache contract
+# the CI agent provides. The agent publishes that contract's path as
+# GRADLE_UNIVERSAL_CACHE_CLI_PATH; this hook knows nothing about the CLI itself. When the
+# variable is absent (local builds, non-EC2 agents) the hook does nothing.
+#
+# Usage: hooks.sh (pre|post)   -- invoked by the thin pre-build/post-build shims.
+
+set -euo pipefail
+
+PHASE="${1:-}"
+case "${PHASE}" in
+  pre|post) ;;
+  *) echo "Usage: $(basename "$0") (pre|post)" >&2; exit 2 ;;
+esac
+
+# Only smoke tests share the integration-test Gradle user home, so only they benefit here.
+if [[ "${BUILD_TYPE_ID:-}" != *SmokeTest* ]]; then
+  echo "Skipping artifact cache: BUILD_TYPE_ID='${BUILD_TYPE_ID:-}' is not a SmokeTest build."
+  exit 0
+fi
+
+# The CI agent provides the artifact-cache contract; without it (local/non-EC2) do nothing.
+if [[ ! -x "${GRADLE_UNIVERSAL_CACHE_CLI_PATH:-}" ]]; then
+  echo "Skipping artifact cache: GRADLE_UNIVERSAL_CACHE_CLI_PATH is not set or not executable."
+  exit 0
+fi
+
+INT_TEST_HOME_DIR="$(pwd)/intTestHomeDir"
+# Homes to restore; on store we only pick up the ones that were populated.
+INT_TEST_DISTRIBUTIONS="${INT_TEST_DISTRIBUTIONS:-full jvm basics native}"
+
+# Image name, stable across builds of the same base branch (release vs master).
+if [[ "${BUILD_TYPE_ID:-}" == Gradle_Release* ]]; then
+  baseBranch="release"
+else
+  baseBranch="master"
+fi
+
+for dist in ${INT_TEST_DISTRIBUTIONS}; do
+  gradleHome="${INT_TEST_HOME_DIR}/distributions-${dist}"
+  imageName="gradle-${BUILD_TYPE_ID}-${baseBranch}-distributions-${dist}"
+
+  if [[ "${PHASE}" == "pre" ]]; then
+    mkdir -p "${gradleHome}"
+    echo "Restoring integration-test Gradle user home '${gradleHome}' from image '${imageName}'..."
+    # Best-effort: a miss or error just means tests download as before.
+    "${GRADLE_UNIVERSAL_CACHE_CLI_PATH}" --restore "${imageName}" "${gradleHome}" || true
+
+    # The Artifact Cache CLI unconditionally injects an init script
+    # (init.d/develocity-inject-restore-metrics.gradle) into every restored Gradle home to
+    # report cache metrics to the build scan; there is no CLI flag to disable it. Smoke tests
+    # reuse this home for their *nested* builds, where that script runs too. It is incompatible
+    # with the older Develocity plugin versions the smoke tests exercise (it NPEs on a null
+    # buildScan), and its stack trace pollutes the nested build output, which the smoke-test
+    # runner rejects. We only want the dependency cache here, not the metrics instrumentation,
+    # so remove the injected init script after restore.
+    rm -f "${gradleHome}/init.d/develocity-inject-restore-metrics.gradle"
+  elif [ -d "${gradleHome}/caches/modules-2" ]; then
+    echo "Storing integration-test Gradle user home '${gradleHome}' to image '${imageName}'..."
+    "${GRADLE_UNIVERSAL_CACHE_CLI_PATH}" --store "${imageName}" "${gradleHome}" || true
+  fi
+done

--- a/.teamcity/hooks/post-build
+++ b/.teamcity/hooks/post-build
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Post-build hook entry point (file name required by the teamcity-hooks-plugin).
+# All logic lives in hooks.sh.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/hooks.sh" post

--- a/.teamcity/hooks/pre-build
+++ b/.teamcity/hooks/pre-build
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Pre-build hook entry point (file name required by the teamcity-hooks-plugin).
+# All logic lives in hooks.sh.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/hooks.sh" pre

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.scan.config.fixtures.ApplyDevelocityPluginFixture
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
@@ -45,17 +46,18 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
-    TestFile homeDir
+
+    // Use the Gradle user home shared by the whole build's integration tests instead of a fresh TestKit home per
+    // test. A fresh home forced every test method to re-download the full Android/Kotlin dependency set (~1GB)
+    // from the mirror. These tests run serially (maxParallelForks = 1), so sharing the home - and reusing its
+    // daemons across methods - is safe.
+    static final TestFile SHARED_GRADLE_USER_HOME = IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir
 
     String kotlinVersion = KOTLIN_VERSIONS.latestStable
 
-    def setup() {
-        homeDir = temporaryFolder.createDir("test-kit-home")
-    }
-
-    def cleanup() {
+    def cleanupSpec() {
         // The daemons started by test kit need to be killed, so no locked files are left behind.
-        DaemonLogsAnalyzer.newAnalyzer(homeDir.file(ToolingApiGradleExecutor.TEST_KIT_DAEMON_DIR_NAME)).killAll()
+        DaemonLogsAnalyzer.newAnalyzer(SHARED_GRADLE_USER_HOME.file(ToolingApiGradleExecutor.TEST_KIT_DAEMON_DIR_NAME)).killAll()
     }
 
     protected void setupCopyOfAndroidProject(TestFile targetDir) {
@@ -97,7 +99,7 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
 
         def runner = agpRunner(agpVersion, *runnerArgs)
             .withProjectDir(projectDir)
-            .withTestKitDir(homeDir)
+            .withTestKitDir(SHARED_GRADLE_USER_HOME)
             .withJdkWarningChecksDisabled() // Kapt seems to be accessing JDK internals. See KT-49187
 
         if (JavaVersion.current().isJava9Compatible()) {


### PR DESCRIPTION
## Why

Closes https://github.com/gradle/gradle-private/issues/5263

We noticed slow smoke tests, [example](https://ge.gradle.org/s/hbdpp7m2cyyno/tests/overview), each test case may take as slow as 10m. Checking out the builds inside the smoke test, we can find that it spend most time on downloading deps: https://ge.gradle.org/s/65cokdhnqwuti/performance/network-activity

This is because:

1. Some smoke tests use dedicated gradle user home instead of `intTestHomeDir`. Every time the test needs to download ~1G deps.
2. We don't share intTestHomeDir on EC2.

## What

**1. Share the integration-test Gradle user home in the heavy Android smoke tests**
`AbstractAndroidProjectSmokeTest` now uses the shared `intTestHomeDir` home (like the rest of the smoke/integ tests) instead of a fresh per-test `test-kit-home`. Dependencies are downloaded once and reused across methods. These tests run serially (`maxParallelForks = 1`), so sharing the home — and reusing its daemons — is safe; the daemon cleanup moves to `cleanupSpec`.

**2. Artifact-cache hooks for the integration-test home**
New repository hooks under `.teamcity/hooks/` (run by the [teamcity-hooks-plugin](https://github.com/gradle/teamcity-hooks-plugin)) restore (pre-build) and store (post-build) the integration-test Gradle user homes `intTestHomeDir/distributions-*`. Each distribution home maps to its own per-base-branch image. Restore/store failures never fail the build.

The hooks know nothing about how the cache works — no CLI jar, no Java version, no agent paths. They go through the single, stable contract the CI agent provides and publishes as `GRADLE_UNIVERSAL_CACHE_CLI_PATH` (added in gradle/dev-infrastructure#3163):

```
"$GRADLE_UNIVERSAL_CACHE_CLI_PATH" (--store|--restore) <image-name> <gradle-home>
```

The repo side decides only **what** to cache:
- `pre-build`/`post-build` are thin shims (those file names are required by the plugin) over a single `hooks.sh (pre|post)`;
- `hooks.sh` gates on `BUILD_TYPE_ID` containing `SmokeTest`, enumerates the distribution homes, and computes the per-base-branch image name;
- **if `GRADLE_UNIVERSAL_CACHE_CLI_PATH` is set and executable it is referenced for store/restore; otherwise the hook does nothing** (local builds, non-EC2 agents). Its presence also implies an EC2 agent with the CLI baked in, so no separate EC2 probe is needed.

> Companion PR: gradle/dev-infrastructure#3163 introduces `universal-cache.sh` and publishes `GRADLE_UNIVERSAL_CACHE_CLI_PATH`. The two land together.

## Verification (live, on real EC2 agents)

Before:

<img width="838" height="403" alt="image" src="https://github.com/user-attachments/assets/e512848f-a116-4321-9808-82231532d686" />

<img width="888" height="422" alt="image" src="https://github.com/user-attachments/assets/32fabee0-214c-4261-b296-8282dc73fc7c" />


After:

<img width="922" height="515" alt="image" src="https://github.com/user-attachments/assets/dee9fce8-6b73-4e49-b60c-dcbe1abe2445" />


<img width="868" height="390" alt="image" src="https://github.com/user-attachments/assets/c89d3d14-b028-4440-9f67-05da5e6cac67" />
