### PR TITLE
Update Documentation: update Build Services page for IP

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -14,11 +14,29 @@
 
 [[service_injection]]
 = Services and Service Injection
-:keywords: services, service, injection, inject, objectfactory, providerfactory, workerexecutor, archiveoperations, execoperations, toolingmodelbuilderregistry, testeventreporterfactory
+:keywords: services, service, injection, inject
 
-Gradle provides a number of useful services that can be used by custom Gradle types.
-For example, the link:{javadocPath}/org/gradle/workers/WorkerExecutor.html[WorkerExecutor] service can be used by a task to run work in parallel, as seen in the <<worker_api.adoc#worker_api,worker API>> section.
-The services are made available through _service injection_.
+Gradle exposes a set of _services_, covering things like file and archive operations, process execution, dependency creation, worker scheduling, problem reporting, build-feature flags, and dataflow scheduling.
+
+A *service* is a collaborator object whose lifecycle Gradle manages; a single instance is shared across the build and supplied to your code on demand.
+These services aren't meant to be constructed directly, since they rely on internal Gradle state.
+
+To use a *service*, your custom type declares a dependency on it and Gradle supplies the instance.
+This pattern is called _service injection_, and it works uniformly across every type Gradle instantiates for you, including tasks, plugins, extensions, value sources, build services, and worker actions.
+
+The most common form is constructor injection on an abstract type.
+The same `CleanTempTask` is shown below as a Kotlin DSL class, a Groovy DSL class, and a stand-alone Java class that you would typically place in `buildSrc` or a binary plugin:
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=clean-temp-inject]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=clean-temp-inject]"]
+include::sample[dir="snippets/reference/gradle-types/services/kotlin/buildSrc/src/main/java/org/example",files="CleanTempTask.java[tags=clean-temp-inject]"]
+====
+
+A task that needs to run work in parallel injects the link:{javadocPath}/org/gradle/workers/WorkerExecutor.html[`WorkerExecutor`] service in the same way, as shown in the <<worker_api.adoc#worker_api,worker API>> section.
+
+Reaching for service injection rather than `project.copy(...)`, `project.exec(...)`, or other ad-hoc `Project` accessors helps keep your code compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, and makes your types easier to unit-test by passing stub services.
+See <<#service_injection_patterns,Service injection patterns>> for the full set of `@Inject` forms used in the rest of this page.
 
 [[services_for_injection]]
 == Available services
@@ -28,35 +46,100 @@ Only inject the services explicitly listed below to ensure stability and compati
 
 The following services are available for injection in all Gradle instantiated objects:
 
-1. <<objectfactory,`ObjectFactory`>> - Allows model objects to be created.
-2. <<providerfactory,`ProviderFactory`>> - Creates `Provider` instances.
-3. <<filesystemoperations,`FileSystemOperations`>> - Allows a task to run operations on the filesystem such as deleting files, copying files or syncing directories.
-4. <<archiveoperations,`ArchiveOperations`>> - Allows a task to run operations on archive files such as ZIP or TAR files.
-5. <<execoperations,`ExecOperations`>> - Allows a task to run external processes with dedicated support for running external `java` programs.
+[%header,cols="1,4"]
+|===
+| Service | Description
+
+| <<objectfactory,`ObjectFactory`>>
+| Creates model objects, properties, collections, and file-related objects. Use it when defining custom Gradle types or nested DSL objects in a plugin or extension.
+
+| <<providerfactory,`ProviderFactory`>>
+| Creates `Provider` instances and exposes environment, system-property, and Gradle-property values. Use it to read environment variables, system properties, or to wrap a computed value as a lazy `Provider`.
+
+| <<filesystemoperations,`FileSystemOperations`>>
+| Runs filesystem operations such as deleting, copying, or syncing files and directories. Use it from a task or worker action that needs to delete, copy, or sync files.
+
+| <<archiveoperations,`ArchiveOperations`>>
+| Runs operations on archive files such as ZIP or TAR. Use it to read or extract the contents of an archive.
+
+| <<execoperations,`ExecOperations`>>
+| Runs external processes, with dedicated support for running external `java` programs. Use it to run an external program or `java` process from a task or worker action.
+
+| <<problems,`Problems`>> incubating-label:[]
+| Reports structured problems that surface in the console, the HTML problems report, and the Tooling API. Use it to surface errors or warnings consistently to the IDE, the problems report, and Build Scan.
+|===
 
 === Additional services in workers
 
 The following services are available for injection in worker API actions and parameters:
 
