### PR TITLE
[DO NOT MERGE] Debug Windows ARM :native:test shutdown timeout

### DIFF
--- a/.github/scripts/capture-thread-dumps.ps1
+++ b/.github/scripts/capture-thread-dumps.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter(Mandatory = $true)][string]$JavaHome,
+    [Parameter(Mandatory = $true)][string]$OutDir,
+    [int]$IntervalSeconds = 8
+)
+
+# Periodically capture a full thread dump (with lock info) of every running
+# java.exe process. Intended to run detached, in parallel with a Gradle build,
+# so that a hang during build shutdown (the build-event listener executor
+# failing to drain within 60s) is captured before the process exits.
+
+$ErrorActionPreference = "Continue"
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$jcmd = Join-Path $JavaHome "bin\jcmd.exe"
+$jstack = Join-Path $JavaHome "bin\jstack.exe"
+
+while ($true) {
+    $ts = Get-Date -Format "yyyyMMdd-HHmmss-fff"
+    foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'java.exe'")) {
+        $procId = $proc.ProcessId
+        $file = Join-Path $OutDir "threaddump-$ts-pid$procId.txt"
+        "==== pid=$procId time=$ts ====" | Out-File -FilePath $file -Encoding utf8
+        ("cmdline: " + $proc.CommandLine) | Out-File -FilePath $file -Append -Encoding utf8
+        "" | Out-File -FilePath $file -Append -Encoding utf8
+        try {
+            if (Test-Path $jcmd) {
+                & $jcmd $procId Thread.print -l 2>&1 | Out-File -FilePath $file -Append -Encoding utf8
+            } else {
+                & $jstack -l $procId 2>&1 | Out-File -FilePath $file -Append -Encoding utf8
+            }
+        } catch {
+            ("FAILED to dump pid {0}: {1}" -f $procId, $_) | Out-File -FilePath $file -Append -Encoding utf8
+        }
+    }
+    Start-Sleep -Seconds $IntervalSeconds
+}

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -87,4 +87,59 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew :native:test --% --stacktrace --info -PrerunAllTests -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
+      - name: Start periodic thread-dump capture
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $dir = Join-Path $env:GITHUB_WORKSPACE 'thread-dumps'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $proc = Start-Process pwsh -PassThru -WindowStyle Hidden -ArgumentList @(
+            '-NoProfile', '-ExecutionPolicy', 'Bypass',
+            '-File', "$env:GITHUB_WORKSPACE\.github\scripts\capture-thread-dumps.ps1",
+            '-JavaHome', "$env:JAVA_HOME",
+            '-OutDir', "$dir",
+            '-IntervalSeconds', '8'
+          )
+          $proc.Id | Out-File -FilePath (Join-Path $env:GITHUB_WORKSPACE 'dumper.pid') -Encoding ascii
+          Write-Host "Started thread-dump capture, pid=$($proc.Id), out=$dir"
+      - name: Run tests
+        run: ./gradlew :native:test --% --stacktrace --info -PrerunAllTests -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
+      - name: Stop thread-dump capture and take final dump
+        if: always()
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $dir = Join-Path $env:GITHUB_WORKSPACE 'thread-dumps'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          # One last dump for good measure, before tearing things down.
+          $ts = Get-Date -Format "yyyyMMdd-HHmmss-fff"
+          foreach ($p in (Get-CimInstance Win32_Process -Filter "Name = 'java.exe'")) {
+            $file = Join-Path $dir "threaddump-final-$ts-pid$($p.ProcessId).txt"
+            ("cmdline: " + $p.CommandLine) | Out-File -FilePath $file -Encoding utf8
+            & "$env:JAVA_HOME\bin\jcmd.exe" $p.ProcessId Thread.print -l 2>&1 | Out-File -FilePath $file -Append -Encoding utf8
+          }
+          $pidFile = Join-Path $env:GITHUB_WORKSPACE 'dumper.pid'
+          if (Test-Path $pidFile) {
+            $dumperPid = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            Write-Host "Stopping thread-dump capture pid=$dumperPid"
+            taskkill /PID $dumperPid /T /F 2>&1 | Write-Host
+          }
+      - name: Collect Gradle daemon logs
+        if: always()
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $dir = Join-Path $env:GITHUB_WORKSPACE 'thread-dumps'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $candidates = New-Object System.Collections.ArrayList
+          if ($env:USERPROFILE) { [void]$candidates.Add((Join-Path $env:USERPROFILE '.gradle\daemon')) }
+          if ($env:GRADLE_USER_HOME) { [void]$candidates.Add((Join-Path $env:GRADLE_USER_HOME 'daemon')) }
+          $candidates = $candidates | Where-Object { Test-Path $_ }
+          foreach ($root in $candidates) {
+            Get-ChildItem -Path $root -Recurse -Filter '*.log' -ErrorAction SilentlyContinue |
+              ForEach-Object { Copy-Item $_.FullName -Destination (Join-Path $dir ("daemon-" + $_.Name)) -ErrorAction SilentlyContinue }
+          }
+      - name: Upload thread dumps
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm-thread-dumps
+          path: thread-dumps
+          if-no-files-found: warn

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -87,4 +87,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew :native:test --% --stacktrace --info -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
+      - run: ./gradlew :native:test --% --stacktrace --info -PrerunAllTests -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -60,64 +60,6 @@ jobs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
       sys-prop-args: ${{ steps.determine-sys-prop-args.outputs.sys-prop-args }}
 
-  sanity-check:
-    name: "Sanity Check on Linux"
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: git clone
-        uses: actions/checkout@v7
-      - name: setup java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 25
-      - uses: actions/download-artifact@v8
-        with:
-          name: build-receipt.properties
-          path: incoming-distributions/build-receipt.properties
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew sanityCheck -DdisableLocalCache=true ${{ needs.build.outputs.sys-prop-args }}
-      - name: Upload Compatibility Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: binary-compatibility-report
-          path: testing/architecture-test/build/reports/binary-compatibility/report.html
-
-  unit-test:
-    name: "${{ matrix.bucket.name }} (Unit Test)"
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        bucket: ${{ fromJson(needs.build.outputs.matrix) }}
-      fail-fast: false
-    steps:
-      - name: git clone
-        uses: actions/checkout@v7
-      - name: setup java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 25
-      - uses: actions/download-artifact@v8
-        with:
-          name: build-receipt.properties
-          path: incoming-distributions/build-receipt.properties
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew ${{ matrix.bucket.tasks }} -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
-
   unit-test-windows-arm:
     name: "Unit Test Windows ARM"
     permissions:
@@ -145,4 +87,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew :native:test --% -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
+      - run: ./gradlew :native:test --% --stacktrace --info -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}


### PR DESCRIPTION
## Purpose

Investigation only — **do not merge / do not review**.

Reproducing the intermittent `Unit Test Windows ARM` failure where
`./gradlew :native:test` fails at shutdown with:

```
Timeout waiting for concurrent jobs to complete.
```

(originating from `AbstractManagedExecutor.stop()`), even though
`:native:test` itself is served `FROM-CACHE`.

## Changes (debug-only)

- Add `--stacktrace --info` to the Windows ARM step to reveal which
  managed executor/service fails to drain within the 60s timeout.
- Trim the workflow to only `Compile All` + `Unit Test Windows ARM`
  so the job can be re-run quickly and cheaply.

Will be closed once root cause is understood.