### PR TITLE
Make ScalaConcurrencyIntegrationTest compatible with Isolated Projects

### DIFF
--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
@@ -38,32 +38,29 @@ class ScalaConcurrencyIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << """
             include 'a', 'b', 'c', 'd'
         """
-        buildFile << """
-            allprojects {
+        // Configure each project from its own build script rather than from the root
+        // via 'allprojects', so the build is compatible with Isolated Projects.
+        ['a', 'b', 'c', 'd'].each { project ->
+            file("${project}/build.gradle") << """
+                plugins {
+                    id 'scala'
+                }
+
                 tasks.withType(AbstractScalaCompile) {
                     options.fork = true
                 }
                 ${mavenCentralRepository()}
-                plugins.withId("scala") {
-                    dependencies {
-                        implementation 'org.scala-lang:scala-library:${latestScala2}'
+                dependencies {
+                    implementation 'org.scala-lang:scala-library:${latestScala2}'
 
-                        testImplementation 'junit:junit:4.12'
-                        testImplementation 'org.scalatest:scalatest_2.13:3.2.0'
-                        testImplementation 'org.scalatestplus:junit-4-12_2.13:3.2.0.0'
-                    }
+                    testImplementation 'junit:junit:4.12'
+                    testImplementation 'org.scalatest:scalatest_2.13:3.2.0'
+                    testImplementation 'org.scalatestplus:junit-4-12_2.13:3.2.0.0'
                 }
                 tasks.withType(Test) { task ->
                     doLast {
                         ${httpServer.callFromBuild('${task.path}')}
                     }
-                }
-            }
-        """
-        ['a', 'b', 'c', 'd'].each { project ->
-            file("${project}/build.gradle") << """
-                plugins {
-                    id 'scala'
                 }
             """
             file("${project}/src/main/scala/${project}/${project.toUpperCase()}.scala") << """


### PR DESCRIPTION
## Summary

`ScalaConcurrencyIntegrationTest.can run tests in parallel with project dependencies` fails under Isolated Projects (e.g. in the [Flaky Test Quarantine - IsolatedProjects](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_IsolatedProjects_21) build).

The test configured all subprojects from the **root** build script via `allprojects { ... }`, touching `Project.tasks` (and dependencies/plugins) of subprojects from the root project. Under Isolated Projects this is a cross-project access violation:

```
Project ':' cannot access 'Project.tasks' functionality on subprojects via 'allprojects'
```

This check was tightened on `master` (9.7), so the test now fails deterministically under IP.

The fix moves the shared configuration into each subproject's own build script, so no cross-project configuration is performed. Behaviour is otherwise unchanged.

Note: `@Flaky` is retained — that is a separate `BlockingHttpServer` timing issue and unrelated to this IP incompatibility.

## Test plan

Verified locally with this branch's distribution under the Isolated Projects executer:

```
./gradlew :scala:isolatedProjectsIntegTest \
  --tests "org.gradle.scala.ScalaConcurrencyIntegrationTest" -PtestJavaVersion=17
```

- Before this change: `tests=1, failures=1` (reproduces the CI failure)
- After this change: `tests=1, failures=0` (passes)