### PR TITLE
Initialize Groovy runtime before replaying system property removals on CC load

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl.fingerprint
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
+import org.codehaus.groovy.vmplugin.VMPluginFactory
 import org.gradle.api.Describable
 import org.gradle.api.internal.GeneratedSubclasses.unpackType
 import org.gradle.api.internal.file.FileCollectionInternal
@@ -183,6 +184,28 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
     private
     fun MutableMap<Path, ProjectInvalidationState>.entryFor(path: Path) = computeIfAbsent(path, ::ProjectInvalidationState)
 
+    /**
+     * Forces Groovy's runtime to initialize before we replay configuration-time removals of
+     * system properties (see the [ConfigurationCacheFingerprint.SystemPropertyRemoved] and
+     * [ConfigurationCacheFingerprint.SystemPropertiesCleared] branches of [check]).
+     *
+     * Replaying those side effects mutates the live `System.getProperties()` of the process that is
+     * loading the cache entry. Removing or clearing JVM-standard properties such as `file.encoding`
+     * or `java.home` breaks the static initializer of any class that reads them lazily. In
+     * particular, Groovy's `VMPluginFactory` is initialized the first time the cached project model
+     * is realized (when a `DefaultProject` is created); with `file.encoding` gone its initialization
+     * fails with "Null charset name", leaving the class permanently unusable ("Could not initialize
+     * class org.codehaus.groovy.vmplugin.VMPluginFactory").
+     *
+     * A non-cached build never hits this because executing the Groovy build scripts initializes the
+     * Groovy runtime before any such mutation runs; we mirror that ordering here. This only matters
+     * in a fresh JVM (e.g. `--no-daemon`); with a reused daemon the runtime is already initialized.
+     */
+    private
+    fun ensureGroovyRuntimeInitialized() {
+        VMPluginFactory.getPlugin()
+    }
+
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private
     fun check(input: ConfigurationCacheFingerprint): InvalidationReason? = structuredMessageOrNull {
@@ -236,11 +259,13 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
             }
 
             is ConfigurationCacheFingerprint.SystemPropertyRemoved -> input.run {
+                ensureGroovyRuntimeInitialized()
                 System.getProperties().remove(key)
                 null
             }
 
             is ConfigurationCacheFingerprint.SystemPropertiesCleared -> input.run {
+                ensureGroovyRuntimeInitialized()
                 System.getProperties().clear()
                 null
             }


### PR DESCRIPTION
### Context

The `Gradle_Master_Check_NoDaemon_12_bucket2` build ("NoDaemon Java17 Adoptium Linux (configuration-cache)") failed with a single test failure in `UndeclaredSystemPropertiesIntegrationTest`:

> `clear() then getProperty on real source returns null and hits cache`

```
* What went wrong:
Could not create an instance of type org.gradle.api.internal.project.DefaultProject.
> Could not initialize class org.codehaus.groovy.vmplugin.VMPluginFactory
```

[Example](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_12_bucket2/113981919?hideTestsFromDependencies=true)

#### Root cause

A build that mutates system properties at configuration time — e.g. `System.getProperties().clear()` or `.remove(key)` — records the mutation in the configuration cache and replays it on **load** to reconstruct the configuration-time environment (`ConfigurationCacheFingerprintChecker`).

Replaying a removal/clear mutates the live `System.getProperties()` of the loading process, wiping JVM-standard properties such as `file.encoding` and `java.home`. If a class whose static initializer reads such a property has not yet been initialized, its first initialization then fails. In particular, Groovy's `VMPluginFactory` is initialized lazily the first time the cached project model is realized (when a `DefaultProject` is created); once `file.encoding` is gone it fails with `IllegalArgumentException: Null charset name` and becomes permanently unusable (`Could not initialize class ...VMPluginFactory`).

A non-cached build never hits this because executing the Groovy build scripts initializes the Groovy runtime **before** any such mutation runs. It also only surfaces in a **fresh JVM**, which is why CI saw it only in the **NoDaemon (configuration-cache)** bucket — a reused daemon already has the runtime initialized.

#### Fix

Initialize the Groovy runtime before the fingerprint checker replays `SystemPropertyRemoved` / `SystemPropertiesCleared`, mirroring the ordering of a non-cached build. The change is confined to `ConfigurationCacheFingerprintChecker`.

### Verification

- **Manual repro** (fresh JVM, exact failing flags): a build calling `System.getProperties().clear()` run with `--no-daemon --configuration-cache -Dorg.gradle.configuration-cache.parallel=true`, stored then reloaded — **crashed before the fix, succeeds after**.
- **Real integration test** under the exact CI executer: `:configuration-cache:noDaemonIntegTest --tests "*UndeclaredSystemPropertiesIntegrationTest"` → **28 tests, 0 failures**, including the previously-failing `clear()` iteration.
