### PR TITLE
Wire Agent-based opener to SerializedLambda codec

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
@@ -242,7 +242,7 @@ class DefaultConfigurationCacheCodecs(
             bind(org.gradle.internal.serialize.codecs.core.ApiTextResourceAdapterCodec)
 
             groovyCodecs()
-            bind(SerializedLambdaParametersCheckingCodec)
+            bind(SerializedLambdaParametersCheckingCodec(objectOpener))
 
             // Dependency management types
             val immutableAttributesCodec = ImmutableAttributesCodec(attributesFactory, managedFactoryRegistry)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/SerializedLambdaParametersCheckingCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/SerializedLambdaParametersCheckingCodec.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.serialize.codecs.core
 
 import org.gradle.internal.configuration.problems.DocumentationSection
 import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.reflection.access.ObjectOpener
 import org.gradle.internal.serialize.beans.services.unsupportedFieldDeclaredTypes
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.IsolateContext
@@ -41,7 +42,9 @@ import kotlin.reflect.KClass
  *
  * @see [org.gradle.internal.serialize.beans.services.unsupportedFieldDeclaredTypes]
  */
-object SerializedLambdaParametersCheckingCodec : Codec<SerializedLambda> {
+class SerializedLambdaParametersCheckingCodec(
+    private val objectOpener: ObjectOpener
+) : Codec<SerializedLambda> {
     override suspend fun ReadContext.decode(): SerializedLambda {
         val capturingClass = readClass()
         val functionalInterfaceClass = readString()
@@ -131,7 +134,7 @@ object SerializedLambdaParametersCheckingCodec : Codec<SerializedLambda> {
 
     private
     val capturingClassField: Field by lazy {
-        SerializedLambda::class.java.getDeclaredField("capturingClass").apply { isAccessible = true }
+        SerializedLambda::class.java.getDeclaredField("capturingClass").also { objectOpener.makeAccessible(it) }
     }
 
     /**

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
@@ -17,7 +17,6 @@
 package org.gradle.internal.serialize.codecs.core.jos
 
 import org.gradle.internal.reflection.access.ObjectOpener
-import org.gradle.internal.serialize.codecs.core.SerializedLambdaParametersCheckingCodec
 import org.gradle.internal.serialize.graph.BeanStateReader
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.EncodingProvider
@@ -42,7 +41,6 @@ import java.io.Serializable
 import java.lang.invoke.MethodHandle
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType.methodType
-import java.lang.invoke.SerializedLambda
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier.isPrivate
 
@@ -121,11 +119,6 @@ class JavaObjectSerializationCodec(
                     readResolve(readNonNull())
                         .also { putIdentity(id, it) }
                 }
-
-                Format.SerializedLambda -> {
-                    readResolve(SerializedLambdaParametersCheckingCodec.run { decode() })
-                        .also { putIdentity(id, it) }
-                }
             }
         }
 
@@ -176,13 +169,6 @@ class JavaObjectSerializationCodec(
             encodePreservingIdentityOf(value) {
                 val replacement = writeReplaceHandle.invokeExact(value)
                 when {
-                    replacement is SerializedLambda -> {
-                        writeEnum(Format.SerializedLambda)
-                        SerializedLambdaParametersCheckingCodec.run {
-                            encode(replacement)
-                        }
-                    }
-
                     replacement::class.java === value::class.java -> {
                         // Avoid a StackOverflowException when the replacement and value are of the same type.
                         // TODO:configuration-cache Skipping Java serialization for the replacement is likely incorrect when the class also supports the `writeObject` protocol
@@ -214,8 +200,7 @@ class JavaObjectSerializationCodec(
         ReadResolveBean,
         ReadResolveAny,
         WriteObject,
-        ReadObject,
-        SerializedLambda
+        ReadObject
     }
 
     private


### PR DESCRIPTION

This replaces the only remaining `setAccessible` in CC serialization code. Now the latter doesn't rely on `--add-opens`.