-1. <<workerexecutor,`WorkerExecutor`>> - Allows a task to run work in parallel.
+[%header,cols="1,4"]
+|===
+| Service | Description
+
+| <<workerexecutor,`WorkerExecutor`>>
+| Schedules work to run in parallel via the Worker API. Use it from a task that needs to run CPU-bound work in parallel or in an isolated classloader.
+|===
+
+=== Additional services in projects and settings
+
+The following services are available for injection in both project and settings plugins, extensions and objects:
+
+[%header,cols="1,4"]
+|===
+| Service | Description
+
+| <<toolingmodelbuilderregistry,`ToolingModelBuilderRegistry`>>
+| Registers a Gradle Tooling API model builder. Use it to expose a custom model to the Tooling API so IDEs and other tools can consume it.
+
+| <<dependencyfactory,`DependencyFactory`>>
+| Creates `Dependency` instances in a type-safe way. Use it to programmatically construct `Dependency` instances in a plugin without a `Project` reference.
+
+| <<dependencyconstraintfactory,`DependencyConstraintFactory`>> incubating-label:[]
+| Creates `DependencyConstraint` instances in a type-safe way. Use it to programmatically construct dependency constraints in a plugin without a `Project` reference.
+
+| <<buildfeatures,`BuildFeatures`>>
+| Reports whether features such as Configuration Cache and Isolated Projects are requested and active. Use it to branch plugin logic on whether the Configuration Cache or Isolated Projects is active.
+
+| <<flow_services,`FlowScope` and `FlowProviders`>> incubating-label:[]
+| Register dataflow actions that run on build lifecycle events such as build completion. Use them to run cleanup, notification, or reporting work at the end of every build.
+
+| <<buildinvocationdetails,`BuildInvocationDetails`>> incubating-label:[]
+| Exposes information about the current build invocation, such as its wall-clock start time. Use it to read the build's start time for timing or reporting.
+|===
 
 === Additional services in projects
 
 The following services are available for injection in project plugins, extensions and objects created in a project:
 
-1. <<sec:projectlayout,`ProjectLayout`>> - Provides access to key project locations.
-2. <<workerexecutor,`WorkerExecutor`>> - Allows a task to run work in parallel.
-3. <<toolingmodelbuilderregistry,`ToolingModelBuilderRegistry`>> - Allows a plugin to registers a Gradle tooling API model.
-4. <<testeventreporterfactory,`TestEventReporterFactory`>> - Allows a plugin to access Gradle's test events and its corresponding API.
-5. <<dependencyfactory,`DependencyFactory`>> - Allows a plugin to create dependencies in a type-safe way.
+[%header,cols="1,4"]
+|===
+| Service | Description
+
+| <<sec:projectlayout,`ProjectLayout`>>
+| Provides access to key project locations such as the project directory and build directory. Use it to resolve paths relative to the project directory or build directory.
+
+| <<workerexecutor,`WorkerExecutor`>>
+| Schedules work to run in parallel via the Worker API. Use it from a task that needs to run CPU-bound work in parallel or in an isolated classloader.
+
+| <<testeventreporterfactory,`TestEventReporterFactory`>> incubating-label:[]
+| Provides access to Gradle's test event reporting API. Use it to emit test events from a custom task that runs tests itself.
+
+| <<softwarecomponentfactory,`SoftwareComponentFactory`>>
+| Creates adhoc software components for publishing. Use it to define a custom publishable software component without a full component model.
+|===
 
 === Additional services in settings
 
-The following services are available for injection in settings plugins, extensions and objects created in a project:
+The following services are available for injection in settings plugins, extensions and objects created in a settings script:
 
-1. <<buildlayout,`BuildLayout`>> - Provides access to important locations for a Gradle build.
-2. <<toolingmodelbuilderregistry,`ToolingModelBuilderRegistry`>> - Allows a plugin to registers a Gradle tooling API model.
-3. <<dependencyfactory,`DependencyFactory`>> - Allows a plugin to create dependencies in a type-safe way.
+[%header,cols="1,4"]
+|===
+| Service | Description
+
+| <<buildlayout,`BuildLayout`>>
+| Provides access to important locations for a Gradle build, such as the root directory and settings file. Use it from a settings plugin to resolve paths relative to the root settings directory.
+|===
 
 [[objectfactory]]
 == `ObjectFactory`
