### PR TITLE
Propagate model builder failures during resilient model building

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
@@ -498,7 +498,11 @@ class IsolatedProjectsToolingApiIdeaProjectIntegrationTest extends AbstractIsola
         fetchModelFails(IdeaProject)
 
         then:
+        // From Gradle 9.7 the plugin application failure captured during resilient model building is propagated,
+        // so the build fails with it while the client still receives the per-model failures.
+        failure.assertHasFailures(1)
         failureHasCause("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+        failureHasCause("Failed to apply plugin class 'org.gradle.plugins.ide.idea.IdeaPlugin'.")
         // TODO:isolated assert model stored successfully
         // TODO:isolated check the model matches the vintage model
         // checkIdeaProject(ideaModel, originalIdeaModel)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.internal.buildtree.BuildTreeModelCreatorResult
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.buildtree.ToolingModelRequestContext
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState
@@ -46,15 +47,18 @@ interface BuildTreeConfigurationCache {
     fun loadRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): BuildTreeWorkGraph.FinalizedGraph
 
     /**
-     * Prepares to load or create a model. Does nothing if the cached model is available or else prepares to capture
-     * configuration fingerprints and validation problems and then runs the given function.
+     * Prepares to load or create a model. Returns an empty result if the cached model is available or else prepares
+     * to capture configuration fingerprints and validation problems, runs the given function and returns its result.
+     * When the result carries failures, the cache entry is discarded instead of stored.
      */
-    fun maybePrepareModel(action: () -> Unit)
+    fun maybePrepareModel(action: () -> BuildTreeModelCreatorResult<Void>): BuildTreeModelCreatorResult<Void>
 
     /**
-     * Loads the cached model, if available, or else runs the given function to create it and then writes the result to the cache.
+     * Loads the cached model, if available, or else runs the given function to create it and then writes the model to
+     * the cache. When the result carries failures, the cache entry is discarded instead of stored, so the next build
+     * re-runs the function and re-reports the failures.
      */
-    fun <T : Any> loadOrCreateModel(creator: () -> T): T
+    fun <T : Any> loadOrCreateModel(creator: () -> BuildTreeModelCreatorResult<T>): BuildTreeModelCreatorResult<T>
 
     /**
      * Loads a cached intermediate model, if available, or else runs the given function to create it and then writes the result to the cache.
@@ -77,12 +81,6 @@ interface BuildTreeConfigurationCache {
      * Flushes any remaining state to the cache and closes any resources
      */
     fun finalizeCacheEntry()
-
-    /**
-     * Requests that the current cache entry is discarded instead of stored, because model building produced failures
-     * and the resulting partial configuration must not be reused. Has no effect when an existing entry is loaded.
-     */
-    fun requestEntryDiscard()
 
     // This is a temporary property to allow migration from a root build scoped cache to a build tree scoped cache
     val isLoaded: Boolean

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
@@ -22,8 +22,8 @@ import org.gradle.internal.buildtree.ToolingModelRequestContext
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
-import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult
 import org.gradle.util.Path
 
 
@@ -65,8 +65,8 @@ interface BuildTreeConfigurationCache {
         project: ProjectIdentity?,
         modelRequestContext: ToolingModelRequestContext,
         parameter: ToolingModelParameterCarrier?,
-        creator: () -> ToolingModelBuilderResultInternal
-    ): ToolingModelBuilderResultInternal
+        creator: () -> ToolingModelScopeResult
+    ): ToolingModelScopeResult
 
     /**
      * Loads cached dependency resolution metadata for the given project, if available, or else runs the given function to create it and then writes the result to the cache.
@@ -77,6 +77,12 @@ interface BuildTreeConfigurationCache {
      * Flushes any remaining state to the cache and closes any resources
      */
     fun finalizeCacheEntry()
+
+    /**
+     * Requests that the current cache entry is discarded instead of stored, because model building produced failures
+     * and the resulting partial configuration must not be reused. Has no effect when an existing entry is loaded.
+     */
+    fun requestEntryDiscard()
 
     // This is a temporary property to allow migration from a root build scoped cache to a build tree scoped cache
     val isLoaded: Boolean

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildToolingModelController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildToolingModelController.kt
@@ -20,9 +20,9 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.build.BuildToolingModelController
 import org.gradle.internal.buildtree.ToolingModelRequestContext
-import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 import org.gradle.tooling.provider.model.internal.ToolingModelScope
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult
 
 
 internal
