### PR TITLE
Detangle VFS and project cache dir

### DIFF
--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
@@ -16,10 +16,11 @@
 
 package org.gradle.internal.watch
 
-import org.gradle.testdistribution.LocalOnly
 import org.gradle.integtests.fixtures.TestBuildCache
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.watch.registry.impl.WatchableHierarchies
+import org.gradle.testdistribution.LocalOnly
 import spock.lang.Issue
 
 @LocalOnly
@@ -49,6 +50,38 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         then:
         outputContains "Hello VFS!"
         executedAndNotSkipped ":compileJava", ":classes", ":run"
+    }
+
+    def "source file changes are recognized when the project cache dir is relocated"() {
+        def cacheDir = file("custom-cache-dir")
+        buildFile << """
+            apply plugin: "application"
+
+            application.mainClass = "Main"
+        """
+        def mainSourceFile = file("src/main/java/Main.java")
+        mainSourceFile.text = sourceFileWithGreeting("Hello World!")
+
+        when:
+        runWithWatchingEnabled("run", "--project-cache-dir", cacheDir.absolutePath)
+        then:
+        outputContains "Hello World!"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+
+        when:
+        mainSourceFile.text = sourceFileWithGreeting("Hello VFS!")
+        waitForChangesToBePickedUp()
+        runWithWatchingEnabled("run", "--project-cache-dir", cacheDir.absolutePath)
+        then:
+        outputContains "Hello VFS!"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+        cacheDir.isDirectory()
+        if (GradleContextualExecuter.isConfigCache()) {
+            // The configuration cache writes its report under the build root's `.gradle` on the load build.
+            file(".gradle").assertIsDir()
+        } else {
+            file(".gradle").assertDoesNotExist()
+        }
     }
 
     def "buildSrc changes are recognized"() {

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -132,16 +132,18 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         watchMode << WatchMode.values()
     }
 
-    def "cannot define a custom build scope cache dir when watching is explicitly enabled"() {
+    def "watching can be explicitly enabled together with a custom project cache dir"() {
         buildFile << """
+            apply plugin: "java"
         """
-        file("buildSrc/build.gradle") << """
-        """
+        def cacheDir = file("custom-cache-dir")
 
         when:
-        fails("help", "--watch-fs", "--project-cache-dir=broken")
+        run("assemble", "--watch-fs", "--info", "--project-cache-dir", cacheDir.absolutePath)
 
         then:
-        failure.assertHasDescription("Enabling file system watching via --watch-fs (or via the org.gradle.vfs.watch property) with --project-cache-dir also specified is not supported; remove either option to fix this problem")
+        outputContains(ENABLED_MESSAGE)
+        outputContains(ACTIVE_MESSAGE)
+        cacheDir.assertIsDir()
     }
 }

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -89,8 +89,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
 
         then:
         outputContains("File system watching is active")
-        !file(".gradle/file-system.probe").exists()
-        file(".gradle").assertIsEmptyDir()
+        file(".gradle").assertDoesNotExist()
         cacheDir.isDirectory()
     }
 

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -17,20 +17,19 @@
 package org.gradle.internal.watch
 
 import com.google.common.collect.ImmutableSet
-import org.gradle.test.fixtures.Flaky
-import org.gradle.test.preconditions.TestExecutionPreconditions
-import org.gradle.testdistribution.LocalOnly
 import org.apache.commons.io.FileUtils
 import org.gradle.cache.GlobalCacheLocations
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.service.scopes.VirtualFileSystemServices
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
-
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.gradle.testdistribution.LocalOnly
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.Issue
@@ -61,6 +60,38 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "run", "--info"
         then:
         assertWatchableHierarchies([ImmutableSet.of(testDirectory)])