@@ -295,9 +378,7 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 You can learn more at <<tooling_api.adoc#tooling_api,Tooling API>>.
 
 [[testeventreporterfactory]]
-== `TestEventReporterFactory`
-
-WARNING: This API is incubating.
+== `TestEventReporterFactory` incubating-label:[]
 
 link:{javadocPath}/org/gradle/api/tasks/testing/TestEventReporterFactory.html[`TestEventReporterFactory`] is a service that provides access to the test event reporting API.
 
@@ -309,6 +390,102 @@ You can learn more at <<test_reporting_api.adoc#test_reporting_api,Test Reportin
 link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyFactory.html[`DependencyFactory`] is a service that provides methods for creating dependencies in a type-safe way.
 
 You can learn more in the <<implementing_gradle_plugins_binary.adoc#sec:differences_with_top_level_dependencies_plugins,Implementing Binary Plugins guide>>.
+
+[[dependencyconstraintfactory]]
+== `DependencyConstraintFactory` incubating-label:[]
+
+link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyConstraintFactory.html[`DependencyConstraintFactory`] is a service that provides methods for creating link:{javadocPath}/org/gradle/api/artifacts/DependencyConstraint.html[`DependencyConstraint`] instances in a type-safe way.
+It is the constraint-creation counterpart to <<dependencyfactory,`DependencyFactory`>> and is typically used by plugins that publish or consume dependency constraints.
+
+The service is only available via `@Inject`, there is no project-level accessor.
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=dependency-constraint-factory-inject]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=dependency-constraint-factory-inject]"]
+====
+
+The `CreateConstraintTask` task receives a `DependencyConstraintFactory` instance through its constructor using the `@Inject` annotation.
+
+[[problems]]
+== `Problems` incubating-label:[]
+
+link:{javadocPath}/org/gradle/api/problems/Problems.html[`Problems`] is a service that allows tasks and plugins to report structured problems.
+Reported problems surface in the console, the HTML <<reporting_problems.adoc#sec:generated_html_report,problems report>>, and through the <<tooling_api.adoc#tooling_api,Tooling API>>, so IDEs and Build Scan can render them consistently.
+
+Obtain a link:{javadocPath}/org/gradle/api/problems/ProblemReporter.html[`ProblemReporter`] from the injected `Problems` service via `problems.getReporter()` and call `report()` (recoverable) or `throwing()` (fatal).
+
+====
+include::sample[dir="snippets/reference/plugin-development/reportingProblems/kotlin",files="plugin/src/main/kotlin/org/example/HelloProblemsPlugin.kt[tags=problems-service]"]
+include::sample[dir="snippets/reference/plugin-development/reportingProblems/groovy",files="plugin/src/main/groovy/org/example/HelloProblemsPlugin.groovy[tags=problems-service]"]
+====
+
+You can learn more in the <<reporting_problems.adoc#sec:reporting_problems,Reporting Plugin Problems with the Problems API>> guide.
+
+[[buildfeatures]]
+== `BuildFeatures`
+
+link:{javadocPath}/org/gradle/api/configuration/BuildFeatures.html[`BuildFeatures`] is a service that exposes the requested and active state of major Gradle features currently the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, so plugins can adapt their behavior accordingly.
+
+A plugin can, for example, gate optional logic that is incompatible with Isolated Projects on the active state of that feature:
+
+[source,java]
+.MyPlugin.java
+----
+include::{snippetsPath}/reference/plugin-development/reactingToBuildFeatures/groovy/buildSrc/src/main/java/MyPlugin.java[tags=my-plugin]
+----
+<1> The `BuildFeatures` service can be injected into plugins, tasks, and other managed types.
+<2> Use `getRequested()` to read the user's opt-in or opt-out, returning a `Provider<Boolean>` that may be empty when the user expressed no preference.
+<3> Use `getActive()` to read whether the feature is actually active in the current build, returning a non-empty `Provider<Boolean>`.
+
+You can learn more in the <<implementing_gradle_plugins_binary.adoc#sec:reacting_to_build_features,Implementing Binary Plugins guide>>.
+
+[[flow_services]]
+== `FlowScope` and `FlowProviders` incubating-label:[]
+
+link:{javadocPath}/org/gradle/api/flow/FlowScope.html[`FlowScope`] and link:{javadocPath}/org/gradle/api/flow/FlowProviders.html[`FlowProviders`] are services that together let a plugin register <<dataflow_actions.adoc#dataflow_action,dataflow actions>> (isolated pieces of work that run when their input providers become available, such as at the end of a build).
+
+`FlowScope` registers the actions; `FlowProviders` exposes build lifecycle events (such as the build work result) as `Provider` values that can be wired into action parameters. Both services are typically injected together into a project or settings plugin:
+
+[source,java]
+.SoundFeedbackPlugin.java
+----
+include::{snippetsPath}/reference/gradle-types/playSound/groovy/plugin/src/main/java/org/gradle/sample/sound/SoundFeedbackPlugin.java[tag=flow-action]
+----
+<1> Use service injection to obtain `FlowScope` and `FlowProviders` instances.
+<2> Register an action in the `always` scope so it runs at the end of every build.
+<3> Wire `FlowProviders.getBuildWorkResult()` into the action's parameters so the action receives the success-or-failure outcome.
+
+You can learn more in the <<dataflow_actions.adoc#dataflow_action,Dataflow Actions>> reference.
+
+[[buildinvocationdetails]]
+== `BuildInvocationDetails` incubating-label:[]
+
+link:{javadocPath}/org/gradle/api/invocation/BuildInvocationDetails.html[`BuildInvocationDetails`] is a service that exposes information about the current build invocation, most notably the wall-clock time at which the build was started.
+It is useful for plugins that report build duration, emit timing metrics, or display a banner with the build's start time.
+
+The service is only available via `@Inject`, there is no project-level accessor.
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=build-invocation-details-inject]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=build-invocation-details-inject]"]
+====
+
+The `ReportBuildStartTask` task receives a `BuildInvocationDetails` instance through its constructor using the `@Inject` annotation.
+
+[[softwarecomponentfactory]]
+== `SoftwareComponentFactory`
+
+link:{javadocPath}/org/gradle/api/component/SoftwareComponentFactory.html[`SoftwareComponentFactory`] is a service that lets a plugin create link:{javadocPath}/org/gradle/api/component/AdhocComponentWithVariants.html[`AdhocComponentWithVariants`] instances (adhoc software components built from outgoing variants) for publication via the <<publishing_setup.adoc#publishing_components,publishing plugins>>.
+It is typically used by plugins that produce custom component types and want to publish them without defining a full component model.
+
+The service is only available via `@Inject`, there is no project-level accessor.
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=software-component-factory-inject]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=software-component-factory-inject]"]
+====
+
+The `CustomComponentPlugin` plugin receives a `SoftwareComponentFactory` instance through its constructor using the `@Inject` annotation, creates an adhoc component, and adds it to the project's components container so it can be referenced by a publication.
 
 [[service_injection_patterns]]
 == Service injection patterns

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
@@ -1,3 +1,7 @@
+import org.gradle.api.artifacts.dsl.DependencyConstraintFactory
+import org.gradle.api.component.SoftwareComponentFactory
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.invocation.BuildInvocationDetails
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
@@ -292,3 +296,78 @@ class OrtModelPlugin implements Plugin<Project> {
     }
 }
 // end::tooling-model[]
