### PR TITLE
Preserve laziness of `ProcessForkOptions.executable(Object)`

### DIFF
--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -42,7 +42,6 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class DefaultProcessForkOptions implements ProcessForkOptions {
     // TODO(mlopatkin) this provider is a good candidate for CC deduplication
@@ -120,7 +119,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
         if (executable instanceof Provider) {
             getExecutable().set(((Provider<?>) executable).map(Object::toString));
         } else {
-            getExecutable().set(Objects.toString(executable));
+            getExecutable().set(Providers.changing(executable::toString));
         }
         return this;
     }

--- a/platforms/core-runtime/process-services/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/platforms/core-runtime/process-services/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -297,6 +297,31 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.allJvmArgs.get() == ['-Xbootclasspath:' + files.join(System.properties['path.separator']), fileEncodingProperty(), *localeProperties()]
     }
 
+    def "executable(Object) evaluates the object's string representation lazily"() {
+        given:
+        def evaluated = false
+        def lazyExecutable = new Object() {
+            @Override
+            String toString() {
+                evaluated = true
+                return "executable"
+            }
+        }
+
+        when:
+        options.executable(lazyExecutable)
+
+        then:
+        !evaluated
+
+        when:
+        def result = options.executable.get()
+
+        then:
+        evaluated
+        result == 'executable'
+    }
+
     def "can copy to target options"() {
         JavaForkOptions target = TestUtil.newInstance(DefaultJavaForkOptions, objectFactory, resolver, fileCollectionFactory)
 


### PR DESCRIPTION
If a non-provider lazy object is used as `executable` (possibly an object wrapping a provider), we would eagerly evaluate its `toString()` representation. This change makes it as lazy as when a proper `Provider` is used. 


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
