### PR TITLE
[DO NOT MERGE] Baseline: Windows ARM :native:test on pre-JDK25 commit

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -60,64 +60,6 @@ jobs:
       matrix: ${{ steps.setup-matrix.outputs.matrix }}
       sys-prop-args: ${{ steps.determine-sys-prop-args.outputs.sys-prop-args }}
 
-  sanity-check:
-    name: "Sanity Check on Linux"
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: git clone
-        uses: actions/checkout@v7
-      - name: setup java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-      - uses: actions/download-artifact@v8
-        with:
-          name: build-receipt.properties
-          path: incoming-distributions/build-receipt.properties
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew sanityCheck -DdisableLocalCache=true ${{ needs.build.outputs.sys-prop-args }}
-      - name: Upload Compatibility Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: binary-compatibility-report
-          path: testing/architecture-test/build/reports/binary-compatibility/report.html
-
-  unit-test:
-    name: "${{ matrix.bucket.name }} (Unit Test)"
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        bucket: ${{ fromJson(needs.build.outputs.matrix) }}
-      fail-fast: false
-    steps:
-      - name: git clone
-        uses: actions/checkout@v7
-      - name: setup java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-      - uses: actions/download-artifact@v8
-        with:
-          name: build-receipt.properties
-          path: incoming-distributions/build-receipt.properties
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew ${{ matrix.bucket.tasks }} -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
-
   unit-test-windows-arm:
     name: "Unit Test Windows ARM"
     permissions:
@@ -145,4 +87,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-      - run: ./gradlew :native:test --% -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}
+      - run: ./gradlew :native:test --% --stacktrace --info -DdisableLocalCache=true -PflakyTests=exclude ${{ needs.build.outputs.sys-prop-args }}


### PR DESCRIPTION
## Purpose

Investigation only — **do not merge / do not review**.

Baseline control for the intermittent `Unit Test Windows ARM` failure
(`Timeout waiting for concurrent jobs to complete.`).

This branch is based on `7af33a98572`, the commit immediately **before**
`#37896 "Build Gradle with JDK 25"` (so the daemon/test JVM is still
JDK 17). If the Windows ARM job is green here on the current runners, it
confirms the failure is caused by the JDK 25 bump and not by GitHub
runner/environment drift.

Trimmed to `Compile All` + `Unit Test Windows ARM`, `--stacktrace` added.