+
+// tag::build-invocation-details-inject[]
+abstract class ReportBuildStartTask extends DefaultTask {
+    private BuildInvocationDetails invocationDetails
+
+    @Inject //@javax.inject.Inject
+    ReportBuildStartTask(BuildInvocationDetails invocationDetails) {
+        this.invocationDetails = invocationDetails
+    }
+
+    @TaskAction
+    void report() {
+        def started = new Date(invocationDetails.buildStartedTime)
+        println("Build started at $started")
+    }
+}
+
+tasks.register("reportBuildStart", ReportBuildStartTask) {}
+// end::build-invocation-details-inject[]
+
+// tag::dependency-constraint-factory-inject[]
+abstract class CreateConstraintTask extends DefaultTask {
+    private DependencyConstraintFactory factory
+
+    @Inject //@javax.inject.Inject
+    CreateConstraintTask(DependencyConstraintFactory factory) {
+        this.factory = factory
+    }
+
+    @TaskAction
+    void create() {
+        def constraint = factory.create("com.example:lib:1.2.3")
+        println("Created constraint: ${constraint.group}:${constraint.name}:${constraint.version}")
+    }
+}
+
+tasks.register("createConstraint", CreateConstraintTask) {}
+// end::dependency-constraint-factory-inject[]
+
+// tag::software-component-factory-inject[]
+// A plugin that uses SoftwareComponentFactory to create an adhoc software
+// component, suitable for publishing custom variants. The factory is only
+// available via @Inject — there is no project-level accessor.
+class CustomComponentPlugin implements Plugin<Project> {
+    private SoftwareComponentFactory componentFactory
+
+    @Inject //@javax.inject.Inject
+    CustomComponentPlugin(SoftwareComponentFactory componentFactory) {
+        this.componentFactory = componentFactory
+    }
+
+    void apply(Project project) {
+        def component = componentFactory.adhoc("custom")
+        project.components.add(component)
+    }
+}
+// end::software-component-factory-inject[]
+
+// tag::clean-temp-inject[]
+abstract class CleanTempTask extends DefaultTask {
+    private FileSystemOperations fs
+
+    @Inject //@javax.inject.Inject
+    CleanTempTask(FileSystemOperations fs) {
+        this.fs = fs
+    }
+
+    @TaskAction
+    void run() {
+        fs.delete { spec -> spec.delete("build/tmp") }
+    }
+}
+
+tasks.register("cleanTemp", CleanTempTask) {}
+// end::clean-temp-inject[]

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
@@ -1,6 +1,10 @@
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyConstraintFactory
+import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.invocation.BuildInvocationDetails
+import java.util.Date
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -247,3 +251,62 @@ class OrtModelPlugin(private val registry: ToolingModelBuilderRegistry) : Plugin
     }
 }
 // end::tooling-model[]
