### PR TITLE
Isolate docsTest sample Gradle user home per worker to fix cache-lock deadlock

### DIFF
--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -181,6 +181,16 @@ tasks.named<Test>("docsTest") {
     }
     jvmArgumentProviders.add(installationEnvProvider)
 
+    // IntegrationTestSamplesExecutor gives each docsTest worker its own Gradle user home next to the shared one, so
+    // that the sample daemons of parallel workers never share - and deadlock on - a cache. Delete those homes before
+    // the run: they live in intTestHomeDir, which is not wiped by `clean`, so leftovers of an earlier (possibly
+    // crashed) build would otherwise pile up on long-lived CI checkouts.
+    val intTestHomeDir = repoRoot().dir("intTestHomeDir").asFile
+    doFirst {
+        intTestHomeDir.listFiles(FileFilter { it.isDirectory && it.name.contains("-sample-worker-") })
+            ?.forEach { it.deleteRecursively() }
+    }
+
     // For unknown reason, this is set to 'sourceSet.getRuntimeClasspath()' in the 'org.gradle.samples' plugin
     testClassesDirs = sourceSets.docsTest.get().output.classesDirs
     // 'integTest.samplesdir' is set to an absolute path by the 'org.gradle.samples' plugin

--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -33,6 +33,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +107,23 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             //    Our operation:
             //    Lock file: /mnt/tcagent1/work/b6cfc23ab10332e6/intTestHomeDir/distributions-full/caches/build-cache-1/build-cache-1.lock
             executer.withGradleUserHomeDir(new File(workingDir, "user-home"));
+        } else {
+            // Snippet samples run in parallel across docsTest workers, each forking its own Gradle daemon.
+            // When those daemons share a single Gradle user home they contend on - and can deadlock on - the
+            // cross-process file lock of its shared dependency/build caches (LockOnDemandCrossProcessCacheAccess),
+            // which hangs :docs:docsTest until the build times out. Give each worker its own writable user home so
+            // parallel workers never share a cache. A worker runs its samples sequentially, so it still reuses that
+            // worker's daemon and warm caches.
+            File sharedUserHome = IntegrationTestBuildContext.INSTANCE.getGradleUserHomeDir();
+            String workerKey = ManagementFactory.getRuntimeMXBean().getName().replaceAll("[^A-Za-z0-9]", "_");
+            executer.withGradleUserHomeDir(new File(sharedUserHome.getParentFile(), sharedUserHome.getName() + "-sample-worker-" + workerKey));
+            // If a shared dependency cache is already populated, serve it read-only so the isolated workers don't
+            // each re-resolve everything. Only set it when the modules cache actually exists, otherwise Gradle
+            // disables the read-only cache and prints a warning that pollutes the sample's asserted output.
+            File sharedCaches = new File(sharedUserHome, "caches");
+            if (new File(sharedCaches, "modules-2").isDirectory()) {
+                executer.withReadOnlyCacheDir(sharedCaches);
+            }
         }
 
         if (flags.stream().anyMatch(NO_STACKTRACE_CHECK::equals)) {

--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -49,6 +49,18 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
 
     private static final String SAMPLE_ENV_PREFIX = "-Dorg.gradle.sampletest.env.";
 
+    /**
+     * The id of the Gradle test worker this JVM is, as set by {@code org.gradle.api.internal.tasks.testing.worker.TestWorker}.
+     * Declared here rather than referenced, as that class is not on the docsTest classpath.
+     */
+    private static final String WORKER_ID_SYS_PROPERTY = "org.gradle.test.worker";
+
+    /**
+     * Infix of the per-worker Gradle user home directory names. Keep in sync with the cleanup in the {@code docsTest}
+     * task in {@code platforms/documentation/docs/build.gradle.kts}, which deletes these directories before each run.
+     */
+    private static final String SAMPLE_WORKER_HOME_INFIX = "-sample-worker-";
+
     private final File workingDir;
     private final boolean expectFailure;
     private final GradleExecuter gradle;
@@ -106,6 +118,22 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             //    Our operation:
             //    Lock file: /mnt/tcagent1/work/b6cfc23ab10332e6/intTestHomeDir/distributions-full/caches/build-cache-1/build-cache-1.lock
             executer.withGradleUserHomeDir(new File(workingDir, "user-home"));
+        } else {
+            // Snippet samples run in parallel across docsTest workers, each forking its own Gradle daemon.
+            // When those daemons share a single Gradle user home they contend on - and can deadlock on - the
+            // cross-process file lock of its shared dependency/build caches (LockOnDemandCrossProcessCacheAccess),
+            // which hangs :docs:docsTest until the build times out. Give each worker its own writable user home so
+            // parallel workers never share a cache. A worker runs its samples sequentially, so for the rest of the
+            // run it still reuses that worker's daemon and its now-warm caches.
+            File sharedUserHome = IntegrationTestBuildContext.INSTANCE.getGradleUserHomeDir();
+            executer.withGradleUserHomeDir(sampleWorkerGradleUserHome(sharedUserHome));
+            // If a shared dependency cache is already populated, serve it read-only so the isolated workers don't
+            // each re-resolve everything. Only set it when the modules cache actually exists, otherwise Gradle
+            // disables the read-only cache and prints a warning that pollutes the sample's asserted output.
+            File sharedCaches = new File(sharedUserHome, "caches");
+            if (new File(sharedCaches, "modules-2").isDirectory()) {
+                executer.withReadOnlyCacheDir(sharedCaches);
+            }
         }
 
         if (flags.stream().anyMatch(NO_STACKTRACE_CHECK::equals)) {
@@ -121,6 +149,18 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             executer.withEnvironmentVars(env);
         }
         return executer;
