### PR TITLE
Fix corrupt test tree for class-level descriptions in JUnit 4

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -527,9 +527,48 @@ public class JUnitTestEventAdapter extends RunListener {
     private void addDescriptorAndChildren(Description parent, TestNode parentNode) {
         descriptionsToDescriptors.put(parent, parentNode);
         for (Description child : parent.getChildren()) {
-            TestNode node = createNode(parentNode, child, RegistrationMode.DETECTED);
+            // A JUnit 4 Description is mutable — children may be added after creation. Some
+            // runners (notably Specs2's JUnitRunner) report a spec-class description whose
+            // children are populated lazily as the runner discovers examples, so at this
+            // tree-walk time isSuite() can return false even though the description WILL
+            // acquire children before the test run finishes. Registering such a description
+            // as a non-composite leaf via the DETECTED branch corrupts the tree: a later
+            // synthetic child (e.g. a BeforeAfterAll/@BeforeClass failure) ends up under a
+            // leaf parent, and the unguarded cast in TestEventReporterAsListener.started
+            // throws ClassCastException. Pre-promote class-level descriptions to SUITE so
+            // they register as composite from the start. This restriction is scoped to the
+            // testRunStarted tree walk; processIgnoredClass and testIgnored continue to
+            // use RegistrationMode.DETECTED.
+            RegistrationMode mode = isClassLevelDescription(child)
+                ? RegistrationMode.SUITE
+                : RegistrationMode.DETECTED;
+            TestNode node = createNode(parentNode, child, mode);
             addDescriptorAndChildren(child, node);
         }
+    }
+
+    /**
+     * Tests whether the given JUnit 4 description names a test class rather than a single test method.
+     *
+     * <p>Class-level descriptions are recognised in two ways: by their backing {@link Class} (JUnit
+     * 4.6+ exposes {@code Description.getTestClass()}), or — for JUnit ≤ 4.5 and custom-runner-produced
+     * synthetic suites — by checking that the stringified form equals the parsed class name. The
+     * fallback also accepts pure string suite descriptions ({@code Description.createSuiteDescription(String)});
+     * the consequence is benign because the composite branch in {@link #createNode} already routes
+     * descriptions without a backing class to {@link DefaultTestSuiteDescriptor} rather than
+     * {@link DefaultTestClassDescriptor}.
+     *
+     * @param description the JUnit description to classify
+     * @return {@code true} if the description names a class (or class-like suite), {@code false} for method-level descriptions
+     */
+    static boolean isClassLevelDescription(Description description) {
+        if (methodName(description) != null) {
+            return false;
+        }
+        if (supportsTestClassMethod() && getTestClassIfPossible(description) != null) {
+            return true;
+        }
+        return description.toString().equals(className(description));
     }
 
     @Nullable

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -539,9 +539,7 @@ public class JUnitTestEventAdapter extends RunListener {
             // they register as composite from the start. This restriction is scoped to the
             // testRunStarted tree walk; processIgnoredClass and testIgnored continue to
             // use RegistrationMode.DETECTED.
-            RegistrationMode mode = isClassLevelDescription(child)
-                ? RegistrationMode.SUITE
-                : RegistrationMode.DETECTED;
+            RegistrationMode mode = isClassLevelDescription(child) ? RegistrationMode.SUITE : RegistrationMode.DETECTED;
             TestNode node = createNode(parentNode, child, mode);
             addDescriptorAndChildren(child, node);
         }
@@ -549,8 +547,8 @@ public class JUnitTestEventAdapter extends RunListener {
 
     /**
      * Tests whether the given JUnit 4 description names a test class rather than a single test method.
-     *
-     * <p>Class-level descriptions are recognised in two ways: by their backing {@link Class} (JUnit
+     * <p>
+     * Class-level descriptions are recognized in two ways: by their backing {@link Class} (JUnit
      * 4.6+ exposes {@code Description.getTestClass()}), or — for JUnit ≤ 4.5 and custom-runner-produced
      * synthetic suites — by checking that the stringified form equals the parsed class name. The
      * fallback also accepts pure string suite descriptions ({@code Description.createSuiteDescription(String)});

--- a/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapterTest.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapterTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit
 
+import org.junit.runner.Description
 import spock.lang.Specification
 
 class JUnitTestEventAdapterTest extends Specification {
@@ -29,5 +30,17 @@ class JUnitTestEventAdapterTest extends Specification {
         'ok(org.gradle.Test)'       | 'org.gradle.Test'           | 'ok'
         'ok(org.gradle.Test)[0]'    | 'org.gradle.Test'           | 'ok'
         'this is not a description' | 'this is not a description' | null
+    }
+
+    def 'recognises class-level descriptions in #scenario'() {
+        expect:
+        JUnitTestEventAdapter.isClassLevelDescription(description) == expected
+
+        where:
+        scenario                                      | description                                                              | expected
+        'class-level with backing class (JUnit 4.6+)' | Description.createSuiteDescription(JUnitTestEventAdapterTest)            | true
+        'method-level with backing class'             | Description.createTestDescription(JUnitTestEventAdapterTest, 'method')   | false
+        'class-level fallback (no backing class)'     | Description.createSuiteDescription('com.example.LegacyRunnerSpec')       | true
+        'method-level fallback (no backing class)'    | Description.createTestDescription('com.example.LegacyRunnerSpec', 'm')   | false
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
@@ -140,5 +140,13 @@ abstract class AbstractSpecs2IntegrationTest extends AbstractTestingMultiVersion
         !errorOutput.contains("No reporter found for test descriptor")
         !errorOutput.contains("GroupTestEventReporterInternal")
         !errorOutput.contains("Test process encountered an unexpected problem")
+
+        and: "the post-fix tree shape matches the Gradle 9.2.1 expected output — single hierarchy, no duplicated synthetic suite"
+        // The count is the load-bearing pin: a duplicated tree (e.g., the registered
+        // class node plus a synthetic suite for the same class) would shift the
+        // total to 5+. The variant-specific test-line shape (JUnit 4 reports the
+        // synthetic test as "classMethod"; JUnit Vintage reports it under the
+        // fully-qualified class name) is not pinned here.
+        errorOutput.contains("4 tests completed, 2 failed, 2 skipped")
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 import org.gradle.testing.fixture.AbstractTestingMultiVersionIntegrationTest
+import spock.lang.Issue
 
 abstract class AbstractSpecs2IntegrationTest extends AbstractTestingMultiVersionIntegrationTest {
 
@@ -61,5 +62,83 @@ abstract class AbstractSpecs2IntegrationTest extends AbstractTestingMultiVersion
         def results = resultsFor(testDirectory)
         results.testPath("BasicSpec").onlyRoot().assertChildCount(1, 0)
         results.testPath("BasicSpec", "Basic Math").onlyRoot().assertHasResult(TestResult.ResultType.SUCCESS)
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38193")
+    def 'a Specs2 spec whose beforeAll() throws reports a test failure rather than an internal reporter error'() {
+        given:
+        buildFile << """
+            plugins {
+                id("scala")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                testImplementation 'org.scala-lang:scala-library:2.13.14'
+                testImplementation 'org.specs2:specs2-core_2.13:4.20.9'
+                testImplementation 'org.specs2:specs2-junit_2.13:4.20.9'
+                testImplementation 'junit:junit:4.13.2'
+                ${testFrameworkDependencies}
+            }
+
+            tasks.named('test', Test) {
+                ${configureTestFramework}
+            }
+        """
+        file('src/test/scala/com/example/FailureCaseSpec.scala') << '''
+            package com.example
+
+            import org.junit.runner.RunWith
+            import org.specs2.mutable.Specification
+            import org.specs2.runner.JUnitRunner
+            import org.specs2.specification.BeforeAfterAll
+
+            @RunWith(classOf[JUnitRunner])
+            class FailureCaseSpec extends Specification with BeforeAfterAll {
+              def beforeAll(): Unit = {
+                sys.error("class-level setup failure (BeforeAfterAll)")
+              }
+              def afterAll(): Unit = ()
+
+              "ZipDownloadSpec" should {
+                "/zip_get_progress should" should {
+                  "report progress for a valid request" in {
+                    ok
+                  }
+                  "fail when the assertion does not hold" in {
+                    1 must_=== 2
+                  }
+                }
+              }
+            }
+        '''
+        file('src/test/scala/com/example/SuccessfulCaseSpec.scala') << '''
+            package com.example
+
+            import org.junit.runner.RunWith
+            import org.specs2.mutable.Specification
+            import org.specs2.runner.JUnitRunner
+
+            @RunWith(classOf[JUnitRunner])
+            class SuccessfulCaseSpec extends Specification {
+
+              "flat unit spec" should {
+                "fail with a normal assertion error" in {
+                  1 must_=== 2
+                }
+              }
+            }
+        '''
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        fails('test')
+
+        then: "the build fails as a normal test failure, not as an internal test-reporter ClassCastException"
+        errorOutput.contains("There were failing tests")
+        !errorOutput.contains("No reporter found for test descriptor")
+        !errorOutput.contains("GroupTestEventReporterInternal")
+        !errorOutput.contains("Test process encountered an unexpected problem")
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractSpecs2IntegrationTest.groovy
@@ -142,11 +142,21 @@ abstract class AbstractSpecs2IntegrationTest extends AbstractTestingMultiVersion
         !errorOutput.contains("Test process encountered an unexpected problem")
 
         and: "the post-fix tree shape matches the Gradle 9.2.1 expected output — single hierarchy, no duplicated synthetic suite"
-        // The count is the load-bearing pin: a duplicated tree (e.g., the registered
-        // class node plus a synthetic suite for the same class) would shift the
-        // total to 5+. The variant-specific test-line shape (JUnit 4 reports the
-        // synthetic test as "classMethod"; JUnit Vintage reports it under the
-        // fully-qualified class name) is not pinned here.
+        // The count is one pin: a duplicated tree (e.g., the registered class node
+        // plus a synthetic suite for the same class) would shift the total to 5+.
+        // The variant-specific test-line shape (JUnit 4 reports the synthetic test
+        // as "classMethod"; JUnit Vintage reports it under the fully-qualified
+        // class name) is not pinned here.
         errorOutput.contains("4 tests completed, 2 failed, 2 skipped")
+
+        and: "the HTML report records exactly one failed direct child under FailureCaseSpec — catches silent suppression of the classMethod (or vintage-equivalent) event that the count pin alone would miss"
+        // Uses VerifiesGenericTestReportResults (mixed in via AbstractTestingMultiVersionIntegrationTest).
+        // The count getter is variant-independent — the child's name differs between
+        // JUnit 4 ("classMethod") and JUnit Vintage (the fully-qualified class name),
+        // but in both cases FailureCaseSpec has exactly one failed direct child.
+        // The path is the fully-qualified class name because the spec lives in
+        // package com.example.
+        def reportResults = resultsFor(testDirectory)
+        reportResults.testPath("com.example.FailureCaseSpec").onlyRoot().getFailedChildCount() == 1
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListener.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListener.java
@@ -54,8 +54,12 @@ public final class TestEventReporterAsListener implements TestListenerInternal, 
     public void started(TestDescriptorInternal testDescriptor, TestStartEvent startEvent) {
         TestEventReporter reporter;
         if (testDescriptor.getParent() != null) {
-            GroupTestEventReporterInternal parentReporter =
-                (GroupTestEventReporterInternal) reportersById.get(testDescriptor.getParent().getId());
+            GroupTestEventReporterInternal parentReporter;
+            try {
+                parentReporter = (GroupTestEventReporterInternal) reportersById.get(testDescriptor.getParent().getId());
+            } catch (ClassCastException e) {
+                throw new IllegalStateException("An internal test structure error occurred. Please file a new issue on https://github.com/gradle/gradle/issues, and if possible include the test class causing this failure.", e);
+            }
 
             if (testDescriptor.isComposite()) {
                 reporter = parentReporter.reportTestGroupDirectly(testDescriptor);

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
@@ -27,19 +27,14 @@ import java.util.function.Function
 
 @Issue("https://github.com/gradle/gradle/issues/38193")
 class TestEventReporterAsListenerTest extends Specification {
-
     /*
-     * Negative regression test: pins the consumer-side invariant that the producer-side
-     * fix in JUnitTestEventAdapter.addDescriptorAndChildren now relies on.
-     *
-     * The cast at TestEventReporterAsListener.java:57-58 is intentionally unguarded.
-     * The producer side guarantees that any descriptor which will acquire children
+     * Negative regression test: pins the consumer-side invariant that any descriptor which will acquire children
      * is registered as composite from the start, so the parent-slot reporter is always
      * a GroupTestEventReporterInternal. If that producer-side invariant is ever broken
      * (a future change emits a non-composite parent slot) the cast will throw
      * ClassCastException — and this test goes red as the canary.
      */
-    def "throws ClassCastException when fed a non-composite parent — pins the consumer-side invariant the producer-side fix relies on"() {
+    def "throws ClassCastException when fed a non-composite parent"() {
         given:
         def rootGroupReporter = Mock(GroupTestEventReporterInternal)
         def specClassReporter = Mock(TestEventReporter)

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
@@ -32,9 +32,9 @@ class TestEventReporterAsListenerTest extends Specification {
      * is registered as composite from the start, so the parent-slot reporter is always
      * a GroupTestEventReporterInternal. If that producer-side invariant is ever broken
      * (a future change emits a non-composite parent slot) the cast will throw
-     * ClassCastException — and this test goes red as the canary.
+     * IllegalStateException — and this test goes red as the canary.
      */
-    def "throws ClassCastException when fed a non-composite parent"() {
+    def "throws IllegalStateException when fed a non-composite parent"() {
         given:
         def rootGroupReporter = Mock(GroupTestEventReporterInternal)
         def specClassReporter = Mock(TestEventReporter)
@@ -67,8 +67,11 @@ class TestEventReporterAsListenerTest extends Specification {
         when: "a synthetic child descriptor is started under the (now-leaf) spec-class"
         listener.started(classMethod, new TestStartEvent(0L))
 
-        then: "the unguarded cast throws ClassCastException naming GroupTestEventReporterInternal"
-        def e = thrown(ClassCastException)
-        e.message.contains("GroupTestEventReporterInternal")
+        then: "the guarded cast throws IllegalStateException with a ClassCastException cause naming GroupTestEventReporterInternal"
+        def e = thrown(IllegalStateException)
+        e.message == "An internal test structure error occurred. Please file a new issue on https://github.com/gradle/gradle/issues, and if possible include the test class causing this failure."
+        def cause = e.cause
+        cause instanceof ClassCastException
+        cause.message.contains("GroupTestEventReporterInternal")
     }
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
@@ -28,7 +28,18 @@ import java.util.function.Function
 @Issue("https://github.com/gradle/gradle/issues/38193")
 class TestEventReporterAsListenerTest extends Specification {
 
-    def "does not throw ClassCastException when a child descriptor's parent was reported as a non-composite leaf"() {
+    /*
+     * Negative regression test: pins the consumer-side invariant that the producer-side
+     * fix in JUnitTestEventAdapter.addDescriptorAndChildren now relies on.
+     *
+     * The cast at TestEventReporterAsListener.java:57-58 is intentionally unguarded.
+     * The producer side guarantees that any descriptor which will acquire children
+     * is registered as composite from the start, so the parent-slot reporter is always
+     * a GroupTestEventReporterInternal. If that producer-side invariant is ever broken
+     * (a future change emits a non-composite parent slot) the cast will throw
+     * ClassCastException — and this test goes red as the canary.
+     */
+    def "throws ClassCastException when fed a non-composite parent — pins the consumer-side invariant the producer-side fix relies on"() {
         given:
         def rootGroupReporter = Mock(GroupTestEventReporterInternal)
         def specClassReporter = Mock(TestEventReporter)
@@ -54,14 +65,15 @@ class TestEventReporterAsListenerTest extends Specification {
         and: "the spec-class descriptor is reported as a non-composite leaf under the root group"
         rootGroupReporter.reportTestDirectly(specClass) >> specClassReporter
 
-        when: "the root and the spec-class start normally"
+        and: "the root and the spec-class start normally"
         listener.started(root, new TestStartEvent(0L))
         listener.started(specClass, new TestStartEvent(0L))
 
-        and: "a synthetic child descriptor is started under the (now-leaf) spec-class — mirrors Specs2 BeforeAfterAll's classMethod failure"
+        when: "a synthetic child descriptor is started under the (now-leaf) spec-class"
         listener.started(classMethod, new TestStartEvent(0L))
 
-        then: "the listener tolerates a non-group parent reporter rather than blowing up with ClassCastException"
-        noExceptionThrown()
+        then: "the unguarded cast throws ClassCastException naming GroupTestEventReporterInternal"
+        def e = thrown(ClassCastException)
+        e.message.contains("GroupTestEventReporterInternal")
     }
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestEventReporterAsListenerTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit.result
+
+import org.gradle.api.internal.tasks.testing.GroupTestEventReporterInternal
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+import org.gradle.api.internal.tasks.testing.TestStartEvent
+import org.gradle.api.tasks.testing.TestEventReporter
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.function.Function
+
+@Issue("https://github.com/gradle/gradle/issues/38193")
+class TestEventReporterAsListenerTest extends Specification {
+
+    def "does not throw ClassCastException when a child descriptor's parent was reported as a non-composite leaf"() {
+        given:
+        def rootGroupReporter = Mock(GroupTestEventReporterInternal)
+        def specClassReporter = Mock(TestEventReporter)
+        Function<TestDescriptorInternal, GroupTestEventReporterInternal> rootCreator = { desc -> rootGroupReporter }
+        def listener = new TestEventReporterAsListener(rootCreator)
+
+        def root = Mock(TestDescriptorInternal) {
+            getId() >> "root"
+            getParent() >> null
+            isComposite() >> true
+        }
+        def specClass = Mock(TestDescriptorInternal) {
+            getId() >> "specClass"
+            getParent() >> root
+            isComposite() >> false
+        }
+        def classMethod = Mock(TestDescriptorInternal) {
+            getId() >> "classMethod"
+            getParent() >> specClass
+            isComposite() >> false
+        }
+
+        and: "the spec-class descriptor is reported as a non-composite leaf under the root group"
+        rootGroupReporter.reportTestDirectly(specClass) >> specClassReporter
+
+        when: "the root and the spec-class start normally"
+        listener.started(root, new TestStartEvent(0L))
+        listener.started(specClass, new TestStartEvent(0L))
+
+        and: "a synthetic child descriptor is started under the (now-leaf) spec-class — mirrors Specs2 BeforeAfterAll's classMethod failure"
+        listener.started(classMethod, new TestStartEvent(0L))
+
+        then: "the listener tolerates a non-group parent reporter rather than blowing up with ClassCastException"
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
## The Problem

`JUnitTestEventAdapter`'s tree-walk during `testRunStarted` could
register a class-level `Description` as a non-composite leaf when
its `isSuite()` returned false because the runner hadn't yet
populated children. The user-reported case is Specs2's JUnitRunner
reporting a spec class whose nested `should` blocks become
children only after the runner's discovery phase. A subsequent
synthetic `classMethod` failure (e.g., from `BeforeAfterAll`'s
`beforeAll()` throwing) attached to that leaf parent caused
`TestEventReporterAsListener`'s unconditional cast at lines 57-58
to throw `ClassCastException`, surfacing as "Test process
encountered an unexpected problem" along with the stack trace
in the user's bug report.

## The Fix

Detect class-level `Description`s in `addDescriptorAndChildren`
via the new `isClassLevelDescription` helper:

```
(methodName == null && (testClass != null || description.toString() == className(description)))
```

and route them to `RegistrationMode.SUITE`
rather than `DETECTED`. Class nodes now register as
`DefaultTestClassDescriptor` (composite) from the start; every
downstream consumer of the event tree sees a consistent shape.

## Limitations and Compatibility with Older JUnit Versions

The fix is scoped to `addDescriptorAndChildren` only.
`createNode`'s existing predicate, `processIgnoredClass`'s child
loop, and `testIgnored` continue to use `RegistrationMode.DETECTED`
unchanged, so JUnit 4 `@Ignore` and `Enclosed` runner behavior is
not affected.

The predicate's fallback branch
`(description.toString() == className)` covers JUnit <= 4.5 and
custom-runner-produced synthetic suites
`(Description.createSuiteDescription(String))`. Routing those to
the composite branch is benign because `createNode` already
sends null-testClass cases to `DefaultTestSuiteDescriptor` rather
than `DefaultTestClassDescriptor`.

Fixes:
- https://github.com/gradle/gradle/issues/38193