### PR TITLE
Fix :docs:serveDocs by configuring javaLauncher

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -27,12 +27,14 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.jvm.toolchain.JavaToolchainService;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -59,7 +61,7 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
         project.apply(target -> target.plugin(GradleDslReferencePlugin.class));
         project.apply(target -> target.plugin(GradleUserManualPlugin.class));
 
-        addUtilityTasks(tasks, extension);
+        addUtilityTasks(project, tasks, extension);
 
         checkDocumentation(tasks, extension);
     }
@@ -124,7 +126,10 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
         }));
     }
 
-    private void addUtilityTasks(TaskContainer tasks, GradleDocumentationExtension extension) {
+    private void addUtilityTasks(Project project, TaskContainer tasks, GradleDocumentationExtension extension) {
+        JavaToolchainService javaToolchains = project.getExtensions().getByType(JavaToolchainService.class);
+        JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+
         tasks.register("serveDocs", ServeDocs.class, task -> {
             task.setDescription("Runs a local webserver to serve generated documentation.");
             task.setGroup("documentation");
@@ -132,6 +137,7 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
             int webserverPort = 8000;
             task.getDocsDirectory().convention(extension.getDocumentationRenderedRoot());
             task.getPort().convention(webserverPort);
+            task.getJavaLauncher().convention(javaToolchains.launcherFor(javaPluginExtension.getToolchain()));
 
             task.dependsOn(extension.getRenderedDocumentation());
         });


### PR DESCRIPTION
## Summary
- `:docs:serveDocs` failed during task validation with `property 'javaLauncher' doesn't have a configured value`. The `ServeDocs` task declares a non-optional `@Nested Property<JavaLauncher> getJavaLauncher()` (used to locate the `java` executable that runs the `jdk.httpserver` module), but the task registration in `GradleBuildDocumentationPlugin` never set a value for it.
- Configure the `javaLauncher` convention from the project's Java toolchain (`JavaToolchainService.launcherFor(javaPluginExtension.getToolchain())`), matching the pattern used elsewhere in `build-logic`.

## Test plan
- [x] `./gradlew :docs:serveDocs` no longer fails validation; the task renders the docs and starts the server (`serving docs at http://localhost:8000`).

Note: a separate, pre-existing build-wide configuration-cache issue (affecting unrelated tasks such as `:kotlin-dsl:shadowJar`, `:wrapper-main:jar`, `AsciidoctorTask`) is unaffected by this change and out of scope.