+    }
+
+    /**
+     * The Gradle user home for the current docsTest worker: a sibling of the shared one, named after the test worker
+     * id so that the set of directories is stable and bounded across builds, and prefixed like the shared home so the
+     * {@code CachesCleaner} sweep of {@code intTestHomeDir/distributions-*} also covers it.
+     */
+    private static File sampleWorkerGradleUserHome(File sharedUserHome) {
+        // Outside a Gradle test worker (e.g. running a sample from the IDE) there is a single JVM, so a constant name
+        // is enough to keep the home isolated from the shared one.
+        String workerId = System.getProperty(WORKER_ID_SYS_PROPERTY, "local").replaceAll("[^A-Za-z0-9]", "_");
+        return new File(sharedUserHome.getParentFile(), sharedUserHome.getName() + SAMPLE_WORKER_HOME_INFIX + workerId);
     }
 
     private String getAvailableJdksFlag() {


### PR DESCRIPTION
## Problem

`:docs:docsTest` intermittently hangs until the build execution-timeout (e.g. the 90-minute cap on `Gradle_Master_Check_DocsTest_Linux`).

**Root cause (reproduced on `master`):** the snippet samples run in parallel across docsTest test workers, each forking a Gradle daemon, and they all share a single Gradle user home (`intTestHomeDir/distributions-full`). The parallel daemons deadlock on the cross-process file lock of that home's shared dependency/build caches:

```
org.gradle.cache.internal.DefaultFileLockManager$AwaitableFileLockReleasedSignal.await
  <- DefaultFileLockManager.acquireFileLock
  <- LockOnDemandCrossProcessCacheAccess.acquireFileLock
```

It only surfaces when the full sample suite actually executes — e.g. on branches that change `core-runtime` and bust the build cache. Cache-hit `master` CI builds are up-to-date and skip the samples, so the hang can look branch-specific when it isn't.

## Fix

Give each docsTest worker its own writable Gradle user home, so parallel workers never share a cache. A worker runs its samples sequentially, so for the rest of the run it still reuses its own daemon and now-warm caches (cheaper than per-sample isolation). When a shared dependency cache is already populated, it is served **read-only** so the isolated workers don't all re-resolve — guarded by an existence check so the RO cache is never pointed at a missing directory (Gradle otherwise disables it with a warning that pollutes the samples' asserted output).

This extends the per-sample isolation that already exists for `--build-cache` samples (for the build cache) to the dependency cache for the remaining samples.

### Lifecycle of the per-worker homes

They are siblings of the shared home, named `distributions-full-sample-worker-<test worker id>`:

- Named after the Gradle test worker id (`org.gradle.test.worker`) rather than the JVM pid, so the set of directory names is small and stable across builds.
- Deleted by `:docs:docsTest` before each run, so nothing accumulates in `intTestHomeDir` (which `clean` deliberately does not wipe) — including leftovers of an earlier crashed run.
- The `distributions-` name prefix keeps them inside the existing `CachesCleaner` sweep of `intTestHomeDir/distributions-*` as a backstop.
- Daemons are unaffected: the daemon registry is `build/daemon`, independent of the Gradle user home, so `DaemonTracker`/`KillLeakingJavaProcesses` still track and kill them as before.

## Verification

- Reproduced the deadlock locally on `master`: thread dumps show the cross-process artifact-cache file-lock waiters among parallel sample daemons sharing the one user home.
- With this change `:docs:docsTest` completes (~14.5 min, 2408 tests) instead of hanging.

**CI validation still needed:** local runs can't fully replicate CI (dependency mirror, worker count), so throughput with per-worker dependency resolution should be confirmed by CI here. The few `declaring-configurations-{android,kmp}` samples depend on `androidHomeWarmup`, which runs on CI but was excluded in the local runs.