+
+// tag::build-invocation-details-inject[]
+abstract class ReportBuildStartTask
+@Inject constructor(private var invocationDetails: BuildInvocationDetails) : DefaultTask() {
+
+    @TaskAction
+    fun report() {
+        val started = Date(invocationDetails.buildStartedTime)
+        println("Build started at $started")
+    }
+}
+
+tasks.register("reportBuildStart", ReportBuildStartTask::class) {}
+// end::build-invocation-details-inject[]
+
+// tag::dependency-constraint-factory-inject[]
+abstract class CreateConstraintTask
+@Inject constructor(private var factory: DependencyConstraintFactory) : DefaultTask() {
+
+    @TaskAction
+    fun create() {
+        val constraint = factory.create("com.example:lib:1.2.3")
+        println("Created constraint: ${constraint.group}:${constraint.name}:${constraint.version}")
+    }
+}
+
+tasks.register("createConstraint", CreateConstraintTask::class) {}
+// end::dependency-constraint-factory-inject[]
+
+// tag::software-component-factory-inject[]
+// A plugin that uses SoftwareComponentFactory to create an adhoc software
+// component, suitable for publishing custom variants. The factory is only
+// available via @Inject — there is no project-level accessor.
+class CustomComponentPlugin
+@Inject constructor(private val componentFactory: SoftwareComponentFactory) : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        val component = componentFactory.adhoc("custom")
+        project.components.add(component)
+    }
+}
+// end::software-component-factory-inject[]
+
+// tag::clean-temp-inject[]
+abstract class CleanTempTask
+@Inject constructor(private val fs: FileSystemOperations) : DefaultTask() {
+
+    @TaskAction
+    fun run() {
+        fs.delete { delete("build/tmp") }
+    }
+}
+
+tasks.register("cleanTemp", CleanTempTask::class) {}
+// end::clean-temp-inject[]
+
+// Also exercise the Java implementation that lives in buildSrc, so the snippets
+// integration test compiles and instantiates org.example.CleanTempTask.
+tasks.register<org.example.CleanTempTask>("cleanTempJava") {}

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/buildSrc/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/buildSrc/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/buildSrc/src/main/java/org/example/CleanTempTask.java
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/buildSrc/src/main/java/org/example/CleanTempTask.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+
+// tag::clean-temp-inject[]
+public abstract class CleanTempTask extends DefaultTask {
+    private final FileSystemOperations fs;
+
+    @Inject
+    public CleanTempTask(FileSystemOperations fs) {
+        this.fs = fs;
+    }
+
+    @TaskAction
+    public void run() {
+        fs.delete(spec -> spec.delete("build/tmp"));
+    }
+}
+// end::clean-temp-inject[]


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
  - Requested by IP team to document "safe" injectable build services

### Documentation Checklist
- [ ] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [ ] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [ ] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [ ] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [ ] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [ ] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [ ] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [ ] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [ ] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description