### PR TITLE
Return Dependency from Kotlin dependency helper

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
@@ -63,6 +63,7 @@ val expectedKotlinDslPluginsVersion: String
 
 package org.gradle.kotlin.dsl
 
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -80,18 +81,18 @@ val embeddedKotlinVersion = "$embeddedKotlinVersion"
  *
  * @param module simple name of the Kotlin module, for example "reflect".
  */
-fun DependencyHandler.embeddedKotlin(module: String): Any =
+fun DependencyHandler.embeddedKotlin(module: String): Dependency =
     kotlin(module, embeddedKotlinVersion)
 
 
 /**
- * Builds the dependency notation for the named Kotlin [module] at the given [version].
+ * Creates a dependency on the named Kotlin [module] at the given [version].
  *
  * @param module simple name of the Kotlin module, for example "reflect".
  * @param version optional desired version, unspecified if null.
  */
-fun DependencyHandler.kotlin(module: String, version: String? = null): Any =
-    "org.jetbrains.kotlin:kotlin-${'$'}module${'$'}{version?.let { ":${'$'}version" } ?: ""}"
+fun DependencyHandler.kotlin(module: String, version: String? = null): Dependency =
+    create("org.jetbrains.kotlin:kotlin-${'$'}module${'$'}{version?.let { ":${'$'}version" } ?: ""}")
 
 
 /**

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
@@ -183,4 +183,25 @@ class DependencyManagementIntegrationTest : AbstractKotlinIntegrationTest() {
             )
         }
     }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/12172")
+    fun `can configure dependency created by kotlin dependency helper`() {
+
+        withBuildScript(
+            """
+          plugins {
+              `java-library`
+          }
+
+          dependencies {
+              implementation(kotlin("reflect")) {
+                  because("reason")
+              }
+          }
+          """
+        )
+
+        build("help")
+    }
 }


### PR DESCRIPTION
Fixes #12172

Context

The kotlin() dependency helper returns dependency notation as Any, which prevents it from being used with a dependency configuration block:

```groovy
implementation(kotlin("reflect")) {
    because("reason")
}
```

Create the dependency through create() and return it as a Dependency, allowing the dependency to be configured without a cast.

An integration test covers this case.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
