### PR TITLE
Convert Tooling API model fetch failures in linear time and reuse shared conversions

### DIFF
--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
@@ -112,28 +112,42 @@ public class DefaultFailure implements Serializable, InternalFailure {
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
+        return fromFailure(buildFailure, mapper, FailureCache.NONE);
+    }
+
+    public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache) {
+        // Reuse the conversion of a throwable already seen, e.g. a configuration failure shared across per-project fetches.
+        InternalFailure cached = cache.get(buildFailure.getOriginal());
+        if (cached != null) {
+            return cached;
+        }
         // Build the failure tree in a single pass: each node carries only its own description. The full description (the
-        // whole cause subtree) is reconstructed lazily from these on demand, so no node prints its subtree here.
+        // whole cause subtree) is reconstructed lazily from these on demand, so no node prints its subtree here. Children
+        // are interned before the parent, so the cache is never re-entered while a single mapping is being computed.
         String ownDescription = FailurePrinter.printNodeToString(buildFailure);
-        List<InternalFailure> causeFailures = convertCausesToFailures(buildFailure.getCauses(), mapper);
+        List<InternalFailure> causeFailures = convertCausesToFailures(buildFailure.getCauses(), mapper, cache);
         List<InternalBasicProblemDetailsVersion3> problemDetails = buildFailure.getProblems().stream()
             .map(mapper)
             .collect(toList());
 
-        return new DefaultFailure(buildFailure.getMessage(), null, ownDescription, causeFailures, problemDetails);
+        DefaultFailure converted = new DefaultFailure(buildFailure.getMessage(), null, ownDescription, causeFailures, problemDetails);
+        return cache.intern(buildFailure.getOriginal(), converted);
     }
 
     private static List<InternalFailure> convertCausesToFailures(
         List<Failure> causes,
-        Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper
+        Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper,
+        FailureCache cache
     ) {
         return causes.stream()
-            // Skip multi cause exceptions - no idea why
-            // For example TaskExecutionException is a MultiCauseException and skipped, so the task that failed is not added as a context here.
+            // Multi cause exceptions are dropped from the cause structure (the reason predates this code); for example
+            // TaskExecutionException is a MultiCauseException, so the failed task is not surfaced as context here.
+            // getDescription reconstructs over this same structure, so it omits the dropped node too, unlike a direct
+            // FailurePrinter.printToString of the source.
             .flatMap(cause -> cause.getOriginal() instanceof MultiCauseException
                 ? cause.getCauses().stream()
                 : Stream.of(cause))
-            .map(cause -> fromFailure(cause, mapper))
+            .map(cause -> fromFailure(cause, mapper, cache))
             .collect(toList());
     }
 

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
@@ -20,10 +20,13 @@ import org.gradle.internal.exceptions.MultiCauseException;
 import org.gradle.internal.problems.failure.DefaultFailureFactory;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.problems.failure.FailurePrinter;
