### PR TITLE
Print `idea.log` on ide-sync test failure

### DIFF
--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
@@ -169,8 +169,7 @@ abstract class AbstractIdeSyncTest extends Specification {
             return
         }
         def lines = ideaLog.readLines()
-        def maxLines = 2000
-        def tail = lines.size() > maxLines ? lines[-maxLines..-1] : lines
+        def tail = lines.takeRight(2000)
         System.err.println("==== Tail of ${ideaLog} (last ${tail.size()} of ${lines.size()} lines) ====")
         tail.each { System.err.println(it) }
         System.err.println("==== End of ${ideaLog} ====")

--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/AbstractIdeSyncTest.groovy
@@ -154,9 +154,26 @@ abstract class AbstractIdeSyncTest extends Specification {
         Logging.setupLogging(testDirectory)
         try {
             ideInvoker.run(ideScenarioDefinition, invocationSettings, {})
+        } catch (Throwable t) {
+            dumpIdeLog(ideSandboxDir)
+            throw t
         } finally {
             Logging.resetLogging()
         }
+    }
+
+    private static void dumpIdeLog(File ideSandboxDir) {
+        def ideaLog = new File(ideSandboxDir, "logs/idea.log")
+        if (!ideaLog.isFile()) {
+            System.err.println("No idea.log found at ${ideaLog} to diagnose the sync failure.")
+            return
+        }
+        def lines = ideaLog.readLines()
+        def maxLines = 2000
+        def tail = lines.size() > maxLines ? lines[-maxLines..-1] : lines
+        System.err.println("==== Tail of ${ideaLog} (last ${tail.size()} of ${lines.size()} lines) ====")
+        tail.each { System.err.println(it) }
+        System.err.println("==== End of ${ideaLog} ====")
     }
 
     /**


### PR DESCRIPTION
Make `idea.log` content appear in the build log.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