@@ -51,7 +51,7 @@ class ConfigurationCacheAwareBuildToolingModelController(
         private val cache: BuildTreeConfigurationCache
     ) : ToolingModelScope {
         override fun getTarget() = delegate.target
-        override fun getModel(modelRequestContext: ToolingModelRequestContext, parameter: ToolingModelParameterCarrier?): ToolingModelBuilderResultInternal {
+        override fun getModel(modelRequestContext: ToolingModelRequestContext, parameter: ToolingModelParameterCarrier?): ToolingModelScopeResult {
             return cache.loadOrCreateIntermediateModel(target?.identity, modelRequestContext, parameter) {
                 delegate.getModel(modelRequestContext, parameter)
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeModelCreator.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeModelCreator.kt
@@ -19,7 +19,6 @@ package org.gradle.internal.cc.impl
 import org.gradle.internal.buildtree.BuildTreeModelAction
 import org.gradle.internal.buildtree.BuildTreeModelCreator
 import org.gradle.internal.buildtree.BuildTreeModelCreatorResult
-import org.gradle.internal.cc.impl.models.BuildTreeModel
 
 
 class ConfigurationCacheAwareBuildTreeModelCreator(
@@ -27,41 +26,14 @@ class ConfigurationCacheAwareBuildTreeModelCreator(
     private val cache: BuildTreeConfigurationCache
 ) : BuildTreeModelCreator {
     override fun beforeTasks(action: BuildTreeModelAction<*>): BuildTreeModelCreatorResult<Void> {
-        // maybePrepareModel runs the delegate only on a cache miss; on a hit the failures stay empty.
-        var configurationFailures = emptyList<Throwable>()
-        var modelBuilderFailures = emptyList<Throwable>()
-
-        cache.maybePrepareModel {
-            val delegateResult = delegate.beforeTasks(action)
-            configurationFailures = delegateResult.configurationFailures
-            modelBuilderFailures = delegateResult.modelBuilderFailures
+        return cache.maybePrepareModel {
+            delegate.beforeTasks(action)
         }
-
-        return discardEntryIfFailed(BuildTreeModelCreatorResult<Void>(null, configurationFailures, modelBuilderFailures))
     }
 
     override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): BuildTreeModelCreatorResult<T> {
-        // loadOrCreateModel runs the delegate only on a cache miss; on a hit the model is loaded and the failures stay empty.
-        var configurationFailures = emptyList<Throwable>()
-        var modelBuilderFailures = emptyList<Throwable>()
-
-        val model: T? = cache.loadOrCreateModel {
-            val delegateResult = delegate.fromBuildModel(action)
-            configurationFailures = delegateResult.configurationFailures
-            modelBuilderFailures = delegateResult.modelBuilderFailures
-            val builtModel = delegateResult.model
-            if (builtModel == null) BuildTreeModel.NullModel else BuildTreeModel.Model(builtModel)
-        }.result()
-
-        return discardEntryIfFailed(BuildTreeModelCreatorResult(model, configurationFailures, modelBuilderFailures))
-    }
-
-    private fun <T : Any> discardEntryIfFailed(result: BuildTreeModelCreatorResult<T>): BuildTreeModelCreatorResult<T> {
-        if (result.hasFailures()) {
-            // The action produced partial models with failures, so the entry must not be reused: discard it so the
-            // next build re-runs the action and re-reports the failures.
-            cache.requestEntryDiscard()
+        return cache.loadOrCreateModel {
+            delegate.fromBuildModel(action)
         }
-        return result
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeModelCreator.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeModelCreator.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.internal.buildtree.BuildTreeModelAction
 import org.gradle.internal.buildtree.BuildTreeModelCreator
+import org.gradle.internal.buildtree.BuildTreeModelCreatorResult
 import org.gradle.internal.cc.impl.models.BuildTreeModel
 
 
@@ -25,16 +26,42 @@ class ConfigurationCacheAwareBuildTreeModelCreator(
     private val delegate: BuildTreeModelCreator,
     private val cache: BuildTreeConfigurationCache
 ) : BuildTreeModelCreator {
-    override fun <T : Any> beforeTasks(action: BuildTreeModelAction<out T>) {
+    override fun beforeTasks(action: BuildTreeModelAction<*>): BuildTreeModelCreatorResult<Void> {
+        // maybePrepareModel runs the delegate only on a cache miss; on a hit the failures stay empty.
+        var configurationFailures = emptyList<Throwable>()
+        var modelBuilderFailures = emptyList<Throwable>()
+
         cache.maybePrepareModel {
-            delegate.beforeTasks(action)
+            val delegateResult = delegate.beforeTasks(action)
+            configurationFailures = delegateResult.configurationFailures
+            modelBuilderFailures = delegateResult.modelBuilderFailures
         }
+
+        return discardEntryIfFailed(BuildTreeModelCreatorResult<Void>(null, configurationFailures, modelBuilderFailures))
     }
 
-    override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): T? {
-        return cache.loadOrCreateModel {
-            val model = delegate.fromBuildModel(action)
-            if (model == null) BuildTreeModel.NullModel else BuildTreeModel.Model(model)
+    override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): BuildTreeModelCreatorResult<T> {
+        // loadOrCreateModel runs the delegate only on a cache miss; on a hit the model is loaded and the failures stay empty.
+        var configurationFailures = emptyList<Throwable>()
+        var modelBuilderFailures = emptyList<Throwable>()
+
+        val model: T? = cache.loadOrCreateModel {
+            val delegateResult = delegate.fromBuildModel(action)
+            configurationFailures = delegateResult.configurationFailures
+            modelBuilderFailures = delegateResult.modelBuilderFailures
+            val builtModel = delegateResult.model
+            if (builtModel == null) BuildTreeModel.NullModel else BuildTreeModel.Model(builtModel)
         }.result()
+
+        return discardEntryIfFailed(BuildTreeModelCreatorResult(model, configurationFailures, modelBuilderFailures))
+    }
+
+    private fun <T : Any> discardEntryIfFailed(result: BuildTreeModelCreatorResult<T>): BuildTreeModelCreatorResult<T> {
+        if (result.hasFailures()) {
+            // The action produced partial models with failures, so the entry must not be reused: discard it so the
+            // next build re-runs the action and re-reports the failures.
+            cache.requestEntryDiscard()
+        }
+        return result
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -75,7 +75,7 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
-import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 import org.gradle.util.Path
 import java.io.File
@@ -117,6 +117,10 @@ class DefaultConfigurationCache internal constructor(
     // Have one or more values been successfully written to the entry?
     private
     var cacheEntryRequiresCommit = false
+
+    // Did model building produce failures, so the entry must be discarded rather than stored?
+    private
+    var entryDiscardRequested = false
 
     private
     val host by lazy { deferredRootBuildGradle.gradle.services.get<HostServiceProvider>() }
@@ -331,8 +335,8 @@ class DefaultConfigurationCache internal constructor(
         project: ProjectIdentity?,
         modelRequestContext: ToolingModelRequestContext,
         parameter: ToolingModelParameterCarrier?,
-        creator: () -> ToolingModelBuilderResultInternal
-    ): ToolingModelBuilderResultInternal {
+        creator: () -> ToolingModelScopeResult
+    ): ToolingModelScopeResult {
         return intermediateModels.loadOrCreateIntermediateModel(project, modelRequestContext, parameter, creator)
     }
 
@@ -352,7 +356,7 @@ class DefaultConfigurationCache internal constructor(
                 require(!cacheEntryRequiresCommit)
             }
 
-            problems.shouldDiscardEntry -> {
+            entryDiscardRequested || problems.shouldDiscardEntry -> {
                 discardEntry()
                 cacheEntryRequiresCommit = false
             }
@@ -371,6 +375,10 @@ class DefaultConfigurationCache internal constructor(
         } finally {
             scopeRegistryListener.dispose()
         }
+    }
+
+    override fun requestEntryDiscard() {
+        entryDiscardRequested = true
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -35,6 +35,7 @@ import org.gradle.internal.cc.operations.withWorkGraphStoreOperation
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.buildtree.BuildActionModelRequirements
+import org.gradle.internal.buildtree.BuildTreeModelCreatorResult
 import org.gradle.internal.buildtree.BuildTreeModelSideEffect
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.buildtree.ToolingModelRequestContext
@@ -53,6 +54,7 @@ import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintStar
 import org.gradle.internal.cc.impl.fingerprint.InvalidationReason
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.cc.impl.metadata.ProjectMetadataController
+import org.gradle.internal.cc.impl.models.BuildTreeModel
 import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
 import org.gradle.internal.cc.impl.models.IntermediateModelController
 import org.gradle.internal.cc.impl.problems.ConfigurationCacheProblems
@@ -293,28 +295,45 @@ class DefaultConfigurationCache internal constructor(
         return loadWorkGraph(graph, graphBuilder, true)
     }
 
-    override fun maybePrepareModel(action: () -> Unit) {
+    override fun maybePrepareModel(action: () -> BuildTreeModelCreatorResult<Void>): BuildTreeModelCreatorResult<Void> {
         if (isLoaded) {
-            return
+            return BuildTreeModelCreatorResult.of(null)
         }
-        runWorkThatContributesToCacheEntry {
-            action()
+        return runWorkThatContributesToCacheEntry {
+            runAndDiscardEntryOnFailures(action)
         }
     }
 
-    override fun <T : Any> loadOrCreateModel(creator: () -> T): T {
+    override fun <T : Any> loadOrCreateModel(creator: () -> BuildTreeModelCreatorResult<T>): BuildTreeModelCreatorResult<T> {
         if (isLoaded) {
             runLoadedSideEffects()
-            return loadModel().uncheckedCast()
+            return BuildTreeModelCreatorResult.of(loadModel().uncheckedCast<BuildTreeModel>().result<T>())
         }
 
         return runWorkThatContributesToCacheEntry {
-            val model = creator()
-            // Graceful degradation. We don't care about the models saving at the moment since it's happening
-            // only when Isolated Projects enabled. That's it, there is no model saving in CC + noIP mode.
-            saveModel(model)
-            model
+            val result = runAndDiscardEntryOnFailures(creator)
+            if (!result.hasFailures()) {
+                // Graceful degradation. We don't care about the models saving at the moment since it's happening
+                // only when Isolated Projects enabled. That's it, there is no model saving in CC + noIP mode.
+                val model = when (val value = result.model) {
+                    null -> BuildTreeModel.NullModel
+                    else -> BuildTreeModel.Model(value)
+                }
+                saveModel(model)
+            }
+            result
         }
+    }
+
+    private
+    fun <T : Any> runAndDiscardEntryOnFailures(action: () -> BuildTreeModelCreatorResult<T>): BuildTreeModelCreatorResult<T> {
+        val result = action()
+        if (result.hasFailures()) {
+            // Model building produced failures, so the resulting partial configuration must not be reused:
+            // discard the entry so the next build re-runs and re-reports the failures.
+            entryDiscardRequested = true
+        }
+        return result
     }
 
     private
@@ -375,10 +394,6 @@ class DefaultConfigurationCache internal constructor(
         } finally {
             scopeRegistryListener.dispose()
         }
-    }
-
-    override fun requestEntryDiscard() {
-        entryDiscardRequested = true
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeModelCreator.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeModelCreator.kt
@@ -17,6 +17,7 @@ package org.gradle.internal.cc.impl.barrier
 
 import org.gradle.internal.buildtree.BuildTreeModelAction
 import org.gradle.internal.buildtree.BuildTreeModelCreator
+import org.gradle.internal.buildtree.BuildTreeModelCreatorResult
 
 /**
  * Prepares models while managing the configuration time barrier in the vintage mode.
@@ -25,13 +26,13 @@ internal class BarrierAwareBuildTreeModelCreator(
     private val runner: VintageConfigurationTimeActionRunner,
     private val delegate: BuildTreeModelCreator
 ) : BuildTreeModelCreator {
-    override fun <T : Any> beforeTasks(action: BuildTreeModelAction<out T>) {
-        runner.runConfigurationTimeAction {
+    override fun beforeTasks(action: BuildTreeModelAction<*>): BuildTreeModelCreatorResult<Void> {
+        return runner.runConfigurationTimeAction {
             delegate.beforeTasks(action)
         }
     }
 
-    override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): T? {
+    override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): BuildTreeModelCreatorResult<T> {
         return runner.runConfigurationTimeAction {
             delegate.fromBuildModel(action)
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/IntermediateModelController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/IntermediateModelController.kt
@@ -30,8 +30,8 @@ import org.gradle.internal.serialize.graph.IsolateOwner
 import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.tooling.provider.model.UnknownModelException
-import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult
 
 
 /**
@@ -67,8 +67,8 @@ class IntermediateModelController(
         project: ProjectIdentity?,
         modelRequestContext: ToolingModelRequestContext,
         parameter: ToolingModelParameterCarrier?,
-        creator: () -> ToolingModelBuilderResultInternal
-    ): ToolingModelBuilderResultInternal {
+        creator: () -> ToolingModelScopeResult
+    ): ToolingModelScopeResult {
         val key = ModelKey(project?.buildTreePath, modelRequestContext.modelName, parameter?.hash, modelRequestContext.inResilientContext())
         return loadOrCreateValue(key) {
             try {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -135,6 +135,7 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
         "runtime"     | "throw RuntimeException(\"broken !!!\")" | /Settings file '.*?' line: 1\s+broken !!!/       | ApiType.GET_MODEL
     }
 
+    @TargetGradleVersion(">=9.3 <9.7.0")
     def "GradleDslBaseScriptModel can be obtained even after a project #typeOfFailure failure with #apiType"() {
         assumeApiSupportedOnVersion(apiType)
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r93/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -107,6 +107,8 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
         listener.hasSeenSomeEvents && listener.configPhaseStartEvents.isEmpty()
     }
 
+    // From Gradle 9.7 a fetched model's captured failures also fail the build, see the r970 spec
+    @TargetGradleVersion(">=9.3 <9.7.0")
     def "GradleDslBaseScriptModel can be obtained even after a settings #typeOfFailure failure with #apiType"() {
         assumeApiSupportedOnVersion(apiType)
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.tooling.builders.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.tooling.BuildAction
+import org.gradle.tooling.BuildController
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.model.dsl.GradleDslBaseScriptModel
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+
+/**
+ * From Gradle 9.7 onwards, a configuration failure observed while resiliently fetching a model (the {@code fetch}
+ * API) is propagated to the client as a {@link BuildException} when the build finishes. Querying the same model with
+ * the classic {@code getModel} API still throws at the call site (so the build action can catch it) and does not
+ * fail the build, which keeps the base script model obtainable for IDE script editing.
+ *
+ * See the {@code <9.7.0} version in {@code r93.GradleDslBaseScriptModelCrossVersionSpec} for the previous behaviour,
+ * where the {@code fetch} path also kept the build successful.
+ */
+@ToolingApiVersion(">=9.3.0")
+@TargetGradleVersion(">=9.7.0")
+class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
+
+    def "fetching a model after a project #typeOfFailure failure fails the build"() {
+        given:
+        buildFileKts << error
+
+        when:
+        fails {
+            action(new FetchBaseModelAfterProjectConfigurationAction(ApiType.FETCH))
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken !!!") }
+
+        where:
+        typeOfFailure | error
+        "compilation" | "broken !!!"
+        "runtime"     | "throw RuntimeException(\"broken !!!\")"
+    }
+
+    def "GradleDslBaseScriptModel is still obtained via getModel even after a project #typeOfFailure failure"() {
+        given:
+        buildFileKts << error
+
+        when:
+        def result = succeeds {
+            action(new FetchBaseModelAfterProjectConfigurationAction(ApiType.GET_MODEL))
+                .run()
+        }
+
+        then:
+        result.errorsBeforeBaseModel.size() == 1
+        result.errorsBeforeBaseModel[0].contains("A problem occurred configuring root project")
+        result.baseModel != null
+        result.baseModel.groovyDslBaseScriptModel != null
+        result.baseModel.kotlinDslBaseScriptModel != null
+
+        where:
+        typeOfFailure | error
+        "compilation" | "broken !!!"
+        "runtime"     | "throw RuntimeException(\"broken !!!\")"
+    }
+
+    private static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
+    }
+
+    static class FetchBaseModelAfterProjectConfigurationAction implements BuildAction<FetchBaseModelLastActionResult>, Serializable {
+
+        final ApiType apiType
+
+        FetchBaseModelAfterProjectConfigurationAction(ApiType apiType) {
+            this.apiType = apiType
+        }
+
+        @Override
+        FetchBaseModelLastActionResult execute(BuildController controller) {
+            def model
+            List<String> failures = []
+            if (apiType == ApiType.FETCH) {
+                def result = controller.fetch(KotlinDslScriptsModel)
+                failures = result.failures.collect { it.message }
+                model = controller.fetch(GradleDslBaseScriptModel).model
+            } else {
+                try {
+                    controller.getModel(KotlinDslScriptsModel)
+                } catch (Exception e) {
+                    failures.add(e.message)
+                }
+                model = controller.getModel(GradleDslBaseScriptModel)
+            }
+            return new FetchBaseModelLastActionResult(failures, model)
+        }
+    }
+
+    static class FetchBaseModelLastActionResult implements Serializable {
+        final List<String> errorsBeforeBaseModel
+        final GradleDslBaseScriptModel baseModel
+
+        FetchBaseModelLastActionResult(List<String> errorsBeforeBaseModel, GradleDslBaseScriptModel baseModel) {
+            this.errorsBeforeBaseModel = errorsBeforeBaseModel
+            this.baseModel = baseModel
+        }
+    }
+
+    enum ApiType {
+        FETCH,
+        GET_MODEL
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -150,17 +150,6 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
         "runtime"     | "throw RuntimeException(\"broken !!!\")" | /Settings file '.*?' line: 1\s+broken !!!/
     }
 
-    private static List<String> collectCauseMessages(Throwable throwable) {
-        def messages = []
-        Throwable current = throwable
-        int depth = 0
-        while (current != null && depth++ < 50) {
-            messages << current.message
-            current = current.cause
-        }
-        return messages
-    }
-
     static class FetchBaseModelAfterSettingsEvaluationAction implements BuildAction<FetchBaseModelLastActionResult>, Serializable {
 
         final ApiType apiType

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -22,7 +22,9 @@ import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVers
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController
 import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
 import org.gradle.tooling.model.dsl.GradleDslBaseScriptModel
+import org.gradle.tooling.model.gradle.GradleBuild
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 /**
@@ -38,19 +40,31 @@ import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 @TargetGradleVersion(">=9.7.0")
 class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
-    def "fetching a model after a project #typeOfFailure failure fails the build"() {
+    def "GradleDslBaseScriptModel can be obtained via fetch even after a project #typeOfFailure failure, but the build fails"() {
         given:
         buildFileKts << error
 
+        def result = null
+
         when:
         fails {
-            action(new FetchBaseModelAfterProjectConfigurationAction(ApiType.FETCH))
+            action()
+                .buildFinished(new FetchBaseModelAfterProjectConfigurationAction(ApiType.FETCH), { result = it } as IntermediateResultHandler)
+                .build()
+                .forTasks()
                 .run()
         }
 
-        then:
+        then: "the build fails with the project configuration failure"
         def e = thrown(BuildException)
         collectCauseMessages(e).any { it?.contains("broken !!!") }
+
+        and: "the base script model is still obtained"
+        result.errorsBeforeBaseModel.size() == 1
+        result.errorsBeforeBaseModel[0].contains("A problem occurred configuring root project")
+        result.baseModel != null
+        result.baseModel.groovyDslBaseScriptModel != null
+        result.baseModel.kotlinDslBaseScriptModel != null
 
         where:
         typeOfFailure | error
@@ -81,6 +95,61 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
         "runtime"     | "throw RuntimeException(\"broken !!!\")"
     }
 
+    def "GradleDslBaseScriptModel can be obtained via fetch even after a settings #typeOfFailure failure, but the build fails"() {
+        given:
+        settingsFileKts << error
+
+        def result = null
+
+        when:
+        fails {
+            action()
+                .buildFinished(new FetchBaseModelAfterSettingsEvaluationAction(ApiType.FETCH), { result = it } as IntermediateResultHandler)
+                .build()
+                .forTasks()
+                .run()
+        }
+
+        then: "the build fails with the settings failure"
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken !!!") }
+
+        and: "the base script model is still obtained"
+        result.errorsBeforeBaseModel.size() == 1
+        result.errorsBeforeBaseModel[0] =~ expectedReportedError
+        result.baseModel != null
+        result.baseModel.groovyDslBaseScriptModel != null
+        result.baseModel.kotlinDslBaseScriptModel != null
+
+        where:
+        typeOfFailure | error                                    | expectedReportedError
+        "compilation" | "broken !!!"                             | /Script compilation error:\s+Line 1: broken !!!/
+        "runtime"     | "throw RuntimeException(\"broken !!!\")" | /Settings file '.*?' line: 1\s+broken !!!/
+    }
+
+    def "GradleDslBaseScriptModel is still obtained via getModel even after a settings #typeOfFailure failure"() {
+        given:
+        settingsFileKts << error
+
+        when:
+        def result = succeeds {
+            action(new FetchBaseModelAfterSettingsEvaluationAction(ApiType.GET_MODEL))
+                .run()
+        }
+
+        then:
+        result.errorsBeforeBaseModel.size() == 1
+        result.errorsBeforeBaseModel[0] =~ expectedReportedError
+        result.baseModel != null
+        result.baseModel.groovyDslBaseScriptModel != null
+        result.baseModel.kotlinDslBaseScriptModel != null
+
+        where:
+        typeOfFailure | error                                    | expectedReportedError
+        "compilation" | "broken !!!"                             | /Script compilation error:\s+Line 1: broken !!!/
+        "runtime"     | "throw RuntimeException(\"broken !!!\")" | /Settings file '.*?' line: 1\s+broken !!!/
+    }
+
     private static List<String> collectCauseMessages(Throwable throwable) {
         def messages = []
         Throwable current = throwable
@@ -90,6 +159,34 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
             current = current.cause
         }
         return messages
+    }
+
+    static class FetchBaseModelAfterSettingsEvaluationAction implements BuildAction<FetchBaseModelLastActionResult>, Serializable {
+
+        final ApiType apiType
+
+        FetchBaseModelAfterSettingsEvaluationAction(ApiType apiType) {
+            this.apiType = apiType
+        }
+
+        @Override
+        FetchBaseModelLastActionResult execute(BuildController controller) {
+            def model
+            List<String> failures = []
+            if (apiType == ApiType.FETCH) {
+                def result = controller.fetch(GradleBuild)
+                failures = result.failures.collect { it.message }
+                model = controller.fetch(GradleDslBaseScriptModel).model
+            } else {
+                try {
+                    controller.getModel(GradleBuild)
+                } catch (Exception e) {
+                    failures.add(e.message)
+                }
+                model = controller.getModel(GradleDslBaseScriptModel)
+            }
+            return new FetchBaseModelLastActionResult(failures, model)
+        }
     }
 
     static class FetchBaseModelAfterProjectConfigurationAction implements BuildAction<FetchBaseModelLastActionResult>, Serializable {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r970/GradleDslBaseScriptModelCrossVersionSpec.groovy
@@ -51,7 +51,6 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
             action()
                 .buildFinished(new FetchBaseModelAfterProjectConfigurationAction(ApiType.FETCH), { result = it } as IntermediateResultHandler)
                 .build()
-                .forTasks()
                 .run()
         }
 
@@ -106,7 +105,6 @@ class GradleDslBaseScriptModelCrossVersionSpec extends AbstractKotlinScriptModel
             action()
                 .buildFinished(new FetchBaseModelAfterSettingsEvaluationAction(ApiType.FETCH), { result = it } as IntermediateResultHandler)
                 .build()
-                .forTasks()
                 .run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
@@ -106,6 +106,7 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         dsl << [GROOVY, KOTLIN]
     }
 
+    @TargetGradleVersion("<9.7.0")
     def "returns a failure if a model builder throws an exception with #dsl DSL"() {
         given:
         setupInitScriptWithCustomModelBuilder("throw new RuntimeException('broken builder')")
@@ -122,7 +123,7 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         result.failureMessages == ["broken builder"]
     }
 
-    @TargetGradleVersion(">=7.6.6")
+    @TargetGradleVersion(">=7.6.6 <9.7.0")
     def "returns a failure if project configuration fails due to #description with #dsl DSL"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -189,7 +190,7 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         "fetch(target,modelType,parameterType,parameterInitializer)" | new FetchCustomModelAction()
     }
 
-    @TargetGradleVersion(">=7.6.6")
+    @TargetGradleVersion(">=7.6.6 <9.7.0")
     def "'#method' returns the same result as other fetch methods in the presence of project build script failures"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -221,7 +222,7 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
     }
 
-    @TargetGradleVersion(">=7.6.6")
+    @TargetGradleVersion(">=7.6.6 <9.7.0")
     def "'#method' method returns the same failed result as other fetch methods with #dsl DSL"() {
         given:
         setupInitScriptWithCustomModelBuilder()

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -73,7 +73,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         result.model.editableBuilds.empty
         result.model.rootProject.projectIdentifier.projectPath == ":"
         // If Settings scripts fails to evaluate the name falls back to directory name
-        result.model.rootProject.name == expectedRootProjectName ?: settingsKotlinFile.parentFile.name
+        result.model.rootProject.name == (expectedRootProjectName ?: settingsKotlinFile.parentFile.name)
         result.model.rootProject.projectIdentifier.buildIdentifier.rootDir == settingsKotlinFile.parentFile
         result.model.projects == [result.model.rootProject] as Set
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -54,6 +54,8 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         }
     }
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
+    @TargetGradleVersion('>=9.3.0 <9.7.0')
     def "should fetch root project model when settings #description"() {
         given:
         settingsKotlinFile << """
@@ -151,6 +153,8 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         result.model.editableBuilds == result.model.includedBuilds
     }
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
+    @TargetGradleVersion('>=9.3.0 <9.7.0')
     def "should fetch root build and included build with a broken settings convention plugin"() {
         given:
         settingsKotlinFile << """
@@ -205,6 +209,8 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         result.model.editableBuilds[0].projects == [result.model.editableBuilds[0].rootProject] as Set
     }
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
+    @TargetGradleVersion('>=9.3.0 <9.7.0')
     def "should fetch root project and included build models despite broken included settings files"() {
         given:
         createRootProject()
@@ -223,6 +229,8 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         model.model.includedBuilds[0].buildIdentifier.rootDir == file("included1")
     }
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
+    @TargetGradleVersion('>=9.3.0 <9.7.0')
     def "should return failure when caching models with isolated projects"() {
         given:
         def intermediateCaching = [

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/CustomResilientModelCrossVersionSpec.groovy
@@ -78,6 +78,7 @@ class CustomPlugin implements Plugin<Project> {
 """
     }
 
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "can query custom model for included build without build configuration errors, even if main project configuration fails#description #queryStrategy"() {
         settingsKotlinFile << """
             rootProject.name = "root"
@@ -140,6 +141,7 @@ class CustomPlugin implements Plugin<Project> {
         " with configure-on-demand" | EDITABLE_BUILDS_FIRST | IP_CONFIGURE_ON_DEMAND_FLAGS | ['build-logic', 'root', 'a', 'c'] | ['b']
     }
 
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "can query custom model for included build without build configuration errors, even if main settings fail#description #queryStrategy"() {
         settingsKotlinFile << """
             pluginManagement {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/FetchBuildActionCrossVersionSpec.groovy
@@ -25,6 +25,8 @@ import org.gradle.integtests.tooling.r930.FetchGradleBuildAction
 @TargetGradleVersion(">=9.4.0")
 class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "returns a failure for GradleBuild model if settings script fails due to #description"() {
         given:
         settingsFile.delete()

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -184,8 +184,9 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         assertModel(model, true, [], ["buildSrc", "buildSrc-included"])
     }
 
+    // From Gradle 9.7 the captured configuration failures also fail the build, see the r970 spec
     @ToolingApiVersion('>=9.3.0')
-    @TargetGradleVersion('>=9.4.0')
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "returns included builds nested within buildSrc composite build partially when compilation failures in #brokenFile"() {
         given:
         settingsKotlinFile << """
@@ -207,7 +208,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         fails { model(it) }
 
         then:
-         def e = thrown(BuildException)
+        def e = thrown(BuildException)
         e.cause.message.contains("Script compilation error")
         def model = modelCollector.model
         assertFailures(model, *expectedFailures.call(targetVersion))

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -742,6 +742,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPlu
         "with isolated projects"   | IP_FLAGS
     }
 
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "resilient Kotlin DSL can be queried with null target #mode"() {
         given:
         skipIfIpNotSupported(extraGradleProperties)
@@ -770,6 +771,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPlu
         "with isolated projects"   | IP_FLAGS
     }
 
+    @TargetGradleVersion('>=9.4.0 <9.7.0')
     def "no resilient Kotlin DSL model is returned if settings fails with null target #mode"() {
         given:
         skipIfIpNotSupported(extraGradleProperties)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r16.CustomModel
+import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+import org.gradle.integtests.tooling.r940.TestResilientModelAction
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
+
+import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.ROOT_BUILD_FIRST
+
+@ToolingApiVersion('>=9.3.0')
+@TargetGradleVersion('>=9.7.0')
+class CustomResilientModelCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
+
+    private static final List<String> IP_ENABLED = [
+        "-Dorg.gradle.isolated-projects=true"
+    ]
+
+    def setup() {
+        settingsFile.delete()
+        file('init.gradle') << """
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import javax.inject.Inject
+
+gradle.lifecycle.beforeProject {
+    it.plugins.apply(CustomPlugin)
+}
+
+class CustomModel implements Serializable {
+    static final INSTANCE = new CustomThing()
+    String getValue() { 'greetings' }
+    CustomThing getThing() { return INSTANCE }
+    Set<CustomThing> getThings() { return [INSTANCE] }
+    Map<String, CustomThing> getThingsByName() { return [child: INSTANCE] }
+    CustomThing findThing(String name) { return INSTANCE }
+}
+
+class CustomThing implements Serializable {
+}
+
+class FailingBuilder implements ToolingModelBuilder {
+    boolean canBuild(String modelName) {
+        return modelName == '${CustomModel.name}'
+    }
+    Object buildAll(String modelName, Project project) {
+        // The project configures successfully; the model builder itself fails for project ':b'.
+        if (project.name == 'b') {
+            throw new RuntimeException("Failing model builder for project ':b'")
+        }
+        return new CustomModel()
+    }
+}
+
+class CustomPlugin implements Plugin<Project> {
+    @Inject
+    CustomPlugin(ToolingModelBuilderRegistry registry) {
+        registry.register(new FailingBuilder())
+    }
+
+    public void apply(Project project) {
+    }
+}
+"""
+    }
+
+    def "resilient sync propagates a model builder failure to the client when a phased build action queries a custom model#description"() {
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("a", "b", "c")
+        """
+        file("a").createDir()
+        file("b").createDir()
+        file("c").createDir()
+
+        def capturedResult = null
+
+        when:
+        // The model builder for project ':b' fails even though configuration succeeded. Such a failure must be
+        // propagated to the client as a BuildException, not silently captured as a per-project model failure.
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(CustomModel, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
+                .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("Failing model builder for project ':b'") }
+        // Partial models are still delivered to the client before the build fails
+        capturedResult.successfullyQueriedProjects == ['root', 'a', 'c']
+        capturedResult.failedToQueryProjects == ['b']
+
+        where:
+        description | extraGradleProperties
+        ""          | []
+        " with IP"  | IP_ENABLED
+    }
+
+    def "resilient sync propagates a project configuration failure to the client when a phased build action queries a custom model#description"() {
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("a", "b", "c")
+        """
+        file("a").createDir()
+        file("c").createDir()
+        // Project ':b' fails to configure. Such a failure must be propagated to the client as a BuildException,
+        // not silently captured as a per-project model failure, while partial models are still returned.
+        file("b/build.gradle.kts") << """
+            throw RuntimeException("Failing during project configuration")
+        """
+
+        def capturedResult = null
+
+        when:
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(CustomModel, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
+                .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("Failing during project configuration") }
+        // Partial models are still delivered to the client before the build fails. A configuration failure fails
+        // the whole build's configuration, so every project fails to be queried.
+        capturedResult.successfullyQueriedProjects == []
+        capturedResult.failedToQueryProjects == ['root', 'a', 'b', 'c']
+
+        where:
+        description | extraGradleProperties
+        ""          | []
+        " with IP"  | IP_ENABLED
+    }
+
+    private static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
@@ -157,14 +157,4 @@ class CustomPlugin implements Plugin<Project> {
         " with IP"  | IP_ENABLED
     }
 
-    private static List<String> collectCauseMessages(Throwable throwable) {
-        def messages = []
-        Throwable current = throwable
-        int depth = 0
-        while (current != null && depth++ < 50) {
-            messages << current.message
-            current = current.cause
-        }
-        return messages
-    }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.integtests.tooling.r940.TestResilientModelAction
 import org.gradle.tooling.BuildException
 import org.gradle.tooling.IntermediateResultHandler
 
+import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.EDITABLE_BUILDS_FIRST
 import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.ROOT_BUILD_FIRST
 
 @ToolingApiVersion('>=9.3.0')
@@ -34,9 +35,18 @@ class CustomResilientModelCrossVersionSpec extends KotlinDslPluginRelatedTooling
         "-Dorg.gradle.isolated-projects=true"
     ]
 
+    private static final List<String> IP_CONFIGURE_ON_DEMAND_FLAGS = [
+        "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
+        "-Dorg.gradle.unsafe.isolated-projects=true"
+    ]
+
     def setup() {
         settingsFile.delete()
-        file('init.gradle') << """
+        file('init.gradle').text = customModelInitScript("return new CustomModel()")
+    }
+
+    private static String customModelInitScript(String buildAllBody) {
+        """
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import javax.inject.Inject
@@ -57,23 +67,19 @@ class CustomModel implements Serializable {
 class CustomThing implements Serializable {
 }
 
-class FailingBuilder implements ToolingModelBuilder {
+class CustomBuilder implements ToolingModelBuilder {
     boolean canBuild(String modelName) {
         return modelName == '${CustomModel.name}'
     }
     Object buildAll(String modelName, Project project) {
-        // The project configures successfully; the model builder itself fails for project ':b'.
-        if (project.name == 'b') {
-            throw new RuntimeException("Failing model builder for project ':b'")
-        }
-        return new CustomModel()
+        $buildAllBody
     }
 }
 
 class CustomPlugin implements Plugin<Project> {
     @Inject
     CustomPlugin(ToolingModelBuilderRegistry registry) {
-        registry.register(new FailingBuilder())
+        registry.register(new CustomBuilder())
     }
 
     public void apply(Project project) {
@@ -83,6 +89,15 @@ class CustomPlugin implements Plugin<Project> {
     }
 
     def "resilient sync propagates a model builder failure to the client when a phased build action queries a custom model#description"() {
+        given:
+        // Every project configures successfully; only the model builder for project ':b' fails,
+        // exercising a model builder failure as opposed to a configuration failure.
+        file('init.gradle').text = customModelInitScript("""
+            if (project.name == 'b') {
+                throw new RuntimeException("Failing model builder for project ':b'")
+            }
+            return new CustomModel()
+        """)
         settingsKotlinFile << """
             rootProject.name = "root"
             include("a", "b", "c")
@@ -101,7 +116,6 @@ class CustomPlugin implements Plugin<Project> {
                 .buildFinished(new TestResilientModelAction(CustomModel, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
-                .forTasks()
                 .run()
         }
 
@@ -113,9 +127,10 @@ class CustomPlugin implements Plugin<Project> {
         capturedResult.failedToQueryProjects == ['b']
 
         where:
-        description | extraGradleProperties
-        ""          | []
-        " with IP"  | IP_ENABLED
+        description                 | extraGradleProperties
+        ""                          | []
+        " with IP"                  | IP_ENABLED
+        " with configure-on-demand" | IP_CONFIGURE_ON_DEMAND_FLAGS
     }
 
     def "resilient sync propagates a project configuration failure to the client when a phased build action queries a custom model#description"() {
@@ -139,22 +154,89 @@ class CustomPlugin implements Plugin<Project> {
                 .buildFinished(new TestResilientModelAction(CustomModel, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
-                .forTasks()
                 .run()
         }
 
         then:
         def e = thrown(BuildException)
         collectCauseMessages(e).any { it?.contains("Failing during project configuration") }
-        // Partial models are still delivered to the client before the build fails. A configuration failure fails
-        // the whole build's configuration, so every project fails to be queried.
-        capturedResult.successfullyQueriedProjects == []
-        capturedResult.failedToQueryProjects == ['root', 'a', 'b', 'c']
+        // Partial models are still delivered to the client before the build fails. Eager configuration fails the
+        // whole build's configuration, so every project fails to be queried. With configure-on-demand, projects are
+        // configured on demand as they are queried, so only the broken project fails.
+        capturedResult.successfullyQueriedProjects == expectedSuccessfulProjects
+        capturedResult.failedToQueryProjects == expectedFailedProjects
 
         where:
-        description | extraGradleProperties
-        ""          | []
-        " with IP"  | IP_ENABLED
+        description                 | extraGradleProperties        | expectedSuccessfulProjects | expectedFailedProjects
+        ""                          | []                           | []                         | ['root', 'a', 'b', 'c']
+        " with IP"                  | IP_ENABLED                   | []                         | ['root', 'a', 'b', 'c']
+        " with configure-on-demand" | IP_CONFIGURE_ON_DEMAND_FLAGS | ['root', 'a', 'c']         | ['b']
+    }
+
+    def "resilient sync fails the build but can query custom model for included build, even if main project configuration fails#description #queryStrategy"() {
+        // The builders succeed; the failure comes from configuring project ':b', which applies a broken convention
+        // plugin from the included build.
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("a", "b", "c")
+            includeBuild("build-logic")
+        """
+        def included = file("build-logic")
+        included.file("settings.gradle.kts") << """
+            rootProject.name = "build-logic"
+
+            pluginManagement {
+               $repositoriesBlock
+            }
+        """
+        included.file("build.gradle.kts") << """
+            plugins {
+                `kotlin-dsl`
+            }
+        """
+        included.file("src/main/kotlin/build-logic.gradle.kts") << """
+            broken !!!
+        """
+        file("a/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+        """
+        file("b/build.gradle.kts") << """
+            plugins {
+                id("build-logic")
+            }
+        """
+        file("c/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+        """
+
+        def capturedResult = null
+
+        when:
+        // Note: no .forTasks() here, matching the r940 original. An empty .forTasks() requests the DEFAULT tasks,
+        // and task scheduling configures all projects eagerly, which would defeat configure-on-demand isolation.
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(CustomModel, queryStrategy), { capturedResult = it } as IntermediateResultHandler)
+                .build()
+                .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
+                .run()
+        }
+
+        then:
+        thrown(BuildException)
+        capturedResult.successfullyQueriedProjects == expectedSuccessfulProjects
+        capturedResult.failedToQueryProjects == expectedFailedProjects
+
+        where:
+        description                 | queryStrategy         | extraGradleProperties        | expectedSuccessfulProjects        | expectedFailedProjects
+        ""                          | ROOT_BUILD_FIRST      | []                           | ['build-logic']                   | ['root', 'a', 'b', 'c']
+        ""                          | EDITABLE_BUILDS_FIRST | []                           | ['build-logic']                   | ['root', 'a', 'b', 'c']
+        " with configure-on-demand" | ROOT_BUILD_FIRST      | IP_CONFIGURE_ON_DEMAND_FLAGS | ['root', 'a', 'c', 'build-logic'] | ['b']
+        " with configure-on-demand" | EDITABLE_BUILDS_FIRST | IP_CONFIGURE_ON_DEMAND_FLAGS | ['build-logic', 'root', 'a', 'c'] | ['b']
     }
 
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r930.FetchCustomModelAction
+import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.tooling.BuildException
+
+import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
+import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
+
+/**
+ * Covers the resilient model building behaviour from Gradle 9.7 onwards: a failure observed while building a model
+ * (a configuration failure or a failing model builder) is propagated to the client as a {@link BuildException}, even
+ * though the per-model failure is still captured in the fetch result. See the {@code <9.7.0} cases in the r930 spec
+ * for the previous behaviour, where such failures were only captured and the build succeeded.
+ */
+@ToolingApiVersion(">=9.3.0")
+@TargetGradleVersion(">=9.7.0")
+class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
+
+    def "resilient sync fails the build when a model builder throws an exception"() {
+        given:
+        setupInitScriptWithCustomModelBuilder("throw new RuntimeException('broken builder')")
+
+        when:
+        fails {
+            action(new FetchCustomModelAction())
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken builder") }
+    }
+
+    def "resilient sync fails the build when project configuration fails due to #description with #dsl DSL"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        setupInitScriptWithCustomModelBuilder()
+        writeBuildFile(dsl, error)
+
+        when:
+        fails {
+            action(new FetchCustomModelAction())
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains(expectedCause) }
+
+        where:
+        description          | error                                                            | expectedCause                  | dsl
+        "script compilation" | "broken !!!"                                                     | "broken !!!"                   | GROOVY
+        "runtime exception"  | """throw new RuntimeException("broken project configuration")""" | "broken project configuration" | GROOVY
+        "script compilation" | "broken !!!"                                                     | "broken !!!"                   | KOTLIN
+        "runtime exception"  | """throw RuntimeException("broken project configuration")"""     | "broken project configuration" | KOTLIN
+    }
+
+    def "'#method' fails the build in the presence of project build script failures"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        setupInitScriptWithCustomModelBuilder()
+        writeBuildFile(GROOVY, "broken !!!")
+
+        when:
+        fails {
+            action(buildAction)
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken !!!") }
+
+        where:
+        method                                                       | buildAction
+        "fetch(modelType)"                                           | FetchCustomModelAction.withFetchModelCall()
+        "fetch(target,modelType)"                                    | FetchCustomModelAction.withFetchTargetModelCall()
+        "fetch(modelType,parameterType,parameterInitializer)"        | FetchCustomModelAction.withFetchModelParametersCall()
+        "fetch(target,modelType,parameterType,parameterInitializer)" | new FetchCustomModelAction()
+    }
+
+    def "'#method' fails the build with the same settings failure as other fetch methods with #dsl DSL"() {
+        given:
+        setupInitScriptWithCustomModelBuilder()
+        writeSettingsFile(dsl, "garbage !!!")
+
+        when:
+        fails {
+            action(buildAction)
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        def expectedCause = dsl == GROOVY ? "Could not compile settings file" : "Script compilation error"
+        collectCauseMessages(e).any { it?.contains(expectedCause) }
+
+        where:
+        method                                                       | buildAction
+        "fetch(modelType)"                                           | FetchCustomModelAction.withFetchModelCall()
+        "fetch(target,modelType)"                                    | FetchCustomModelAction.withFetchTargetModelCall()
+        "fetch(modelType,parameterType,parameterInitializer)"        | FetchCustomModelAction.withFetchModelParametersCall()
+        "fetch(target,modelType,parameterType,parameterInitializer)" | new FetchCustomModelAction()
+
+        combined:
+        dsl << [GROOVY, KOTLIN]
+    }
+
+    private void writeBuildFile(GradleDsl dsl, String s) {
+        if (dsl == KOTLIN) {
+            buildFileKts << s
+        } else {
+            buildFile << s
+        }
+    }
+
+    private void writeSettingsFile(GradleDsl dsl, String s) {
+        if (dsl == KOTLIN) {
+            settingsFile.delete()
+            settingsKotlinFile << s
+        } else {
+            settingsFile << s
+        }
+    }
+
+    private static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
+    }
+
+    def setupInitScriptWithCustomModelBuilder(String builderLogic = "return new CustomModel()") {
+        file("init.gradle").text = """
+            import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+            import org.gradle.tooling.provider.model.ToolingModelBuilder
+            import javax.inject.Inject
+
+            allprojects {
+                project.plugins.apply(CustomPlugin)
+            }
+
+            class CustomModel implements Serializable {
+                static final INSTANCE = new CustomThing()
+                String getValue() { 'greetings' }
+                CustomThing getThing() { return INSTANCE }
+                Set<CustomThing> getThings() { return [INSTANCE] }
+                Map<String, CustomThing> getThingsByName() { return [child: INSTANCE] }
+                CustomThing findThing(String name) { return INSTANCE }
+            }
+
+            class CustomThing implements Serializable {
+            }
+
+            class CustomBuilder implements ToolingModelBuilder {
+                boolean canBuild(String modelName) {
+                    return modelName == '${org.gradle.integtests.tooling.r16.CustomModel.name}'
+                }
+                Object buildAll(String modelName, Project project) {
+                    ${builderLogic}
+                }
+            }
+            class CustomPlugin implements Plugin<Project> {
+                @Inject
+                CustomPlugin(ToolingModelBuilderRegistry registry) {
+                    registry.register(new CustomBuilder())
+                }
+                public void apply(Project project) {
+                    println "Registered CustomBuilder for project: " + (project != null ? project.name : "<no project>")
+                }
+            }
+            """
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
@@ -20,8 +20,11 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r930.FetchCustomModelAction
+import org.gradle.integtests.tooling.r930.FetchGradleBuildAction
+import org.gradle.integtests.tooling.r930.Result
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
 
 import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
@@ -128,6 +131,87 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         combined:
         dsl << [GROOVY, KOTLIN]
+    }
+
+    def "resilient sync fails the build when a build-scoped model builder throws"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        file("init.gradle") << """
+            import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+
+            class FailingBuildScopedModelBuilder implements org.gradle.tooling.provider.model.internal.BuildScopeModelBuilder {
+                boolean canBuild(String modelName) {
+                    return modelName == 'org.gradle.integtests.tooling.r16.CustomModel'
+                }
+                Object create(org.gradle.internal.build.BuildState target) {
+                    throw new RuntimeException("broken build-scoped builder")
+                }
+            }
+
+            beforeSettings { settings ->
+                settings.services.get(ToolingModelBuilderRegistry).register(new FailingBuildScopedModelBuilder())
+            }
+        """
+
+        when:
+        fails {
+            action(FetchCustomModelAction.withFetchModelCall())
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken build-scoped builder") }
+    }
+
+    def "resilient sync fails the build but returns a partial GradleBuild model when root settings fail"() {
+        given:
+        settingsFile << """throw new RuntimeException("broken root settings")"""
+        Result<List<String>> fetchResult = null
+
+        when:
+        fails {
+            action()
+                .buildFinished(new FetchGradleBuildAction(), { fetchResult = it } as IntermediateResultHandler)
+                .build()
+                .run()
+        }
+
+        then: "the build fails with the settings failure"
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken root settings") }
+
+        and: "the client still receives the fetch result carrying the failure"
+        fetchResult != null
+        (fetchResult.failureMessages + fetchResult.causes).any { it?.contains("broken root settings") }
+    }
+
+    def "resilient sync fails the build but returns a partial GradleBuild model when included build settings fail"() {
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            includeBuild("nested")
+        """
+        file("nested/settings.gradle") << """throw new RuntimeException("broken included settings")"""
+        Result<List<String>> fetchResult = null
+
+        when:
+        fails {
+            action()
+                .buildFinished(new FetchGradleBuildAction(), { fetchResult = it } as IntermediateResultHandler)
+                .build()
+                .run()
+        }
+
+        then: "the build fails with the settings failure"
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("broken included settings") }
+
+        and: "the client still receives a partial model carrying the failure"
+        fetchResult != null
+        fetchResult.modelValue == ['root']
+        (fetchResult.failureMessages + fetchResult.causes).any { it?.contains("broken included settings") }
     }
 
     private void writeBuildFile(GradleDsl dsl, String s) {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/FetchBuildActionCrossVersionSpec.groovy
@@ -231,17 +231,6 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         }
     }
 
-    private static List<String> collectCauseMessages(Throwable throwable) {
-        def messages = []
-        Throwable current = throwable
-        int depth = 0
-        while (current != null && depth++ < 50) {
-            messages << current.message
-            current = current.cause
-        }
-        return messages
-    }
-
     def setupInitScriptWithCustomModelBuilder(String builderLogic = "return new CustomModel()") {
         file("init.gradle").text = """
             import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r16.CustomModel
 import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
 
 @ToolingApiVersion('>=9.7.0')
 @TargetGradleVersion('>=9.7.0')
@@ -29,6 +31,8 @@ class ResilientFetchFailureCrossVersionSpec extends KotlinDslPluginRelatedToolin
         "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
         "-Dorg.gradle.unsafe.isolated-projects=true"
     ]
+
+    private FetchFailureTreeAction.Result fetchResult
 
     def setup() {
         settingsFile.delete()
@@ -109,9 +113,11 @@ class CustomPlugin implements Plugin<Project> {
 
     def "an eager configuration failure converts to the same whole tree text for every project"() {
         when:
-        def result = fetchFailures()
+        fetchFailures()
 
         then: "eager configuration aborts at the first failure and attaches it to every project"
+        thrown(BuildException)
+        def result = fetchResult
         result.failedToQueryProjects.toSet() == ['root', 'a', 'b', 'c'] as Set
 
         and: "every failed project shares the same whole failure tree text"
@@ -127,9 +133,11 @@ class CustomPlugin implements Plugin<Project> {
 
     def "configure-on-demand wrappers differ per project but the shared included build cause is identical"() {
         when:
-        def result = fetchFailures(CONFIGURE_ON_DEMAND_ON)
+        fetchFailures(CONFIGURE_ON_DEMAND_ON)
 
         then: "only the projects applying the broken convention plugin fail, each lazily"
+        thrown(BuildException)
+        def result = fetchResult
         result.failedToQueryProjects.toSet() == ['b', 'c'] as Set
         result.successfullyQueriedProjects.containsAll(['root', 'a', 'build-logic'])
 
@@ -150,9 +158,11 @@ class CustomPlugin implements Plugin<Project> {
         result.rootDescriptionByProject['c'].contains("Caused by:")
     }
 
-    private FetchFailureTreeAction.Result fetchFailures(List<String> extraGradleProperties = []) {
-        succeeds {
-            action(new FetchFailureTreeAction(CustomModel))
+    private void fetchFailures(List<String> extraGradleProperties = []) {
+        fails {
+            action()
+                .buildFinished(new FetchFailureTreeAction(CustomModel), { fetchResult = it } as IntermediateResultHandler)
+                .build()
                 .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
                 .run()
         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -158,6 +158,32 @@ class CustomPlugin implements Plugin<Project> {
         result.rootDescriptionByProject['c'].contains("Caused by:")
     }
 
+    def "a configuration failure attached to every fetched project fails the build only once"() {
+        given: "a project failing eager configuration, with no other failure source"
+        settingsKotlinFile.text = """
+            rootProject.name = "root"
+            include("a", "b", "c")
+        """
+        file("b/build.gradle.kts").text = """
+            error("boom during configuration of b")
+        """
+        file("c/build.gradle.kts").text = """
+            plugins {
+                id("java")
+            }
+        """
+
+        when:
+        fetchFailures()
+
+        then: "the same configuration failure is delivered to every project's fetch result"
+        def e = thrown(BuildException)
+        fetchResult.failedToQueryProjects.toSet() == ['root', 'a', 'b', 'c'] as Set
+
+        and: "the build fails with that failure only once"
+        countCauseMessages(e, "boom during configuration of b") == 1
+    }
+
     private void fetchFailures(List<String> extraGradleProperties = []) {
         fails {
             action()
@@ -166,5 +192,21 @@ class CustomPlugin implements Plugin<Project> {
                 .withArguments("--init-script=${file('init.gradle').absolutePath}", *extraGradleProperties)
                 .run()
         }
+    }
+
+    /**
+     * Counts how many failures in the whole failure tree carry the given message, following all causes of
+     * multi-cause exceptions rather than just the first one.
+     */
+    private static int countCauseMessages(Throwable throwable, String text, int depth = 0) {
+        if (throwable == null || depth > 50) {
+            return 0
+        }
+        int count = throwable.message == text ? 1 : 0
+        def causes = throwable.respondsTo('getCauses')
+            ? throwable.causes
+            : (throwable.cause != null ? [throwable.cause] : [])
+        causes.each { count += countCauseMessages(it as Throwable, text, depth + 1) }
+        return count
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -112,7 +112,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         result.model.includedBuilds.empty
         result.model.editableBuilds.empty
         result.model.rootProject.projectIdentifier.projectPath == ":"
-        result.model.rootProject.name == expectedRootProjectName ?: settingsKotlinFile.parentFile.name
+        result.model.rootProject.name == (expectedRootProjectName ?: settingsKotlinFile.parentFile.name)
         result.model.projects == [result.model.rootProject] as Set
 
         where:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+import org.gradle.integtests.tooling.r930.ResilientGradleBuildBuilderCrossVersionSpec.BuildActionResult
+import org.gradle.integtests.tooling.r930.ResilientGradleBuildBuilderCrossVersionSpec.FetchModelAction
+import org.gradle.integtests.tooling.r940.GradleBuildAction
+import org.gradle.integtests.tooling.r940.GradleBuildModel
+import org.gradle.integtests.tooling.r940.GradleBuildModelCollector
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.gradle.GradleBuild
+
+import java.util.regex.Pattern
+
+/**
+ * Covers the resilient {@code GradleBuild} model building behaviour from Gradle 9.7 onwards: configuration failures
+ * captured while building the model also fail the build, while the partial model is still returned to the client.
+ * See the {@code <9.7.0} cases in the r930/r940 specs for the previous behaviour, where the build succeeded.
+ */
+@ToolingApiVersion('>=9.3.0')
+@TargetGradleVersion('>=9.7.0')
+class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
+
+    static final String BROKEN_SETTINGS_CONTENT = "broken settings file content!!!"
+    static final String BROKEN_BUILD_CONTENT = "broken build file content!!!"
+    static final String ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.internal.isolated-projects.tooling=true"
+    static final String UNSAFE_ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.unsafe.isolated-projects=true"
+
+    private BuildException buildFailure
+
+    GradleBuildModelCollector modelCollector
+    TestFile initScriptFile
+
+    def setup() {
+        settingsFile.delete() // This is automatically created by `ToolingApiSpecification`
+        modelCollector = new GradleBuildModelCollector()
+        initScriptFile = file("init.gradle")
+        initScriptFile << """
+            import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+            import org.gradle.tooling.provider.model.ToolingModelBuilder
+            import javax.inject.Inject
+            gradle.lifecycle.beforeProject {
+                it.plugins.apply(CustomPlugin)
+            }
+            class StartParametersModel implements Serializable {
+                String getValue() { 'greetings' }
+            }
+            class SetupStartParametersBuilder implements ToolingModelBuilder {
+                boolean canBuild(String modelName) {
+                    return modelName == 'org.gradle.integtests.tooling.r940.StartParametersModel'
+                }
+                Object buildAll(String modelName, Project project) {
+                    def tasks = new HashSet<String>(project.gradle.startParameter.taskNames)
+                    tasks.add("prepareKotlinBuildScriptModel")
+                    tasks.add("printHelloTask")
+                    project.gradle.startParameter.setTaskNames(tasks)
+                    return new StartParametersModel()
+                }
+            }
+            class CustomPlugin implements Plugin<Project> {
+                @Inject
+                CustomPlugin(ToolingModelBuilderRegistry registry) {
+                    registry.register(new SetupStartParametersBuilder())
+                }
+                public void apply(Project project) {
+                    project.tasks.register("printHelloTask") {
+                        doLast {
+                            println "Hello from a task"
+                        }
+                    }
+                }
+            }
+            """.stripIndent()
+    }
+
+    def "fails the build but returns partial root project model when settings #description"() {
+        given:
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            $causeOfFailure
+        """
+
+        when:
+        def result = runFetchModelActionExpectingFailure()
+
+        then: "the build fails with the settings failure"
+        anyCauseContains(buildFailure, expectedFailure)
+
+        and: "the partial model with the failure is still returned"
+        result.failures.size() == 1
+        result.failures[0].contains(expectedFailure)
+        result.model.includedBuilds.empty
+        result.model.editableBuilds.empty
+        result.model.rootProject.projectIdentifier.projectPath == ":"
+        result.model.rootProject.name == expectedRootProjectName ?: settingsKotlinFile.parentFile.name
+        result.model.projects == [result.model.rootProject] as Set
+
+        where:
+        description         | causeOfFailure                                         | expectedRootProjectName | expectedFailure
+        "compilation error" | "broken settings file content!!!"                      | null                    | "Script compilation error"
+        "runtime error"     | "throw GradleException(\"Gradle exception boom !!!\")" | "root"                  | "Gradle exception boom !!!"
+    }
+
+    def "fails the build but returns root build and included build models when a settings convention plugin is broken"() {
+        given:
+        settingsKotlinFile << """
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+            rootProject.name = "root"
+            plugins {
+                id("build-logic")
+            }
+            include("a")
+        """
+        def included = file("build-logic")
+        included.file("settings.gradle.kts") << """
+            rootProject.name = "build-logic"
+            pluginManagement {
+                $repositoriesBlock
+            }
+        """
+        included.file("build.gradle.kts") << """
+            plugins {
+                `kotlin-dsl`
+            }
+            repositories {
+                mavenCentral()
+                gradlePluginPortal()
+            }
+        """
+        included.file("src/main/kotlin/build-logic.settings.gradle.kts") << """
+            broken !!!
+        """
+        file("a/build.gradle.kts") << """
+        """
+
+        when:
+        def result = runFetchModelActionExpectingFailure()
+
+        then: "the build fails with the plugin failure"
+        anyCauseContains(buildFailure, "Execution failed for task ':build-logic:compileKotlin'")
+
+        and: "the partial models with the failure are still returned"
+        result.failures.size() == 1
+        result.model.rootProject.projectIdentifier.projectPath == ":"
+        result.model.projects == [result.model.rootProject] as Set
+        result.model.includedBuilds.size() == 0
+        result.model.editableBuilds.size() == 1
+        result.model.editableBuilds[0].rootProject.name == "build-logic"
+    }
+
+    def "fails the build but returns root project and included build models when included settings files are broken"() {
+        given:
+        createRootProject()
+        createFailingSettingsIncludedProject("included1")
+        // The second included build will be skipped due to failure in the first one
+        createFailingSettingsIncludedProject("included2")
+
+        when:
+        def result = runFetchModelActionExpectingFailure()
+
+        then: "the build fails with the settings failure"
+        anyCauseContains(buildFailure, "Script compilation error")
+
+        and: "the partial models with the failure are still returned"
+        result.failures.size() == 1
+        result.failures.toString().contains("Script compilation error")
+        result.model.includedBuilds.size() == 1
+        result.model.includedBuilds[0].buildIdentifier.rootDir == file("included1")
+    }
+
+    def "fails the build on every invocation when caching models with isolated projects"() {
+        given:
+        def intermediateCaching = [
+            ISOLATED_PROJECTS_FLAG,
+            UNSAFE_ISOLATED_PROJECTS_FLAG
+        ]
+        createRootProject()
+        createFailingSettingsIncludedProject("included")
+
+        when:
+        def result = runFetchModelActionExpectingFailure(intermediateCaching)
+
+        then:
+        anyCauseContains(buildFailure, "Script compilation error")
+        result.failures.toString().contains("Script compilation error")
+        !result.model.includedBuilds.isEmpty()
+
+        when: "the failed result is not reused from the cache"
+        result = runFetchModelActionExpectingFailure(intermediateCaching)
+
+        then:
+        anyCauseContains(buildFailure, "Script compilation error")
+        result.failures.toString().contains("Script compilation error")
+        !result.model.includedBuilds.isEmpty()
+    }
+
+    def "fails the build and returns included builds nested within buildSrc composite build partially when compilation failures in #brokenFile"() {
+        given:
+        settingsKotlinFile << """
+            rootProject.name = "root"
+        """
+
+        def buildSrcSettingsFile = file("buildSrc/settings.gradle.kts")
+        buildSrcSettingsFile << """
+            includeBuild("../buildSrc-included")
+        """
+
+        def buildSrcIncluded = file("buildSrc-included")
+        buildSrcIncluded.file("settings.gradle.kts") << """
+            rootProject.name = "buildSrc-included"
+        """
+
+        when:
+        file(brokenFile) << """ broken !!! """
+        fails { model(it) }
+
+        then:
+        def e = thrown(BuildException)
+        e.cause.message.contains(expectedTopFailure)
+        expectedInFailureTree.every { anyCauseContains(e, it) }
+        def model = modelCollector.model
+        assertFailures(model, *expectedFailures)
+        assertModel(model, modelAvailable, expectedIncludedBuilds, expectedEditableBuilds)
+
+        where:
+        brokenFile                              | modelAvailable | expectedTopFailure                 | expectedInFailureTree                                                     | expectedFailures | expectedIncludedBuilds | expectedEditableBuilds
+        "settings.gradle.kts"                   | false
+                | "Build completed with 2 failures."
+                | ["Script compilation error", "The settings are not yet available for build ':'."]
+                | ["The settings are not yet available for build ':'\\."]
+                | []
+                | []
+
+        "buildSrc/settings.gradle.kts"          | true
+                | "Script compilation error"
+                | []
+                | [".*Settings file.*buildSrc\\" + File.separatorChar + "settings\\.gradle\\.kts.*Script compilation error.*"]
+                | []
+                | ["buildSrc"]
+
+        "buildSrc/build.gradle.kts"             | true
+                | "Script compilation error"
+                | []
+                | [".*Build file.*buildSrc\\" + File.separatorChar + "build\\.gradle\\.kts.*Script compilation error.*",
+                   "A problem occurred configuring project ':buildSrc'."]
+                | []
+                | ["buildSrc", "buildSrc-included"]
+
+        "buildSrc-included/settings.gradle.kts" | true
+                | "Script compilation error"
+                | []
+                | [".*Settings file.*buildSrc-included\\" + File.separatorChar + "settings\\.gradle\\.kts.*Script compilation error.*"]
+                | ["UNKNOWN"]
+                | ["buildSrc", "UNKNOWN"]
+
+        "buildSrc-included/build.gradle.kts"    | true
+                | "Script compilation error"
+                | []
+                | [".*Build file.*buildSrc-included\\" + File.separatorChar + "build\\.gradle\\.kts.*Script compilation error.*",
+                   "A problem occurred configuring project ':buildSrc-included'."]
+                | []
+                | ["buildSrc", "buildSrc-included"]
+    }
+
+    private GradleBuildModel model(ProjectConnection conn) {
+        def model = null
+        conn.action()
+            .buildFinished(new GradleBuildAction(true)) {
+                modelCollector.onComplete(it)
+                model = it
+            }.build()
+            .forTasks([])
+            .withArguments("--init-script=${initScriptFile.absolutePath}")
+            .run()
+        return model
+    }
+
+    private void assertModel(GradleBuildModel model, boolean available, List includedBuilds, List editableBuilds) {
+        if (available) {
+            assert model.model != null
+            assert model.model.includedBuilds.collect { getRootProjectName(it) } == includedBuilds
+            assert model.model.editableBuilds.collect { getRootProjectName(it) } == editableBuilds
+        } else {
+            assert model.model == null
+        }
+    }
+
+    private static String getRootProjectName(GradleBuild gradleBuild) {
+        if (gradleBuild.rootProject == null) {
+            return "UNKNOWN"
+        } else {
+            return gradleBuild.rootProject.name
+        }
+    }
+
+    private static void assertFailures(GradleBuildModel model, String... expected) {
+        assert model.failures.size() == expected.size(): "Expected ${expected.size()} failures, but got ${model.failures.size()}"
+        int i = 0
+        for (String failure : model.failures) {
+            def pattern = Pattern.compile(expected[i++], Pattern.DOTALL)
+            assert pattern.matcher(failure).matches(): "Exception \"${failure}\" doesn't match expected pattern \"${expected[i - 1]}\""
+        }
+    }
+
+    private BuildActionResult runFetchModelActionExpectingFailure(List<String> extraArgs = []) {
+        BuildActionResult captured = null
+        buildFailure = null
+        try {
+            withConnection { connection ->
+                def action = connection.action()
+                    .buildFinished(new FetchModelAction(), { captured = it } as IntermediateResultHandler)
+                    .build()
+                if (extraArgs) {
+                    action.addArguments(extraArgs)
+                }
+                action.run()
+            }
+        } catch (BuildException e) {
+            buildFailure = e
+        }
+        assert buildFailure != null: "expected the build to fail"
+        assert captured != null: "expected the fetch result to be delivered"
+        return captured
+    }
+
+    private static boolean anyCauseContains(Throwable throwable, String text, int depth = 0) {
+        if (throwable == null || depth > 50) {
+            return false
+        }
+        if (throwable.message?.contains(text)) {
+            return true
+        }
+        def causes = throwable.respondsTo('getCauses')
+            ? throwable.causes
+            : (throwable.cause != null ? [throwable.cause] : [])
+        return causes.any { anyCauseContains(it as Throwable, text, depth + 1) }
+    }
+
+    TestFile createRootProject() {
+        settingsKotlinFile << """
+            rootProject.name = "root"
+        """
+    }
+
+    def createFailingSettingsIncludedProject(String includedProjectName) {
+        settingsKotlinFile << """
+            includeBuild("${includedProjectName}")
+        """
+        def included = file(includedProjectName)
+        included.file(settingsKotlinFileName) << BROKEN_SETTINGS_CONTENT
+        included.file(defaultBuildKotlinFileName) << BROKEN_BUILD_CONTENT
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
 import org.gradle.integtests.tooling.r940.TestResilientModelAction
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
 import org.gradle.tooling.model.GradleProject
 
 import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.ROOT_BUILD_FIRST
@@ -36,7 +38,7 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
         settingsFile.delete()
     }
 
-    def "can query GradleProject for included build, even if main project configuration fails#description"() {
+    def "resilient sync fails the build but still returns partial GradleProject models when main project configuration fails#description"() {
         settingsKotlinFile << """
             rootProject.name = "root"
             include("a", "b", "c")
@@ -75,16 +77,24 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
             }
         """
 
+        def capturedResult = null
+
         when:
-        def result = succeeds {
-            action(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST))
+        // A configuration failure must be propagated to the client as a BuildException, while the partial models
+        // gathered during resilient model building are still delivered.
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
                 .withArguments(*extraGradleProperties)
+                .forTasks()
                 .run()
         }
 
         then:
-        result.successfullyQueriedProjects == ['build-logic']
-        result.failedToQueryProjects == ['root', 'a', 'b', 'c']
+        thrown(BuildException)
+        capturedResult.successfullyQueriedProjects == ['build-logic']
+        capturedResult.failedToQueryProjects == ['root', 'a', 'b', 'c']
 
         where:
         description | extraGradleProperties
@@ -92,7 +102,7 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
         " with IP"  | IP_ENABLED
     }
 
-    def "can query GradleProject for included build, even if main settings fail#description"() {
+    def "resilient sync fails the build but still returns partial GradleProject models when main settings fail#description"() {
         settingsKotlinFile << """
             pluginManagement {
                 includeBuild("build-logic")
@@ -130,17 +140,23 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
             }
         """
 
+        def capturedResult = null
+
         when:
-        def result = succeeds {
-            action(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST))
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
                 .withArguments(*extraGradleProperties)
+                .forTasks()
                 .run()
         }
 
         then:
-        result.successfullyQueriedProjects == ['build-logic']
+        thrown(BuildException)
+        capturedResult.successfullyQueriedProjects == ['build-logic']
         // Since the settings file fails to configure, only the root of the main project can be seen
-        result.failedToQueryProjects == [settingsKotlinFile.parentFile.name]
+        capturedResult.failedToQueryProjects == [settingsKotlinFile.parentFile.name]
 
         where:
         description | extraGradleProperties

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
@@ -87,7 +87,6 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
                 .buildFinished(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments(*extraGradleProperties)
-                .forTasks()
                 .run()
         }
 
@@ -148,7 +147,6 @@ class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedTooli
                 .buildFinished(new TestResilientModelAction(GradleProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments(*extraGradleProperties)
-                .forTasks()
                 .run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
 import org.gradle.integtests.tooling.r940.TestResilientModelAction
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
 import org.gradle.tooling.model.idea.IdeaProject
 
 import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.ROOT_BUILD_FIRST
@@ -36,7 +38,7 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
         settingsFile.delete()
     }
 
-    def "can query IdeaProject for included build, even if main project configuration fails#description"() {
+    def "resilient sync fails the build but still returns partial IdeaProject models when main project configuration fails#description"() {
         settingsKotlinFile << """
             rootProject.name = "root"
             include("a", "b", "c")
@@ -75,16 +77,24 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
             }
         """
 
+        def capturedResult = null
+
         when:
-        def result = succeeds {
-            action(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST))
+        // A configuration failure must be propagated to the client as a BuildException, while the partial models
+        // gathered during resilient model building are still delivered.
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
                 .withArguments(*extraGradleProperties)
+                .forTasks()
                 .run()
         }
 
         then:
-        result.successfullyQueriedProjects == ['build-logic']
-        result.failedToQueryProjects == ['root', 'a', 'b', 'c']
+        thrown(BuildException)
+        capturedResult.successfullyQueriedProjects == ['build-logic']
+        capturedResult.failedToQueryProjects == ['root', 'a', 'b', 'c']
 
         where:
         description | extraGradleProperties
@@ -92,7 +102,7 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
         " with IP"  | IP_ENABLED
     }
 
-    def "can query IdeaProject for included build, even if main settings fail#description"() {
+    def "resilient sync fails the build but still returns partial IdeaProject models when main settings fail#description"() {
         settingsKotlinFile << """
             pluginManagement {
                 includeBuild("build-logic")
@@ -130,21 +140,87 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
             }
         """
 
+        def capturedResult = null
+
         when:
-        def result = succeeds {
-            action(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST))
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
+                .build()
                 .withArguments(*extraGradleProperties)
+                .forTasks()
                 .run()
         }
 
         then:
-        result.successfullyQueriedProjects == ['build-logic']
+        thrown(BuildException)
+        capturedResult.successfullyQueriedProjects == ['build-logic']
         // Since the settings file fails to configure, only the root of the main project can be seen
-        result.failedToQueryProjects == [settingsKotlinFile.parentFile.name]
+        capturedResult.failedToQueryProjects == [settingsKotlinFile.parentFile.name]
 
         where:
         description | extraGradleProperties
         ""          | []
         " with IP"  | IP_ENABLED
+    }
+
+    def "resilient sync propagates a model builder failure to the client when a phased build action queries IdeaProject#description"() {
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("a", "b", "c")
+        """
+        file("a/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+        """
+        file("b/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+            // Configuration succeeds. The IdeaProject model builder enumerates tasks (via the GradleProject model),
+            // which realizes this task and runs its failing configuration action *while building the model* - i.e.
+            // a model builder failure rather than a configuration failure.
+            tasks.register("brokenTask") {
+                throw RuntimeException("Failing during task configuration")
+            }
+        """
+        file("c/build.gradle.kts") << """
+            plugins {
+                id("java")
+            }
+        """
+
+        when:
+        // A failure inside the model builder (not a configuration failure) must be propagated to the client as a
+        // BuildException, not silently captured as a per-project failure.
+        fails {
+            action()
+                .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { } as IntermediateResultHandler)
+                .build()
+                .withArguments(*extraGradleProperties)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("Failing during task configuration") }
+
+        where:
+        description | extraGradleProperties
+        ""          | []
+        " with IP"  | IP_ENABLED
+    }
+
+    private static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
@@ -87,7 +87,6 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
                 .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments(*extraGradleProperties)
-                .forTasks()
                 .run()
         }
 
@@ -148,7 +147,6 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
                 .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { capturedResult = it } as IntermediateResultHandler)
                 .build()
                 .withArguments(*extraGradleProperties)
-                .forTasks()
                 .run()
         }
 
@@ -199,7 +197,6 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
                 .buildFinished(new TestResilientModelAction(IdeaProject, ROOT_BUILD_FIRST), { } as IntermediateResultHandler)
                 .build()
                 .withArguments(*extraGradleProperties)
-                .forTasks()
                 .run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientIdeaProjectCrossVersionSpec.groovy
@@ -213,14 +213,4 @@ class ResilientIdeaProjectCrossVersionSpec extends KotlinDslPluginRelatedTooling
         " with IP"  | IP_ENABLED
     }
 
-    private static List<String> collectCauseMessages(Throwable throwable) {
-        def messages = []
-        Throwable current = throwable
-        int depth = 0
-        while (current != null && depth++ < 50) {
-            messages << current.message
-            current = current.cause
-        }
-        return messages
-    }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r970
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+import org.gradle.integtests.tooling.r940.KotlinModelOnNullTargetAction
+import org.gradle.tooling.BuildException
+
+/**
+ * From Gradle 9.7 onwards a failure observed during resilient model building is propagated to the client as a
+ * {@link BuildException} (the build fails when it finishes), even for the Kotlin DSL scripts model. See the
+ * {@code <9.7.0} versions of these tests in {@code r940.ResilientKotlinDslScriptsModelBuilderCrossVersionSpec}
+ * for the previous behaviour, where the partial model was returned and the build succeeded.
+ */
+@ToolingApiVersion('>=9.3.0')
+@TargetGradleVersion('>=9.7.0')
+class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
+
+    private static final List<String> NO_EXTRA_PROPERTIES = []
+    private static final List<String> IP_FLAGS = [
+        "-Dorg.gradle.unsafe.isolated-projects=true",
+    ]
+
+    def setup() {
+        settingsFile.delete()
+    }
+
+    def "resilient Kotlin DSL with null target fails the build when a project build script fails to compile #mode"() {
+        given:
+        settingsKotlinFile << """
+            rootProject.name = "root"
+        """
+        buildFileKts << """
+            broken !!!
+        """
+
+        when:
+        fails {
+            action(new KotlinModelOnNullTargetAction())
+                .withArguments(*extraGradleProperties)
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("Script compilation error") }
+
+        where:
+        mode                       | extraGradleProperties
+        ""                         | NO_EXTRA_PROPERTIES
+        "with isolated projects"   | IP_FLAGS
+    }
+
+    def "resilient Kotlin DSL with null target fails the build when settings fail to compile #mode"() {
+        given:
+        settingsKotlinFile << """
+            broken !!!
+        """
+
+        when:
+        fails {
+            action(new KotlinModelOnNullTargetAction())
+                .withArguments(*extraGradleProperties)
+                .run()
+        }
+
+        then:
+        def e = thrown(BuildException)
+        collectCauseMessages(e).any { it?.contains("Script compilation error") }
+
+        where:
+        mode                       | extraGradleProperties
+        ""                         | NO_EXTRA_PROPERTIES
+        "with isolated projects"   | IP_FLAGS
+    }
+
+    private static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -90,14 +90,4 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPlu
         "with isolated projects"   | IP_FLAGS
     }
 
-    private static List<String> collectCauseMessages(Throwable throwable) {
-        def messages = []
-        Throwable current = throwable
-        int depth = 0
-        while (current != null && depth++ < 50) {
-            messages << current.message
-            current = current.cause
-        }
-        return messages
-    }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r930/FetchCustomModelAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r930/FetchCustomModelAction.java
@@ -25,9 +25,9 @@ import org.gradle.tooling.FetchModelResult;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class FetchCustomModelAction implements BuildAction<Result<String>> {
+public class FetchCustomModelAction implements BuildAction<Result<String>> {
 
-    static FetchCustomModelAction withFetchModelCall() {
+    public static FetchCustomModelAction withFetchModelCall() {
         return new FetchCustomModelAction() {
             @Override
             public FetchModelResult<CustomModel> fetch(BuildController controller) {
@@ -36,7 +36,7 @@ class FetchCustomModelAction implements BuildAction<Result<String>> {
         };
     }
 
-    static FetchCustomModelAction withFetchTargetModelCall() {
+    public static FetchCustomModelAction withFetchTargetModelCall() {
         return new FetchCustomModelAction() {
             @Override
             public FetchModelResult<CustomModel> fetch(BuildController controller) {
@@ -45,7 +45,7 @@ class FetchCustomModelAction implements BuildAction<Result<String>> {
         };
     }
 
-    static FetchCustomModelAction withFetchModelParametersCall() {
+    public static FetchCustomModelAction withFetchModelParametersCall() {
         return new FetchCustomModelAction() {
             @Override
             public FetchModelResult<CustomModel> fetch(BuildController controller) {

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildAction.java
@@ -24,11 +24,11 @@ import org.gradle.tooling.model.gradle.GradleBuild;
 import java.io.Serializable;
 import java.util.Collections;
 
-class GradleBuildAction implements BuildAction<GradleBuildModel>, Serializable {
+public class GradleBuildAction implements BuildAction<GradleBuildModel>, Serializable {
 
     private final boolean resilient;
 
-    GradleBuildAction(boolean resilient) {
+    public GradleBuildAction(boolean resilient) {
         this.resilient = resilient;
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildModel.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildModel.java
@@ -23,12 +23,12 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-class GradleBuildModel implements Serializable {
+public class GradleBuildModel implements Serializable {
 
-    final GradleBuild model;
-    final Collection<String> failures;
+    public final GradleBuild model;
+    public final Collection<String> failures;
 
-    GradleBuildModel(GradleBuild model, Collection<? extends Failure> failures) {
+    public GradleBuildModel(GradleBuild model, Collection<? extends Failure> failures) {
         this.model = model;
         this.failures = failures.stream().map(Failure::getMessage).collect(Collectors.toList());
     }

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildModelCollector.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/GradleBuildModelCollector.java
@@ -18,8 +18,8 @@ package org.gradle.integtests.tooling.r940;
 
 import org.gradle.tooling.IntermediateResultHandler;
 
-class GradleBuildModelCollector implements IntermediateResultHandler<GradleBuildModel> {
-    GradleBuildModel model;
+public class GradleBuildModelCollector implements IntermediateResultHandler<GradleBuildModel> {
+    public GradleBuildModel model;
 
     @Override
     public void onComplete(GradleBuildModel result) {

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/KotlinModelOnNullTargetAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r940/KotlinModelOnNullTargetAction.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import static org.gradle.integtests.tooling.r940.KotlinModelAction.queryResilientKotlinDslScriptsModel;
 
-class KotlinModelOnNullTargetAction implements BuildAction<KotlinModel>, Serializable {
+public class KotlinModelOnNullTargetAction implements BuildAction<KotlinModel>, Serializable {
     @Override
     public KotlinModel execute(BuildController controller) {
         GradleBuild build = controller.fetch(GradleBuild.class).getModel();

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -548,6 +548,20 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
         GradleVersion.version(targetDist.version.baseVersion.version)
     }
 
+    /**
+     * Collects the message of the given throwable and of every cause in its cause chain.
+     */
+    protected static List<String> collectCauseMessages(Throwable throwable) {
+        def messages = []
+        Throwable current = throwable
+        int depth = 0
+        while (current != null && depth++ < 50) {
+            messages << current.message
+            current = current.cause
+        }
+        return messages
+    }
+
     protected static String mavenCentralRepository() {
         RepoScriptBlockUtil.mavenCentralRepository()
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildToolingModelController.java
@@ -25,11 +25,10 @@ import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal;
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DefaultBuildToolingModelController implements BuildToolingModelController {
 
@@ -57,22 +56,14 @@ public class DefaultBuildToolingModelController implements BuildToolingModelCont
         // Look for a build scoped builder
         ToolingModelBuilderLookup.Builder builder = buildScopeLookup.maybeLocateForBuildScope(toolingModelContext.getModelName(), toolingModelContext.getParameter().isPresent(), buildState);
         if (builder != null) {
-            return new BuildToolingScope(builder);
+            return createBuildScope(builder);
         }
 
         // Force configuration of the containing build
         Try<Void> buildConfiguration = configureBuild();
         // Try to get the default project, but it may not be available if settings failed to load
         Try<ProjectState> defaultProject = Try.ofFailable(() -> buildState.getMutableModel().getDefaultProjectState());
-
-        // Locate a builder for the default project
-        Try<ToolingModelScope> toolingModelScope = defaultProject
-            // If getting the default project failed, we won't be able to locate a builder
-            // and we will fail, but let's prefer to report a build configuration failure
-            .mapFailure(failure -> buildConfiguration.getFailure().orElse(failure))
-            // If getting the default project succeeded, let's try to locate a builder
-            .flatMap(project -> doLocate(checkNotNull(project), toolingModelContext, buildConfiguration));
-        return checkNotNull(toolingModelScope.get());
+        return doLocateForProjectScope(defaultProject, toolingModelContext, buildConfiguration).get();
     }
 
     @Override
@@ -83,16 +74,21 @@ public class DefaultBuildToolingModelController implements BuildToolingModelCont
 
         // Force configuration of the containing build and then locate the builder for target project
         Try<Void> buildConfiguration = configureBuild();
-        Try<ToolingModelScope> toolingModelScope = doLocate(target, toolingModelContext, buildConfiguration);
-        return checkNotNull(toolingModelScope.get());
+        return doLocateForProjectScope(Try.successful(target), toolingModelContext, buildConfiguration).get();
     }
 
     protected Try<Void> configureBuild() {
         return tryRunConfiguration(buildController::configureProjects);
     }
 
-    protected Try<ToolingModelScope> doLocate(ProjectState targetProject, ToolingModelRequestContext toolingModelContext, Try<Void> buildConfiguration) {
-        return buildConfiguration.map(__ -> new ProjectToolingScope(targetProject, toolingModelContext));
+    protected ToolingModelScope createBuildScope(ToolingModelBuilderLookup.Builder builder) {
+        return new BuildToolingScope(builder);
+    }
+
+    protected Try<ToolingModelScope> doLocateForProjectScope(Try<ProjectState> targetProject, ToolingModelRequestContext toolingModelContext, Try<Void> buildConfiguration) {
+        // Prefer a build configuration failure over the missing-project failure by checking it first. The failed Try
+        // rethrows on get(), so the non-resilient default fails fast; resilient model building overrides this.
+        return buildConfiguration.flatMap(__ -> targetProject).map(project -> new ProjectToolingScope(project, toolingModelContext));
     }
 
     protected static Try<Void> tryRunConfiguration(Runnable configuration) {
@@ -106,32 +102,31 @@ public class DefaultBuildToolingModelController implements BuildToolingModelCont
         abstract ToolingModelBuilderLookup.Builder locateBuilder() throws UnknownModelException;
 
         @Override
-        public ToolingModelBuilderResultInternal getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
-            Object model = buildModelWithParameter(parameter);
-            if (!(model instanceof ToolingModelBuilderResultInternal)) {
-                return ToolingModelBuilderResultInternal.of(model);
-            }
-
-            ToolingModelBuilderResultInternal resultInternal = (ToolingModelBuilderResultInternal) model;
-            if (!modelRequestContext.inResilientContext()) {
-                resultInternal.throwFailureIfPresent();
-            }
-            return resultInternal;
+        public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
+            ToolingModelBuilderResultInternal clientResult = buildModelWithParameter(parameter);
+            clientResult.throwFailureIfPresent();
+            return ToolingModelScopeResult.of(clientResult);
         }
 
-        private Object buildModelWithParameter(@Nullable ToolingModelParameterCarrier parameter) {
+        protected ToolingModelBuilderResultInternal buildModelWithParameter(@Nullable ToolingModelParameterCarrier parameter) {
             ToolingModelBuilderLookup.Builder builder = locateBuilder();
+            Object model;
             if (parameter == null) {
-                return builder.build(null);
+                model = builder.build(null);
             } else {
                 Class<?> expectedParameterType = Objects.requireNonNull(builder.getParameterType(), "Expected builder with parameter support");
-                Object parameterValue = parameter.getView(expectedParameterType);
-                return builder.build(parameterValue);
+                model = builder.build(parameter.getView(expectedParameterType));
             }
+
+            // A builder may return a raw model or a ToolingModelBuilderResultInternal carrying its own failures.
+            return model instanceof ToolingModelBuilderResultInternal
+                ? (ToolingModelBuilderResultInternal) model
+                : ToolingModelBuilderResultInternal.of(model);
         }
     }
 
-    private static class BuildToolingScope extends AbstractToolingScope {
+    @SuppressWarnings("ExposedPrivateType")
+    protected static class BuildToolingScope extends AbstractToolingScope {
         private final ToolingModelBuilderLookup.Builder builder;
 
         public BuildToolingScope(ToolingModelBuilderLookup.Builder builder) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
@@ -22,20 +22,16 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.Try;
 import org.gradle.internal.buildtree.ToolingModelRequestContext;
-import org.gradle.internal.lazy.Lazy;
-import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal;
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult;
 import org.jspecify.annotations.Nullable;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -65,8 +61,30 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
     }
 
     @Override
-    protected Try<ToolingModelScope> doLocate(ProjectState targetProject, ToolingModelRequestContext toolingModelContext, Try<Void> buildConfiguration) {
-        return Try.successful(new ResilientProjectToolingScope(targetProject, toolingModelContext, buildConfiguration, failureFactory));
+    protected ToolingModelScope createBuildScope(ToolingModelBuilderLookup.Builder builder) {
+        return new ResilientBuildToolingScope(builder);
+    }
+
+    @Override
+    protected Try<ToolingModelScope> doLocateForProjectScope(Try<ProjectState> targetProject, ToolingModelRequestContext toolingModelContext, Try<Void> buildConfiguration) {
+        if (!targetProject.isSuccessful()) {
+            // No project could be created (e.g. a failing settings script), so no project scope exists. Surface the
+            // failure through a result instead of throwing, so the client still gets partial models and the build still
+            // fails. Prefer a build configuration failure.
+            Throwable configurationFailure = buildConfiguration.getFailure().orElseGet(() -> targetProject.getFailure().get());
+            return Try.successful(new FixedResultScope(configurationFailureResult(failureFactory, configurationFailure, null)));
+        }
+        return Try.successful(new ResilientProjectToolingScope(targetProject.get(), toolingModelContext, buildConfiguration, failureFactory));
+    }
+
+    private static ToolingModelScopeResult configurationFailureResult(FailureFactory failureFactory, Throwable configurationFailure, @Nullable Object model) {
+        ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.attachFailures(model, ImmutableList.of(failureFactory.create(configurationFailure)));
+        return ToolingModelScopeResult.withConfigurationFailure(clientResult, configurationFailure);
+    }
+
+    private static boolean canRunEvenIfProjectNotFullyConfigured(String modelName) {
+        // Some internal model builders can run even if the project is not fully configured.
+        return MODELS_ALLOWED_TO_RUN_FOR_PARTIALLY_CONFIGURED_PROJECTS.contains(modelName);
     }
 
     private static class ResilientProjectToolingScope extends ProjectToolingScope {
@@ -86,75 +104,80 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
         }
 
         @Override
-        public ToolingModelBuilderResultInternal getModel(ToolingModelRequestContext modelName, @Nullable ToolingModelParameterCarrier parameter) {
-            // If evaluation of settings fails, a project could not be created, and we should return the failure before locateBuilder is called
+        public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
+            // If settings evaluation fails the project is never created, so return the failure before locating a builder.
             if (!targetProject.isCreated()) {
                 checkArgument(!ownerBuildConfiguration.isSuccessful(), "Project has not been created, but build configuration has succeeded, this is a bug, please report.");
-                return ToolingModelBuilderResultInternal.of(getConfigurationFailure(failureFactory, ownerBuildConfiguration));
+                return configurationFailureResult(failureFactory, ownerBuildConfiguration.getFailure().get(), null);
             }
-            return super.getModel(modelName, parameter);
-        }
 
-        @Override
-        ToolingModelBuilderLookup.Builder locateBuilder() throws UnknownModelException {
-            // Force configuration of the target project to ensure all builders have been registered
+            // Force configuration of the target project so that all builders have been registered.
             Try<Void> projectConfiguration = ownerBuildConfiguration.isSuccessful()
                 ? tryRunConfiguration(targetProject::ensureConfigured)
                 : ownerBuildConfiguration;
 
-            // We need to query the delegate builder lazily, since builders may not be registered if project configuration fails
-            ProjectInternal project = targetProject.getMutableModelEvenAfterFailure();
-            ToolingModelBuilderLookup lookup = project.getServices().get(ToolingModelBuilderLookup.class);
-
-            Supplier<ToolingModelBuilderLookup.Builder> builder = () -> lookup.locateForClientOperation(modelName, parameter, targetProject, project);
-            boolean canRunEvenIfProjectNotFullyConfigured = canRunEvenIfProjectNotFullyConfigured(modelName);
-            return new ResilientToolingModelBuilder(builder, projectConfiguration, failureFactory, canRunEvenIfProjectNotFullyConfigured);
-        }
-    }
-
-    private static boolean canRunEvenIfProjectNotFullyConfigured(String modelName) {
-        // Some internal model builders can run even if the project is not fully configured.
-        return MODELS_ALLOWED_TO_RUN_FOR_PARTIALLY_CONFIGURED_PROJECTS.contains(modelName);
-    }
-
-    private static List<Failure> getConfigurationFailure(FailureFactory failureFactory, Try<Void> configuration) {
-        Optional<Throwable> failure = configuration.getFailure();
-        return failure.map(e -> ImmutableList.of(failureFactory.create(e))).orElseGet(ImmutableList::of);
-    }
-
-    private static class ResilientToolingModelBuilder implements ToolingModelBuilderLookup.Builder {
-
-        private final Lazy<ToolingModelBuilderLookup.Builder> delegate;
-        private final Try<Void> projectConfiguration;
-        private final FailureFactory failureFactory;
-        private final boolean canRunEvenIfProjectNotFullyConfigured;
-
-        public ResilientToolingModelBuilder(
-            Supplier<ToolingModelBuilderLookup.Builder> delegate,
-            Try<Void> projectConfiguration,
-            FailureFactory failureFactory,
-            boolean canRunEvenIfProjectNotFullyConfigured
-        ) {
-            this.delegate = Lazy.unsafe().of(delegate);
-            this.projectConfiguration = projectConfiguration;
-            this.failureFactory = failureFactory;
-            this.canRunEvenIfProjectNotFullyConfigured = canRunEvenIfProjectNotFullyConfigured;
-        }
-
-        @Override
-        public @Nullable Class<?> getParameterType() {
-            return delegate.get().getParameterType();
-        }
-
-        @Override
-        public Object build(@Nullable Object parameter) {
-            if (projectConfiguration.isSuccessful()) {
-                return delegate.get().build(parameter);
+            if (!projectConfiguration.isSuccessful()) {
+                // Configuration failed. Defer it so the build fails, mirroring a non-resilient sync. For models that
+                // tolerate a partially-configured project, still build the model on a best-effort basis.
+                Object model = canRunEvenIfProjectNotFullyConfigured(modelName)
+                    ? Try.ofFailable(() -> buildModelWithParameter(parameter)).getOrMapFailure(failure -> null)
+                    : null;
+                return configurationFailureResult(failureFactory, projectConfiguration.getFailure().get(), model);
             }
 
-            Object model = canRunEvenIfProjectNotFullyConfigured ? delegate.get().build(parameter) : null;
-            List<Failure> failures = getConfigurationFailure(failureFactory, projectConfiguration);
-            return ToolingModelBuilderResultInternal.attachFailures(model, failures);
+            // The project configured successfully, but the model builder itself may still fail.
+            //noinspection DataFlowIssue
+            return Try.ofFailable(() -> ToolingModelScopeResult.of(buildModelWithParameter(parameter))).getOrMapFailure(failure -> {
+                if (failure instanceof UnknownModelException) {
+                    throw (UnknownModelException) failure;
+                }
+                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.create(failure)));
+                return ToolingModelScopeResult.withModelBuilderFailure(clientResult, failure);
+            });
+        }
+
+        @Override
+        ToolingModelBuilderLookup.Builder locateBuilder() throws UnknownModelException {
+            // Configuration has already been forced by getModel, so just locate the builder. Use the mutable model even
+            // after a failure, since builders may still be registered when the project configured only partially.
+            ProjectInternal project = targetProject.getMutableModelEvenAfterFailure();
+            ToolingModelBuilderLookup lookup = project.getServices().get(ToolingModelBuilderLookup.class);
+            return lookup.locateForClientOperation(modelName, parameter, targetProject, project);
+        }
+    }
+
+    private static class ResilientBuildToolingScope extends BuildToolingScope {
+
+        public ResilientBuildToolingScope(ToolingModelBuilderLookup.Builder builder) {
+            super(builder);
+        }
+
+        @Override
+        public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
+            // Do not throw failure if present opposed to BuildToolingScope
+            return ToolingModelScopeResult.of(buildModelWithParameter(parameter));
+        }
+    }
+
+    /**
+     * A scope that always returns the same fixed result, used when a builder cannot even be located.
+     */
+    private static class FixedResultScope implements ToolingModelScope {
+        private final ToolingModelScopeResult result;
+
+        public FixedResultScope(ToolingModelScopeResult result) {
+            this.result = result;
+        }
+
+        @Nullable
+        @Override
+        public ProjectState getTarget() {
+            return null;
+        }
+
+        @Override
+        public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
+            return result;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
@@ -168,7 +168,8 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
 
         private ToolingModelScopeResult buildScopeResult(@Nullable ToolingModelParameterCarrier parameter) {
             ToolingModelBuilderResultInternal clientResult = buildModelWithParameter(parameter);
-            // Failures attached by a build-scoped builder (e.g. GradleBuildBuilder) are configuration failures of the visited builds, so they must still fail the build.
+            // Failures attached by a build-scoped builder (e.g. GradleBuildBuilder) are configuration failures
+            // of the visited builds, so they must still fail the build.
             List<Throwable> configurationFailures = clientResult.getFailures().stream()
                 .map(Failure::getOriginal)
                 .collect(toImmutableList());

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.Try;
 import org.gradle.internal.buildtree.ToolingModelRequestContext;
+import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
@@ -31,9 +32,11 @@ import org.gradle.tooling.provider.model.internal.ToolingModelScope;
 import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class ResilientBuildToolingModelController extends DefaultBuildToolingModelController {
 
@@ -62,7 +65,7 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
 
     @Override
     protected ToolingModelScope createBuildScope(ToolingModelBuilderLookup.Builder builder) {
-        return new ResilientBuildToolingScope(builder);
+        return new ResilientBuildToolingScope(builder, failureFactory);
     }
 
     @Override
@@ -148,14 +151,28 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
 
     private static class ResilientBuildToolingScope extends BuildToolingScope {
 
-        public ResilientBuildToolingScope(ToolingModelBuilderLookup.Builder builder) {
+        private final FailureFactory failureFactory;
+
+        public ResilientBuildToolingScope(ToolingModelBuilderLookup.Builder builder, FailureFactory failureFactory) {
             super(builder);
+            this.failureFactory = failureFactory;
         }
 
         @Override
         public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
-            // Do not throw failure if present opposed to BuildToolingScope
-            return ToolingModelScopeResult.of(buildModelWithParameter(parameter));
+            return Try.ofFailable(() -> buildScopeResult(parameter)).getOrMapFailure(failure -> {
+                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.create(failure)));
+                return ToolingModelScopeResult.withModelBuilderFailure(clientResult, failure);
+            });
+        }
+
+        private ToolingModelScopeResult buildScopeResult(@Nullable ToolingModelParameterCarrier parameter) {
+            ToolingModelBuilderResultInternal clientResult = buildModelWithParameter(parameter);
+            // Failures attached by a build-scoped builder (e.g. GradleBuildBuilder) are configuration failures of the visited builds, so they must still fail the build.
+            List<Throwable> configurationFailures = clientResult.getFailures().stream()
+                .map(Failure::getOriginal)
+                .collect(toImmutableList());
+            return ToolingModelScopeResult.withConfigurationFailures(clientResult, configurationFailures);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreator.java
@@ -16,14 +16,15 @@
 
 package org.gradle.internal.buildtree;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Responsible for creating a model from the build tree model.
+ * <p>
+ * Each phase returns a {@link BuildTreeModelCreatorResult} carrying the client model together with any failures that
+ * resilient model building held behind partial results. Those failures must still fail the build, even though partial
+ * models were returned to the client.
  */
 public interface BuildTreeModelCreator {
-    <T> void beforeTasks(BuildTreeModelAction<? extends T> action);
+    BuildTreeModelCreatorResult<Void> beforeTasks(BuildTreeModelAction<?> action);
 
-    @Nullable
-    <T> T fromBuildModel(BuildTreeModelAction<? extends T> action);
+    <T> BuildTreeModelCreatorResult<T> fromBuildModel(BuildTreeModelAction<? extends T> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreatorResult.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreatorResult.java
@@ -70,4 +70,11 @@ public final class BuildTreeModelCreatorResult<T> {
     public static <T> BuildTreeModelCreatorResult<T> of(@Nullable T model, ResilientBuildTreeFailureCollector failures) {
         return new BuildTreeModelCreatorResult<>(model, failures.getConfigurationFailures(), failures.getModelBuilderFailures());
     }
+
+    /**
+     * A result carrying the given model and no failures.
+     */
+    public static <T> BuildTreeModelCreatorResult<T> of(@Nullable T model) {
+        return new BuildTreeModelCreatorResult<>(model, ImmutableList.of(), ImmutableList.of());
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreatorResult.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreatorResult.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import com.google.common.collect.ImmutableList;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * The result of a {@link BuildTreeModelCreator} phase: the model built for the client (if any) together with the
+ * failures that resilient model building held behind partial results. Those failures must still fail the build even
+ * though the (partial) model was returned to the client.
+ */
+@NullMarked
+public final class BuildTreeModelCreatorResult<T> {
+
+    @Nullable
+    private final T model;
+    private final List<Throwable> configurationFailures;
+    private final List<Throwable> modelBuilderFailures;
+
+    public BuildTreeModelCreatorResult(@Nullable T model, List<Throwable> configurationFailures, List<Throwable> modelBuilderFailures) {
+        this.model = model;
+        this.configurationFailures = ImmutableList.copyOf(configurationFailures);
+        this.modelBuilderFailures = ImmutableList.copyOf(modelBuilderFailures);
+    }
+
+    @Nullable
+    public T getModel() {
+        return model;
+    }
+
+    /**
+     * Configuration failures that a project or the build itself hit while configuring, held behind a partial result.
+     */
+    public List<Throwable> getConfigurationFailures() {
+        return configurationFailures;
+    }
+
+    /**
+     * Failures thrown by tooling model builders after their target project configured successfully.
+     */
+    public List<Throwable> getModelBuilderFailures() {
+        return modelBuilderFailures;
+    }
+
+    public boolean hasFailures() {
+        return !configurationFailures.isEmpty() || !modelBuilderFailures.isEmpty();
+    }
+
+    /**
+     * A result carrying the given model together with the failures the collector accumulated while it was built.
+     */
+    public static <T> BuildTreeModelCreatorResult<T> of(@Nullable T model, ResilientBuildTreeFailureCollector failures) {
+        return new BuildTreeModelCreatorResult<>(model, failures.getConfigurationFailures(), failures.getModelBuilderFailures());
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -83,8 +83,8 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
     @Override
     public <T> T fromBuildModel(boolean runTasks, BuildTreeModelAction<? extends T> action) {
         return runBuild(() -> {
-            // Run before tasks (the projectsLoaded phase). If it throws, skip tasks and the model action, but still
-            // fail the build with whatever failures it collected before throwing.
+            // Run before tasks (the projectsLoaded phase). If it throws, skip tasks and the model action and fail
+            // the build with the thrown failure.
             ExecutionResult<BuildTreeModelCreatorResult<Void>> beforeTasksResult = runModelAction(() -> modelCreator.beforeTasks(action));
             if (!beforeTasksResult.isSuccessful()) {
                 return beforeTasksResult.<T>asFailure();
@@ -113,12 +113,13 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         ExecutionResult<T> buildResult = modelResult.withFailures(taskRunResult);
 
         // Model builder failures held behind partial results always fail the build. They come from both phases, but
-        // from fromBuildModel only when it produced a result rather than throwing.
+        // from fromBuildModel only when it produced a result rather than throwing. Both phases can observe the same
+        // failure instance when a cached model is returned for both, so report it only once.
         List<Throwable> modelBuilderFailures = new ArrayList<>(beforeTasksResult.getModelBuilderFailures());
         if (buildModelResult.isSuccessful()) {
             modelBuilderFailures.addAll(buildModelResult.getValue().getModelBuilderFailures());
         }
-        ExecutionResult<T> result = buildResult.withFailures(ExecutionResult.maybeFailed(modelBuilderFailures));
+        ExecutionResult<T> result = buildResult.withFailures(ExecutionResult.maybeFailed(modelBuilderFailures.stream().distinct().collect(Collectors.toList())));
 
         // A configuration failure is surfaced here only when the build isn't failing yet: if tasks were requested,
         // and task execution fails the build, attaching the collected copy would very likely report the identical exception twice.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -120,7 +120,8 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         }
         ExecutionResult<T> result = buildResult.withFailures(ExecutionResult.maybeFailed(modelBuilderFailures));
 
-        // Surface suppressed configuration failures only when the build isn't already failing to avoid duplicating same errors.
+        // A configuration failure is surfaced here only when the build isn't failing yet: if tasks were requested,
+        // and task execution fails the build, attaching the collected copy would very likely report the identical exception twice.
         if (buildResult.isSuccessful()) {
             List<Throwable> suppressedConfigurationFailures = new ArrayList<>(beforeTasksResult.getConfigurationFailures());
             suppressedConfigurationFailures.addAll(buildModelResult.getValue().getConfigurationFailures());

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -32,9 +32,13 @@ import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleController {
     private enum State implements StateTransitionController.State {
@@ -79,23 +83,62 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
     @Override
     public <T> T fromBuildModel(boolean runTasks, BuildTreeModelAction<? extends T> action) {
         return runBuild(() -> {
-            modelCreator.beforeTasks(action);
-            ExecutionResult<Void> taskRunResult = ExecutionResult.succeeded();
-            if (runTasks) {
-                taskRunResult = runTasks();
+            // Run before tasks (the projectsLoaded phase). If it throws, skip tasks and the model action, but still
+            // fail the build with whatever failures it collected before throwing.
+            ExecutionResult<BuildTreeModelCreatorResult<Void>> beforeTasksResult = runModelAction(() -> modelCreator.beforeTasks(action));
+            if (!beforeTasksResult.isSuccessful()) {
+                return beforeTasksResult.<T>asFailure();
             }
-            // Allow model action to run even if tasks failed
-            ExecutionResult<T> modelResult = runFromBuildModel(action);
-            return modelResult.withFailures(taskRunResult);
+
+            // Run tasks
+            ExecutionResult<Void> taskRunResult = runTasks ? runTasks() : ExecutionResult.succeeded();
+
+            // Allow the model action to run even if tasks failed
+            ExecutionResult<BuildTreeModelCreatorResult<T>> buildModelResult = runModelAction(() -> modelCreator.fromBuildModel(action));
+
+            // The held failures must still fail the build.
+            return attachCollectedFailures(beforeTasksResult.getValue(), buildModelResult, taskRunResult);
         });
     }
 
+    private static <T> ExecutionResult<T> attachCollectedFailures(
+        BuildTreeModelCreatorResult<Void> beforeTasksResult,
+        ExecutionResult<BuildTreeModelCreatorResult<T>> buildModelResult,
+        ExecutionResult<Void> taskRunResult
+    ) {
+        // The client model (or the action failure if fromBuildModel threw), plus task and model builder failures.
+        ExecutionResult<T> modelResult = buildModelResult.isSuccessful()
+            ? ExecutionResult.succeeded(buildModelResult.getValue().getModel())
+            : buildModelResult.asFailure();
+        ExecutionResult<T> buildResult = modelResult.withFailures(taskRunResult);
+
+        // Model builder failures held behind partial results always fail the build. They come from both phases, but
+        // from fromBuildModel only when it produced a result rather than throwing.
+        List<Throwable> modelBuilderFailures = new ArrayList<>(beforeTasksResult.getModelBuilderFailures());
+        if (buildModelResult.isSuccessful()) {
+            modelBuilderFailures.addAll(buildModelResult.getValue().getModelBuilderFailures());
+        }
+        ExecutionResult<T> result = buildResult.withFailures(ExecutionResult.maybeFailed(modelBuilderFailures));
+
+        // Surface suppressed configuration failures only when the build isn't already failing to avoid duplicating same errors.
+        if (buildResult.isSuccessful()) {
+            List<Throwable> suppressedConfigurationFailures = new ArrayList<>(beforeTasksResult.getConfigurationFailures());
+            suppressedConfigurationFailures.addAll(buildModelResult.getValue().getConfigurationFailures());
+            result = result.withFailures(ExecutionResult.maybeFailed(suppressedConfigurationFailures.stream().distinct().collect(Collectors.toList())));
+        }
+        return result;
+    }
+
+    /**
+     * Runs a phase of the model action (beforeTasks or fromBuildModel), capturing a failure as a build action failure
+     * instead of throwing, so the caller can still fold in any failures collected before it.
+     */
     @SuppressWarnings("DataFlowIssue")
-    private <T> ExecutionResult<T> runFromBuildModel(BuildTreeModelAction<? extends T> action) {
-        Try<T> model = Try.ofFailable(() -> modelCreator.fromBuildModel(action));
-        return model.getFailure().isPresent()
-            ? ExecutionResult.failed(BuildActionExecutionException.wrap(model.getFailure().get()))
-            : ExecutionResult.succeeded(model.get());
+    private <T> ExecutionResult<T> runModelAction(Callable<T> phase) {
+        Try<T> result = Try.ofFailable(phase);
+        return result.getFailure().isPresent()
+            ? ExecutionResult.failed(BuildActionExecutionException.wrap(result.getFailure().get()))
+            : ExecutionResult.succeeded(result.get());
     }
 
     private ExecutionResult<Void> runTasks() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
@@ -29,6 +29,7 @@ import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal;
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
@@ -58,16 +59,26 @@ public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
     }
 
     @Override
-    public <T> void beforeTasks(BuildTreeModelAction<? extends T> action) {
-        action.beforeTasks(new DefaultBuildTreeModelController());
+    public BuildTreeModelCreatorResult<Void> beforeTasks(BuildTreeModelAction<?> action) {
+        ResilientBuildTreeFailureCollector failures = new ResilientBuildTreeFailureCollector();
+        action.beforeTasks(new DefaultBuildTreeModelController(failures));
+        return BuildTreeModelCreatorResult.of(null, failures);
     }
 
     @Override
-    public <T> T fromBuildModel(BuildTreeModelAction<? extends T> action) {
-        return action.fromBuildModel(new DefaultBuildTreeModelController());
+    public <T> BuildTreeModelCreatorResult<T> fromBuildModel(BuildTreeModelAction<? extends T> action) {
+        ResilientBuildTreeFailureCollector failures = new ResilientBuildTreeFailureCollector();
+        T model = action.fromBuildModel(new DefaultBuildTreeModelController(failures));
+        return BuildTreeModelCreatorResult.of(model, failures);
     }
 
     private class DefaultBuildTreeModelController implements BuildTreeModelController {
+        private final ResilientBuildTreeFailureCollector buildTreeFailureCollector;
+
+        public DefaultBuildTreeModelController(ResilientBuildTreeFailureCollector buildTreeFailureCollector) {
+            this.buildTreeFailureCollector = buildTreeFailureCollector;
+        }
+
         @Override
         public GradleInternal getConfiguredModel() {
             return defaultTarget.withToolingModels(false, BuildToolingModelController::getConfiguredModel);
@@ -82,10 +93,14 @@ public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
                 @Nullable
                 public ToolingModelBuilderResultInternal call(BuildOperationContext context) {
                     ToolingModelScope scope = locateBuilderForTarget(target, modelRequestContext);
-                    return scope.getModel(modelRequestContext,
-                        modelRequestContext.getParameter()
-                            .map(parameterCarrierFactory::createCarrier)
-                            .orElse(null));
+                    ToolingModelParameterCarrier parameter = modelRequestContext.getParameter()
+                        .map(parameterCarrierFactory::createCarrier)
+                        .orElse(null);
+                    ToolingModelScopeResult result = scope.getModel(modelRequestContext, parameter);
+                    // A failure held behind a partial result is collected here, at the build-tree model boundary, so
+                    // the build still fails when it finishes, while the client result is returned unchanged.
+                    buildTreeFailureCollector.collectFrom(result);
+                    return result.getClientResult();
                 }
 
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects failures that resilient model building did not throw straight away, so that partial models could still be
+ * returned to the client. Model results are collected as they are built and their failures are raised when the build
+ * finishes, so the build still fails. The two kinds are kept apart because they are reported differently at finish
+ * (see {@code DefaultBuildTreeLifecycleController}).
+ * <p>
+ * Thread-safe: models may be queried in parallel.
+ */
+@NullMarked
+public final class ResilientBuildTreeFailureCollector {
+
+    private final List<Throwable> modelBuilderFailures = new ArrayList<>();
+    private final List<Throwable> configurationFailures = new ArrayList<>();
+
+    /**
+     * Collects any failure held behind the given result, so the build fails when it finishes even though the (partial)
+     * client result is returned.
+     */
+    public synchronized void collectFrom(ToolingModelScopeResult result) {
+        Throwable modelBuilderFailure = result.getModelBuilderFailure();
+        if (modelBuilderFailure != null) {
+            modelBuilderFailures.add(modelBuilderFailure);
+        }
+        Throwable configurationFailure = result.getConfigurationFailure();
+        if (configurationFailure != null) {
+            configurationFailures.add(configurationFailure);
+        }
+    }
+
+    public synchronized List<Throwable> getModelBuilderFailures() {
+        return ImmutableList.copyOf(modelBuilderFailures);
+    }
+
+    public synchronized List<Throwable> getConfigurationFailures() {
+        return ImmutableList.copyOf(configurationFailures);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
@@ -34,29 +34,29 @@ import java.util.List;
 @NullMarked
 public final class ResilientBuildTreeFailureCollector {
 
-    private final List<Throwable> modelBuilderFailures = new ArrayList<>();
     private final List<Throwable> configurationFailures = new ArrayList<>();
+    private final List<Throwable> modelBuilderFailures = new ArrayList<>();
 
     /**
      * Collects any failure held behind the given result, so the build fails when it finishes even though the (partial)
      * client result is returned.
      */
     public synchronized void collectFrom(ToolingModelScopeResult result) {
-        Throwable modelBuilderFailure = result.getModelBuilderFailure();
-        if (modelBuilderFailure != null) {
-            modelBuilderFailures.add(modelBuilderFailure);
-        }
         Throwable configurationFailure = result.getConfigurationFailure();
         if (configurationFailure != null) {
             configurationFailures.add(configurationFailure);
         }
-    }
-
-    public synchronized List<Throwable> getModelBuilderFailures() {
-        return ImmutableList.copyOf(modelBuilderFailures);
+        Throwable modelBuilderFailure = result.getModelBuilderFailure();
+        if (modelBuilderFailure != null) {
+            modelBuilderFailures.add(modelBuilderFailure);
+        }
     }
 
     public synchronized List<Throwable> getConfigurationFailures() {
         return ImmutableList.copyOf(configurationFailures);
+    }
+
+    public synchronized List<Throwable> getModelBuilderFailures() {
+        return ImmutableList.copyOf(modelBuilderFailures);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ResilientBuildTreeFailureCollector.java
@@ -42,10 +42,7 @@ public final class ResilientBuildTreeFailureCollector {
      * client result is returned.
      */
     public synchronized void collectFrom(ToolingModelScopeResult result) {
-        Throwable configurationFailure = result.getConfigurationFailure();
-        if (configurationFailure != null) {
-            configurationFailures.add(configurationFailure);
-        }
+        configurationFailures.addAll(result.getConfigurationFailures());
         Throwable modelBuilderFailure = result.getModelBuilderFailure();
         if (modelBuilderFailure != null) {
             modelBuilderFailures.add(modelBuilderFailure);

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
@@ -77,10 +77,12 @@ public class DefaultIntermediateToolingModelProvider implements IntermediateTool
 
     private static <T> List<Throwable> collectFailures(IntermediateToolingModelResult<T> result, Class<T> modelType) {
         List<Throwable> failures = new ArrayList<>();
-        if (result.getModel() == null) {
+        result.getFailures().forEach(f -> failures.add(f.getOriginal()));
+        if (result.getModel() == null && failures.isEmpty()) {
+            // Only report the missing model when there is no failure explaining it. When there is one, it is the
+            // actual cause, and it must stay first so clients walking the getCause() chain can find it.
             failures.add(new IllegalStateException(String.format("Expected model of type %s but found null", modelType.getName())));
         }
-        result.getFailures().forEach(f -> failures.add(f.getOriginal()));
         return failures;
     }
 
@@ -119,10 +121,12 @@ public class DefaultIntermediateToolingModelProvider implements IntermediateTool
         List<Supplier<ToolingModelBuilderResultInternal>> fetchActions = targets.stream()
             .map(target -> (Supplier<ToolingModelBuilderResultInternal>) () -> {
                 try {
-                    return controller.locateBuilderForTarget(target, context).getModel(context, carrier);
+                    // Only the client-facing result is needed here; a deferred build failure (if any) is reported
+                    // to the build-tree model boundary, not on this nested fan-out path.
+                    return controller.locateBuilderForTarget(target, context).getModel(context, carrier).getClientResult();
                 } catch (Throwable t) {
                     // Safety net for an unexpected throw; the resilient controller normally
-                    // captures configuration failures into the result wrapper itself.
+                    // captures configuration failures into the result itself.
                     return ToolingModelBuilderResultInternal.of(ImmutableList.of(failureFactory.create(t)));
                 }
             })

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScope.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScope.java
@@ -37,7 +37,7 @@ public interface ToolingModelScope {
      * <p>
      * Can configure the target build or project to locate the corresponding model builder.
      *
-     * @return the created model (null is a valid model)
+     * @return the created model result, including any failure that must still fail the build
      */
-    ToolingModelBuilderResultInternal getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter);
+    ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter);
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.provider.model.internal;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The outcome of building a model in a {@link ToolingModelScope}: the {@link #getClientResult() result returned to the
+ * client} and, when resilient model building did not throw a failure straight away, the failure that must still fail
+ * the build. At most one of {@link #getModelBuilderFailure()} / {@link #getConfigurationFailure()} is set. Keeping
+ * these here rather than on the client result keeps the client result free of build-lifecycle concerns.
+ */
+@NullMarked
+public final class ToolingModelScopeResult {
+
+    private final ToolingModelBuilderResultInternal clientResult;
+    @Nullable
+    private final Throwable modelBuilderFailure;
+    @Nullable
+    private final Throwable configurationFailure;
+
+    private ToolingModelScopeResult(ToolingModelBuilderResultInternal clientResult, @Nullable Throwable modelBuilderFailure, @Nullable Throwable configurationFailure) {
+        this.clientResult = clientResult;
+        this.modelBuilderFailure = modelBuilderFailure;
+        this.configurationFailure = configurationFailure;
+    }
+
+    /**
+     * The model built cleanly.
+     */
+    public static ToolingModelScopeResult of(ToolingModelBuilderResultInternal clientResult) {
+        return new ToolingModelScopeResult(clientResult, null, null);
+    }
+
+    /**
+     * A tooling model builder threw after its target project had configured successfully.
+     */
+    public static ToolingModelScopeResult withModelBuilderFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
+        return new ToolingModelScopeResult(clientResult, failure, null);
+    }
+
+    /**
+     * A project or the build itself failed to configure.
+     */
+    public static ToolingModelScopeResult withConfigurationFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
+        return new ToolingModelScopeResult(clientResult, null, failure);
+    }
+
+    public ToolingModelBuilderResultInternal getClientResult() {
+        return clientResult;
+    }
+
+    /**
+     * A model builder failure hidden behind {@link #getClientResult() the result}, or {@code null} if none.
+     */
+    @Nullable
+    public Throwable getModelBuilderFailure() {
+        return modelBuilderFailure;
+    }
+
+    /**
+     * A configuration failure hidden behind {@link #getClientResult() the result}, or {@code null} if none.
+     */
+    @Nullable
+    public Throwable getConfigurationFailure() {
+        return configurationFailure;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
@@ -16,26 +16,28 @@
 
 package org.gradle.tooling.provider.model.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * The outcome of building a model in a {@link ToolingModelScope}: the {@link #getClientResult() result returned to the
- * client} and, when resilient model building did not throw a failure straight away, the failure that must still fail
- * the build. At most one of {@link #getConfigurationFailure()} / {@link #getModelBuilderFailure()} is set. Keeping
- * these here rather than on the client result keeps the client result free of build-lifecycle concerns.
+ * client} and, when resilient model building did not throw a failure straight away, the failures that must still fail
+ * the build. Only one of the two failure kinds is present. Keeping these here rather than on the client result keeps
+ * the client result free of build-lifecycle concerns.
  */
 @NullMarked
 public final class ToolingModelScopeResult {
 
-    @Nullable
-    private final Throwable configurationFailure;
+    private final List<Throwable> configurationFailures;
     @Nullable
     private final Throwable modelBuilderFailure;
     private final ToolingModelBuilderResultInternal clientResult;
 
-    private ToolingModelScopeResult(@Nullable Throwable configurationFailure, @Nullable Throwable modelBuilderFailure, ToolingModelBuilderResultInternal clientResult) {
-        this.configurationFailure = configurationFailure;
+    private ToolingModelScopeResult(List<Throwable> configurationFailures, @Nullable Throwable modelBuilderFailure, ToolingModelBuilderResultInternal clientResult) {
+        this.configurationFailures = ImmutableList.copyOf(configurationFailures);
         this.modelBuilderFailure = modelBuilderFailure;
         this.clientResult = clientResult;
     }
@@ -44,29 +46,35 @@ public final class ToolingModelScopeResult {
      * The model built cleanly.
      */
     public static ToolingModelScopeResult of(ToolingModelBuilderResultInternal clientResult) {
-        return new ToolingModelScopeResult(null, null, clientResult);
+        return new ToolingModelScopeResult(ImmutableList.of(), null, clientResult);
     }
 
     /**
      * A project or the build itself failed to configure.
      */
     public static ToolingModelScopeResult withConfigurationFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
-        return new ToolingModelScopeResult(failure, null, clientResult);
+        return new ToolingModelScopeResult(ImmutableList.of(failure), null, clientResult);
+    }
+
+    /**
+     * One or more builds visited by a build-scoped builder failed to configure.
+     */
+    public static ToolingModelScopeResult withConfigurationFailures(ToolingModelBuilderResultInternal clientResult, List<Throwable> failures) {
+        return new ToolingModelScopeResult(failures, null, clientResult);
     }
 
     /**
      * A tooling model builder threw after its target project had configured successfully.
      */
     public static ToolingModelScopeResult withModelBuilderFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
-        return new ToolingModelScopeResult(null, failure, clientResult);
+        return new ToolingModelScopeResult(ImmutableList.of(), failure, clientResult);
     }
 
     /**
-     * A configuration failure hidden behind {@link #getClientResult() the result}, or {@code null} if none.
+     * Configuration failures hidden behind {@link #getClientResult() the result}, empty if none.
      */
-    @Nullable
-    public Throwable getConfigurationFailure() {
-        return configurationFailure;
+    public List<Throwable> getConfigurationFailures() {
+        return configurationFailures;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScopeResult.java
@@ -22,47 +22,51 @@ import org.jspecify.annotations.Nullable;
 /**
  * The outcome of building a model in a {@link ToolingModelScope}: the {@link #getClientResult() result returned to the
  * client} and, when resilient model building did not throw a failure straight away, the failure that must still fail
- * the build. At most one of {@link #getModelBuilderFailure()} / {@link #getConfigurationFailure()} is set. Keeping
+ * the build. At most one of {@link #getConfigurationFailure()} / {@link #getModelBuilderFailure()} is set. Keeping
  * these here rather than on the client result keeps the client result free of build-lifecycle concerns.
  */
 @NullMarked
 public final class ToolingModelScopeResult {
 
-    private final ToolingModelBuilderResultInternal clientResult;
-    @Nullable
-    private final Throwable modelBuilderFailure;
     @Nullable
     private final Throwable configurationFailure;
+    @Nullable
+    private final Throwable modelBuilderFailure;
+    private final ToolingModelBuilderResultInternal clientResult;
 
-    private ToolingModelScopeResult(ToolingModelBuilderResultInternal clientResult, @Nullable Throwable modelBuilderFailure, @Nullable Throwable configurationFailure) {
-        this.clientResult = clientResult;
-        this.modelBuilderFailure = modelBuilderFailure;
+    private ToolingModelScopeResult(@Nullable Throwable configurationFailure, @Nullable Throwable modelBuilderFailure, ToolingModelBuilderResultInternal clientResult) {
         this.configurationFailure = configurationFailure;
+        this.modelBuilderFailure = modelBuilderFailure;
+        this.clientResult = clientResult;
     }
 
     /**
      * The model built cleanly.
      */
     public static ToolingModelScopeResult of(ToolingModelBuilderResultInternal clientResult) {
-        return new ToolingModelScopeResult(clientResult, null, null);
-    }
-
-    /**
-     * A tooling model builder threw after its target project had configured successfully.
-     */
-    public static ToolingModelScopeResult withModelBuilderFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
-        return new ToolingModelScopeResult(clientResult, failure, null);
+        return new ToolingModelScopeResult(null, null, clientResult);
     }
 
     /**
      * A project or the build itself failed to configure.
      */
     public static ToolingModelScopeResult withConfigurationFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
-        return new ToolingModelScopeResult(clientResult, null, failure);
+        return new ToolingModelScopeResult(failure, null, clientResult);
     }
 
-    public ToolingModelBuilderResultInternal getClientResult() {
-        return clientResult;
+    /**
+     * A tooling model builder threw after its target project had configured successfully.
+     */
+    public static ToolingModelScopeResult withModelBuilderFailure(ToolingModelBuilderResultInternal clientResult, Throwable failure) {
+        return new ToolingModelScopeResult(null, failure, clientResult);
+    }
+
+    /**
+     * A configuration failure hidden behind {@link #getClientResult() the result}, or {@code null} if none.
+     */
+    @Nullable
+    public Throwable getConfigurationFailure() {
+        return configurationFailure;
     }
 
     /**
@@ -73,11 +77,7 @@ public final class ToolingModelScopeResult {
         return modelBuilderFailure;
     }
 
-    /**
-     * A configuration failure hidden behind {@link #getClientResult() the result}, or {@code null} if none.
-     */
-    @Nullable
-    public Throwable getConfigurationFailure() {
-        return configurationFailure;
+    public ToolingModelBuilderResultInternal getClientResult() {
+        return clientResult;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
@@ -38,6 +38,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
 
     def setup() {
         buildController.gradle >> gradle
+        modelCreator.beforeTasks(_) >> new BuildTreeModelCreatorResult(null, [], [])
     }
 
     def "runs tasks"() {
@@ -96,7 +97,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.succeeded())
 
         and:
-        1 * modelCreator.fromBuildModel(action) >> "result"
+        1 * modelCreator.fromBuildModel(action) >> new BuildTreeModelCreatorResult("result", [], [])
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null
@@ -115,6 +116,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
 
         and:
         1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.failed(failure))
+        1 * modelCreator.fromBuildModel(action) >> new BuildTreeModelCreatorResult(null, [], [])
         0 * action._
 
         and:
@@ -134,7 +136,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         0 * workController.scheduleAndRunRequestedTasks(null)
 
         and:
-        1 * modelCreator.fromBuildModel(action) >> "result"
+        1 * modelCreator.fromBuildModel(action) >> new BuildTreeModelCreatorResult("result", [], [])
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderResultInternal
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 import org.gradle.tooling.provider.model.internal.ToolingModelScope
+import org.gradle.tooling.provider.model.internal.ToolingModelScopeResult
 import spock.lang.Specification
 
 import javax.annotation.Nullable
@@ -40,7 +41,7 @@ class DefaultBuildTreeModelCreatorTest extends Specification {
 
         def modelScope = Mock(ToolingModelScope) {
             getModel(_, _) >> { ToolingModelRequestContext modelName, @Nullable ToolingModelParameterCarrier parameter ->
-                model
+                ToolingModelScopeResult.of(model)
             }
         }
         def modelController = Mock(BuildToolingModelController) {
@@ -117,6 +118,6 @@ class DefaultBuildTreeModelCreatorTest extends Specification {
             Object fromBuildModel(BuildTreeModelController controller) {
                 return controller.getModel(target, new ToolingModelRequestContext(modelName, parameter, false))
             }
-        })
+        }).getModel()
     }
 }


### PR DESCRIPTION
Previously, when a tooling model builder failed after its target project
had configured successfully, the failure was only captured as a per-model
failure (`FetchModelResult`) and the overall build still succeeded — so a
resilient IDE sync (phased build action) was never told that model building
had failed.

Now we collect errors for whole build tree and fail at the end.