+import org.gradle.tooling.internal.protocol.FailureDescriptionReconstructor;
 import org.gradle.tooling.internal.protocol.InternalBasicProblemDetailsVersion3;
 import org.gradle.tooling.internal.protocol.InternalFailure;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -34,17 +37,24 @@ import static java.util.stream.Collectors.toList;
 public class DefaultFailure implements Serializable, InternalFailure {
 
     private final String message;
-    private final String description;
+    private final @Nullable String fullDescription;
+    private final String ownDescription;
     private final List<? extends InternalFailure> causes;
     private final List<InternalBasicProblemDetailsVersion3> problems;
+    private transient @Nullable String reconstructedDescription;
 
     DefaultFailure(String message, String description, List<? extends InternalFailure> causes) {
         this(message, description, causes, Collections.emptyList());
     }
 
     DefaultFailure(String message, String description, List<? extends InternalFailure> causes, List<InternalBasicProblemDetailsVersion3> problems) {
+        this(message, description, description, causes, problems);
+    }
+
+    private DefaultFailure(String message, @Nullable String fullDescription, String ownDescription, List<? extends InternalFailure> causes, List<InternalBasicProblemDetailsVersion3> problems) {
         this.message = message;
-        this.description = description;
+        this.fullDescription = fullDescription;
+        this.ownDescription = ownDescription;
         this.causes = causes;
         this.problems = problems;
     }
@@ -56,7 +66,25 @@ public class DefaultFailure implements Serializable, InternalFailure {
 
     @Override
     public String getDescription() {
-        return description;
+        if (fullDescription != null) {
+            return fullDescription;
+        }
+        String reconstructed = reconstructedDescription;
+        if (reconstructed == null) {
+            // Walk the concrete node tree, not the InternalFailure interface, so this stays callable when an older
+            // Tooling API consumer (whose InternalFailure has no getOwnDescription) deserializes and reads this object.
+            reconstructed = FailureDescriptionReconstructor.reconstruct(this, DefaultFailure::getOwnDescription, DefaultFailure::ownCauses);
+            reconstructedDescription = reconstructed;
+        }
+        return reconstructed;
+    }
+
+    private List<DefaultFailure> ownCauses() {
+        List<DefaultFailure> result = new ArrayList<>(causes.size());
+        for (InternalFailure cause : causes) {
+            result.add((DefaultFailure) cause);
+        }
+        return result;
     }
 
     @Override
@@ -69,6 +97,11 @@ public class DefaultFailure implements Serializable, InternalFailure {
         return problems;
     }
 
+    @Override
+    public String getOwnDescription() {
+        return ownDescription;
+    }
+
     public static InternalFailure fromThrowable(Throwable throwable) {
         return fromThrowable(throwable, p -> null);
     }
@@ -79,15 +112,15 @@ public class DefaultFailure implements Serializable, InternalFailure {
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
-        // Iterate through the cause hierarchy and convert them to a corresponding Failure with the same cause structure. If the current failure has a
-        // corresponding problem (ie the exception was thrown via ProblemReporter.throwing()), then the problem will be also available in the new failure object.
-        String failureString = FailurePrinter.printToString(buildFailure);
+        // Build the failure tree in a single pass: each node carries only its own description. The full description (the
+        // whole cause subtree) is reconstructed lazily from these on demand, so no node prints its subtree here.
+        String ownDescription = FailurePrinter.printNodeToString(buildFailure);
         List<InternalFailure> causeFailures = convertCausesToFailures(buildFailure.getCauses(), mapper);
         List<InternalBasicProblemDetailsVersion3> problemDetails = buildFailure.getProblems().stream()
             .map(mapper)
             .collect(toList());
 
-        return new DefaultFailure(buildFailure.getMessage(), failureString, causeFailures, problemDetails);
+        return new DefaultFailure(buildFailure.getMessage(), null, ownDescription, causeFailures, problemDetails);
     }
 
     private static List<InternalFailure> convertCausesToFailures(
@@ -109,7 +142,7 @@ public class DefaultFailure implements Serializable, InternalFailure {
     public String toString() {
         return "DefaultFailure{" +
             "message='" + message + '\'' +
-            ", description='" + description + '\'' +
+            ", ownDescription='" + ownDescription + '\'' +
             ", causes=" + causes +
             ", problems=" + problems +
             '}';

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/FailureCache.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/FailureCache.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.build.event.types;
+
+import org.gradle.tooling.internal.protocol.InternalFailure;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Deduplicates failure conversion by the identity of the original {@link Throwable}.
+ * <p>
+ * A failed Isolated Projects sync attaches the same configuration failure to every per-project fetch, so the same
+ * {@code Throwable} (the whole tree or a shared deep cause) is converted many times. Keying by {@code Throwable}
+ * identity lets those conversions reuse a single {@link InternalFailure}.
+ */
+@NullMarked
+public interface FailureCache {
+
+    /**
+     * Returns the failure already converted from {@code original}, or {@code null} if none has been converted yet.
+     */
+    @Nullable
+    InternalFailure get(Throwable original);
+
+    /**
+     * Records {@code converted} as the conversion of {@code original} unless one already exists, and returns the
+     * canonical instance for that throwable (the pre-existing one if another conversion won the race).
+     */
+    InternalFailure intern(Throwable original, InternalFailure converted);
+
+    /**
+     * A cache that stores nothing; every conversion stays independent. Used when conversion cannot benefit from reuse.
+     */
+    FailureCache NONE = new FailureCache() {
+        @Override
+        @Nullable
+        public InternalFailure get(Throwable original) {
+            return null;
+        }
+
+        @Override
+        public InternalFailure intern(Throwable original, InternalFailure converted) {
+            return converted;
+        }
+    };
+}

--- a/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
+++ b/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
@@ -16,7 +16,18 @@
 
 package org.gradle.internal.build.event.types
 
+import org.gradle.api.problems.internal.ProblemInternal
+import org.gradle.internal.exceptions.DefaultMultiCauseException
+import org.gradle.internal.problems.failure.DefaultFailureFactory
+import org.gradle.internal.problems.failure.Failure
+import org.gradle.internal.problems.failure.FailurePrinter
+import org.gradle.internal.problems.failure.StackFramePredicate
+import org.gradle.internal.problems.failure.StackTraceRelevance
+import org.gradle.tooling.internal.protocol.InternalFailure
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Function
 
 class DefaultFailureTest extends Specification {
 
@@ -25,5 +36,163 @@ class DefaultFailureTest extends Specification {
         def df = DefaultFailure.fromThrowable(new RuntimeException("test"))
         then:
         df.problems.empty
+    }
+
+    def "own description excludes descendant nodes while full description includes them"() {
+        def failure = DefaultFailureFactory.withDefaultClassifier().create(deepChain())
+
+        when:
+        def root = DefaultFailure.fromFailure(failure, { p -> null } as Function)
+
+        then:
+        root.description.contains("level2-DEEP")
+        !root.ownDescription.contains("level2-DEEP")
+
+        and:
+        def mid = root.causes[0]
+        mid.description.contains("level2-DEEP")
+        !mid.ownDescription.contains("level2-DEEP")
+    }
+
+    def "full description is built lazily without printing each node's subtree"() {
+        def headerCount = new AtomicInteger()
+        def source = new CountingFailure(DefaultFailureFactory.withDefaultClassifier().create(chainOfDepth(6)), headerCount)
+
+        when:
+        def root = DefaultFailure.fromFailure(source, { p -> null } as Function)
+
+        then: "each of the 6 nodes is visited once, not once per ancestor (which would be quadratic)"
+        headerCount.get() == 6
+
+        and: "the full description is memoized"
+        root.getDescription().is(root.getDescription())
+    }
+
+    def "lazy full description equals the printed failure for #scenario"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(throwable)
+        def expected = FailurePrinter.printToString(source)
+
+        when:
+        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function)
+
+        then:
+        converted.getDescription() == expected
+
+        where:
+        scenario                  | throwable
+        "simple"                  | new RuntimeException("boom")
+        "single cause"            | new RuntimeException("boom", new IllegalStateException("inner"))
+        "suppressed"              | withSuppressed()
+        // A tab-indented continuation line in a cause's message must not be mistaken for a stack frame, or the cause's
+        // frames lose their common-tail elision against the parent and the text stops matching the direct print.
+        "multi-line cause message" | new RuntimeException("outer", new IllegalStateException("inner\n\tindented detail"))
+    }
+
+    def "full description renders multiple causes"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(
+            new DefaultMultiCauseException("multi", new RuntimeException("one"), new RuntimeException("two")))
+
+        when:
+        def text = DefaultFailure.fromFailure(source, { p -> null } as Function).getDescription()
+
+        then:
+        text.contains("Cause 1: java.lang.RuntimeException: one")
+        text.contains("Cause 2: java.lang.RuntimeException: two")
+    }
+
+    def "an interior multi cause exception is dropped from both the cause structure and the description"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(
+            new RuntimeException("outer", new DefaultMultiCauseException("INTERIOR-MULTI", new RuntimeException("branch-one"), new RuntimeException("branch-two"))))
+
+        when:
+        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function)
+
+        then: "the multi cause node is flattened away, promoting its children as direct causes"
+        converted.causes.size() == 2
+
+        and: "the reconstructed description follows that structure, so the multi cause node's header is absent"
+        def text = converted.getDescription()
+        !text.contains("INTERIOR-MULTI")
+        text.contains("Cause 1: java.lang.RuntimeException: branch-one")
+        text.contains("Cause 2: java.lang.RuntimeException: branch-two")
+
+        and: "this intentionally diverges from a full recursive print, which keeps the multi cause node"
+        FailurePrinter.printToString(source).contains("INTERIOR-MULTI")
+    }
+
+    def "converted failure survives serialization and reconstructs its description"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(new RuntimeException("boom", new IllegalStateException("inner")))
+        def expected = FailurePrinter.printToString(source)
+        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function)
+
+        when:
+        def restored = roundTrip(converted)
+
+        then:
+        restored.getOwnDescription() == converted.getOwnDescription()
+        restored.getDescription() == expected
+    }
+
+    private static InternalFailure roundTrip(InternalFailure failure) {
+        def bytes = new ByteArrayOutputStream()
+        new ObjectOutputStream(bytes).withCloseable { it.writeObject(failure) }
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray())).withCloseable { (InternalFailure) it.readObject() }
+    }
+
+    private static Throwable withSuppressed() {
+        def e = new RuntimeException("boom")
+        e.addSuppressed(new IllegalStateException("suppressed-one"))
+        e
+    }
+
+    private static Throwable chainOfDepth(int depth) {
+        Throwable t = new RuntimeException("leaf")
+        (1..(depth - 1)).each { t = new RuntimeException("level-$it", t) }
+        t
+    }
+
+    private static Throwable deepChain() {
+        new RuntimeException("root", level1())
+    }
+
+    private static Throwable level1() {
+        new RuntimeException("level1", level2())
+    }
+
+    private static Throwable level2() {
+        new RuntimeException("level2-DEEP")
+    }
+
+    private static class CountingFailure implements Failure {
+        private final Failure delegate
+        private final AtomicInteger headerCount
+
+        CountingFailure(Failure delegate, AtomicInteger headerCount) {
+            this.delegate = delegate
+            this.headerCount = headerCount
+        }
+
+        Class<? extends Throwable> getExceptionType() { delegate.getExceptionType() }
+
+        Throwable getOriginal() { delegate.getOriginal() }
+
+        String getHeader() {
+            headerCount.incrementAndGet()
+            delegate.getHeader()
+        }
+
+        String getMessage() { delegate.getMessage() }
+
+        List<StackTraceElement> getStackTrace() { delegate.getStackTrace() }
+
+        StackTraceRelevance getStackTraceRelevance(int frameIndex) { delegate.getStackTraceRelevance(frameIndex) }
+
+        List<Failure> getSuppressed() { delegate.getSuppressed().collect { new CountingFailure(it, headerCount) } }
+
+        List<Failure> getCauses() { delegate.getCauses().collect { new CountingFailure(it, headerCount) } }
+
+        int indexOfStackFrame(int start, StackFramePredicate predicate) { delegate.indexOfStackFrame(start, predicate) }
+
+        List<ProblemInternal> getProblems() { delegate.getProblems() }
     }
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/FailurePrinter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/FailurePrinter.java
@@ -42,6 +42,16 @@ public class FailurePrinter {
         new Job(output, listener).print(failure);
     }
 
