### PR TITLE
Deprecate the public StartParameter constructor

### DIFF
--- a/platforms/core-runtime/build-profile/src/test/groovy/org/gradle/profile/BuildProfileTest.groovy
+++ b/platforms/core-runtime/build-profile/src/test/groovy/org/gradle/profile/BuildProfileTest.groovy
@@ -15,13 +15,13 @@
  */
 package org.gradle.profile
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.tasks.TaskState
 import org.gradle.internal.buildevents.BuildStartedTime
 import spock.lang.Specification
 
 class BuildProfileTest extends Specification {
-    private profile = new BuildProfile(new StartParameter(), new BuildStartedTime(0))
+    private profile = new BuildProfile(new StartParameterInternal(), new BuildStartedTime(0))
 
     def "creates dependency set profile on first get"() {
         expect:
@@ -65,7 +65,7 @@ class BuildProfileTest extends Specification {
 
     def "contains build description"() {
         given:
-        def param = new StartParameter()
+        def param = new StartParameterInternal()
         param.setTaskNames(["foo", "bar"])
         param.setExcludedTaskNames(["one", "two"])
 
@@ -78,7 +78,7 @@ class BuildProfileTest extends Specification {
 
     def "build description looks nice even if no tasks specified"() {
         given:
-        def param = new StartParameter()
+        def param = new StartParameterInternal()
 
         when:
         profile = new BuildProfile(param, new BuildStartedTime(0))
@@ -99,7 +99,7 @@ class BuildProfileTest extends Specification {
         given:
         def buildStartedAt = 1000L
         def buildFinishedAt = 2000L
-        def startParameter = new StartParameter()
+        def startParameter = new StartParameterInternal()
         def buildStartedTime = new BuildStartedTime(buildStartedAt)
 
         when:

--- a/platforms/core-runtime/build-profile/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
+++ b/platforms/core-runtime/build-profile/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.profile
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.tasks.TaskState
 import org.gradle.internal.buildevents.BuildStartedTime
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -30,7 +30,7 @@ class ProfileReportRendererTest extends Specification {
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def "renders report"() {
-        def model = new BuildProfile(new StartParameter(), new BuildStartedTime(0))
+        def model = new BuildProfile(new StartParameterInternal(), new BuildStartedTime(0))
         def file = temp.file("report.html")
 
         model.profilingStarted   = time(12, 20, 0)

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -64,7 +64,7 @@ import static java.util.Collections.emptyList;
  * <p>{@code StartParameter} defines the configuration used by a Gradle instance to execute a build. The properties of {@code StartParameter} generally correspond to the command-line options of
  * Gradle.
  *
- * <p>You can obtain an instance of a {@code StartParameter} by duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
+ * <p>The {@code StartParameter} for a build is provided by Gradle, e.g. via {@link org.gradle.api.invocation.Gradle#getStartParameter()}. It is not intended to be created or copied directly.</p>
  */
 @HasInternalProtocol
 public class StartParameter implements LoggingConfiguration, ParallelismConfiguration, Serializable {
@@ -254,14 +254,22 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     /**
      * Creates a {@code StartParameter} with default values. This is roughly equivalent to running Gradle on the command-line with no arguments.
      *
-     * @deprecated A {@code StartParameter} is provided by the build (e.g. {@code gradle.startParameter}) and should not be created directly. Derive a copy from that one with {@link #newInstance} or {@link #newBuild} if you need to.
+     * @deprecated The {@code StartParameter} for a build is provided by Gradle (e.g. {@code gradle.startParameter}) and is not intended to be created directly.
      */
     @Deprecated
     public StartParameter() {
-        this(new BuildLayoutParameters());
-        // Only direct construction reaches here; Gradle's own duplication goes through the protected
-        // constructor, so this nags third-party callers without nagging internal usage.
+        this((Void) null);
+        // Only direct construction reaches here; Gradle's own construction goes through the protected
+        // constructors, so this nags third-party callers without nagging internal usage.
         StartParameterDeprecations.nagOnStartParameterConstructor();
+    }
+
+    /**
+     * Creates a {@code StartParameter} with default values, for internal use. The {@code Void} parameter
+     * exists only to distinguish this from the deprecated public no-arg constructor; pass {@code null}.
+     */
+    protected StartParameter(@SuppressWarnings("unused") Void marker) {
+        this(new BuildLayoutParameters());
     }
 
     /**
@@ -282,9 +290,12 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Duplicates this {@code StartParameter} instance.
      *
      * @return the new parameters.
+     * @deprecated The {@code StartParameter} for a build is provided by Gradle and is not intended to be copied.
      */
+    @Deprecated
     public StartParameter newInstance() {
-        return prepareNewInstance(new StartParameter(new BuildLayoutParameters()));
+        StartParameterDeprecations.nagOnStartParameterCopy("newInstance()");
+        return prepareNewInstance(new StartParameter((Void) null));
     }
 
     protected StartParameter prepareNewInstance(StartParameter p) {
@@ -310,9 +321,12 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * build specific properties (eg task names).</p>
      *
      * @return The new parameters.
+     * @deprecated The {@code StartParameter} for a build is provided by Gradle and is not intended to be copied.
      */
+    @Deprecated
     public StartParameter newBuild() {
-        return prepareNewBuild(new StartParameter(new BuildLayoutParameters()));
+        StartParameterDeprecations.nagOnStartParameterCopy("newBuild()");
+        return prepareNewBuild(new StartParameter((Void) null));
     }
 
     protected StartParameter prepareNewBuild(StartParameter p) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -64,7 +64,7 @@ import static java.util.Collections.emptyList;
  * <p>{@code StartParameter} defines the configuration used by a Gradle instance to execute a build. The properties of {@code StartParameter} generally correspond to the command-line options of
  * Gradle.
  *
- * <p>You can obtain an instance of a {@code StartParameter} by either creating a new one, or duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
+ * <p>You can obtain an instance of a {@code StartParameter} by duplicating an existing one using {@link #newInstance} or {@link #newBuild}.</p>
  */
 @HasInternalProtocol
 public class StartParameter implements LoggingConfiguration, ParallelismConfiguration, Serializable {
@@ -120,7 +120,8 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * here: a plain {@code StartParameter} is a freely mutable value object, and this module knows
      * nothing about how a mutation should be reported. {@code StartParameterInternal} overrides it to
      * notify a listener, but only the running build's own start parameter has such a listener armed
-     * (after settings have been evaluated), so detached or user-constructed copies stay silent.
+     * (after settings have been evaluated), so detached copies (e.g. one derived via {@link #newInstance}
+     * or the copy a {@code GradleBuild} task configures) stay silent.
      *
      * @param methodSignature the source-level signature of the setter that was called
      */
@@ -252,9 +253,15 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     /**
      * Creates a {@code StartParameter} with default values. This is roughly equivalent to running Gradle on the command-line with no arguments.
+     *
+     * @deprecated A {@code StartParameter} is provided by the build (e.g. {@code gradle.startParameter}) and should not be created directly. Derive a copy from that one with {@link #newInstance} or {@link #newBuild} if you need to.
      */
+    @Deprecated
     public StartParameter() {
         this(new BuildLayoutParameters());
+        // Only direct construction reaches here; Gradle's own duplication goes through the protected
+        // constructor, so this nags third-party callers without nagging internal usage.
+        StartParameterDeprecations.nagOnStartParameterConstructor();
     }
 
     /**
@@ -277,7 +284,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return the new parameters.
      */
     public StartParameter newInstance() {
-        return prepareNewInstance(new StartParameter());
+        return prepareNewInstance(new StartParameter(new BuildLayoutParameters()));
     }
 
     protected StartParameter prepareNewInstance(StartParameter p) {
@@ -305,7 +312,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * @return The new parameters.
      */
     public StartParameter newBuild() {
-        return prepareNewBuild(new StartParameter());
+        return prepareNewBuild(new StartParameter(new BuildLayoutParameters()));
     }
 
     protected StartParameter prepareNewBuild(StartParameter p) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -258,18 +258,10 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     @Deprecated
     public StartParameter() {
-        this((Void) null);
+        this(new BuildLayoutParameters());
         // Only direct construction reaches here; Gradle's own construction goes through the protected
         // constructors, so this nags third-party callers without nagging internal usage.
         StartParameterDeprecations.nagOnStartParameterConstructor();
-    }
-
-    /**
-     * Creates a {@code StartParameter} with default values, for internal use. The {@code Void} parameter
-     * exists only to distinguish this from the deprecated public no-arg constructor; pass {@code null}.
-     */
-    protected StartParameter(@SuppressWarnings("unused") Void marker) {
-        this(new BuildLayoutParameters());
     }
 
     /**
@@ -295,7 +287,11 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     @Deprecated
     public StartParameter newInstance() {
         StartParameterDeprecations.nagOnStartParameterCopy("newInstance()");
-        return prepareNewInstance(new StartParameter((Void) null));
+        return prepareNewInstance(createStartParameter());
+    }
+
+    private static StartParameter createStartParameter() {
+        return new StartParameter(new BuildLayoutParameters());
     }
 
     protected StartParameter prepareNewInstance(StartParameter p) {
@@ -326,7 +322,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     @Deprecated
     public StartParameter newBuild() {
         StartParameterDeprecations.nagOnStartParameterCopy("newBuild()");
-        return prepareNewBuild(new StartParameter((Void) null));
+        return prepareNewBuild(createStartParameter());
     }
 
     protected StartParameter prepareNewBuild(StartParameter p) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -69,6 +69,8 @@ public class StartParameterInternal extends StartParameter {
     private transient @Nullable Consumer<String> mutationListener;
 
     public StartParameterInternal() {
+        // Delegate to the protected constructor rather than the deprecated no-arg super().
+        this(new BuildLayoutParameters());
     }
 
     protected StartParameterInternal(BuildLayoutParameters layoutParameters) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -106,13 +106,28 @@ public class StartParameterInternal extends StartParameter {
         }
     }
 
+    // The public copy methods are deprecated. They are still reached at runtime via a StartParameter
+    // reference to the (internal) running build's start parameter, so the overrides must nag too;
+    // internal code calls newInstanceInternal()/newBuildInternal() instead, which do not nag.
     @Override
+    @SuppressWarnings("deprecation")
     public StartParameterInternal newInstance() {
-        return (StartParameterInternal) prepareNewInstance(new StartParameterInternal());
+        StartParameterDeprecations.nagOnStartParameterCopy("newInstance()");
+        return newInstanceInternal();
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public StartParameterInternal newBuild() {
+        StartParameterDeprecations.nagOnStartParameterCopy("newBuild()");
+        return newBuildInternal();
+    }
+
+    public StartParameterInternal newInstanceInternal() {
+        return (StartParameterInternal) prepareNewInstance(new StartParameterInternal());
+    }
+
+    public StartParameterInternal newBuildInternal() {
         return prepareNewBuild(new StartParameterInternal());
     }
 

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/StartParameterDeprecations.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/StartParameterDeprecations.java
@@ -20,6 +20,14 @@ import org.gradle.StartParameter;
 
 public class StartParameterDeprecations {
 
+    public static void nagOnStartParameterConstructor() {
+        DeprecationLogger.deprecate("Creating a StartParameter instance directly")
+            .withAdvice("A StartParameter is provided by the build; obtain it (e.g. 'gradle.startParameter') and derive a copy with newInstance() or newBuild() if you need one.")
+            .willBeRemovedInGradle10()
+            .undocumented()
+            .nagUser();
+    }
+
     public static void nagOnIsConfigurationCacheRequested() {
         DeprecationLogger.deprecateProperty(StartParameter.class, "isConfigurationCacheRequested")
             .withAdvice("Please use 'configurationCache.requested' property on 'BuildFeatures' service instead.")

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/StartParameterDeprecations.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/StartParameterDeprecations.java
@@ -22,9 +22,17 @@ public class StartParameterDeprecations {
 
     public static void nagOnStartParameterConstructor() {
         DeprecationLogger.deprecate("Creating a StartParameter instance directly")
-            .withAdvice("A StartParameter is provided by the build; obtain it (e.g. 'gradle.startParameter') and derive a copy with newInstance() or newBuild() if you need one.")
+            .withAdvice("The StartParameter for a build is provided by Gradle and is not intended to be created directly.")
             .willBeRemovedInGradle10()
-            .undocumented()
+            .withUpgradeGuideSection(9, "deprecated_startparameter_construction")
+            .nagUser();
+    }
+
+    public static void nagOnStartParameterCopy(String methodWithParams) {
+        DeprecationLogger.deprecateMethod(StartParameter.class, methodWithParams)
+            .withAdvice("The StartParameter for a build is provided by Gradle and is not intended to be copied.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_startparameter_construction")
             .nagUser();
     }
 

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -43,6 +43,18 @@ class StartParameterTest extends Specification {
         new StartParameter() != null
     }
 
+    @ExpectDeprecation("The StartParameter.newInstance() method has been deprecated")
+    void "copying a StartParameter with newInstance emits a deprecation warning"() {
+        expect:
+        newStartParameter().newInstance() != null
+    }
+
+    @ExpectDeprecation("The StartParameter.newBuild() method has been deprecated")
+    void "copying a StartParameter with newBuild emits a deprecation warning"() {
+        expect:
+        newStartParameter().newBuild() != null
+    }
+
     void "new instance has correct state"() {
         def parameter = newStartParameter()
         parameter.taskNames = ['a']
@@ -65,7 +77,7 @@ class StartParameterTest extends Specification {
         parameter.includeBuild(new File('participant'))
 
         when:
-        def newInstance = parameter.newInstance()
+        def newInstance = newInstanceOf(parameter)
 
         then:
         parameter == newInstance
@@ -87,7 +99,7 @@ class StartParameterTest extends Specification {
         parameter.includedBuilds = [new File('participant'), new File("/path/to/another/participant")]
 
         when:
-        def newInstance = parameter.newInstance()
+        def newInstance = newInstanceOf(parameter)
 
         then:
         !parameter.initScripts.is(newInstance.initScripts)
@@ -230,7 +242,7 @@ class StartParameterTest extends Specification {
         assertThat(parameter, isSerializable())
 
         when:
-        StartParameter newParameter = parameter.newBuild()
+        StartParameter newParameter = newBuildOf(parameter)
 
         then:
         newParameter != parameter
@@ -322,10 +334,18 @@ class StartParameterTest extends Specification {
         assert parameter.taskRequests.size() == 1 && parameter.taskRequests[0] instanceof RunDefaultTasksExecutionRequest
     }
 
-    // The public constructor is deprecated; this test class exercises StartParameter itself, so it
-    // constructs through the deprecated entry point with the deprecation nag suppressed.
+    // The public constructor and the copy methods are deprecated; this test class exercises
+    // StartParameter itself, so it goes through those entry points with the deprecation nag suppressed.
     private static StartParameter newStartParameter() {
         DeprecationLogger.whileDisabled({ new StartParameter() } as Factory)
+    }
+
+    private static StartParameter newInstanceOf(StartParameter parameter) {
+        DeprecationLogger.whileDisabled({ parameter.newInstance() } as Factory)
+    }
+
+    private static StartParameter newBuildOf(StartParameter parameter) {
+        DeprecationLogger.whileDisabled({ parameter.newBuild() } as Factory)
     }
 
     // Previously StartParameter's toString got wildly out of sync with the state inside of it

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -19,7 +19,10 @@ package org.gradle
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.internal.DefaultTaskExecutionRequest
+import org.gradle.internal.Factory
 import org.gradle.internal.RunDefaultTasksExecutionRequest
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.SetSystemProperties
 import org.junit.Rule
@@ -34,8 +37,14 @@ class StartParameterTest extends Specification {
     @Rule private TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule private SetSystemProperties systemProperties = new SetSystemProperties()
 
+    @ExpectDeprecation("Creating a StartParameter instance directly has been deprecated")
+    void "constructing a StartParameter directly emits a deprecation warning"() {
+        expect:
+        new StartParameter() != null
+    }
+
     void "new instance has correct state"() {
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
         parameter.taskNames = ['a']
         parameter.buildProjectDependencies = true
         parameter.currentDir = new File('a')
@@ -69,7 +78,7 @@ class StartParameterTest extends Specification {
     }
 
     void "mutable collections are not shared"() {
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
         parameter.taskNames = ['a']
         parameter.excludedTaskNames = ['foo']
         parameter.projectProperties = [a: 'a']
@@ -98,7 +107,7 @@ class StartParameterTest extends Specification {
     }
 
     void "default values"() {
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
 
         expect:
         parameter.gradleUserHomeDir == StartParameter.DEFAULT_GRADLE_USER_HOME
@@ -126,13 +135,13 @@ class StartParameterTest extends Specification {
         System.setProperty(StartParameter.GRADLE_USER_HOME_PROPERTY_KEY, gradleUserHome.absolutePath)
 
         when:
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
         then:
         parameter.gradleUserHomeDir == gradleUserHome
     }
 
     void "canonicalizes current dir"() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
         File dir = new File('current')
 
         when:
@@ -144,7 +153,7 @@ class StartParameterTest extends Specification {
     }
 
     void "can configure project dir"() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
         File file = new File('test/project dir')
 
         when:
@@ -156,7 +165,7 @@ class StartParameterTest extends Specification {
     }
 
     void "can configure null project dir"() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
         parameter.projectDir = new File('test/project dir')
 
         when:
@@ -168,7 +177,7 @@ class StartParameterTest extends Specification {
     }
 
     void "can configure null user home dir"() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
 
         when:
         parameter.gradleUserHomeDir = null
@@ -183,7 +192,7 @@ class StartParameterTest extends Specification {
         System.setProperty(StartParameter.GRADLE_USER_HOME_PROPERTY_KEY, gradleUserHome.absolutePath)
 
         given:
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
         parameter.gradleUserHomeDir = tmpDir.file("ignore-me")
 
         when:
@@ -195,7 +204,7 @@ class StartParameterTest extends Specification {
     }
 
     void "creates parameter for new build"() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
 
         // Copied properties
         parameter.gradleUserHomeDir = new File("home")
@@ -250,7 +259,7 @@ class StartParameterTest extends Specification {
     void "gets all init scripts"() {
         def gradleUserHomeDir = tmpDir.testDirectory.createDir("gradleUserHomeDie")
         def gradleHomeDir = tmpDir.testDirectory.createDir("gradleHomeDir")
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
 
         when:
         parameter.gradleUserHomeDir = gradleUserHomeDir
@@ -280,7 +289,7 @@ class StartParameterTest extends Specification {
     }
 
     def 'taskNames getter defaults to taskParameters'() {
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
         def requests = [new DefaultTaskExecutionRequest(['a']), new DefaultTaskExecutionRequest(['b'])]
 
         when:
@@ -292,7 +301,7 @@ class StartParameterTest extends Specification {
     }
 
     def 'taskNames setter defaults to taskParameters'() {
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = newStartParameter()
 
         when:
         parameter.taskNames = [ 'a', 'b' ]
@@ -313,12 +322,18 @@ class StartParameterTest extends Specification {
         assert parameter.taskRequests.size() == 1 && parameter.taskRequests[0] instanceof RunDefaultTasksExecutionRequest
     }
 
+    // The public constructor is deprecated; this test class exercises StartParameter itself, so it
+    // constructs through the deprecated entry point with the deprecation nag suppressed.
+    private static StartParameter newStartParameter() {
+        DeprecationLogger.whileDisabled({ new StartParameter() } as Factory)
+    }
+
     // Previously StartParameter's toString got wildly out of sync with the state inside of it
     // Ensure that all state is represented in the toString, so it's more useful for debugging
     // In the future StartParameter should be replaced with a `record` so this doesn't need to be checked
     void "all state is represented in toString"() {
         given:
-        def parameter = new StartParameter()
+        def parameter = newStartParameter()
         def fieldNames = StartParameter.class.getDeclaredFields()
             .findAll { !it.synthetic }
             .collect { it.name }

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle
 
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.internal.DefaultTaskExecutionRequest
@@ -53,6 +54,22 @@ class StartParameterTest extends Specification {
     void "copying a StartParameter with newBuild emits a deprecation warning"() {
         expect:
         newStartParameter().newBuild() != null
+    }
+
+    // StartParameter is part of the public API and declares Serializable, so verify that contract on the
+    // public type. StartParameterInternal (used by the tests below) is not Java-serializable by design.
+    void "public StartParameter is serializable"() {
+        given:
+        StartParameter parameter = DeprecationLogger.whileDisabled({ new StartParameter() } as Factory)
+        parameter.taskNames = ['a', 'b']
+        parameter.excludedTaskNames = ['c']
+        parameter.projectProperties = [p: 'v']
+        parameter.systemPropertiesArgs = [s: 'v']
+        parameter.initScripts = [new File('init.gradle')]
+        parameter.currentDir = new File('some-dir')
+
+        expect:
+        assertThat(parameter, isSerializable())
     }
 
     void "new instance has correct state"() {
@@ -138,8 +155,6 @@ class StartParameterTest extends Specification {
         !parameter.buildCacheEnabled
         !parameter.writeDependencyLocks
         parameter.lockedDependenciesToUpdate.isEmpty()
-
-        assertThat(parameter, isSerializable())
     }
 
     void "uses gradle user home system property"() {
@@ -161,7 +176,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.currentDir == dir.canonicalFile
-        assertThat(parameter, isSerializable())
     }
 
     void "can configure project dir"() {
@@ -173,7 +187,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.currentDir == file.canonicalFile
-        assertThat(parameter, isSerializable())
     }
 
     void "can configure null project dir"() {
@@ -185,7 +198,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.currentDir == new File(System.getProperty("user.dir")).getCanonicalFile()
-        assertThat(parameter, isSerializable())
     }
 
     void "can configure null user home dir"() {
@@ -196,7 +208,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.gradleUserHomeDir == StartParameter.DEFAULT_GRADLE_USER_HOME
-        assertThat(parameter, isSerializable())
     }
 
     void "considers system properties for null user home dir"() {
@@ -212,7 +223,6 @@ class StartParameterTest extends Specification {
 
         then:
         parameter.gradleUserHomeDir == gradleUserHome
-        assertThat(parameter, isSerializable())
     }
 
     void "creates parameter for new build"() {
@@ -239,8 +249,6 @@ class StartParameterTest extends Specification {
         parameter.writeDependencyLocks = true
         parameter.lockedDependenciesToUpdate = ['foo']
 
-        assertThat(parameter, isSerializable())
-
         when:
         StartParameter newParameter = newBuildOf(parameter)
 
@@ -265,7 +273,6 @@ class StartParameterTest extends Specification {
         assertRunsDefaultTasks(newParameter)
         newParameter.excludedTaskNames.empty
         newParameter.currentDir == new File(System.getProperty("user.dir")).getCanonicalFile()
-        assertThat(newParameter, isSerializable())
     }
 
     void "gets all init scripts"() {
@@ -334,18 +341,19 @@ class StartParameterTest extends Specification {
         assert parameter.taskRequests.size() == 1 && parameter.taskRequests[0] instanceof RunDefaultTasksExecutionRequest
     }
 
-    // The public constructor and the copy methods are deprecated; this test class exercises
-    // StartParameter itself, so it goes through those entry points with the deprecation nag suppressed.
-    private static StartParameter newStartParameter() {
-        DeprecationLogger.whileDisabled({ new StartParameter() } as Factory)
+    // These tests exercise StartParameterInternal, the type actually used at runtime, via its
+    // non-deprecated internal construction and copy methods. The deprecation warnings on the public
+    // constructor and copy methods are covered by the dedicated tests at the top of this class.
+    private static StartParameterInternal newStartParameter() {
+        new StartParameterInternal()
     }
 
-    private static StartParameter newInstanceOf(StartParameter parameter) {
-        DeprecationLogger.whileDisabled({ parameter.newInstance() } as Factory)
+    private static StartParameterInternal newInstanceOf(StartParameterInternal parameter) {
+        parameter.newInstanceInternal()
     }
 
-    private static StartParameter newBuildOf(StartParameter parameter) {
-        DeprecationLogger.whileDisabled({ parameter.newBuild() } as Factory)
+    private static StartParameterInternal newBuildOf(StartParameterInternal parameter) {
+        parameter.newBuildInternal()
     }
 
     // Previously StartParameter's toString got wildly out of sync with the state inside of it

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterInternalMutationInstrumentationTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterInternalMutationInstrumentationTest.groovy
@@ -209,7 +209,9 @@ class StartParameterInternalMutationInstrumentationTest extends Specification {
         "isVfsVerboseLogging()",
         "isWriteDependencyLocks()",
         "newBuild()",
+        "newBuildInternal()",
         "newInstance()",
+        "newInstanceInternal()",
         "toBuildLayoutConfiguration()",
         "toString()",
     ]

--- a/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterInternalTest.groovy
+++ b/platforms/core-runtime/start-parameter/src/test/groovy/org/gradle/api/internal/StartParameterInternalTest.groovy
@@ -22,6 +22,26 @@ import spock.lang.Specification
 
 class StartParameterInternalTest extends Specification {
 
+    // The running build's start parameter is a StartParameterInternal, so copying it via the public
+    // (deprecated) methods must still nag at runtime even though dispatch lands on the override.
+    @ExpectDeprecation("The StartParameter.newInstance() method has been deprecated")
+    def 'copying the internal start parameter via newInstance is deprecated'() {
+        expect:
+        new StartParameterInternal().newInstance() != null
+    }
+
+    @ExpectDeprecation("The StartParameter.newBuild() method has been deprecated")
+    def 'copying the internal start parameter via newBuild is deprecated'() {
+        expect:
+        new StartParameterInternal().newBuild() != null
+    }
+
+    def 'copying the internal start parameter for internal use does not nag'() {
+        expect:
+        new StartParameterInternal().newInstanceInternal() != null
+        new StartParameterInternal().newBuildInternal() != null
+    }
+
     @ExpectDeprecation("The StartParameter.isConfigurationCacheRequested property has been deprecated")
     def 'can query whether configuration caching is requested'() {
         def parameter = new StartParameterInternal()

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -221,16 +221,16 @@ See <<configuration_cache_requirements.adoc#config_cache:requirements:custom_col
 [[deprecated_startparameter_construction]]
 ==== Deprecation of creating and copying `StartParameter`
 
-The `StartParameter` for a build is provided by Gradle and is accessed through `Gradle.getStartParameter()`.
+Starting in Gradle 10, constructing new instances of link:{javadocPath}/org/gradle/StartParameter.html[`StartParameter`] will no longer be permitted.
 It was never intended to be instantiated or copied by build logic, but the public no-argument constructor and the `newInstance()` / `newBuild()` methods made that possible.
 
-These are now deprecated and will be removed in Gradle 10:
+The following have been deprecated for removal:
 
-- the public `StartParameter()` constructor;
-- `StartParameter.newInstance()`;
-- `StartParameter.newBuild()`.
+- the public link:{javadocPath}/org/gradle/StartParameter.html[`StartParameter()`] constructor
+- link:{javadocPath}/org/gradle/StartParameter.html#newInstance()[`StartParameter.newInstance()`]
+- link:{javadocPath}/org/gradle/StartParameter.html#newBuild()[`StartParameter.newBuild()`]
 
-Obtain the start parameter from the build (for example via `gradle.startParameter`) instead of constructing or copying one.
+The existing `StartParameter` instance for a build may be obtained via link:{javadocPath}/org/gradle/api/invocation/Gradle.html#getStartParameter()[`Gradle.getStartParameter()`] instead of constructing or copying one.
 
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -218,6 +218,20 @@ To fix it, use a standard collection or map type instead of a custom subtype, an
 
 See <<configuration_cache_requirements.adoc#config_cache:requirements:custom_collection_types, Custom Collection and Map Types>> for details.
 
+[[deprecated_startparameter_construction]]
+==== Deprecation of creating and copying `StartParameter`
+
+The `StartParameter` for a build is provided by Gradle and is accessed through `Gradle.getStartParameter()`.
+It was never intended to be instantiated or copied by build logic, but the public no-argument constructor and the `newInstance()` / `newBuild()` methods made that possible.
+
+These are now deprecated and will be removed in Gradle 10:
+
+- the public `StartParameter()` constructor;
+- `StartParameter.newInstance()`;
+- `StartParameter.newBuild()`.
+
+Obtain the start parameter from the build (for example via `gradle.startParameter`) instead of constructing or copying one.
+
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.transport
 
 import com.google.common.collect.Lists
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.credentials.Credentials
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride
@@ -44,7 +44,7 @@ class RepositoryTransportFactoryTest extends Specification {
         connectorFactory2.getSupportedProtocols() >> (["protocol2a", "protocol2b"] as Set)
         connectorFactory2.getSupportedAuthentication() >> ([] as Set)
         List<ResourceConnectorFactory> resourceConnectorFactories = Lists.newArrayList(connectorFactory1, connectorFactory2)
-        StartParameterResolutionOverride override = new StartParameterResolutionOverride(new StartParameter(), new File("dummy"))
+        StartParameterResolutionOverride override = new StartParameterResolutionOverride(new StartParameterInternal(), new File("dummy"))
         repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, override, producerGuard, Mock(FileResourceRepository), TestUtil.checksumService)
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -99,7 +99,7 @@ public class BuildStateFactory {
     }
 
     private static StartParameterInternal buildSrcStartParameterFor(File buildSrcDir, StartParameterInternal containingBuildParameters) {
-        final StartParameterInternal buildSrcStartParameter = containingBuildParameters.newBuild();
+        final StartParameterInternal buildSrcStartParameter = containingBuildParameters.newBuildInternal();
         buildSrcStartParameter.setCurrentDir(buildSrcDir);
         buildSrcStartParameter.setProjectProperties(containingBuildParameters.getProjectPropertiesUntracked());
         buildSrcStartParameter.doNotSearchUpwards();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
@@ -133,7 +133,7 @@ public class BuildDefinition {
     }
 
     private static StartParameterInternal startParameterForIncludedBuildFrom(StartParameterInternal startParameter, @Nullable File buildRootDir) {
-        StartParameterInternal includedBuildStartParam = startParameter.newBuild();
+        StartParameterInternal includedBuildStartParam = startParameter.newBuildInternal();
         includedBuildStartParam.setCurrentDir(buildRootDir);
         includedBuildStartParam.doNotSearchUpwards();
         includedBuildStartParam.setInitScripts(startParameter.getInitScripts());
@@ -145,6 +145,6 @@ public class BuildDefinition {
      * Creates a defensive copy of this build definition, to isolate this instance from mutations made to the {@link StartParameter} during execution of the build.
      */
     public BuildDefinition newInstance() {
-        return new BuildDefinition(name, buildRootDir, startParameter.newInstance(), injectedSettingsPlugins, dependencySubstitutions, fromBuild, pluginBuild);
+        return new BuildDefinition(name, buildRootDir, startParameter.newInstanceInternal(), injectedSettingsPlugins, dependencySubstitutions, fromBuild, pluginBuild);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -275,7 +275,7 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
 
     private SettingsState createEmptySettings(GradleInternal gradle, StartParameterInternal startParameter, ClassLoaderScope classLoaderScope) {
         logger.debug("Creating empty settings for build: '{}'", gradle.getIdentityPath());
-        StartParameterInternal noSearchParameter = startParameter.newInstance();
+        StartParameterInternal noSearchParameter = startParameter.newInstanceInternal();
         noSearchParameter.useEmptySettings();
         noSearchParameter.doNotSearchUpwards();
         BuildLayout layout = buildLayoutFactory.getLayoutFor(noSearchParameter.toBuildLayoutConfiguration());

--- a/subprojects/core/src/main/java/org/gradle/internal/build/NestedRootBuildRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/NestedRootBuildRunner.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
 public class NestedRootBuildRunner {
 
     public static StartParameter createStartParameterForNewBuild(ServiceRegistry services) {
-        return services.get(StartParameter.class).newBuild();
+        return services.get(StartParameterInternal.class).newBuildInternal();
     }
 
     public static void runNestedRootBuild(String buildName, StartParameterInternal startParameter, ServiceRegistry services, ClassPath injectedPluginClassPath) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskExecutionModeResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskExecutionModeResolverTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.changedetection.changes
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskInternal
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 class DefaultTaskExecutionModeResolverTest extends Specification {
 
-    def startParameter = new StartParameter()
+    def startParameter = new StartParameterInternal()
     def repository = new DefaultTaskExecutionModeResolver(startParameter)
     def inputs = Stub(TaskInputsInternal)
     def outputs = Stub(TaskOutputsInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.configuration.project
 
-import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.ProjectEvaluationListener
@@ -51,7 +51,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         project.displayName >> "<project>"
         project.gradle >> gradle
         gradle.getIdentityPath() >> Path.path(":")
-        gradle.startParameter >> new StartParameter()
+        gradle.startParameter >> new StartParameterInternal()
         project.projectPath >> Path.path(":project1")
         project.path >> project.projectPath.toString()
         project.identityPath >> Path.path(":project1")

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsCommonTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsCommonTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.initialization
 import org.gradle.StartParameter
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
@@ -55,7 +56,7 @@ class DefaultSettingsCommonTest extends Specification {
 
     def createSettings(String path = '/somepath/root') {
         settingsDir = new File(path).absoluteFile
-        startParameter = new StartParameter(currentDir: new File(settingsDir, 'current'), gradleUserHomeDir: new File('gradleUserHomeDir'))
+        startParameter = new StartParameterInternal(currentDir: new File(settingsDir, 'current'), gradleUserHomeDir: new File('gradleUserHomeDir'))
 
         fileResolver.resolve(_) >> { args -> args[0].canonicalFile }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.initialization
 
 import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
@@ -43,7 +44,7 @@ class InstantiatingBuildLoaderTest extends Specification {
     File rootProjectDir
     File childProjectDir
     ProjectDescriptorRegistry projectDescriptorRegistry = new DefaultProjectDescriptorRegistry()
-    StartParameter startParameter = new StartParameter()
+    StartParameter startParameter = new StartParameterInternal()
     ProjectDescriptorInternal rootDescriptor
     ProjectInternal rootProject
     ProjectDescriptorInternal childDescriptor

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectSpecsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectSpecsTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.initialization
 
 import org.gradle.StartParameter
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.SettingsInternal
 import spock.lang.Specification
 
@@ -38,7 +39,7 @@ class ProjectSpecsTest extends Specification {
 
     def "project dir based spec"() {
         given:
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = new StartParameterInternal()
         parameter.setProjectDir(projectDir)
         parameter.setCurrentDir(currentDir)
 
@@ -48,7 +49,7 @@ class ProjectSpecsTest extends Specification {
 
     def "current dir based spec"() {
         given:
-        StartParameter parameter = new StartParameter()
+        StartParameter parameter = new StartParameterInternal()
         parameter.setCurrentDir(currentDir)
 
         expect:

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Constructor org.gradle.StartParameter(java.lang.Void)",
+            "acceptation": "Internal-only constructor that centralizes creation of a parameterless StartParameter; not part of the advertised public API.",
+            "changes": []
+        }
+    ]
 }

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,10 +1,3 @@
 {
-    "acceptedApiChanges": [
-        {
-            "type": "org.gradle.StartParameter",
-            "member": "Constructor org.gradle.StartParameter(java.lang.Void)",
-            "acceptation": "Internal-only constructor that centralizes creation of a parameterless StartParameter; not part of the advertised public API.",
-            "changes": []
-        }
-    ]
+    "acceptedApiChanges": []
 }


### PR DESCRIPTION
Stacked on top of #38152 (base branch `jvandort/ip/add-start-parameter-violations`).

## What

A `StartParameter` is always provided by the running build, which operates on a `StartParameterInternal`. A directly constructed `StartParameter` is a detached value object that no build ever sees, so offering a public constructor is misleading.

This deprecates the public no-arg `StartParameter()` constructor:

- **Compile-time**: `@Deprecated` + `@deprecated` Javadoc, pointing to `newInstance()` / `newBuild()`.
- **Runtime nag**: emits a deprecation warning when called directly by third parties.
- **Internal usage does not nag**: Gradle's own duplication (`newInstance()`/`newBuild()`, and `StartParameterInternal`) routes through the protected `StartParameter(BuildLayoutParameters)` constructor, so a real build never warns.

## Test migration

Tests that constructed `new StartParameter()` directly (which now nags, and throws in unit tests where `DeprecationLogger` is uninitialized) were updated:

- Collaborator usages switched to `StartParameterInternal` (the real runtime type).
- `StartParameterTest` keeps exercising the class itself, constructing via a `DeprecationLogger.whileDisabled { ... }` helper so it still validates the deprecated constructor's behaviour.