+    }
+
+    def "removes the watch probe after the build with the default project cache dir, keeping the cache dir"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        file("src/main/java/Main.java") << "public class Main {}"
+
+        when:
+        withWatchFs().run "assemble", "--info"
+
+        then:
+        outputContains("File system watching is active")
+        !file(".gradle/file-system.probe").exists()
+        file(".gradle").isDirectory()
+    }
+
+    def "removes the watch probe after the build with a custom project cache dir"() {
+        def cacheDir = file("custom-cache-dir")
+        buildFile << """
+            apply plugin: "java"
+        """
+        file("src/main/java/Main.java") << "public class Main {}"
+
+        when:
+        withWatchFs().run "assemble", "--info", "--project-cache-dir", cacheDir.absolutePath
+
+        then:
+        outputContains("File system watching is active")
+        !file(".gradle/file-system.probe").exists()
+        file(".gradle").assertIsEmptyDir()
+        cacheDir.isDirectory()
     }
 
     def "watches the project directory when buildSrc is present"() {

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherProbeRegistry.java
@@ -53,4 +53,6 @@ public interface FileWatcherProbeRegistry {
     void triggerWatchProbe(String path);
 
     File getProbeDirectory(File hierarchy);
+
+    void removeProbeFiles();
 }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -120,4 +120,11 @@ public interface FileWatcherUpdater {
      * @see FileWatcherUpdater
      */
     FileHierarchySet getWatchedFiles();
+
+    /**
+     * Removes the probe files created under the watchable hierarchies. Called when a build finishes.
+     *
+     * @see FileWatcherProbeRegistry#removeProbeFiles()
+     */
+    void removeProbeFiles();
 }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
@@ -32,6 +32,18 @@ import java.util.function.Predicate;
 public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractNativeFileEventFunctions<W>, W extends FileWatcher> implements FileWatcherRegistryFactory {
     private static final int FILE_EVENT_QUEUE_SIZE = 4096;
 
+    /**
+     * The directory, relative to a watched hierarchy's root, in which the watch probe file is created.
+     *
+     * <p>The probe must live <em>inside the watched hierarchy</em>: arming it writes a file and we rely on
+     * the OS reporting that change through the watch registered for the hierarchy - that is how we verify the
+     * hierarchy actually receives file system events.
+     *
+     * With default settings, the directory is the same as project cache dir (.gradle), but they are unrelated.
+     */
+    private static final String PROBE_DIRECTORY_NAME = ".gradle";
+    private static final String PROBE_FILE_NAME = "file-system.probe";
+
     protected final T fileEventFunctions;
     private final Predicate<String> immutableLocationsFilter;
 
@@ -51,9 +63,8 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractNativ
     public FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler) {
         BlockingQueue<FileWatchEvent> fileEvents = new ArrayBlockingQueue<>(FILE_EVENT_QUEUE_SIZE);
         try {
-            // TODO How can we avoid hard-coding ".gradle" here?
-            FileWatcherProbeRegistry probeRegistry = new DefaultFileWatcherProbeRegistry(buildDir ->
-                new File(new File(buildDir, ".gradle"), "file-system.probe"));
+            FileWatcherProbeRegistry probeRegistry = new DefaultFileWatcherProbeRegistry(watchableHierarchyRoot ->
+                new File(new File(watchableHierarchyRoot, PROBE_DIRECTORY_NAME), PROBE_FILE_NAME));
             W watcher = createFileWatcher(fileEvents);
             WatchableHierarchies watchableHierarchies = new WatchableHierarchies(probeRegistry, immutableLocationsFilter);
             FileWatcherUpdater fileWatcherUpdater = createFileWatcherUpdater(watcher, probeRegistry, watchableHierarchies);

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -128,6 +128,11 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
+    public void removeProbeFiles() {
+        probeRegistry.removeProbeFiles();
+    }
+
+    @Override
     public void triggerWatchProbe(String path) {
         probeRegistry.triggerWatchProbe(path);
     }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
@@ -187,14 +187,14 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
         }
 
         public synchronized void deleteProbeFile() {
-            if (probeFile.delete()) {
-                File probeDirectory = probeFile.getParentFile();
-                String[] remaining = probeDirectory.list();
-                if (remaining != null && remaining.length == 0 && !probeDirectory.delete()) {
-                    LOGGER.debug("Could not delete empty probe directory: {}", probeDirectory);
-                }
-            } else if (probeFile.exists()) {
+            if (!probeFile.delete() && probeFile.exists()) {
                 LOGGER.debug("Could not delete probe file: {}", probeFile);
+                return;
+            }
+            File probeDirectory = probeFile.getParentFile();
+            String[] remaining = probeDirectory.list();
+            if (remaining != null && remaining.length == 0 && !probeDirectory.delete()) {
+                LOGGER.debug("Could not delete empty probe directory: {}", probeDirectory);
             }
         }
 

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
@@ -187,7 +187,13 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
         }
 
         public synchronized void deleteProbeFile() {
-            if (!probeFile.delete() && probeFile.exists()) {
+            if (probeFile.delete()) {
+                File probeDirectory = probeFile.getParentFile();
+                String[] remaining = probeDirectory.list();
+                if (remaining != null && remaining.length == 0 && !probeDirectory.delete()) {
+                    LOGGER.debug("Could not delete empty probe directory: {}", probeDirectory);
+                }
+            } else if (probeFile.exists()) {
                 LOGGER.debug("Could not delete probe file: {}", probeFile);
             }
         }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
@@ -98,6 +98,11 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
     }
 
     @Override
+    public void removeProbeFiles() {
+        watchProbesByHierarchy.values().forEach(WatchProbe::deleteProbeFile);
+    }
+
+    @Override
     public File getProbeDirectory(File hierarchy) {
         WatchProbe watchProbe = watchProbesByHierarchy.get(hierarchy);
         if (watchProbe == null) {
@@ -179,6 +184,12 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
 
         public synchronized boolean leftArmed() {
             return state == State.ARMED;
+        }
+
+        public synchronized void deleteProbeFile() {
+            if (!probeFile.delete() && probeFile.exists()) {
+                LOGGER.debug("Could not delete probe file: {}", probeFile);
+            }
         }
 
         public File getProbeFile() {

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -154,7 +154,9 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
 
     @Override
     public SnapshotHierarchy updateVfsBeforeBuildFinished(SnapshotHierarchy root, int maximumNumberOfWatchedHierarchies, List<File> unsupportedFileSystems) {
-        return fileWatcherUpdater.updateVfsBeforeBuildFinished(root, maximumNumberOfWatchedHierarchies, unsupportedFileSystems);
+        SnapshotHierarchy newRoot = fileWatcherUpdater.updateVfsBeforeBuildFinished(root, maximumNumberOfWatchedHierarchies, unsupportedFileSystems);
+        fileWatcherUpdater.removeProbeFiles();
+        return newRoot;
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -70,8 +70,10 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
             .filter(watchableHierarchies::shouldWatch)
             .forEach(snapshot -> {
                 String previousWatchedRoot = watchedDirectoryForSnapshot.remove(snapshot.getAbsolutePath());
-                decrement(previousWatchedRoot, changedWatchedDirectories);
-                snapshot.accept(new SubdirectoriesToWatchVisitor(path -> decrement(path, changedWatchedDirectories)));
+                if (previousWatchedRoot != null) {
+                    decrement(previousWatchedRoot, changedWatchedDirectories);
+                    snapshot.accept(new SubdirectoriesToWatchVisitor(path -> decrement(path, changedWatchedDirectories)));
+                }
             });
         addedSnapshots.stream()
             .filter(watchableHierarchies::shouldWatch)

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @ServiceScope(Scope.UserHome.class)
 public class FileWatchingFilter implements FileSystemAccess.WriteListener {
     private final FileHierarchySet immutableLocations;
-    private final AtomicReference<FileHierarchySet> currentBuildImmutableLocations = new AtomicReference<>(FileHierarchySet.empty());
+    private final AtomicReference<FileHierarchySet> currentSessionImmutableLocations = new AtomicReference<>(FileHierarchySet.empty());
     private final AtomicReference<FileHierarchySet> locationsWrittenByCurrentBuild = new AtomicReference<>(FileHierarchySet.empty());
     private volatile boolean buildRunning;
 
@@ -45,12 +45,12 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
         this.immutableLocations = immutableLocations;
     }
 
-    public void addCurrentBuildImmutableLocation(File location) {
-        currentBuildImmutableLocations.updateAndGet(locations -> locations.plus(location));
+    public void addCurrentSessionImmutableLocation(File location) {
+        currentSessionImmutableLocations.updateAndGet(locations -> locations.plus(location));
     }
 
     public boolean isImmutableLocation(String location) {
-        return immutableLocations.contains(location) || currentBuildImmutableLocations.get().contains(location);
+        return immutableLocations.contains(location) || currentSessionImmutableLocations.get().contains(location);
     }
 
     @Override
@@ -78,8 +78,11 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
 
     public void buildFinished() {
         resetLocationsWritten();
-        currentBuildImmutableLocations.set(FileHierarchySet.empty());
         buildRunning = false;
+    }
+
+    public void sessionFinished() {
+        currentSessionImmutableLocations.set(FileHierarchySet.empty());
     }
 
     private void resetLocationsWritten() {

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
@@ -21,6 +21,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.vfs.FileSystemAccess;
 
+import java.io.File;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -36,11 +37,20 @@ import java.util.concurrent.atomic.AtomicReference;
 @ServiceScope(Scope.UserHome.class)
 public class FileWatchingFilter implements FileSystemAccess.WriteListener {
     private final FileHierarchySet immutableLocations;
+    private final AtomicReference<FileHierarchySet> currentBuildImmutableLocations = new AtomicReference<>(FileHierarchySet.empty());
     private final AtomicReference<FileHierarchySet> locationsWrittenByCurrentBuild = new AtomicReference<>(FileHierarchySet.empty());
     private volatile boolean buildRunning;
 
     public FileWatchingFilter(FileHierarchySet immutableLocations) {
         this.immutableLocations = immutableLocations;
+    }
+
+    public void addCurrentBuildImmutableLocation(File location) {
+        currentBuildImmutableLocations.updateAndGet(locations -> locations.plus(location));
+    }
+
+    public boolean isImmutableLocation(String location) {
+        return immutableLocations.contains(location) || currentBuildImmutableLocations.get().contains(location);
     }
 
     @Override
@@ -61,10 +71,6 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
         return !locationsWrittenByCurrentBuild.get().contains(location);
     }
 
-    public FileHierarchySet getImmutableLocations() {
-        return immutableLocations;
-    }
-
     public void buildStarted() {
         resetLocationsWritten();
         buildRunning = true;
@@ -72,6 +78,7 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
 
     public void buildFinished() {
         resetLocationsWritten();
+        currentBuildImmutableLocations.set(FileHierarchySet.empty());
         buildRunning = false;
     }
 

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.internal.watch.registry.impl
 
 import org.gradle.fileevents.FileWatcher
+import org.gradle.internal.file.FileMetadata.AccessType
+import org.gradle.internal.snapshot.MissingFileSnapshot
 import org.gradle.internal.watch.registry.FileWatcherUpdater
 
 class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
@@ -28,6 +30,20 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
 
     @Override
     int getIfNonHierarchical() { 1 }
+
+    def "removing a snapshot whose directory to watch is outside any watchable hierarchy does not fail"() {
+        def watchableHierarchy = file("watchable")
+        registerWatchableHierarchies([watchableHierarchy])
+        def missingSnapshot = new MissingFileSnapshot(watchableHierarchy.file("sub/missing.txt").absolutePath, AccessType.DIRECT)
+        addSnapshot(missingSnapshot)
+
+        when:
+        invalidate(missingSnapshot)
+
+        then:
+        noExceptionThrown()
+        0 * _
+    }
 
     def "only watches directories in hierarchies to watch"() {
         def watchableHierarchies = ["first", "second", "third"].collect { file(it).createDir() }

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.vfs.impl
+
+import org.gradle.internal.file.FileHierarchySet
+import spock.lang.Specification
+
+class FileWatchingFilterTest extends Specification {
+    def globalCache = new File("global-cache").absoluteFile
+    def filter = new FileWatchingFilter(FileHierarchySet.empty().plus(globalCache))
+
+    def "a current-build location is immutable alongside the global immutable locations"() {
+        def cacheDir = new File("project/.gradle").absoluteFile
+
+        expect:
+        !filter.isImmutableLocation(cacheDir.absolutePath)
+
+        when:
+        filter.addCurrentBuildImmutableLocation(cacheDir)
+
+        then:
+        filter.isImmutableLocation(cacheDir.absolutePath)
+        filter.isImmutableLocation(globalCache.absolutePath)
+    }
+
+    def "current-build immutable locations are forgotten on build finish, global ones are kept"() {
+        def cacheDir = new File("project/.gradle").absoluteFile
+        filter.addCurrentBuildImmutableLocation(cacheDir)
+
+        when:
+        filter.buildFinished()
+
+        then:
+        !filter.isImmutableLocation(cacheDir.absolutePath)
+        filter.isImmutableLocation(globalCache.absolutePath)
+    }
+}

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/FileWatchingFilterTest.groovy
@@ -23,26 +23,38 @@ class FileWatchingFilterTest extends Specification {
     def globalCache = new File("global-cache").absoluteFile
     def filter = new FileWatchingFilter(FileHierarchySet.empty().plus(globalCache))
 
-    def "a current-build location is immutable alongside the global immutable locations"() {
+    def "a current-session location is immutable alongside the global immutable locations"() {
         def cacheDir = new File("project/.gradle").absoluteFile
 
         expect:
         !filter.isImmutableLocation(cacheDir.absolutePath)
 
         when:
-        filter.addCurrentBuildImmutableLocation(cacheDir)
+        filter.addCurrentSessionImmutableLocation(cacheDir)
 
         then:
         filter.isImmutableLocation(cacheDir.absolutePath)
         filter.isImmutableLocation(globalCache.absolutePath)
     }
 
-    def "current-build immutable locations are forgotten on build finish, global ones are kept"() {
+    def "current-session immutable locations survive a build finishing, so they stay excluded across a continuous build"() {
         def cacheDir = new File("project/.gradle").absoluteFile
-        filter.addCurrentBuildImmutableLocation(cacheDir)
+        filter.addCurrentSessionImmutableLocation(cacheDir)
 
         when:
+        filter.buildStarted()
         filter.buildFinished()
+
+        then:
+        filter.isImmutableLocation(cacheDir.absolutePath)
+    }
+
+    def "current-session immutable locations are forgotten on session finish, global ones are kept"() {
+        def cacheDir = new File("project/.gradle").absoluteFile
+        filter.addCurrentSessionImmutableLocation(cacheDir)
+
+        when:
+        filter.sessionFinished()
 
         then:
         !filter.isImmutableLocation(cacheDir.absolutePath)

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -19,7 +19,6 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.changedetection.state.FileHasherStatistics;
 import org.gradle.deployment.internal.DeploymentRegistryInternal;
-import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
@@ -93,22 +92,6 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         }
         if (verboseVfsLogging == VfsLogging.VERBOSE) {
             logVfsStatistics("since last build", statStatisticsCollector, fileHasherStatisticsCollector, directorySnapshotterStatisticsCollector);
-        }
-
-        if (action.getStartParameter().getProjectCacheDir() != null) {
-            // We'd like to create the probe in the `.gradle` directory under the build root,
-            // but if project cache is somewhere else, then we don't want to put trash in there
-            // See https://github.com/gradle/gradle/issues/17262
-            switch (watchFileSystemMode) {
-                case ENABLED:
-                    throw new IllegalStateException("Enabling file system watching via --watch-fs (or via the " + StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY + " property) with --project-cache-dir also specified is not supported; remove either option to fix this problem");
-                case DEFAULT:
-                    LOGGER.info("File system watching is disabled because --project-cache-dir is specified");
-                    watchFileSystemMode = WatchMode.DISABLED;
-                    break;
-                default:
-                    break;
-            }
         }
 
         LOGGER.debug("Watching the file system computed to be {}", watchFileSystemMode.getDescription());

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -97,39 +97,33 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
         WatchMode.DISABLED | VfsLogging.NORMAL  | false
     }
 
-    def "watching enabled by default is disabled when project cache dir is specified"() {
-        _ * startParameter.watchFileSystemMode >> WatchMode.DEFAULT
+    def "specifying a project cache dir does not affect file system watching being #watchMode.description"() {
+        _ * startParameter.watchFileSystemMode >> watchMode
         _ * startParameter.projectCacheDir >> Mock(File)
 
         when:
         runner.run(buildAction, buildController)
 
         then:
-        1 * watchingHandler.afterBuildStarted(WatchMode.DISABLED, _, buildOperationRunner)
+        1 * watchingHandler.afterBuildStarted(watchMode, _, buildOperationRunner) >> actuallyEnabled
 
         then:
-        1 * buildOperationProgressEventEmitter.emitNowForCurrent({ FileSystemWatchingSettingsFinalizedProgressDetails details -> !details.enabled })
+        1 * buildOperationProgressEventEmitter.emitNowForCurrent({ FileSystemWatchingSettingsFinalizedProgressDetails details -> details.enabled == actuallyEnabled })
 
         then:
         1 * delegate.run(buildAction, buildController)
 
         then:
-        1 * watchingHandler.beforeBuildFinished(WatchMode.DISABLED, _, buildOperationRunner, _)
+        1 * watchingHandler.beforeBuildFinished(watchMode, _, buildOperationRunner, _)
 
         then:
         0 * _
-    }
 
-    def "fails when watching is enabled and project cache dir is specified"() {
-        _ * startParameter.watchFileSystemMode >> WatchMode.ENABLED
-        _ * startParameter.projectCacheDir >> Mock(File)
-
-        when:
-        runner.run(buildAction, buildController)
-
-        then:
-        def ex = thrown IllegalStateException
-        ex.message == "Enabling file system watching via --watch-fs (or via the org.gradle.vfs.watch property) with --project-cache-dir also specified is not supported; remove either option to fix this problem"
+        where:
+        watchMode          | actuallyEnabled
+        WatchMode.DEFAULT  | false
+        WatchMode.ENABLED  | true
+        WatchMode.DISABLED | false
     }
 
     def "force-enables watching when #description"() {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -239,12 +239,20 @@ See the [Type-safe model accessors](userguide/kotlin_dsl.html#type-safe-accessor
 
 #### File system watching now works with a custom project cache directory
 
-Previously, using a custom project cache directory (`--project-cache-dir`) together with [file system watching](userguide/file_system_watching.html) was unsupported: combining it with `--watch-fs` failed the build, and otherwise watching was silently disabled.
+[File system watching](userguide/file_system_watching.html) lets Gradle skip work between builds by tracking file changes from the operating system.
+The project cache directory, by default `.gradle/` in the root project, stores per-project state that Gradle reuses across builds.
 
-Gradle no longer watches project cache directory.
-As a result, file system watching now works together with `--project-cache-dir`, and the project cache directory can live on a separate file system — even one that does not support watching.
+Some teams move this state out of the project tree using `--project-cache-dir` or `org.gradle.projectcachedir`, for example to keep build state on a separate or faster file system, or to share a project across users on CI.
+Until now, doing so was incompatible with file system watching, so these users could not benefit from it.
 
-See [Enable file system watching](userguide/file_system_watching.html) for more details.
+Gradle has decoupled the two.
+File system watching works with any project cache directory location, including one on a file system that does not support watching:
+
+```bash
+$ ./gradlew build --watch-fs --project-cache-dir /custom/path
+```
+
+See the [Excluding files and directories](userguide/file_system_watching.html#sec:excluding_files_and_directories) section in the Gradle User Manual for more details.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -237,6 +237,15 @@ Kotlin DSL script compilation continues to be cached as before.
 
 See the [Type-safe model accessors](userguide/kotlin_dsl.html#type-safe-accessors) section in the Gradle User Manual for more details.
 
+#### File system watching now works with a custom project cache directory
+
+Previously, using a custom project cache directory (`--project-cache-dir`) together with [file system watching](userguide/file_system_watching.html) was unsupported: combining it with `--watch-fs` failed the build, and otherwise watching was silently disabled.
+
+Gradle no longer watches project cache directory.
+As a result, file system watching now works together with `--project-cache-dir`, and the project cache directory can live on a separate file system — even one that does not support watching.
+
+See [Enable file system watching](userguide/file_system_watching.html) for more details.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ========================================================== -->

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/file_system_watching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/file_system_watching.adoc
@@ -46,6 +46,10 @@ To disable file system watching:
 
 Gradle automatically excludes some common directories (like `.git`, `.gradle`, and `build/`) from file system watching.
 
+Locations managed by Gradle are never watched, because Gradle is their only writer and keeps the virtual file system up to date directly.
+This includes Gradle's global caches and the _project cache directory_ — the `.gradle` directory in the root project, or a custom location configured with `--project-cache-dir`.
+Because the project cache directory is not watched, it can be placed on any file system, including one that does not support watching, without affecting file system watching.
+
 There is no public mechanism to configure additional file system watch excludes.
 
 To reduce unnecessary watching and re-execution, consider limiting the inputs of specific tasks using link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html#exclude(java.lang.String...)[`fileTree.exclude()`].
@@ -89,6 +93,10 @@ When enabled by default, file system watching acts conservatively when it encoun
 This can happen if you mount a project directory or subdirectory from a network drive.
 Gradle doesn't retain information about unsupported file systems between builds when enabled by default.
 If you explicitly enable file system watching, Gradle retains information about unsupported file systems between builds.
+
+To verify that the operating system actually delivers events for a watched directory, Gradle writes a small probe file (`file-system.probe`).
+This probe is always created in the `.gradle` directory under the build root.
+The probe is removed when the build finishes.
 
 [[symlinks]]
 === Symlinks

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -44,13 +44,15 @@ The previous step will help you identify potential problems by issuing deprecati
 ==== The project cache directory is no longer watched
 
 Gradle no longer watches the _project cache directory_ (the `.gradle` directory in the root project, or a custom location set with `--project-cache-dir`).
-It is managed by Gradle and kept consistent without watching.
+Because Gradle is the only writer to this directory, it keeps the virtual file system up to date directly, without relying on OS file system events.
 
-A direct consequence is that a custom project cache directory no longer turns file system watching off.
-Previously, specifying `--project-cache-dir` (or `org.gradle.projectcachedir`) was incompatible with watching: combining it with `--watch-fs` failed the build, and otherwise it silently disabled watching.
-Now watching follows the usual rules regardless of the project cache directory.
+As a result, a custom project cache directory no longer disables file system watching.
+Previously, `--project-cache-dir` (or `org.gradle.projectcachedir`) was incompatible with watching: passing `--watch-fs` alongside it failed the build, and leaving watching at its default silently disabled it.
+File system watching now follows the usual rules regardless of where the project cache directory is located.
 
-See <<file_system_watching.adoc#sec:enable,Enable file system watching>> for details.
+This also applies to source-dependency check-outs, which live under the project cache directory: their roots are no longer registered as watchable hierarchies.
+
+See <<file_system_watching.adoc#sec:excluding_files_and_directories,Excluding files and directories>> for details.
 
 ==== Upgrade to Kotlin 2.4.0
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,6 +41,17 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+==== The project cache directory is no longer watched
+
+Gradle no longer watches the _project cache directory_ (the `.gradle` directory in the root project, or a custom location set with `--project-cache-dir`).
+It is managed by Gradle and kept consistent without watching.
+
+A direct consequence is that a custom project cache directory no longer turns file system watching off.
+Previously, specifying `--project-cache-dir` (or `org.gradle.projectcachedir`) was incompatible with watching: combining it with `--watch-fs` failed the build, and otherwise it silently disabled watching.
+Now watching follows the usual rules regardless of the project cache directory.
+
+See <<file_system_watching.adoc#sec:enable,Enable file system watching>> for details.
+
 ==== Upgrade to Kotlin 2.4.0
 
 The embedded Kotlin has been upgraded from 2.3.21 to link:https://github.com/JetBrains/kotlin/releases/tag/v2.4.0[Kotlin 2.4.0].

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -65,7 +65,18 @@ public interface BuildState {
     boolean isImplicitBuild();
 
     /**
-     * Should this build be imported into an IDE? Some implicit builds, such as source dependency builds, are not intended to be imported into the IDE or editable by users.
+     * Is this a user-facing build whose sources users address and edit directly?
+     *
+     * <p>Returns {@code false} for implicit builds that Gradle manages and reproduces itself and
+     * that are not intended to be edited by users, most notably source-dependency (VCS) builds.
+     *
+     * <p>This governs whether a build takes part in user-facing behavior:
+     * <ul>
+     *     <li>it is exposed to the IDE / Tooling API build model (see {@code DefaultBuildTreeModelCreator} and
+     *         {@code GradleBuildBuilder});</li>
+     *     <li>its tasks can be targeted by task selectors (see {@code DefaultBuildTaskSelector});</li>
+     *     <li>its root directory is registered for file system watching (see {@code VirtualFileSystemServices}).</li>
+     * </ul>
      */
     boolean isImportableBuild();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -100,7 +100,6 @@ import org.gradle.internal.watch.vfs.impl.WatchingNotSupportedVirtualFileSystem;
 import org.gradle.internal.watch.vfs.impl.WatchingVirtualFileSystem;
 import org.jspecify.annotations.Nullable;
 
-import java.io.File;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -229,8 +228,9 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 ))
                 .orElse(new WatchingNotSupportedVirtualFileSystem(root));
             listenerManager.addListener((BuildAddedListener) buildState -> {
-                    File buildRootDir = buildState.getBuildRootDir();
-                    virtualFileSystem.registerWatchableHierarchy(buildRootDir);
+                    if (buildState.isImportableBuild()) {
+                        virtualFileSystem.registerWatchableHierarchy(buildState.getBuildRootDir());
+                    }
                 }
             );
             return virtualFileSystem;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -79,6 +79,7 @@ import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
+import org.gradle.internal.session.BuildSessionLifecycleListener;
 import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.snapshot.ValueSnapshotter;
@@ -353,7 +354,13 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
             ProjectCacheDir projectCacheDir,
             FileWatchingFilter fileWatchingFilter
         ) {
-            fileWatchingFilter.addCurrentBuildImmutableLocation(projectCacheDir.getDir());
+            fileWatchingFilter.addCurrentSessionImmutableLocation(projectCacheDir.getDir());
+            listenerManager.addListener(new BuildSessionLifecycleListener() {
+                @Override
+                public void beforeComplete() {
+                    fileWatchingFilter.sessionFinished();
+                }
+            });
 
             DefaultFileSystemAccess buildSessionsScopedVirtualFileSystem = new DefaultFileSystemAccess(
                 hasher,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -43,6 +43,7 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.buildoption.InternalOption;
 import org.gradle.internal.buildoption.InternalOptions;
@@ -217,7 +218,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 OperatingSystem.current(),
                 nativeCapabilities,
                 fileEvents,
-                fileWatchingFilter.getImmutableLocations()::contains)
+                fileWatchingFilter::isImmutableLocation)
                 .<BuildLifecycleAwareVirtualFileSystem>map(watcherRegistryFactory -> new WatchingVirtualFileSystem(
                     watcherRegistryFactory,
                     root,
@@ -348,8 +349,12 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
             StringInterner stringInterner,
             VirtualFileSystem root,
             FileSystemAccess.WriteListener writeListener,
-            DirectorySnapshotterStatistics.Collector statisticsCollector
+            DirectorySnapshotterStatistics.Collector statisticsCollector,
+            ProjectCacheDir projectCacheDir,
+            FileWatchingFilter fileWatchingFilter
         ) {
+            fileWatchingFilter.addCurrentBuildImmutableLocation(projectCacheDir.getDir());
+
             DefaultFileSystemAccess buildSessionsScopedVirtualFileSystem = new DefaultFileSystemAccess(
                 hasher,
                 stringInterner,


### PR DESCRIPTION
Summary of changes:

- Exclude the project cache directory from watching.
- Remove the `--watch-fs` + `--project-cache-dir` restriction.
- Remove the watch probe after each build.
- Make the probe location explicit.
- Don't register non-importable builds as watchable hierarchies -  Source-dependency build checkouts live under the project cache dir; since they're Gradle-managed and not user-editable, their roots are no longer registered for watching.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
