### PR TITLE
Fix soak ScriptCachingIntegrationTest after disabling Kotlin DSL accessor caching

### DIFF
--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -300,7 +300,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
                     settings = sameContent, root = sameContent,
                     left = sameContent, right = sameContent,
                 ).apply {
-                    buildForCacheInspection("help", "--build-cache").apply {
+                    buildForCacheInspection("help", "--build-cache", "-Dorg.gradle.internal.kotlin-script-accessors-caching-disabled=false").apply {
                         compilationCache {
                             misses(rootBuildFile, leftBuildFile, rightBuildFile)
                         }
@@ -332,7 +332,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
                     settings = sameContent, root = sameContent,
                     left = sameContent, right = sameContent,
                 ).apply {
-                    buildForCacheInspection("help", "--build-cache").apply {
+                    buildForCacheInspection("help", "--build-cache", "-Dorg.gradle.internal.kotlin-script-accessors-caching-disabled=false").apply {
                         compilationCache {
                             hits(rootBuildFile, leftBuildFile, rightBuildFile)
                         }
@@ -385,7 +385,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
                 }
             }
 
-            val result = buildForCacheInspection("help", "--build-cache", "--info", "-Dorg.gradle.internal.kotlin-script-caching-disabled=$scriptCachingDisabled")
+            val result = buildForCacheInspection("help", "--build-cache", "--info", "-Dorg.gradle.internal.kotlin-script-caching-disabled=$scriptCachingDisabled", "-Dorg.gradle.internal.kotlin-script-accessors-caching-disabled=false")
 
             if (scriptCachingDisabled) {
                 result.assertNotOutput("Stored cache entry for Kotlin DSL script compilation")


### PR DESCRIPTION
## Summary

Commit 0d4961a1232 ("Disable Kotlin DSL accessor build caching by default", #37278) changed the default of `org.gradle.internal.kotlin-script-accessors-caching-disabled` to `true`. This disables build caching for the three Kotlin DSL accessor-generation work units (version-catalog plugin accessors, plugin-specs accessors, project accessors).

The companion `KotlinDslBuildCacheIntegrationTest` was updated, but the soak `ScriptCachingIntegrationTest` was not. Since soak tests don't run on PRs, the breakage only surfaced in the nightly Soak builds:

- `Gradle_Master_Check_Soak_8_0` #114280503
- `Gradle_Master_Check_Soak_9_0` #114280504
- `Gradle_Master_Check_Soak_35_0` #114280505

Two tests failed:
- `writes build cache entries` — expected 5 cache entries, only 2 written (accessors no longer cached)
- `kotlin script compilation is relocatable` — asserts accessor entries are stored/loaded

## Fix

Re-enable accessor caching for these specific builds via `-Dorg.gradle.internal.kotlin-script-accessors-caching-disabled=false`, preserving the tests' original intent of verifying accessor caching and relocatability.

## Verification

Re-ran the soak builds on this branch — both originally-failing `ScriptCachingIntegrationTest` tests now pass:

- Soak 8.0 (Java25 Linux): ✅ SUCCESS — https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Soak_8_0/114286102
- Soak 9.0 (Java17 Windows): ✅ SUCCESS — https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Soak_9_0/114286101

(Soak 9.0 also hit an unrelated, pre-existing flake `LockCommunicationSoakTest.lock contention - daemon expires if too many errors are seen` — a timeout — which was auto-retried and did not fail the build.)