### PR TITLE
Make ResolutionResult CC compatible

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -40,7 +40,6 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery
 import org.gradle.api.artifacts.repositories.ArtifactRepository
-import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributeMatchingStrategy
 import org.gradle.api.attributes.AttributesSchema
@@ -69,7 +68,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultRe
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.api.internal.artifacts.resolver.DefaultResolutionOutputs.DefaultArtifactView
-import org.gradle.api.internal.artifacts.result.DefaultResolutionResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -96,22 +94,21 @@ import org.gradle.internal.locking.DefaultDependencyLockingHandler
 import org.gradle.invocation.DefaultGradle
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
-
 import spock.lang.Shared
 
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors.DefaultThreadFactory
-import java.util.concurrent.ThreadFactory
-import java.util.concurrent.locks.ReentrantLock
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import java.util.concurrent.locks.Lock
-import java.util.concurrent.locks.ReadWriteLock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Exchanger
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors.DefaultThreadFactory
 import java.util.concurrent.Phaser
 import java.util.concurrent.Semaphore
-import java.util.concurrent.Exchanger
 import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReadWriteLock
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -297,7 +294,6 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         DefaultResolvedConfiguration          | ResolvedConfiguration          | "project.configurations.maybeCreate('some').resolvedConfiguration"
         EmptyLenientConfiguration             | LenientConfiguration           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
         ConfigurationResolvableDependencies   | ResolvableDependencies         | "project.configurations.maybeCreate('some').incoming"
-        DefaultResolutionResult               | ResolutionResult               | "project.configurations.maybeCreate('some').incoming.resolutionResult"
         DefaultDependencyConstraintSet        | DependencyConstraintSet        | "project.configurations.maybeCreate('some').dependencyConstraints"
         DefaultRepositoryHandler              | RepositoryHandler              | "project.repositories"
         DefaultMavenArtifactRepository        | ArtifactRepository             | "project.repositories.mavenCentral()"

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
@@ -120,7 +120,6 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<ResolvedConfiguration>())
     bind(unsupported<LenientConfiguration>())
     bind(unsupported<ResolvableDependencies>())
-    bind(unsupported<ResolutionResult>())
     bind(unsupported<DependencyConstraintSet>())
     bind(unsupported<RepositoryHandler>())
     bind(unsupported<ArtifactRepository>())

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -70,6 +70,49 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 ### Configuration Cache improvements
 Gradle provides a [Configuration Cache](userguide/configuration_cache.html) that improves build time by caching the result of the configuration phase and reusing it for subsequent builds.
 
+#### `ResolutionResult` is fully Configuration Cache compatible
+
+A [`ResolutionResult`](javadoc/org/gradle/api/artifacts/result/ResolutionResult.html) may now be included directly as a task input when using Configuration Cache.
+Previously, its root [`ResolvedComponentResult`](javadoc/org/gradle/api/artifacts/result/ResolvedComponentResult.html) and [`ResolvedVariantResult`](javadoc/org/gradle/api/artifacts/result/ResolvedVariantResult.html) needed to be extracted and included on the task separately.
+This provides easy access to convenience APIs on `ResolutionResult`, avoiding the need to traverse the graph manually to access them.
+
+```kotlin
+// Before
+abstract class PreviousTask : DefaultTask() {
+    @get:Input
+    abstract val rootComponent: Property<ResolvedComponentResult>
+    @get:Input
+    abstract val rootVariant: Property<ResolvedVariantResult>
+
+    @TaskAction
+    fun execute() {
+        // No access to APIs on ResolutionResult, requiring manual graph traversal.
+    }
+}
+
+tasks.register<PreviousTask>("before") {
+    rootComponent = configurations.runtimeClasspath.flatMap { it.incoming.resolutionResult.rootComponent }
+    rootVariant = configurations.runtimeClasspath.flatMap { it.incoming.resolutionResult.rootVariant }
+}
+
+// After
+abstract class NewTask : DefaultTask() {
+    @get:Input
+    abstract val resolutionResult: Property<ResolutionResult>
+
+    @TaskAction
+    fun traverse() {
+        // Access to convenience APIs on ResolutionResult.
+        resolutionResult.get().allDependencies
+        resolutionResult.get().allComponents
+    }
+}
+
+tasks.register<NewTask>("after") {
+    resolutionResult = configurations.runtimeClasspath.map { it.incoming.resolutionResult }
+}
+```
+
 ### Isolated Projects improvements
 Gradle provides [Isolated Projects](userguide/isolated_projects.html), an incubating feature that enables parallel project configuration.
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.api
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.dsl.GradleDsl
 import spock.lang.Issue
 
 @FluidDependenciesResolveTest