+    /**
+     * Prints a single node: its header, own frames, and any suppressed exceptions, without descending into its causes.
+     * The node's own frames are printed as if it had no parent, so no common tail elision is applied to them.
+     */
+    public static String printNodeToString(Failure failure) {
+        StringBuilder output = new StringBuilder();
+        new Job(output, FailurePrinterListener.NO_OP).printNode(failure);
+        return output.toString();
+    }
+
     private static final class Job {
 
         private final FailurePrinterListener listener;
@@ -62,7 +72,20 @@ public class FailurePrinter {
             }
         }
 
+        public void printNode(Failure failure) {
+            try {
+                printNodeOnly("", "", null, failure);
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
+
         private void printRecursively(String caption, String prefix, @Nullable Failure parent, Failure failure) throws IOException {
+            printNodeOnly(caption, prefix, parent, failure);
+            appendCauses(prefix, failure);
+        }
+
+        private void printNodeOnly(String caption, String prefix, @Nullable Failure parent, Failure failure) throws IOException {
             builder.append(prefix)
                 .append(caption)
                 .append(failure.getHeader())
@@ -73,7 +96,6 @@ public class FailurePrinter {
             listener.afterFrames();
 
             appendSuppressed(prefix, failure);
-            appendCauses(prefix, failure);
         }
 
         private void appendSuppressed(String prefix, Failure failure) throws IOException {

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/failure/FailurePrinterTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/failure/FailurePrinterTest.groovy
@@ -74,6 +74,23 @@ class FailurePrinterTest extends Specification {
         actual.contains("Cause 2: java.lang.RuntimeException: two")
     }
 
+    def "printNodeToString prints only the node header and its own frames"() {
+        def cause = SimulatedJavaException.simulateDeeperException()
+        def e = new RuntimeException("BOOM", cause)
+        def f = toFailure(e)
+
+        when:
+        def node = FailurePrinter.printNodeToString(f)
+
+        then:
+        node.contains("java.lang.RuntimeException: BOOM")
+        node.contains("\tat " + e.stackTrace[0].toString())
+
+        and:
+        !node.contains("Caused by:")
+        !node.contains(cause.stackTrace[0].toString())
+    }
+
     def "notifies the listener"() {
         def e = new RuntimeException("BOOM")
         def firstFrame = e.stackTrace[0]

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
@@ -32,19 +32,22 @@ public class BuildControllerFactory {
     private final BuildEventConsumer buildEventConsumer;
     private final BuildTreeModelSideEffectExecutor sideEffectExecutor;
     private final PayloadSerializer payloadSerializer;
+    private final FetchFailureConverter failureConverter;
 
     public BuildControllerFactory(
         WorkerThreadRegistry workerThreadRegistry,
         BuildCancellationToken buildCancellationToken,
         BuildEventConsumer buildEventConsumer,
         BuildTreeModelSideEffectExecutor sideEffectExecutor,
-        PayloadSerializer payloadSerializer
+        PayloadSerializer payloadSerializer,
+        FetchFailureConverter failureConverter
     ) {
         this.workerThreadRegistry = workerThreadRegistry;
         this.buildCancellationToken = buildCancellationToken;
         this.buildEventConsumer = buildEventConsumer;
         this.sideEffectExecutor = sideEffectExecutor;
         this.payloadSerializer = payloadSerializer;
+        this.failureConverter = failureConverter;
     }
 
     public DefaultBuildController controllerFor(BuildTreeModelController controller) {
@@ -53,7 +56,8 @@ public class BuildControllerFactory {
             buildCancellationToken,
             buildEventConsumer,
             sideEffectExecutor,
-            payloadSerializer
+            payloadSerializer,
+            failureConverter
         );
     }
 }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -69,6 +69,7 @@ class DefaultBuildController implements
     private final BuildEventConsumer buildEventConsumer;
     private final BuildTreeModelSideEffectExecutor sideEffectExecutor;
     private final PayloadSerializer payloadSerializer;
+    private final FetchFailureConverter failureConverter;
 
     public DefaultBuildController(
         BuildTreeModelController controller,
@@ -76,7 +77,8 @@ class DefaultBuildController implements
         BuildCancellationToken cancellationToken,
         BuildEventConsumer buildEventConsumer,
         BuildTreeModelSideEffectExecutor sideEffectExecutor,
-        PayloadSerializer payloadSerializer
+        PayloadSerializer payloadSerializer,
+        FetchFailureConverter failureConverter
     ) {
         this.workerThreadRegistry = workerThreadRegistry;
         this.controller = controller;
@@ -84,6 +86,7 @@ class DefaultBuildController implements
         this.buildEventConsumer = buildEventConsumer;
         this.sideEffectExecutor = sideEffectExecutor;
         this.payloadSerializer = payloadSerializer;
+        this.failureConverter = failureConverter;
     }
 
     /**
@@ -181,10 +184,10 @@ class DefaultBuildController implements
         }
     }
 
-    private static List<InternalFailure> toInternalFailures(List<Failure> failures) {
+    private List<InternalFailure> toInternalFailures(List<Failure> failures) {
         return failures
             .stream()
-            .map(failure -> DefaultFailure.fromFailure(failure, dummy -> null))
+            .map(failureConverter::convert)
             .collect(toImmutableList());
     }
 }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import org.gradle.api.problems.internal.ProblemInternal;
+import org.gradle.internal.build.event.types.DefaultFailure;
+import org.gradle.internal.build.event.types.FailureCache;
+import org.gradle.internal.problems.failure.Failure;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.tooling.internal.protocol.InternalBasicProblemDetailsVersion3;
+import org.gradle.tooling.internal.protocol.InternalFailure;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Build tree scoped {@link FailureCache} for the fetch path: converts source {@link Failure} values into protocol
+ * {@link InternalFailure} values, interning by {@link Throwable} identity at every recursion step (see
+ * {@link FailureCache} for why this reuse matters). Its lifetime is this build tree, so it is freed when the model
+ * phase ends and never retains failure graphs across syncs.
+ */
+@ServiceScope(Scope.BuildTree.class)
+@NullMarked
+public class FetchFailureConverter implements FailureCache {
+
+    private final ConcurrentMap<Throwable, InternalFailure> cache = new ConcurrentHashMap<>();
+
+    InternalFailure convert(Failure failure) {
+        return DefaultFailure.fromFailure(failure, FetchFailureConverter::noProblemDetails, this);
+    }
+
+    @Nullable
+    private static InternalBasicProblemDetailsVersion3 noProblemDetails(ProblemInternal problem) {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public InternalFailure get(Throwable original) {
+        return cache.get(original);
+    }
+
+    @Override
+    public InternalFailure intern(Throwable original, InternalFailure converted) {
+        InternalFailure previous = cache.putIfAbsent(original, converted);
+        return previous != null ? previous : converted;
+    }
+}

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -29,6 +29,7 @@ public class ToolingBuilderServices extends AbstractGradleModuleServices {
 
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
+        registration.add(FetchFailureConverter.class);
         registration.add(BuildControllerFactory.class);
         registration.add(BuildActionRunner.class, BuildModelActionRunner.class);
         registration.add(BuildActionRunner.class, TestExecutionRequestActionRunner.class);

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -52,7 +52,8 @@ class DefaultBuildControllerTest extends Specification {
         cancellationToken,
         buildEventConsumer,
         sideEffectExecutor,
-        payloadSerializer
+        payloadSerializer,
+        new FetchFailureConverter()
     )
 
     def "cannot get build model from unmanaged thread"() {

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner
+
+import org.gradle.internal.problems.failure.DefaultFailureFactory
+import org.gradle.internal.problems.failure.Failure
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class FetchFailureConverterTest extends Specification {
+
+    def converter = new FetchFailureConverter()
+
+    def "reuses the converted failure when two failures share the same original throwable"() {
+        def throwable = new RuntimeException("boom")
+
+        when:
+        def first = converter.convert(failureOf(throwable))
+        def second = converter.convert(failureOf(throwable))
+
+        then:
+        first.is(second)
+    }
+
+    def "converts failures with distinct originals into distinct instances"() {
+        when:
+        def first = converter.convert(failureOf(new RuntimeException("one")))
+        def second = converter.convert(failureOf(new RuntimeException("two")))
+
+        then:
+        !first.is(second)
+    }
+
+    def "reuses the whole converted tree when two failures share the same throwable tree"() {
+        def shared = chainOfDepth(4)
+
+        when:
+        def first = converter.convert(failureOf(shared))
+        def second = converter.convert(failureOf(shared))
+
+        then:
+        first.is(second)
+        first.causes[0].is(second.causes[0])
+    }
+
+    def "reuses a shared deep cause while keeping distinct top wrappers distinct"() {
+        def sharedCause = new RuntimeException("shared included build failure")
+        def topA = new RuntimeException("project :a failed", sharedCause)
+        def topB = new RuntimeException("project :b failed", sharedCause)
+
+        when:
+        def a = converter.convert(failureOf(topA))
+        def b = converter.convert(failureOf(topB))
+
+        then: "the per-project wrappers differ but the shared deep cause is converted once"
+        !a.is(b)
+        a.causes[0].is(b.causes[0])
+    }
+
+    def "parallel conversions of a shared failure converge on one canonical instance"() {
+        def shared = chainOfDepth(5)
+        def threads = 50
+        def executor = Executors.newFixedThreadPool(threads)
+        def start = new CountDownLatch(1)
+
+        when:
+        def futures = (1..threads).collect {
+            executor.submit({
+                start.await()
+                converter.convert(failureOf(shared))
+            } as Callable)
+        }
+        start.countDown()
+        def results = futures.collect { it.get() }
+
+        then: "every thread sees the same canonical conversion and none failed"
+        results.every { it.is(results[0]) }
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    private static Failure failureOf(Throwable throwable) {
+        DefaultFailureFactory.withDefaultClassifier().create(throwable)
+    }
+
+    private static Throwable chainOfDepth(int depth) {
+        Throwable t = new RuntimeException("leaf")
+        (1..(depth - 1)).each { t = new RuntimeException("level-$it", t) }
+        t
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r16.CustomModel
+import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+
+@ToolingApiVersion('>=9.7.0')
+@TargetGradleVersion('>=9.7.0')
+class ResilientFetchFailureCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
+
+    private static final List<String> CONFIGURE_ON_DEMAND_ON = [
+        "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
+        "-Dorg.gradle.unsafe.isolated-projects=true"
+    ]
+
+    def setup() {
+        settingsFile.delete()
+        file('init.gradle') << """
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import javax.inject.Inject
+
+gradle.lifecycle.beforeProject {
+    it.plugins.apply(CustomPlugin)
+}
+
+class CustomModel implements Serializable {
+    String getValue() { 'greetings' }
+}
+
+class CustomBuilder implements ToolingModelBuilder {
+    boolean canBuild(String modelName) {
+        return modelName == '${CustomModel.name}'
+    }
+    Object buildAll(String modelName, Project project) {
+        return new CustomModel()
+    }
+}
+
+class CustomPlugin implements Plugin<Project> {
+    @Inject
+    CustomPlugin(ToolingModelBuilderRegistry registry) {
+        registry.register(new CustomBuilder())
+    }
+
+    public void apply(Project project) {
+    }
+}
+"""
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("a", "b", "c")
+            includeBuild("build-logic")
+        """
+
+        def included = file("build-logic")
+        included.file("settings.gradle.kts") << """
+            rootProject.name = "build-logic"
+
+            pluginManagement {
+               $repositoriesBlock
+            }
+
+            dependencyResolutionManagement {
+                $repositoriesBlock
+            }
+        """
+        included.file("build.gradle.kts") << """
+            plugins {
+                `kotlin-dsl`
+            }
+        """
+        included.file("src/main/kotlin/build-logic.gradle.kts") << """
+            broken !!!
+        """
+        file("a/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+        """
+        file("b/build.gradle.kts") << """
+            plugins {
+                id("build-logic")
+            }
+        """
+        file("c/build.gradle.kts") << """
+            plugins {
+                id("build-logic")
+            }
+        """
+    }
+
+    def "an eager configuration failure converts to the same whole tree text for every project"() {
+        when:
+        def result = fetchFailures()
+
+        then: "eager configuration aborts at the first failure and attaches it to every project"
+        result.failedToQueryProjects.toSet() == ['root', 'a', 'b', 'c'] as Set
+
+        and: "every failed project shares the same whole failure tree text"
+        def fullDescriptions = ['root', 'a', 'b', 'c'].collect { result.rootDescriptionByProject[it] }
+        fullDescriptions.every { it != null }
+        fullDescriptions.toSet().size() == 1
+
+        and: "the cause structure survives the round trip and the full description reassembles the whole chain"
+        def root = result.failureTreeByProject['root']
+        !root.causes.isEmpty()
+        result.rootDescriptionByProject['root'].contains("Caused by:")
+    }
+
+    def "configure-on-demand wrappers differ per project but the shared included build cause is identical"() {
+        when:
+        def result = fetchFailures(CONFIGURE_ON_DEMAND_ON)
+
+        then: "only the projects applying the broken convention plugin fail, each lazily"
+        result.failedToQueryProjects.toSet() == ['b', 'c'] as Set
+        result.successfullyQueriedProjects.containsAll(['root', 'a', 'build-logic'])
+
+        and: "the per project top wrappers differ and each names its own project path"
+        def b = result.failureTreeByProject['b']
+        def c = result.failureTreeByProject['c']
+        b.message != c.message
+        b.message.contains(":b")
+        c.message.contains(":c")
+
+        and: "each chain bottoms out at the same shared included build cause"
+        b.deepest().message != null
+        b.deepest().message == c.deepest().message
+        b.message != b.deepest().message
+
+        and: "the full description embeds the cause chain for each project"
+        result.rootDescriptionByProject['b'].contains("Caused by:")
+        result.rootDescriptionByProject['c'].contains("Caused by:")
+    }
+
+    private FetchFailureTreeAction.Result fetchFailures(List<String> extraGradleProperties = []) {
+        succeeds {
+            action(new FetchFailureTreeAction(CustomModel))
+                .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
+                .run()
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r970/FetchFailureTreeAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r970/FetchFailureTreeAction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.Failure;
+import org.gradle.tooling.FetchModelResult;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fetches {@code modelType} for every project of the root build and its editable builds, capturing for
+ * each failed project the root failure's full {@link Failure#getDescription() description} plus a
+ * serializable tree of per node messages and causes. Used by the end to end resilient fetch validation
+ * to assert the reconstructed failure text and cause structure across the wire.
+ */
+public class FetchFailureTreeAction implements BuildAction<FetchFailureTreeAction.Result>, Serializable {
+
+    private final Class<?> modelType;
+
+    public FetchFailureTreeAction(Class<?> modelType) {
+        this.modelType = modelType;
+    }
+
+    @Override
+    public Result execute(BuildController controller) {
+        GradleBuild gradleBuild = controller.fetch(GradleBuild.class).getModel();
+        assert gradleBuild != null;
+        Result result = new Result();
+        collect(controller, gradleBuild, result);
+        for (GradleBuild includedBuild : gradleBuild.getEditableBuilds()) {
+            collect(controller, includedBuild, result);
+        }
+        return result;
+    }
+
+    private void collect(BuildController controller, GradleBuild gradleBuild, Result result) {
+        for (BasicGradleProject project : gradleBuild.getProjects()) {
+            FetchModelResult<?> fetched = controller.fetch(project, modelType);
+            if (fetched.getFailures().isEmpty() && fetched.getModel() != null) {
+                result.successfullyQueriedProjects.add(project.getName());
+            } else {
+                result.failedToQueryProjects.add(project.getName());
+                Failure failure = fetched.getFailures().iterator().next();
+                result.rootDescriptionByProject.put(project.getName(), failure.getDescription());
+                result.failureTreeByProject.put(project.getName(), snapshot(failure));
+            }
+        }
+    }
+
+    private static FailureNode snapshot(Failure failure) {
+        List<FailureNode> causes = new ArrayList<FailureNode>();
+        for (Failure cause : failure.getCauses()) {
+            causes.add(snapshot(cause));
+        }
+        return new FailureNode(failure.getMessage(), causes);
+    }
+
+    public static class Result implements Serializable {
+        public final List<String> successfullyQueriedProjects = new ArrayList<String>();
+        public final List<String> failedToQueryProjects = new ArrayList<String>();
+        public final Map<String, String> rootDescriptionByProject = new LinkedHashMap<String, String>();
+        public final Map<String, FailureNode> failureTreeByProject = new LinkedHashMap<String, FailureNode>();
+    }
+
+    public static class FailureNode implements Serializable {
+        public final String message;
+        public final List<FailureNode> causes;
+
+        public FailureNode(String message, List<FailureNode> causes) {
+            this.message = message;
+            this.causes = causes;
+        }
+
+        public FailureNode deepest() {
+            FailureNode node = this;
+            while (!node.causes.isEmpty()) {
+                node = node.causes.get(0);
+            }
+            return node;
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFailure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFailure.java
@@ -18,28 +18,42 @@ package org.gradle.tooling.internal.consumer;
 
 import org.gradle.tooling.Failure;
 import org.gradle.tooling.events.problems.Problem;
+import org.gradle.tooling.internal.protocol.FailureDescriptionReconstructor;
+import org.jspecify.annotations.Nullable;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class DefaultFailure implements Failure {
 
     private final String message;
-    private final String description;
+    private final @Nullable String fullDescription;
+    private final @Nullable String ownDescription;
     private final List<? extends Failure> causes;
     private final List<Problem> problems;
+    private @Nullable String reconstructedDescription;
 
     public DefaultFailure(String message, String description, List<? extends Failure> causes) {
         this(message, description, causes, Collections.<Problem>emptyList());
     }
 
     public DefaultFailure(String message, String description, List<? extends Failure> causes, List<Problem> problems) {
+        this(message, description, description, causes, problems);
+    }
+
+    private DefaultFailure(String message, @Nullable String fullDescription, @Nullable String ownDescription, List<? extends Failure> causes, List<Problem> problems) {
         this.message = message;
-        this.description = description;
+        this.fullDescription = fullDescription;
+        this.ownDescription = ownDescription;
         this.causes = causes;
         this.problems = problems;
+    }
+
+    public static DefaultFailure fromOwnDescription(String message, String ownDescription, List<? extends Failure> causes, List<Problem> problems) {
+        return new DefaultFailure(message, null, ownDescription, causes, problems);
     }
 
     @Override
@@ -49,7 +63,29 @@ public class DefaultFailure implements Failure {
 
     @Override
     public String getDescription() {
-        return description;
+        if (fullDescription != null) {
+            return fullDescription;
+        }
+        String reconstructed = reconstructedDescription;
+        if (reconstructed == null) {
+            // Walk the concrete node type rather than the Failure interface: own text is an internal detail used only
+            // to reassemble the full description, and is not part of the public Failure API.
+            reconstructed = FailureDescriptionReconstructor.reconstruct(this, DefaultFailure::getOwnDescription, DefaultFailure::ownCauses);
+            reconstructedDescription = reconstructed;
+        }
+        return reconstructed;
+    }
+
+    private @Nullable String getOwnDescription() {
+        return ownDescription;
+    }
+
+    private List<DefaultFailure> ownCauses() {
+        List<DefaultFailure> result = new ArrayList<>(causes.size());
+        for (Failure cause : causes) {
+            result.add((DefaultFailure) cause);
+        }
+        return result;
     }
 
     @Override
@@ -77,7 +113,7 @@ public class DefaultFailure implements Failure {
     public String toString() {
         return "DefaultFailure{" +
             "message='" + message + '\'' +
-            ", description='" + description + '\'' +
+            ", ownDescription='" + ownDescription + '\'' +
             ", causes=" + causes +
             ", problems=" + problems +
             '}';

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -1342,7 +1342,7 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
     }
 
     @Nullable
-    private static Failure toFailure(InternalFailure origFailure) {
+    private static Failure toFailure(@Nullable InternalFailure origFailure) {
         if (origFailure == null) {
             return null;
         }
@@ -1393,11 +1393,13 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
                 ((InternalTestFrameworkFailure) origFailure).getStacktrace()
             );
         }
-        return new DefaultFailure(
-            origFailure.getMessage(),
-            origFailure.getDescription(),
-            toFailures(origFailure.getCauses()),
-            clientProblems);
+        List<Failure> causes = toFailures(origFailure.getCauses());
+        try {
+            return DefaultFailure.fromOwnDescription(origFailure.getMessage(), origFailure.getOwnDescription(), causes, clientProblems);
+        } catch (NoSuchMethodError | AbstractMethodError ignore) {
+            // Older Gradle versions don't have the own description; fall back to the full description
+            return new DefaultFailure(origFailure.getMessage(), origFailure.getDescription(), causes, clientProblems);
+        }
     }
 
     private static @Nullable List<AnnotationProcessorResult> toAnnotationProcessorResults(@Nullable List<InternalAnnotationProcessorResult> protocolResults) {

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/FailureDescriptionReconstructor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/FailureDescriptionReconstructor.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rebuilds the full description of a failure, the text of its whole cause subtree, from the per-node own descriptions.
+ * <p>
+ * Each own description is parent independent. This walk reapplies the parent relative stack trace tail elision so the
+ * result matches what a single recursive print would produce.
+ */
+@NullMarked
+public final class FailureDescriptionReconstructor {
+
+    private static final String FRAME_PREFIX = "\tat ";
+    private static final String SUPPRESSED_PREFIX = "\tSuppressed: ";
+    // Only used for the synthesized "... N more" elision line; every other line is re-emitted with its own original
+    // terminator (see splitLines), so the reconstruction reproduces the printer's separators rather than normalizing
+    // them. The daemon prints with its own line separator and the daemon is always local, so the local one matches it.
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final Pattern LINE_TERMINATOR = Pattern.compile("\\R");
+
+    private FailureDescriptionReconstructor() {
+    }
+
+    public static <T> String reconstruct(
+        T root,
+        Function<? super T, String> ownDescription,
+        Function<? super T, ? extends List<? extends T>> causes
+    ) {
+        StringBuilder builder = new StringBuilder();
+        append(builder, "", root, null, ownDescription, causes);
+        return builder.toString();
+    }
+
+    private static <T> void append(
+        StringBuilder builder,
+        String caption,
+        T node,
+        @Nullable List<String> parentFrames,
+        Function<? super T, String> ownDescription,
+        Function<? super T, ? extends List<? extends T>> causes
+    ) {
+        List<Line> lines = splitLines(ownDescription.apply(node));
+
+        // The header (message) can span several tab-indented lines, so it ends at the first own frame or "Suppressed:"
+        // caption, not at any tab. A message line shaped exactly like a frame ("\tat ...") is indistinguishable from a
+        // real frame here, the one case this text-only reconstruction can misclassify.
+        int framesStart = 0;
+        while (framesStart < lines.size() && !isFrame(lines.get(framesStart)) && !isSuppressed(lines.get(framesStart))) {
+            framesStart++;
+        }
+        int framesEnd = framesStart;
+        while (framesEnd < lines.size() && isFrame(lines.get(framesEnd))) {
+            framesEnd++;
+        }
+        List<Line> header = lines.subList(0, framesStart);
+        List<Line> frames = lines.subList(framesStart, framesEnd);
+        List<Line> tail = lines.subList(framesEnd, lines.size());
+
+        List<String> frameContents = contentsOf(frames);
+        int common = parentFrames == null ? 0 : commonTailSize(frameContents, parentFrames);
+
+        builder.append(caption);
+        appendLines(builder, header);
+        appendLines(builder, frames.subList(0, frames.size() - common));
+        if (common > 0) {
+            builder.append("\t... ").append(common).append(" more").append(LINE_SEPARATOR);
+        }
+        appendLines(builder, tail);
+
+        List<? extends T> nodeCauses = causes.apply(node);
+        if (nodeCauses.size() == 1) {
+            append(builder, "Caused by: ", nodeCauses.get(0), frameContents, ownDescription, causes);
+        } else {
+            for (int c = 0; c < nodeCauses.size(); c++) {
+                append(builder, "Cause " + (c + 1) + ": ", nodeCauses.get(c), frameContents, ownDescription, causes);
+            }
+        }
+    }
+
+    private static void appendLines(StringBuilder builder, List<Line> lines) {
+        for (Line line : lines) {
+            builder.append(line.content).append(terminatorOf(line));
+        }
+    }
+
+    private static List<String> contentsOf(List<Line> lines) {
+        List<String> contents = new ArrayList<>(lines.size());
+        for (Line line : lines) {
+            contents.add(line.content);
+        }
+        return contents;
+    }
+
+    private static boolean isFrame(Line line) {
+        return line.content.startsWith(FRAME_PREFIX);
+    }
+
+    private static boolean isSuppressed(Line line) {
+        return line.content.startsWith(SUPPRESSED_PREFIX);
+    }
+
+    private static String terminatorOf(Line line) {
+        // The printer terminates every line, so a captured terminator is always present; fall back defensively to the
+        // platform separator only if an own description ever ended without one.
+        return line.terminator.isEmpty() ? LINE_SEPARATOR : line.terminator;
+    }
+
+    private static int commonTailSize(List<String> frames, List<String> parentFrames) {
+        int i = frames.size() - 1;
+        int j = parentFrames.size() - 1;
+        int common = 0;
+        while (i >= 0 && j >= 0 && frames.get(i).equals(parentFrames.get(j))) {
+            i--;
+            j--;
+            common++;
+        }
+        return common;
+    }
+
+    private static List<Line> splitLines(String text) {
+        List<Line> lines = new ArrayList<>();
+        Matcher matcher = LINE_TERMINATOR.matcher(text);
+        int start = 0;
+        while (matcher.find()) {
+            lines.add(new Line(text.substring(start, matcher.start()), text.substring(matcher.start(), matcher.end())));
+            start = matcher.end();
+        }
+        // A final line terminator leaves no trailing content, so there is no extra blank line to add. Trailing content
+        // without a terminator (not produced by the printer, which always ends a line) is kept as a last line.
+        if (start < text.length()) {
+            lines.add(new Line(text.substring(start), ""));
+        }
+        return lines;
+    }
+
+    /**
+     * A line of an own description together with the exact terminator that followed it. Preserving the terminator lets
+     * reconstruction reproduce the printer's separators, including a message's embedded newline that differs from the
+     * platform separator (e.g. a multi-line message on Windows), rather than normalizing every line break to the
+     * platform separator.
+     */
+    private static final class Line {
+        final String content;
+        final String terminator;
+
+        Line(String content, String terminator) {
+            this.content = content;
+            this.terminator = terminator;
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalFailure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalFailure.java
@@ -56,4 +56,17 @@ public interface InternalFailure {
     @Incubating
     List<InternalBasicProblemDetailsVersion3> getProblems();
 
+    /**
+     * The description of this failure node alone, without its causes.
+     * <p>
+     * Unlike {@link #getDescription()}, which returns the text of the whole cause subtree, this returns only the
+     * header, own frames, and any suppressed exceptions of this node, without descending into its causes. It allows
+     * walking a failure tree in linear time.
+     *
+     * @return the node-only description
+     * @since 9.7.0
+     */
+    @Incubating
+    String getOwnDescription();
+
 }

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/FailureReconstructionTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/FailureReconstructionTest.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.parameters
+
+import org.gradle.tooling.internal.protocol.FailureDescriptionReconstructor
+import org.gradle.tooling.internal.protocol.InternalFailure
+import spock.lang.Specification
+
+import java.util.function.Function
+
+class FailureReconstructionTest extends Specification {
+
+    def "preserves the original line terminators instead of normalizing them to the platform separator"() {
+        // The printer writes a failure's message verbatim, then its own line separator before the frames. When the
+        // message embeds a newline that differs from the frame separator (e.g. a multi-line message on Windows, where
+        // frames end with \r\n), reconstruction must reproduce both terminators rather than rewrite them, or the text
+        // stops matching a direct print. A single node with no causes must round-trip its own description unchanged.
+        def own = "java.lang.IllegalStateException: inner\n\tindented detail\r\n\tat Foo.bar(Foo.java:1)\r\n"
+
+        when:
+        def result = FailureDescriptionReconstructor.reconstruct(own, { it } as Function, { [] } as Function)
+
+        then:
+        result == own
+    }
+
+    def "elides each cause's common frame tail against the parent across the multiple-cause branch"() {
+        def nl = System.lineSeparator()
+        def shared = "${nl}\tat Shared.a(S.java:9)${nl}\tat Shared.b(S.java:10)"
+        def root = node("java.lang.RuntimeException: multi${nl}\tat Root.run(R.java:1)${shared}${nl}", [
+            node("java.lang.RuntimeException: one${nl}\tat One.x(One.java:1)${shared}${nl}", []),
+            node("java.lang.RuntimeException: two${nl}\tat Two.y(Two.java:1)${shared}${nl}", []),
+        ])
+
+        when:
+        def text = FailureDescriptionReconstructor.reconstruct(root, { it.own } as Function, { it.causes } as Function)
+
+        then: "each cause keeps only its own distinct frame and elides the two it shares with the parent"
+        text.contains("Cause 1: java.lang.RuntimeException: one${nl}\tat One.x(One.java:1)${nl}\t... 2 more")
+        text.contains("Cause 2: java.lang.RuntimeException: two${nl}\tat Two.y(Two.java:1)${nl}\t... 2 more")
+
+        and: "the shared frames are printed once under the parent, not repeated under either cause"
+        text.count("\tat Shared.a(S.java:9)") == 1
+    }
+
+    private static Map node(String own, List causes) {
+        [own: own, causes: causes]
+    }
+
+    def "rebuilds each node from its own description and preserves the cause tree"() {
+        def leaf = internalFailure("java.lang.IllegalStateException: inner\n\tat Inner.run(Inner.java:5)", [])
+        def root = internalFailure("java.lang.RuntimeException: boom\n\tat Root.run(Root.java:9)", [leaf])
+
+        when:
+        def failures = BuildProgressListenerAdapter.toFailures([root])
+
+        then:
+        failures.size() == 1
+        def rebuiltRoot = failures[0]
+        rebuiltRoot.message == "msg"
+        rebuiltRoot.causes.size() == 1
+        rebuiltRoot.causes[0].message == "msg"
+
+        and: "the full description is reassembled from each node's own text, not from the daemon's per-node full text"
+        rebuiltRoot.description.contains("java.lang.RuntimeException: boom")
+        rebuiltRoot.description.contains("Caused by: java.lang.IllegalStateException: inner")
+        !rebuiltRoot.description.contains("FULL-NOT-USED")
+    }
+
+    def "falls back to the full description when the daemon has no own description (#error.class.simpleName)"() {
+        def origFailure = Stub(InternalFailure) {
+            getMessage() >> "boom"
+            getOwnDescription() >> { throw error }
+            getDescription() >> "FULL TEXT FROM OLD DAEMON"
+            getCauses() >> []
+            getProblems() >> []
+        }
+
+        when:
+        def failures = BuildProgressListenerAdapter.toFailures([origFailure])
+
+        then:
+        failures[0].description == "FULL TEXT FROM OLD DAEMON"
+
+        where:
+        // An old daemon's InternalFailure implements the interface without the method (AbstractMethodError) or
+        // predates it entirely (NoSuchMethodError); the consumer must fall back in both cases.
+        error << [new AbstractMethodError("old daemon"), new NoSuchMethodError("old daemon")]
+    }
+
+    def "does not read the full per-node description when own descriptions are available"() {
+        def leaf = Mock(InternalFailure)
+        def root = Mock(InternalFailure)
+
+        when:
+        BuildProgressListenerAdapter.toFailures([root])
+
+        then:
+        _ * root.getOwnDescription() >> "java.lang.RuntimeException: boom\n\tat Root.run(Root.java:9)"
+        _ * root.getCauses() >> [leaf]
+        _ * root.getMessage() >> "boom"
+        _ * root.getProblems() >> []
+        _ * leaf.getOwnDescription() >> "java.lang.IllegalStateException: inner\n\tat Inner.run(Inner.java:5)"
+        _ * leaf.getCauses() >> []
+        _ * leaf.getMessage() >> "inner"
+        _ * leaf.getProblems() >> []
+        0 * root.getDescription()
+        0 * leaf.getDescription()
+    }
+
+    private InternalFailure internalFailure(String own, List<InternalFailure> causes) {
+        Stub(InternalFailure) {
+            getMessage() >> "msg"
+            getOwnDescription() >> own
+            getDescription() >> "FULL-NOT-USED"
+            getCauses() >> causes
+            getProblems() >> []
+        }
+    }
+}

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -373,7 +373,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 600 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 603 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Kotlin DSL
         assertIsGradleJar(contentsDir.file("lib/gradle-kotlin-dsl-${baseVersion}.jar"))


### PR DESCRIPTION
Addresses the daemon side stall reported in 
* #38184.

## Why
An IDE that builds models through the resilient `fetch` API (`BuildController.fetch`, which returns a
model or failures result instead of throwing) makes the daemon convert every returned failure eagerly,
in `DefaultBuildController.fetch`. Converting one failure rendered its entire cause subtree again at
every node (quadratic in the cause chain depth), so even a single deep failure was expensive per fetch.
Under Isolated Projects this turns pathological: the IDE fetches a model per project, and with eager
configuration (configure-on-demand off) a single configuration failure is aggregated and attached to
every project's result, so that same failure is reconverted once per project. On a reproduction of the
reported scenario (100 failing projects) the sync pegged a daemon CPU core for about three minutes before
surfacing any error.

## What changes
The daemon side conversion of a source failure to the Tooling API `Failure` is now linear, and converted
failures are cached by the identity of the original throwable so a failure shared across per project
fetches is converted once. Each node now carries only its own text and the full `getDescription()` is
reassembled lazily, so the serialized payload per failure shrinks from O(N²) to O(N). The displayed text
is unchanged (`getDescription()`, `getMessage()`, and `getCauses()` behave exactly as before) and no
public API is added: the own text accessor lives only on the internal protocol.

## Implementation
`DefaultFailure.fromFailure` builds the failure tree in one pass, each node carrying only its own
description (`FailurePrinter.printNodeToString`); `getDescription()` reconstructs the full subtree text
lazily and memoized via `FailureDescriptionReconstructor`, which reapplies the parent relative stack
trace tail elision and preserves each line's original terminator. A build tree scoped `FetchFailureConverter`
holds a `Throwable` identity cache consulted at every recursion step, threaded through `DefaultBuildController`.
The own text accessor is added only to the protocol `InternalFailure.getOwnDescription()`, so the daemon
ships per node text instead of a full subtree per node; the consumer reconstructs over the concrete node
type and falls back to `getDescription()` on `NoSuchMethodError`/`AbstractMethodError` for an old daemon.
The public `org.gradle.tooling.Failure` is untouched.

## Performance
Per fetch conversion goes from O(N²) to O(N) in the cause chain depth N, the identity cache removes the
per project reconversion, and the per failure payload shrinks from O(N²) to O(N). In an end to end
reproduction against the parent commit: converting a deep failure across 100 independent per project
fetches drops from about 26 s to about 0.5 s at depth 160, and a 100 project failing Isolated Projects
sync drops from about three minutes to about 10 seconds. This removes the daemon side cost the thread
dump shows; the IDEs checked (IntelliJ, Buildship) render failures from per node message and stack plus
the cause structure rather than `getDescription()`, and IntelliJ's deep sync failures are currently
`Throwable` driven. One scalability limit is left untouched and out of scope here: under eager Isolated
Projects the configuration failure is aggregated and attached to every project, so the node count stays
quadratic in the project count, which configure-on-demand on already avoids.

## How to review
The three commits are tracer bullets and read well commit by commit: (1) linear conversion, (2) shared
failure dedup, (3) end to end cross version coverage. Suggested file order: `FailurePrinter` (single node
print), `DefaultFailure` (single pass build, lazy `getDescription`), `FailureDescriptionReconstructor`
(lazy full text rebuild), then `InternalFailure.getOwnDescription()` with the `BuildProgressListenerAdapter`
fallback, `FailureCache`/`FetchFailureConverter` with the `DefaultBuildController` wiring, and finally
`r970/ResilientFetchFailureCrossVersionSpec`. This touches no public API but does change the cross
version protocol, so validate with `./gradlew :tooling-api:forkingCrossVersionTest` alongside the
`:logging`, `:daemon-messaging`, and `:tooling-api` unit tests.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
