### PR TITLE
Use bounded location captures under `--warning-mode=all` and `fail`

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -349,7 +349,8 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         mode << [WarningMode.None, WarningMode.Summary]
     }
 
-    def "collects stack traces for deprecation usages without limit for warning mode #mode"() {
+    @ToBeFixedForIsolatedProjects(skipBecause = "Isolated Projects raises the cap to 5000, so all 100 stay full and never reach the bounded path; IP also emits extra deprecation events that make the count unstable")
+    def "collects full stack traces up to the cap then bounded captures past it for warning mode #mode"() {
         file('settings.gradle') << "rootProject.name = 'root'"
 
         100.times {
@@ -373,7 +374,14 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         then:
         def events = operations.only("Apply build file 'build.gradle' to root project 'root'").progress.findAll { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         events.size() == 100
-        events.every { it.details['deprecation'].stackTrace.length() > 0 }
+        // Every problem, within the cap or past it, resolves to the build script.
+        events.every { (it.details['deprecation'].stackTrace as String).contains('build.gradle') }
+
+        and:
+        // Within the cap the full stack descends past the script into the Gradle runtime; past the 50 cap the
+        // bounded capture is cut at the script, so its trace is strictly shorter.
+        def lineCount = { int i -> (events[i].details['deprecation'].stackTrace as String).readLines().count { !it.trim().isEmpty() } }
+        lineCount(99) < lineCount(0)
 
         and:
         THRESHOLD_DEFAULT_VALUE.times {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -159,7 +159,7 @@ As a result, the [console](userguide/command_line_interface.html), the [problems
 ![Problems report listing many problems with their source locations](release-notes-assets/problems-locations.png)
 
 Run with `--warning-mode=all` to remove the limit and capture a source location for every problem.
-Past the cap, including under `--warning-mode=all`, the capture keeps the originating build logic down to the calling script, enough to locate the problem, rather than the full call chain.
+Past the cap, including under `--warning-mode=all` and `fail`, the capture keeps the originating build logic down to the calling script, enough to locate the problem, rather than the full call chain.
 
 See the [CLI reference](userguide/command_line_interface.html#sec:command_line_warnings) in the Gradle User Manual for more details.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -159,6 +159,7 @@ As a result, the [console](userguide/command_line_interface.html), the [problems
 ![Problems report listing many problems with their source locations](release-notes-assets/problems-locations.png)
 
 Run with `--warning-mode=all` to remove the limit and capture a source location for every problem.
+Past the cap, including under `--warning-mode=all`, the capture keeps the originating build logic down to the calling script, enough to locate the problem, rather than the full call chain.
 
 See the [CLI reference](userguide/command_line_interface.html#sec:command_line_warnings) in the Gradle User Manual for more details.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/reporting_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/reporting_problems.adoc
@@ -189,7 +189,7 @@ It’s a central place to review issues and complements the console and Build Sc
 [NOTE]
 ====
 To keep stack trace capture affordable, Gradle infers a source location for only a limited number of problems per build, so very large builds may list some problems without a file and line.
-Run with `--warning-mode=all` to lift the limit and infer a location for every problem.
+Run with `--warning-mode=all` or `--warning-mode=fail` to infer a location for every problem; past the cap, the trace is reduced to the originating build logic and calling script.
 ====
 
 - The report is skipped if no problems are found.

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -760,7 +760,8 @@ Set to `summary` to suppress all warnings and log a summary at the end of the bu
 +
 Set to `none` to suppress all warnings, including the summary at the end of the build.
 +
-In `all` mode, Gradle also lifts the limit it puts on capturing source locations, so a file and line is inferred for every problem rather than only the first ones.
+In `all` and `fail` modes, Gradle infers a source location for every problem rather than only the first ones.
+Past the stack-capture cap (50 problems by default, 5000 under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>), the trace is reduced to the originating build logic and the calling script (enough to locate the problem) rather than the full call chain.
 
 [[sec:rich_console]]
 === Rich console

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationPastCapIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationPastCapIntegrationTest.groovy
@@ -25,9 +25,10 @@ import spock.lang.Issue
 
 /**
  * Past the stack-capture cap, locations are inferred from a cheap bounded caller-stack capture rather than
- * a full stack. This pins that path end to end: it must run (a capping warning mode, so the cap actually
- * applies, the dedicated test must not use {@code --warning-mode=all}, which lifts it), resolve the location
- * to the calling script by seeing through a build-logic helper, and keep that helper frame as context.
+ * a full stack. This pins that path end to end across warning modes: {@code summary} keeps the default
+ * bounded budget, {@code all} lifts it, but both keep the full-stack cap at 50, so problems past it take the
+ * bounded path either way. The location must resolve to the calling script by seeing through a build-logic
+ * helper, keeping that helper frame as context.
  */
 @Issue("https://github.com/gradle/gradle/issues/32362")
 class ProblemLocationPastCapIntegrationTest extends AbstractIntegrationSpec {
@@ -35,7 +36,7 @@ class ProblemLocationPastCapIntegrationTest extends AbstractIntegrationSpec {
     def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)
 
     @ToBeFixedForIsolatedProjects(because = "under Isolated Projects the stack-capture cap is 5000, so the problems fired here stay within it and never reach the bounded path")
-    def "problems past the stack-capture cap resolve to the calling script and keep the build-logic frame"() {
+    def "problems past the stack-capture cap resolve to the calling script and keep the build-logic frame for warning mode #warningMode"() {
         given:
         // A compiled helper (build logic, not a script) reports the problem. The bounded capture must see
         // through it to the calling script for the location, and keep the helper frame above it.
@@ -61,8 +62,8 @@ class ProblemLocationPastCapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        // Capping mode (not --warning-mode=all) so problems past the cap go through the bounded capture.
-        executer.withWarningMode(WarningMode.Summary)
+        // Both modes keep the full cap at 50; problems past it take the bounded path (all lifts only the bounded budget).
+        executer.withWarningMode(warningMode)
         succeeds 'help'
 
         then:
@@ -94,5 +95,8 @@ class ProblemLocationPastCapIntegrationTest extends AbstractIntegrationSpec {
         and:
         // Each call site resolves to its own line; without a cache nothing can be conflated to one location.
         bounded.collect { it.fileLocation.line }.unique().size() == bounded.size()
+
+        where:
+        warningMode << [WarningMode.Summary, WarningMode.All]
     }
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
@@ -107,7 +107,7 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
     @Override
     public ProblemStream newUnlimitedStream() {
-        return new DefaultProblemStream(Integer.MAX_VALUE, maxBoundedCaptures);
+        return new DefaultProblemStream(maxStackTraces, Integer.MAX_VALUE);
     }
 
     @Override

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
@@ -34,7 +34,6 @@ import org.jspecify.annotations.Nullable;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFactory {
 
@@ -103,14 +102,12 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
     @Override
     public ProblemStream newStream() {
-        return new DefaultProblemStream();
+        return new DefaultProblemStream(maxStackTraces, maxBoundedCaptures);
     }
 
     @Override
     public ProblemStream newUnlimitedStream() {
-        DefaultProblemStream defaultProblemStream = new DefaultProblemStream();
-        defaultProblemStream.remainingStackTraces.set(Integer.MAX_VALUE);
-        return defaultProblemStream;
+        return new DefaultProblemStream(Integer.MAX_VALUE, maxBoundedCaptures);
     }
 
     @Override
@@ -140,12 +137,10 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
     @NullMarked
     private class DefaultProblemStream implements ProblemStream {
-        private final AtomicInteger remainingStackTraces = new AtomicInteger();
-        private final AtomicInteger remainingBoundedCaptures = new AtomicInteger();
+        private final StackTraceCapturer capturer;
 
-        public DefaultProblemStream() {
-            remainingStackTraces.set(maxStackTraces);
-            remainingBoundedCaptures.set(maxBoundedCaptures);
+        public DefaultProblemStream(int fullBudget, int boundedBudget) {
+            this.capturer = new StackTraceCapturer(fullBudget, boundedBudget, boundedCallerStackCapturer);
         }
 
         @Override
@@ -174,22 +169,12 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
         @Nullable
         private Throwable getImplicitCallerThrowable() {
-            if (remainingStackTraces.getAndDecrement() > 0) {
-                return EXCEPTION_FACTORY.get();
-            }
-            if (remainingBoundedCaptures.getAndDecrement() > 0) {
-                return boundedCallerStackCapturer.captureCallerStack();
-            }
-            return null;
+            return capturer.captureStack(EXCEPTION_FACTORY, true);
         }
 
         @Nullable
         private Throwable getImplicitThrowable(Supplier<? extends Throwable> factory) {
-            if (remainingStackTraces.getAndDecrement() > 0) {
-                return factory.get();
-            } else {
-                return null;
-            }
+            return capturer.captureStack(factory, false);
         }
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
@@ -47,13 +47,6 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
     private static final ProblemStream.StackTraceTransformer NO_OP = new CopyStackTraceTransFormer();
 
-    private static final Supplier<Throwable> EXCEPTION_FACTORY = new Supplier<Throwable>() {
-        @Override
-        public Throwable get() {
-            return new Exception();
-        }
-    };
-
     private static final int MAX_STACKTRACE_COUNT = 50;
     private static final int ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT = 5000;
 
@@ -169,12 +162,12 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
         @Nullable
         private Throwable getImplicitCallerThrowable() {
-            return capturer.captureStack(EXCEPTION_FACTORY, true);
+            return capturer.captureCaller();
         }
 
         @Nullable
         private Throwable getImplicitThrowable(Supplier<? extends Throwable> factory) {
-            return capturer.captureStack(factory, false);
+            return capturer.captureSupplied(factory);
         }
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.problems;
+
+import com.google.common.base.Supplier;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Captures a stack trace for a problem within per-stream budgets: a full trace while the full budget
+ * lasts, then a cheaper bounded caller-stack capture while the bounded budget lasts, then nothing.
+ */
+final class StackTraceCapturer {
+
+    private final AtomicInteger remainingFull;
+    private final AtomicInteger remainingBounded;
+    private final BoundedCallerStackCapturer boundedCallerStackCapturer;
+
+    StackTraceCapturer(int fullBudget, int boundedBudget, BoundedCallerStackCapturer boundedCallerStackCapturer) {
+        this.remainingFull = new AtomicInteger(fullBudget);
+        this.remainingBounded = new AtomicInteger(boundedBudget);
+        this.boundedCallerStackCapturer = boundedCallerStackCapturer;
+    }
+
+    @Nullable
+    Throwable captureStack(Supplier<? extends Throwable> fullFactory, boolean allowBounded) {
+        if (remainingFull.getAndDecrement() > 0) {
+            return fullFactory.get();
+        }
+        if (allowBounded && remainingBounded.getAndDecrement() > 0) {
+            return boundedCallerStackCapturer.captureCallerStack();
+        }
+        return null;
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
@@ -22,8 +22,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Captures a stack trace for a problem within per-stream budgets: a full trace while the full budget
- * lasts, then a cheaper bounded caller-stack capture while the bounded budget lasts, then nothing.
+ * Captures the stack trace that locates a problem, within per-stream budgets.
  */
 final class StackTraceCapturer {
 
@@ -38,12 +37,20 @@ final class StackTraceCapturer {
     }
 
     @Nullable
-    Throwable captureStack(Supplier<? extends Throwable> fullFactory, boolean allowBounded) {
+    Throwable captureCaller() {
         if (remainingFull.getAndDecrement() > 0) {
-            return fullFactory.get();
+            return new Exception();
         }
-        if (allowBounded && remainingBounded.getAndDecrement() > 0) {
+        if (remainingBounded.getAndDecrement() > 0) {
             return boundedCallerStackCapturer.captureCallerStack();
+        }
+        return null;
+    }
+
+    @Nullable
+    Throwable captureSupplied(Supplier<? extends Throwable> factory) {
+        if (remainingFull.getAndDecrement() > 0) {
+            return factory.get();
         }
         return null;
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemDiagnosticsFactory.java
@@ -32,7 +32,9 @@ public interface ProblemDiagnosticsFactory {
     ProblemStream newStream();
 
     /**
-     * Creates a new stream of problems without any limits.
+     * Creates a stream that caps full stack-trace captures like {@link #newStream()} but applies no limit to
+     * the cheaper bounded location captures past that cap, so every problem still gets a location. Used for
+     * {@code --warning-mode=all} and {@code --warning-mode=fail}.
      */
     ProblemStream newUnlimitedStream();
 

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
@@ -22,20 +22,20 @@ import spock.lang.Specification
 class StackTraceCapturerTest extends Specification {
 
     def boundedCapturer = Mock(BoundedCallerStackCapturer)
-    def fullException = new Exception()
-    def fullFactory = { fullException } as Supplier
 
-    def "spends the full budget, then the bounded budget, then captures nothing"() {
+    def "captureCaller spends the full budget, then the bounded budget, then captures nothing"() {
         given:
         def boundedException = new Exception()
         def capturer = new StackTraceCapturer(2, 3, boundedCapturer)
 
         when:
-        def results = (1..6).collect { capturer.captureStack(fullFactory, true) }
+        def results = (1..6).collect { capturer.captureCaller() }
 
         then:
-        results[0].is(fullException)
-        results[1].is(fullException)
+        results[0] != null
+        results[1] != null
+        !results[0].is(boundedException)
+        !results[1].is(boundedException)
         results[2].is(boundedException)
         results[3].is(boundedException)
         results[4].is(boundedException)
@@ -44,43 +44,46 @@ class StackTraceCapturerTest extends Specification {
         3 * boundedCapturer.captureCallerStack() >> boundedException
     }
 
-    def "without bounded fallback, captures full then nothing and leaves the bounded budget untouched"() {
+    def "captureSupplied returns the supplied throwable until the full budget is spent, never falling back to bounded"() {
         given:
+        def supplied = new Exception()
+        def factory = { supplied } as Supplier
         def capturer = new StackTraceCapturer(2, 3, boundedCapturer)
 
         when:
-        def results = (1..4).collect { capturer.captureStack(fullFactory, false) }
+        def results = (1..4).collect { capturer.captureSupplied(factory) }
 
         then:
-        results[0].is(fullException)
-        results[1].is(fullException)
+        results[0].is(supplied)
+        results[1].is(supplied)
         results[2] == null
         results[3] == null
 
         0 * boundedCapturer.captureCallerStack()
     }
 
-    def "an unbounded bounded budget keeps capturing past the full cap"() {
+    def "captureCaller with an unbounded bounded budget keeps capturing past the full cap"() {
         given:
         def boundedException = new Exception()
         def capturer = new StackTraceCapturer(1, Integer.MAX_VALUE, boundedCapturer)
 
         when:
-        def results = (1..100).collect { capturer.captureStack(fullFactory, true) }
+        def results = (1..100).collect { capturer.captureCaller() }
 
         then:
-        results[0].is(fullException)
+        results[0] != null
+        !results[0].is(boundedException)
         results[1..99].every { it.is(boundedException) }
 
         99 * boundedCapturer.captureCallerStack() >> boundedException
     }
 
-    def "a null bounded capture still spends the bounded budget"() {
+    def "captureCaller spends the bounded budget even when the bounded capture is null"() {
         given:
         def capturer = new StackTraceCapturer(0, 2, boundedCapturer)
 
         when:
-        def results = (1..3).collect { capturer.captureStack(fullFactory, true) }
+        def results = (1..3).collect { capturer.captureCaller() }
 
         then:
         results.every { it == null }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.problems
+
+import com.google.common.base.Supplier
+import spock.lang.Specification
+
+class StackTraceCapturerTest extends Specification {
+
+    def boundedCapturer = Mock(BoundedCallerStackCapturer)
+    def fullException = new Exception()
+    def fullFactory = { fullException } as Supplier
+
+    def "spends the full budget, then the bounded budget, then captures nothing"() {
+        given:
+        def boundedException = new Exception()
+        def capturer = new StackTraceCapturer(2, 3, boundedCapturer)
+
+        when:
+        def results = (1..6).collect { capturer.captureStack(fullFactory, true) }
+
+        then:
+        results[0].is(fullException)
+        results[1].is(fullException)
+        results[2].is(boundedException)
+        results[3].is(boundedException)
+        results[4].is(boundedException)
+        results[5] == null
+
+        3 * boundedCapturer.captureCallerStack() >> boundedException
+    }
+
+    def "without bounded fallback, captures full then nothing and leaves the bounded budget untouched"() {
+        given:
+        def capturer = new StackTraceCapturer(2, 3, boundedCapturer)
+
+        when:
+        def results = (1..4).collect { capturer.captureStack(fullFactory, false) }
+
+        then:
+        results[0].is(fullException)
+        results[1].is(fullException)
+        results[2] == null
+        results[3] == null
+
+        0 * boundedCapturer.captureCallerStack()
+    }
+
+    def "an unbounded bounded budget keeps capturing past the full cap"() {
+        given:
+        def boundedException = new Exception()
+        def capturer = new StackTraceCapturer(1, Integer.MAX_VALUE, boundedCapturer)
+
+        when:
+        def results = (1..100).collect { capturer.captureStack(fullFactory, true) }
+
+        then:
+        results[0].is(fullException)
+        results[1..99].every { it.is(boundedException) }
+
+        99 * boundedCapturer.captureCallerStack() >> boundedException
+    }
+
+    def "a null bounded capture still spends the bounded budget"() {
+        given:
+        def capturer = new StackTraceCapturer(0, 2, boundedCapturer)
+
+        when:
+        def results = (1..3).collect { capturer.captureStack(fullFactory, true) }
+
+        then:
+        results.every { it == null }
+
+        2 * boundedCapturer.captureCallerStack() >> null
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/problems/DefaultProblemDiagnosticsFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/problems/DefaultProblemDiagnosticsFactoryTest.groovy
@@ -117,6 +117,20 @@ class DefaultProblemDiagnosticsFactoryTest extends Specification {
         3 * boundedCallerStackCapturer.captureCallerStack() >> null
     }
 
+    def "unlimited stream caps full captures and uses bounded captures past the cap"() {
+        given:
+        def boundedThrowable = new Exception()
+        def stream = factory.newUnlimitedStream()
+
+        when:
+        def diagnostics = (1..5).collect { stream.forCurrentCaller() }
+
+        then:
+        !diagnostics[0].stack.empty
+        !diagnostics[1].stack.empty
+        3 * boundedCallerStackCapturer.captureCallerStack() >> boundedThrowable
+    }
+
     def "each stream has an independent stack trace limit"() {
         def stream1 = factory.newStream()
         def stream2 = factory.newStream()


### PR DESCRIPTION
### Why
Follow-up to #38127, implementing the bounded-capture variant proposed in #32362. `--warning-mode=all` and `fail` captured a full stack trace for every problem so each gets a source location. On a very large build, particularly an IDE sync that re-fires the same deprecations tens of thousands of times, that does not scale.

### What changes
`all` and `fail` now keep the full-stack cap (50, or 5000 under Isolated Projects) and give every problem past it a cheap bounded location with no upper limit, rather than a full stack for all. Every problem still resolves to a location; only the first 50 carry a complete trace. The capped modes (`summary`, `none`) are unchanged, and there is no public API change.

### Implementation
The capture policy and its per-stream budgets, previously inlined in the diagnostics factory, move into a per-stream `StackTraceCapturer`; `all` and `fail` differ from the default stream only by lifting the bounded budget. The capturer offers a caller-derived capture and a supplied-throwable capture as distinct operations, so the bounded fallback can never substitute for a supplied throwable.

### Performance
Bounded and negligible. Lifting only the bounded budget, not the full-stack cap, means each problem past the cap pays the cheap bounded walk from #38127 instead of a full stack, so cost stays flat as build size grows. Covered by the existing `--warning-mode=all` scenario in `DeprecationCreationPerformanceTest`.

Before that, using `--warning-mode=all` on a build with a large number of projects emitting problems was very costly, crawling to a halt in extreme cases.

### Documentation
The #38127 release note already presents `--warning-mode=all` as giving every problem a location through the cheaper capture; this adds one sentence clarifying that past the cap the trace is reduced to the originating build logic and calling script, not the full call chain.

### How to review
Best read commit by commit: the behavior-preserving capturer extraction, the budget change that makes `all` and `fail` use bounded captures past the cap, the release-note clarification, and the split into caller and supplied captures. `ProblemLocationPastCapIntegrationTest` (over `summary` and `all`) and the `all`/`fail` case in `DeprecatedUsageBuildOperationProgressIntegrationTest` pin the bounded path end to end.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