@@ -52,10 +53,10 @@ class ResolutionResultApiIntegrationTest extends AbstractDependencyResolutionTes
             dependencies {
                 conf 'org:foo:0.5', 'org:bar:1.0', 'org:baz:1.0'
             }
+            def result = configurations.conf.incoming.resolutionResult
             task resolutionResult {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         if(it.id instanceof ModuleComponentIdentifier) {
                             println it.id.module + ":" + it.id.version + " " + it.selectionReason
                         }
@@ -111,9 +112,9 @@ baz:1.0 requested
             }
 
             task checkDeps {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
+                def result = configurations.conf.incoming.resolutionResult
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         if (it.id instanceof ModuleComponentIdentifier && it.id.module == 'leaf') {
                             def selectionReason = it.selectionReason
                             assert selectionReason.conflictResolution
@@ -182,9 +183,9 @@ baz:1.0 requested
             }
 
             tasks.register("checkResolutionResult") {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
+                def result = configurations.conf.incoming.resolutionResult
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         if (it.id instanceof ModuleComponentIdentifier && it.id.module == 'leaf') {
                             def selectionReason = it.selectionReason
                             assert selectionReason.conflictResolution
@@ -260,9 +261,9 @@ baz:1.0 requested
             }
 
             task checkWithApi {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
+                def result = configurations.conf.incoming.resolutionResult
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         if (it.id instanceof ModuleComponentIdentifier) {
                             println "Module \$it.id"
                             it.selectionReason.descriptions.each {
@@ -316,9 +317,9 @@ baz:1.0 requested
             }
 
             task checkWithApi {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
+                def result = configurations.conf.incoming.resolutionResult
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         if (it.id instanceof ModuleComponentIdentifier) {
                             println "Module \$it.id"
                             it.selectionReason.descriptions.each {
@@ -381,9 +382,9 @@ baz:1.0 requested
             }
 
             task resolveTwice {
-                def allComponents = provider { configurations.conf.incoming.resolutionResult.allComponents }
+                def result = configurations.conf.incoming.resolutionResult
                 doLast {
-                    allComponents.get().each {
+                    result.allComponents {
                         it.selectionReason.descriptions.each {
                            println "\${it.cause} : \${it.description}"
                         }
@@ -392,7 +393,7 @@ baz:1.0 requested
                     // see org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.CachedStoreFactory
                     Thread.sleep(800) // must be > cache expiry
                     println 'Read result again'
-                    allComponents.get().each {
+                    result.allComponents {
                         it.selectionReason.descriptions.each {
                            println "\${it.cause} : \${it.description}"
                         }
@@ -414,15 +415,16 @@ baz:1.0 requested
         mavenRepo.module("com", "foo", "1.0").publish()
         mavenRepo.module("com", "bar", "1.0").publish()
         mavenRepo.module("com", "baz", "1.0").publish()
-        settingsFile << """
-            include 'lib'
-            include 'tool'
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("lib")
+            include("tool")
             dependencyResolutionManagement {
-                ${mavenTestRepository()}
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
             }
         """
 
-        buildFile << """
+        buildKotlinFile << """
             plugins {
                 id("java-library")
             }
@@ -434,56 +436,77 @@ baz:1.0 requested
             }
         """
 
-        file("lib/build.gradle") << """
+        file("lib/build.gradle.kts") << """
             plugins {
                 id("java-library")
             }
 
             dependencies {
-               api "org:dep:1.0"
+                api("org:dep:1.0")
             }
         """
 
-        file("tool/build.gradle") << """
+        file("tool/build.gradle.kts") << """
             plugins {
                 id("java-library")
                 id("java-test-fixtures")
             }
 
             dependencies {
-                api "com:baz:1.0"
-                testFixturesApi "com:foo:1.0"
-                testFixturesImplementation "com:bar:1.0"
+                api("com:baz:1.0")
+                testFixturesApi("com:foo:1.0")
+                testFixturesImplementation("com:bar:1.0")
             }
-
         """
 
-        withResolutionResultDumper("testCompileClasspath", "testRuntimeClasspath")
+        buildKotlinFile << """
+            ${graphTraverserTask}
+            ${variantPrinterCallback}
+
+            tasks.register<TraverseTask>("traverseCompile") {
+                resolutionResult = configurations.testCompileClasspath.map { it.incoming.resolutionResult }
+                callback = printVariant
+                outputFile = layout.buildDirectory.file("traverse-compile.txt")
+            }
+
+            tasks.register<TraverseTask>("traverseRuntime") {
+                resolutionResult = configurations.testRuntimeClasspath.map { it.incoming.resolutionResult }
+                callback = printVariant
+                outputFile = layout.buildDirectory.file("traverse-runtime.txt")
+            }
+        """
 
         when:
-        succeeds 'resolve'
+        succeeds("traverseCompile", "traverseRuntime")
 
         then:
-        outputContains """
-testCompileClasspath
+        file("build/traverse-compile.txt").text.trim() == """
+root project 'root' (testCompileClasspath)
    project ':lib' (apiElements)
-      org:dep:1.0 (compile)
    project ':tool' (testFixturesApiElements)
-      project ':tool' (apiElements)
-         com:baz:1.0 (compile)
-      com:foo:1.0 (compile)
-"""
+project ':lib' (apiElements)
+   org:dep:1.0 (compile)
+project ':tool' (testFixturesApiElements)
+   project ':tool' (apiElements)
+   com:foo:1.0 (compile)
+project ':tool' (apiElements)
+   com:baz:1.0 (compile)
+""".trim()
 
         and:
-        outputContains """testRuntimeClasspath
+        file("build/traverse-runtime.txt").text.trim() == """
+root project 'root' (testRuntimeClasspath)
    project ':lib' (runtimeElements)
-      org:dep:1.0 (runtime)
    project ':tool' (testFixturesRuntimeElements)
-      project ':tool' (runtimeElements)
-         com:baz:1.0 (runtime)
-      com:foo:1.0 (runtime)
-      com:bar:1.0 (runtime)
-"""
+project ':lib' (runtimeElements)
+   org:dep:1.0 (runtime)
+project ':tool' (testFixturesRuntimeElements)
+   project ':tool' (runtimeElements)
+   com:foo:1.0 (runtime)
+   com:bar:1.0 (runtime)
+project ':tool' (runtimeElements)
+   com:baz:1.0 (runtime)
+""".trim()
     }
 
     def "requested dependency attributes are reported on dependency result as desugared attributes"() {
@@ -498,9 +521,9 @@ testCompileClasspath
             }
 
             task checkDependencyAttributes {
-                def rootDependencies = provider { configurations.compileClasspath.incoming.resolutionResult.root.dependencies }
+                def rootComponent = configurations.compileClasspath.incoming.resolutionResult.rootComponent
                 doLast {
-                    rootDependencies.get().each {
+                    rootComponent.get().dependencies.each {
                         def desugaredCategory = Attribute.of("org.gradle.category", String)
                         assert it.requested.attributes.getAttribute(desugaredCategory) == 'platform'
                     }
@@ -524,66 +547,86 @@ testCompileClasspath
         mavenRepo.module('org', 'baz', '1.0').publish()
         mavenRepo.module('org', 'gaz', '1.0').publish()
 
-        settingsFile << """
-            include 'producer'
+        settingsKotlinFile << """
+            rootProject.name = "root"
+            include("producer")
             dependencyResolutionManagement {
-                ${mavenTestRepository()}
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
             }
         """
 
-        file("producer/build.gradle") << """
+        file("producer/build.gradle.kts") << """
             plugins {
                 id("java-library")
                 id("java-test-fixtures")
             }
             dependencies {
-                testFixturesApi('org:foo:1.0')
-                testFixturesImplementation('org:bar:1.0')
-                testFixturesImplementation('org:baz:1.0')
+                testFixturesApi("org:foo:1.0")
+                testFixturesImplementation("org:bar:1.0")
+                testFixturesImplementation("org:baz:1.0")
 
-                api('org:baz:1.0')
-                implementation('org:gaz:1.0')
+                api("org:baz:1.0")
+                implementation("org:gaz:1.0")
             }
         """
 
-        buildFile << """
+        buildKotlinFile << """
             plugins {
                 id("java-library")
             }
 
             dependencies {
-                implementation(project(':producer'))
-                testImplementation(testFixtures(project(':producer')))
+                implementation(project(":producer"))
+                testImplementation(testFixtures(project(":producer")))
             }
         """
 
-        withResolutionResultDumper("testCompileClasspath", "testRuntimeClasspath")
+        buildKotlinFile << """
+            ${graphTraverserTask}
+            ${variantPrinterCallback}
+
+            tasks.register<TraverseTask>("traverseCompile") {
+                resolutionResult = configurations.testCompileClasspath.map { it.incoming.resolutionResult }
+                callback = printVariant
+                outputFile = layout.buildDirectory.file("traverse-compile.txt")
+            }
+
+            tasks.register<TraverseTask>("traverseRuntime") {
+                resolutionResult = configurations.testRuntimeClasspath.map { it.incoming.resolutionResult }
+                callback = printVariant
+                outputFile = layout.buildDirectory.file("traverse-runtime.txt")
+            }
+        """
 
         when: "baz should appear in both apiElements and testFixturesRuntimeElements"
-        succeeds 'resolve'
+        succeeds("traverseCompile", "traverseRuntime")
 
         then:
-        outputContains("""
-testCompileClasspath
+        file("build/traverse-compile.txt").text.trim() == """
+root project 'root' (testCompileClasspath)
    project ':producer' (apiElements)
-      org:baz:1.0 (compile)
    project ':producer' (testFixturesApiElements)
-      project ':producer' (apiElements)
-      org:foo:1.0 (compile)
-""")
+project ':producer' (apiElements)
+   org:baz:1.0 (compile)
+project ':producer' (testFixturesApiElements)
+   project ':producer' (apiElements)
+   org:foo:1.0 (compile)
+""".trim()
 
         and:
-        outputContains("""
-testRuntimeClasspath
+        file("build/traverse-runtime.txt").text.trim() == """
+root project 'root' (testRuntimeClasspath)
    project ':producer' (runtimeElements)
-      org:baz:1.0 (runtime)
-      org:gaz:1.0 (runtime)
    project ':producer' (testFixturesRuntimeElements)
-      project ':producer' (runtimeElements)
-      org:foo:1.0 (runtime)
-      org:bar:1.0 (runtime)
-      org:baz:1.0 (runtime)
-""")
+project ':producer' (runtimeElements)
+   org:baz:1.0 (runtime)
+   org:gaz:1.0 (runtime)
+project ':producer' (testFixturesRuntimeElements)
+   project ':producer' (runtimeElements)
+   org:foo:1.0 (runtime)
+   org:bar:1.0 (runtime)
+   org:baz:1.0 (runtime)
+""".trim()
     }
 
     def "reports if we try to get dependencies from a different variant"() {
@@ -616,14 +659,12 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def result = provider { configurations.testCompileClasspath.incoming.resolutionResult }
-                def rootComponent = result.map { it.root }
-                def allComponents = result.map { it.allComponents }
+                def result = configurations.testCompileClasspath.incoming.resolutionResult
                 doLast {
-                    def childComponent = allComponents.get().find { it.toString() == "project ':producer'" }
+                    def childComponent = result.allComponents.find { it.toString() == "project ':producer'" }
                     def childVariant = childComponent.variants[0]
                     // try to get dependencies for child variant on the wrong component
-                    println(rootComponent.get().getDependenciesForVariant(childVariant))
+                    println(result.rootComponent.get().getDependenciesForVariant(childVariant))
                 }
             }
         """
@@ -664,9 +705,9 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def allDependencies = provider { configurations.compileClasspath.incoming.resolutionResult.allDependencies }
+                def result = configurations.compileClasspath.incoming.resolutionResult
                 doLast {
-                    allDependencies.get().each {
+                    result.allDependencies {
                         assert it instanceof ResolvedDependencyResult
                         assert it.resolvedVariant != null
                     }
@@ -678,63 +719,25 @@ testRuntimeClasspath
         succeeds 'resolve'
     }
 
-    private void withResolutionResultDumper(String... configurations) {
-        def confSetup = configurations.collect { configuration ->
-            """def root_$configuration = configurations.${configuration}.incoming.resolutionResult.root
-                def requestedAttributes_$configuration = configurations.${configuration}.incoming.resolutionResult.requestedAttributes
-                def consumerAttributes_$configuration = configurations.${configuration}.attributes"""
-        }
-
-        def confExec = configurations.collect { configuration ->
-            """
-                // dump variant dependencies
-                dump.call("$configuration", root_${configuration}, null, 0, [] as Set)
-
-                // check that configuration attributes are visible and desugared
-                assert requestedAttributes_${configuration}.keySet().size() == consumerAttributes_${configuration}.keySet().size()
-                consumerAttributes_${configuration}.keySet().each {
-                    println "Checking \$it of type \$it.type"
-                    def desugared = Attribute.of(it.name, String)
-                    assert requestedAttributes_${configuration}.getAttribute(desugared) == consumerAttributes_${configuration}.getAttribute(it).toString()
-                }
-            """
-        }
-        buildFile << """
-
-            task resolve {
-                ${confSetup.join('\n')}
-                doLast {
-                    Closure dump = null
-                    dump = { String root, ResolvedComponentResult result, ResolvedVariantResult variant, int depth, Set visited ->
-                        if (visited.add([result, variant])) {
-                            if (variant == null) {
-                                println(root)
-                            }
-                            def dependencies = variant == null ? result.dependencies : result.getDependenciesForVariant(variant)
-                            depth++
-                            dependencies.each {
-                                if (it instanceof ResolvedDependencyResult) {
-                                    def resolvedVariant = it.resolvedVariant
-                                    def selected = it.selected
-                                    println("   " * depth + "\$selected (\$resolvedVariant)")
-                                    dump.call(root, selected, resolvedVariant, depth, visited)
-                                } else {
-                                    println("   " * depth + "\$it (unresolved)")
-                                }
+    private static String getVariantPrinterCallback() {
+        """
+            val printVariant: (ResolvedComponentResult, ResolvedVariantResult) -> String = { component, variant ->
+                val deps = component.getDependenciesForVariant(variant)
+                if (deps.isEmpty()) {
+                    ""
+                } else {
+                    buildString {
+                        appendLine("\$component (\${variant.displayName})")
+                        deps.forEach { dep ->
+                            when (dep) {
+                                is ResolvedDependencyResult -> appendLine("   \${dep.selected} (\${dep.resolvedVariant.displayName})")
+                                else -> appendLine("   \$dep (unresolved)")
                             }
                         }
                     }
-                    ${confExec.join('\n')}
-                    println()
-                    println 'Waiting for the cache to expire'
-                    // see org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.CachedStoreFactory
-                    Thread.sleep(800) // must be > cache expiry
-                    println 'Read result again to make sure serialization state is ok'
-                    println()
-                    ${confExec.join('\n')}
                 }
             }
-"""
+        """
     }
 
     @Issue("https://github.com/gradle/gradle/issues/26334")
@@ -832,9 +835,9 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def rootComponent = provider { configurations.conf.incoming.resolutionResult.rootComponent }
+                def rootComponent = configurations.conf.incoming.resolutionResult.rootComponent
                 doLast {
-                    def root = rootComponent.get().get()
+                    def root = rootComponent.get()
                     assert root.dependencies.size() == 1
                     def producer = root.dependencies[0].selected
                     assert producer.variants.first().displayName == "conf"
@@ -872,12 +875,11 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def result = provider { configurations.runtimeClasspath.incoming.resolutionResult }
-                def rootComponent = result.map { it.rootComponent }
-                def rootVariant = result.map { it.rootVariant }
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                def rootVariant = configurations.runtimeClasspath.incoming.resolutionResult.rootVariant
                 doLast {
-                    def componentRootVariant = rootComponent.get().get().variants.find { it.displayName == "runtimeClasspath" }
-                    assert rootVariant.get().get() == componentRootVariant
+                    def componentRootVariant = rootComponent.get().variants.find { it.displayName == "runtimeClasspath" }
+                    assert rootVariant.get() == componentRootVariant
                 }
             }
         """
@@ -931,12 +933,11 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def result = provider { configurations.runtimeClasspath.incoming.resolutionResult }
-                def rootComponentProvider = result.map { it.rootComponent }
-                def rootVariantProvider = result.map { it.rootVariant }
+                def rootVariantProvider = configurations.runtimeClasspath.incoming.resolutionResult.rootVariant
+                def rootComponentProvider = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
                 doLast {
-                    def rootVariant = rootVariantProvider.get().get()
-                    def rootComponent = rootComponentProvider.get().get()
+                    def rootVariant = rootVariantProvider.get()
+                    def rootComponent = rootComponentProvider.get()
 
                     def rootDependencies = rootComponent.getDependenciesForVariant(rootVariant)
                     assert rootComponent.dependencies.size() == 1
@@ -972,7 +973,11 @@ testRuntimeClasspath
         succeeds("resolve")
     }
 
-    def "can traverse a graph at the variant level"() {
+    def "resolution result is a valid task input"() {
+        mavenRepo.module("org", "foo")
+            .dependsOn(mavenRepo.module("org", "bar").publish())
+            .publish()
+
         settingsKotlinFile << """
             rootProject.name = "root"
             include("other")
@@ -997,39 +1002,81 @@ testRuntimeClasspath
             group = "org"
             version = "1.0"
 
+            ${mavenTestRepository(GradleDsl.KOTLIN)}
+
             dependencies {
+                implementation("org:foo:1.0")
                 implementation(project(":other"))
                 testImplementation(testFixtures(project(":other")))
             }
 
+            ${graphTraverserTask}
+            tasks.register<TraverseTask>("traverse") {
+                resolutionResult = configurations.testRuntimeClasspath.map { it.incoming.resolutionResult }
+                callback = { _, variant ->
+                    val displayName = when (val owner = variant.owner) {
+                        is ProjectComponentIdentifier -> "\${owner.buildTreePath}:\${variant.displayName}"
+                        is ModuleComponentIdentifier -> "\${owner.displayName}:\${variant.displayName}"
+                        else -> error("Unknown component type")
+                    }
+                    "\$displayName\\n"
+                }
+                outputFile = layout.buildDirectory.file("traverse.txt")
+            }
+        """
+
+        def expected = """
+::testRuntimeClasspath
+org:foo:1.0:runtime
+:other:runtimeElements
+::testFixturesRuntimeElements
+:other:testFixturesRuntimeElements
+org:bar:1.0:runtime
+::runtimeElements
+""".trim()
+
+        when:
+        succeeds("traverse")
+
+        then:
+        file("build/traverse.txt").text.trim() == expected
+
+        when:
+        succeeds("traverse")
+
+        then:
+        result.assertAllTasksSkipped()
+        file("build/traverse.txt").text.trim() == expected
+    }
+
+    private static String getGraphTraverserTask() {
+        """
             abstract class TraverseTask : DefaultTask() {
 
                 @get:Input
-                abstract val rootComponent: Property<ResolvedComponentResult>
+                abstract val resolutionResult: Property<ResolutionResult>
 
                 @get:Input
-                abstract val rootVariant: Property<ResolvedVariantResult>
+                abstract val callback: Property<(ResolvedComponentResult, ResolvedVariantResult) -> String>
+
+                @get:OutputFile
+                abstract val outputFile: RegularFileProperty
 
                 @TaskAction
                 fun traverse() {
-                    val variants = mutableListOf<String>()
-                    traverseGraphVariants(rootComponent.get(), rootVariant.get()) { variant ->
-                        val owner = variant.owner as ProjectComponentIdentifier
-                        variants.add("\${owner.buildTreePath}:\${variant.displayName}")
+                    val result = resolutionResult.get()
+                    val cb = callback.get()
+                    val output = StringBuilder()
+                    traverseGraphVariants(result.rootComponent.get(), result.rootVariant.get()) { component, variant ->
+                        output.append(cb(component, variant))
                     }
-                    assert(variants == listOf(
-                        "::testRuntimeClasspath",
-                        ":other:runtimeElements",
-                        "::testFixturesRuntimeElements",
-                        ":other:testFixturesRuntimeElements",
-                        "::runtimeElements"
-                    ))
+                    outputFile.get().asFile.writeText(output.toString())
                 }
 
                 fun traverseGraphVariants(
                     rootComponent: ResolvedComponentResult,
                     rootVariant: ResolvedVariantResult,
-                    callback: (ResolvedVariantResult) -> Unit
+                    callback: (ResolvedComponentResult, ResolvedVariantResult) -> Unit
                 ) {
                     val seen = mutableSetOf(rootVariant)
                     val queue = ArrayDeque(listOf(rootVariant to rootComponent))
@@ -1037,7 +1084,7 @@ testRuntimeClasspath
                     while (queue.isNotEmpty()) {
                         val (variant, component) = queue.removeFirst()
 
-                        callback(variant)
+                        callback(component, variant)
 
                         // Traverse this variant's dependencies
                         component.getDependenciesForVariant(variant).forEach { dependency ->
@@ -1054,15 +1101,7 @@ testRuntimeClasspath
                     }
                 }
             }
-
-            tasks.register<TraverseTask>("traverse") {
-                rootComponent = configurations.testRuntimeClasspath.flatMap { it.incoming.resolutionResult.rootComponent }
-                rootVariant = configurations.testRuntimeClasspath.flatMap { it.incoming.resolutionResult.rootVariant }
-            }
         """
-
-        expect:
-        succeeds("traverse")
     }
 
     def "attributes on root variant can be requested using Stringly or strongly-typed values"() {
@@ -1086,14 +1125,14 @@ testRuntimeClasspath
             }
 
             task resolve {
-                def root = provider { configurations.runtimeClasspath.incoming.resolutionResult.rootVariant }
+                def root = configurations.runtimeClasspath.incoming.resolutionResult.rootVariant
 
                 doLast {
-                    def usage = root.get().get().attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
+                    def usage = root.get().attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
                     assert Usage.class.isAssignableFrom(usage.class)
                     assert usage.name == "java-runtime"
 
-                    def usageAsString = root.get().get().attributes.getAttribute(Attribute.of(Usage.USAGE_ATTRIBUTE.name, String.class))
+                    def usageAsString = root.get().attributes.getAttribute(Attribute.of(Usage.USAGE_ATTRIBUTE.name, String.class))
                     assert usageAsString == "java-runtime"
                 }
             }
@@ -1118,9 +1157,9 @@ testRuntimeClasspath
             }
 
             tasks.register("resolve") {
-                def rootComponent = provider { configurations.runtimeClasspath.incoming.resolutionResult.rootComponent }
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
                 doLast {
-                    def variant = rootComponent.get().get().dependencies.first().resolvedVariant
+                    def variant = rootComponent.get().dependencies.first().resolvedVariant
                     assert variant.capabilities.is(variant.capabilities)
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
@@ -36,6 +37,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectorSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedComponentResultSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedVariantResultSerializer;
 import org.gradle.api.internal.artifacts.metadata.ComponentArtifactIdentifierSerializer;
@@ -80,7 +82,8 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         ComponentSelectionDescriptor.class,
         ComponentSelectionReason.class,
         ComponentSelector.class,
-        ResolvedComponentResult.class
+        ResolvedComponentResult.class,
+        ResolutionResult.class
     );
 
     public DependencyManagementValueSnapshotterSerializerRegistry(
@@ -116,6 +119,11 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         registerWithFactory(ResolvedComponentResult.class, () -> {
             ResolvedVariantResultSerializer resolvedVariantResultSerializer = new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer);
             return new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer, resolvedVariantResultSerializer, componentSelectionReasonSerializer);
+        });
+        registerWithFactory(ResolutionResult.class, () -> {
+            ResolvedVariantResultSerializer resolvedVariantResultSerializer = new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer);
+            ResolvedComponentResultSerializer resolvedComponentResultSerializer = new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer, resolvedVariantResultSerializer, componentSelectionReasonSerializer);
+            return new ResolutionResultSerializer(resolvedComponentResultSerializer, attributeContainerSerializer);
         });
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -571,6 +571,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private class ConfigurationResolutionAccess implements ResolutionAccess {
 
         @Override
+        public Path getIdentityPath() {
+            return identityPath;
+        }
+
+        @Override
         public ResolutionHost getHost() {
             return new DefaultResolutionHost(identityPath, displayName, configurationServices.getProblems(), configurationServices.getExceptionMapper());
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
+
+import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.Serializer;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A serializer for {@link ResolutionResult} that is not thread-safe and not reusable.
+ */
+@NotThreadSafe
+public class ResolutionResultSerializer implements Serializer<ResolutionResult> {
+
+    private final Serializer<ResolvedComponentResult> componentResultSerializer;
+    private final Serializer<AttributeContainer> attributeContainerSerializer;
+
+    public ResolutionResultSerializer(
+        Serializer<ResolvedComponentResult> componentResultSerializer,
+        Serializer<AttributeContainer> attributeContainerSerializer
+    ) {
+        this.componentResultSerializer = componentResultSerializer;
+        this.attributeContainerSerializer = attributeContainerSerializer;
+    }
+
+    @Override
+    public ResolutionResult read(Decoder decoder) throws Exception {
+        throw new UnsupportedOperationException("This serializer is only intended for input snapshotting.");
+    }
+
+    @Override
+    public void write(Encoder encoder, ResolutionResult value) throws Exception {
+        componentResultSerializer.write(encoder, value.getRootComponent().get());
+        attributeContainerSerializer.write(encoder, value.getRequestedAttributes());
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
@@ -65,7 +65,7 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
 
     @Override
     public ResolvedComponentResult read(Decoder decoder) throws Exception {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("This serializer is only intended for input snapshotting.");
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedVariantResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedVariantResultSerializer.java
@@ -15,22 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
-import org.gradle.internal.Describables;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.ListSerializer;
 import org.gradle.internal.serialize.Serializer;
 
 import javax.annotation.concurrent.NotThreadSafe;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,8 +31,8 @@ import java.util.Map;
  */
 @NotThreadSafe
 public class ResolvedVariantResultSerializer implements Serializer<ResolvedVariantResult> {
+
     private final Map<ResolvedVariantResult, Integer> written = new HashMap<>();
-    private final List<ResolvedVariantResult> read = new ArrayList<>();
 
     private final ComponentIdentifierSerializer componentIdentifierSerializer;
     private final AttributeContainerSerializer attributeContainerSerializer;
@@ -53,22 +46,7 @@ public class ResolvedVariantResultSerializer implements Serializer<ResolvedVaria
 
     @Override
     public ResolvedVariantResult read(Decoder decoder) throws Exception {
-        int index = decoder.readSmallInt();
-        if (index == -1) {
-            return null;
-        }
-        if (index == read.size()) {
-            ComponentIdentifier owner = componentIdentifierSerializer.read(decoder);
-            String variantName = decoder.readString();
-            AttributeContainer attributes = attributeContainerSerializer.read(decoder);
-            ImmutableList<Capability> capabilities = capabilitySerializer.read(decoder);
-            read.add(null);
-            ResolvedVariantResult externalVariant = read(decoder);
-            DefaultResolvedVariantResult result = new DefaultResolvedVariantResult(owner, Describables.of(variantName), attributes, capabilities, externalVariant);
-            this.read.set(index, result);
-            return result;
-        }
-        return read.get(index);
+        throw new UnsupportedOperationException("This serializer is only intended for input snapshotting.");
     }
 
     @Override
@@ -92,8 +70,4 @@ public class ResolvedVariantResultSerializer implements Serializer<ResolvedVaria
         }
     }
 
-    void reset() {
-        written.clear();
-        read.clear();
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionAccess.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionAccess.java
@@ -21,12 +21,18 @@ import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.util.Path;
 
 /**
  * An internal lazy reference to a graph resolution. Provides access to the inputs and
  * outputs of a graph resolution.
  */
 public interface ResolutionAccess {
+
+    /**
+     * The identity path of resolution.
+     */
+    Path getIdentityPath();
 
     /**
      * Get the owner of the resolution.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
@@ -26,29 +26,34 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
 import org.gradle.api.internal.artifacts.resolver.ResolutionAccess;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Actions;
+import org.gradle.internal.serialization.Cached;
+import org.gradle.util.Path;
 import org.gradle.util.internal.ConfigureUtil;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 
 public class DefaultResolutionResult implements ResolutionResult {
 
-    private final ResolutionAccess resolutionAccess;
-    private final AttributeDesugaring attributeDesugaring;
+    private final Path path;
+    private final Cached<ResolvedGraphResult> graph;
+    private final Cached<ImmutableAttributes> attributes;
 
     public DefaultResolutionResult(
         ResolutionAccess resolutionAccess,
         AttributeDesugaring attributeDesugaring
     ) {
-        this.resolutionAccess = resolutionAccess;
-        this.attributeDesugaring = attributeDesugaring;
+        this.path = resolutionAccess.getIdentityPath();
+        this.graph = Cached.of(() -> resolutionAccess.getResults().getValue().getVisitedGraph().getResolvedGraphResultSource().get());
+        this.attributes = Cached.of(() -> attributeDesugaring.desugar(resolutionAccess.getAttributes()));
     }
 
     @Override
@@ -59,7 +64,7 @@ public class DefaultResolutionResult implements ResolutionResult {
     @Override
     public Provider<ResolvedComponentResult> getRootComponent() {
         return new DefaultProvider<>(() -> {
-            ResolvedGraphResult graph = getGraph();
+            ResolvedGraphResult graph = this.graph.get();
             GraphStructure.Nodes nodes = graph.structure().nodes();
             return graph.getComponent(nodes.owner(nodes.root()));
         });
@@ -68,18 +73,14 @@ public class DefaultResolutionResult implements ResolutionResult {
     @Override
     public Provider<ResolvedVariantResult> getRootVariant() {
         return new DefaultProvider<>(() -> {
-            ResolvedGraphResult graph = getGraph();
+            ResolvedGraphResult graph = this.graph.get();
             return graph.getVariant(graph.structure().nodes().root());
         });
     }
 
-    private ResolvedGraphResult getGraph() {
-        return resolutionAccess.getResults().getValue().getVisitedGraph().getResolvedGraphResultSource().get();
-    }
-
     @Override
     public AttributeContainer getRequestedAttributes() {
-        return attributeDesugaring.desugar(resolutionAccess.getAttributes());
+        return attributes.get();
     }
 
     // TODO: The below methods should operate directly on a GraphStructure
@@ -122,7 +123,7 @@ public class DefaultResolutionResult implements ResolutionResult {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -130,12 +131,12 @@ public class DefaultResolutionResult implements ResolutionResult {
             return false;
         }
         DefaultResolutionResult that = (DefaultResolutionResult) o;
-        return Objects.equals(resolutionAccess, that.resolutionAccess);
+        return path.equals(that.path);
     }
 
     @Override
     public int hashCode() {
-        return resolutionAccess.hashCode();
+        return path.hashCode();
     }
 
 }


### PR DESCRIPTION
Allow ResolutionResult to be serialized by the Configuration Cache. Its components, ResolvedComponentResult and AttributeContainer were already compatible, so making its also compatible is relatively trivial and gives users access to the utility methods on ResolutionResult during CC.

We also ensure it is properly snapshottable, meaning you can mark it as a task input


Fixes https://github.com/gradle/gradle/issues/26897

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
