### PR TITLE
Update Documentation: add upgrade guide hint for finding a task by type

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -377,6 +377,18 @@ The examples below use a generic `container` placeholder; replace it with `tasks
 |`val x = provider.get()`
 |===
 
+When a container holds exactly one element of a given type, you can look it up by type instead of by name.
+This is useful for plugin-contributed tasks whose names are not part of a public contract:
+
+[source,kotlin]
+----
+// Eagerly resolves the single task of type MyTaskType, regardless of its name.
+val myTask = rootProject.tasks.withType<MyTaskType>().single()
+----
+
+NOTE: `withType(...).single()` is eager. The task must already exist when this line runs.
+For lazy configuration, use `tasks.withType<MyTaskType>().configureEach { ... }` instead.
+
 **Property, extra, and value delegates:**
 
 [cols="1,1"]


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
  - Address https://github.com/gradle/gradle/issues/37555#issuecomment-4721047548

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description