### PR TITLE
Update Develocity plugin to 4.4.3

### DIFF
--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -3,7 +3,7 @@
 asciidoctor = "3.0.1"
 bytebuddy = "1.18.8"
 checkstyle = "10.25.0"
-develocity = "4.4.2"
+develocity = "4.4.3"
 groovy = "4.0.32"
 hamcrest = "3.0"
 javaPoet = "1.13.0"

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedDevelocityPlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "develocity-gradle-plugin";
-    public static final String VERSION = "4.4.2";
+    public static final String VERSION = "4.4.3";
 
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
@@ -168,6 +168,7 @@ class DevelocityPluginSmokeTest extends AbstractSmokeTest {
         "4.4.0",
         "4.4.1",
         "4.4.2",
+        "4.4.3",
     ]
 
     // Current injection scripts support Develocity plugin 3.6.4 and above


### PR DESCRIPTION
Post-release bump of the Develocity Gradle plugin to 4.4.3 (also adds 4.4.3 to the smoke-test supported-versions list).

## Test plan
- `@bot-gradle test this` — relies on CI (incl. `DevelocityPluginSmokeTest`) to validate the new version resolves and auto-applies correctly.