### PR TITLE
Add getAttributes getCapabilities to ResolvedArtifactResult

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
@@ -271,7 +271,7 @@ class DefaultConfigurationCacheCodecs(
             bind(WorkNodeActionCodec)
             bind(CapabilitySerializer())
             bind(DefaultComponentArtifactsResultCodec())
-            bind(DefaultResolvedArtifactResultCodec())
+            bind(DefaultResolvedArtifactResultCodec(immutableAttributesCodec, immutableCapabilitiesCodec))
             bind(DefaultUnresolvedComponentResultCodec())
 
             val graphStructureCodec = DefaultGraphStructureCodec(

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvedArtifactResultCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvedArtifactResultCodec.kt
@@ -17,9 +17,9 @@
 package org.gradle.internal.serialize.codecs.dm
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
-import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.component.Artifact
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult
+import org.gradle.internal.Describables
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
@@ -29,19 +29,28 @@ import org.gradle.internal.serialize.graph.writeFile
 /**
  * [Codec] for [DefaultResolvedArtifactResult] used for serializing resolved artifacts to the configuration cache.
  */
-class DefaultResolvedArtifactResultCodec : Codec<DefaultResolvedArtifactResult> {
+class DefaultResolvedArtifactResultCodec(
+    private val attributesCodec: ImmutableAttributesCodec,
+    private val capabilitiesCodec: ImmutableCapabilitiesCodec
+) : Codec<DefaultResolvedArtifactResult> {
+
     override suspend fun WriteContext.encode(value: DefaultResolvedArtifactResult) {
         write(value.id)
-        write(value.variant)
+        attributesCodec.run { encode(value.attributes) }
+        capabilitiesCodec.run { encode(value.capabilities) }
+        writeString(value.variant.displayName)
         writeClass(value.type)
         writeFile(value.file)
     }
 
     override suspend fun ReadContext.decode(): DefaultResolvedArtifactResult {
         val id = read() as ComponentArtifactIdentifier
-        val variant = read() as ResolvedVariantResult
+        val attributes = attributesCodec.run { decode() }
+        val capabilities = capabilitiesCodec.run { decode() }
+        val displayName = readString()
         @Suppress("UNCHECKED_CAST") val type = readClass() as Class<out Artifact>
         val file = readFile()
-        return DefaultResolvedArtifactResult(id, variant, type, file)
+        return DefaultResolvedArtifactResult(id, attributes, capabilities, Describables.of(displayName), type, file)
     }
+
 }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -246,6 +246,11 @@ tasks.withType<AbstractArchiveTask>().configureEach {
 }
 ```
 
+#### New APIs on `ResolvedArtifactResult`
+
+The [`ResolvedArtifactResult.getAttributes()`](javadoc/org/gradle/api/artifacts/result/ResolvedArtifactResult.html#getAttributes()) and [`ResolvedArtifactResult.getCapabilities()`](javadoc/org/gradle/api/artifacts/result/ResolvedArtifactResult.html#getCapabilities()) methods have been introduced to provide access to the attributes and capabilities of a resolved artifact without going through the [`ResolvedArtifactResult.getVariant()`](javadoc/org/gradle/api/artifacts/result/ResolvedArtifactResult.html#getVariant()) method.
+`ResolvedArtifactResult.getVariant()` is still available, but will be deprecated in a future release.
+
 See the [Timestamp for files inside archives](userguide/working_with_files.html#sec:reproducible_timestamp) section in the Gradle User Manual for more details.
 
 #### New `getInputStream()` method on `BuildCacheEntryWriter`

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionResultProviderIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionResultProviderIntegrationTest.groovy
@@ -93,7 +93,6 @@ class ArtifactCollectionResultProviderIntegrationTest extends AbstractHttpDepend
                     assert result.id.componentIdentifier.version == '1.0'
                     assert result.id.fileName == 'external-lib-1.0.jar'
 
-                    assert result.variant instanceof org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult
                     assert result.variant.owner == result.id.componentIdentifier
                     assert result.variant.attributes.getAttribute(org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE) == 'jar'
                     assert result.variant.attributes.getAttribute(org.gradle.api.internal.project.ProjectInternal.STATUS_ATTRIBUTE) == 'release'

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.component.Artifact;
@@ -54,7 +53,7 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
         try {
             if (seenArtifacts.add(artifact.getId())) {
                 File file = artifact.getFile();
-                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), attributeDesugaring.desugar(attributes), ImmutableList.copyOf(capabilities.asSet()), artifactSetName, Artifact.class, file));
+                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), attributeDesugaring.desugar(attributes), capabilities, artifactSetName, Artifact.class, file));
             }
         } catch (Exception t) {
             failures.add(t);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -24,6 +24,8 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
@@ -221,6 +223,16 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
             @Override
             public ComponentArtifactIdentifier getId() {
                 return artifact.getId();
+            }
+
+            @Override
+            public AttributeContainer getAttributes() {
+                return artifact.getAttributes();
+            }
+
+            @Override
+            public Collection<? extends Capability> getCapabilities() {
+                return artifact.getCapabilities();
             }
 
             @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.query;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -46,6 +45,7 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -215,7 +215,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
             BuildableArtifactResolveResult resolveResult = new DefaultBuildableArtifactResolveResult();
             artifactResolver.resolveArtifact(component, artifactMetaData, resolveResult);
             try {
-                artifacts.addArtifact(externalResolverFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, ImmutableList.of(), Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult().getFile())));
+                artifacts.addArtifact(externalResolverFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult().getFile())));
             } catch (Exception e) {
                 artifacts.addArtifact(new DefaultUnresolvedArtifactResult(artifactMetaData.getId(), type, e));
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -17,46 +17,47 @@ package org.gradle.api.internal.artifacts.result;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.Artifact;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
+import java.util.List;
+import java.util.Optional;
 
 public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
+
     private final ComponentArtifactIdentifier identifier;
-    private final ResolvedVariantResult variant;
+    private final ImmutableAttributes attributes;
+    private final ImmutableCapabilities capabilities;
+    private final DisplayName displayName;
     private final Class<? extends Artifact> type;
     private final File file;
 
-    public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,
-                                         AttributeContainer variantAttributes,
-                                         ImmutableList<Capability> capabilities,
-                                         DisplayName variantDisplayName,
-                                         Class<? extends Artifact> type,
-                                         File file) {
+    private final ResolvedVariantResult variantView;
+
+    public DefaultResolvedArtifactResult(
+        ComponentArtifactIdentifier identifier,
+        ImmutableAttributes attributes,
+        ImmutableCapabilities capabilities,
+        DisplayName displayName,
+        Class<? extends Artifact> type,
+        File file
+    ) {
         this.identifier = identifier;
-        this.variant = new DefaultResolvedVariantResult(identifier.getComponentIdentifier(), variantDisplayName, variantAttributes, capabilities, null);
+        this.attributes = attributes;
+        this.capabilities = capabilities;
+        this.displayName = displayName;
         this.type = type;
         this.file = file;
-    }
-
-    public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,
-                                         ResolvedVariantResult variant,
-                                         Class<? extends Artifact> type,
-                                         File file) {
-        this.identifier = identifier;
-        this.variant = variant;
-        this.type = type;
-        this.file = file;
-    }
-
-    @Override
-    public String toString() {
-        return identifier.getDisplayName();
+        this.variantView = new ArtifactVariantView();
     }
 
     @Override
@@ -65,17 +66,72 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     }
 
     @Override
-    public Class<? extends Artifact> getType() {
-        return type;
-    }
-
-    @Override
     public File getFile() {
         return file;
     }
 
     @Override
-    public ResolvedVariantResult getVariant() {
-        return variant;
+    public ImmutableAttributes getAttributes() {
+        return attributes;
     }
+
+    @Override
+    public ImmutableCapabilities getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public String toString() {
+        return identifier.getDisplayName();
+    }
+
+    // Below methods to be deprecated in 10.x
+
+    @Override
+    public Class<? extends Artifact> getType() {
+        return type;
+    }
+
+    @Override
+    public ResolvedVariantResult getVariant() {
+        return variantView;
+    }
+
+    private class ArtifactVariantView implements ResolvedVariantResult {
+
+        private volatile @Nullable ImmutableList<Capability> capabilitiesList = null;
+
+        @Override
+        public ComponentIdentifier getOwner() {
+            return identifier.getComponentIdentifier();
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return displayName.getDisplayName();
+        }
+
+        @Override
+        public List<Capability> getCapabilities() {
+            ImmutableList<Capability> capabilities = capabilitiesList;
+            if (capabilities == null) {
+                ImmutableList<Capability> copy = ImmutableList.copyOf(DefaultResolvedArtifactResult.this.capabilities);
+                this.capabilitiesList = copy;
+                return copy;
+            }
+            return capabilities;
+        }
+
+        @Override
+        public Optional<ResolvedVariantResult> getExternalVariant() {
+            return Optional.empty();
+        }
+
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -41,7 +41,7 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     private final Class<? extends Artifact> type;
     private final File file;
 
-    private final ResolvedVariantResult variantView;
+    private volatile @Nullable ResolvedVariantResult variantView;
 
     public DefaultResolvedArtifactResult(
         ComponentArtifactIdentifier identifier,
@@ -57,7 +57,6 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
         this.displayName = displayName;
         this.type = type;
         this.file = file;
-        this.variantView = new ArtifactVariantView();
     }
 
     @Override
@@ -94,16 +93,46 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
 
     @Override
     public ResolvedVariantResult getVariant() {
-        return variantView;
+        ResolvedVariantResult view = variantView;
+        if (view == null) {
+            view = new ArtifactVariantView(
+                getId().getComponentIdentifier(),
+                getAttributes(),
+                ImmutableList.copyOf(getCapabilities()),
+                displayName.getDisplayName()
+            );
+            this.variantView = view;
+            return view;
+        }
+        return view;
     }
 
-    private class ArtifactVariantView implements ResolvedVariantResult {
+    private static class ArtifactVariantView implements ResolvedVariantResult {
 
-        private volatile @Nullable ImmutableList<Capability> capabilitiesList = null;
+        private final ComponentIdentifier owner;
+        private final AttributeContainer attributes;
+        private final ImmutableList<Capability> capabilities;
+        private final String displayName;
+
+        private final int hashCode;
+
+        public ArtifactVariantView(
+            ComponentIdentifier owner,
+            AttributeContainer attributes,
+            ImmutableList<Capability> capabilities,
+            String displayName
+        ) {
+            this.owner = owner;
+            this.attributes = attributes;
+            this.capabilities = capabilities;
+            this.displayName = displayName;
+
+            this.hashCode = computeHashCode(owner, attributes, capabilities, displayName);
+        }
 
         @Override
         public ComponentIdentifier getOwner() {
-            return identifier.getComponentIdentifier();
+            return owner;
         }
 
         @Override
@@ -112,24 +141,58 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
         }
 
         @Override
-        public String getDisplayName() {
-            return displayName.getDisplayName();
+        public List<Capability> getCapabilities() {
+            return capabilities;
         }
 
         @Override
-        public List<Capability> getCapabilities() {
-            ImmutableList<Capability> capabilities = capabilitiesList;
-            if (capabilities == null) {
-                ImmutableList<Capability> copy = ImmutableList.copyOf(DefaultResolvedArtifactResult.this.capabilities);
-                this.capabilitiesList = copy;
-                return copy;
-            }
-            return capabilities;
+        public String getDisplayName() {
+            return displayName;
         }
 
         @Override
         public Optional<ResolvedVariantResult> getExternalVariant() {
             return Optional.empty();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (o == this) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ArtifactVariantView that = (ArtifactVariantView) o;
+            return owner.equals(that.owner) &&
+                attributes.equals(that.attributes) &&
+                capabilities.equals(that.capabilities) &&
+                displayName.equals(that.displayName);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        private static int computeHashCode(
+            ComponentIdentifier owner,
+            AttributeContainer attributes,
+            List<Capability> capabilities,
+            String displayName
+        ) {
+            int result = owner.hashCode();
+            result = 31 * result + attributes.hashCode();
+            result = 31 * result + capabilities.hashCode();
+            result = 31 * result + displayName.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return displayName;
         }
 
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -16,26 +16,24 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.jspecify.annotations.Nullable;
 
+import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
 /**
- * A deeply immutable implementation of {@link CapabilitiesMetadata}.
+ * A deeply immutable collection of {@link Capability capabilities}.
  *
  * This type will ensure that all contents are immutable upon construction,
  * in order to allow instances of this type to be safely reused whenever possible
  * to avoid unnecessary memory allocations.
- *
- * Note that while this class is not itself {@code final}, all fields are private, so
- * subclassing should not break the immutability contract.
  */
-public class ImmutableCapabilities implements Iterable<ImmutableCapability> {
+public final class ImmutableCapabilities extends AbstractCollection<ImmutableCapability> {
+
     public static final ImmutableCapabilities EMPTY = new ImmutableCapabilities(ImmutableSet.of());
 
     private final ImmutableSet<ImmutableCapability> capabilities;
@@ -67,6 +65,7 @@ public class ImmutableCapabilities implements Iterable<ImmutableCapability> {
         return new ImmutableCapabilities(builder.build());
     }
 
+    // Avoid this method if possible. ImmutableCapabilitie is already a Collection.
     public ImmutableSet<ImmutableCapability> asSet() {
         return capabilities;
     }
@@ -80,8 +79,9 @@ public class ImmutableCapabilities implements Iterable<ImmutableCapability> {
         return capabilities.iterator();
     }
 
-    public boolean isEmpty() {
-        return capabilities.isEmpty();
+    @Override
+    public int size() {
+        return capabilities.size();
     }
 
     /**
@@ -100,7 +100,7 @@ public class ImmutableCapabilities implements Iterable<ImmutableCapability> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -115,4 +115,5 @@ public class ImmutableCapabilities implements Iterable<ImmutableCapability> {
     public int hashCode() {
         return capabilities.hashCode();
     }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.api.artifacts.result;
 
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
+
 import java.io.File;
+import java.util.Collection;
 
 /**
  * The result of successfully resolving an artifact.
@@ -23,13 +27,32 @@ import java.io.File;
  * @since 2.0
  */
 public interface ResolvedArtifactResult extends ArtifactResult {
+
     /**
      * The file for the artifact.
      */
     File getFile();
 
     /**
+     * The attributes that describe this artifact.
+     *
+     * @since 9.7.0
+     */
+    AttributeContainer getAttributes();
+
+    /**
+     * The capabilities that describe this artifact.
+     *
+     * @since 9.7.0
+     */
+    Collection<? extends Capability> getCapabilities();
+
+    /**
      * The variant that included this artifact.
+     * <p>
+     * Prefer {@link #getAttributes()} and {@link #getCapabilities()} instead.
+     * This method will be deprecated for removal in a future release.
      */
     ResolvedVariantResult getVariant();
+
 }

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -7,6 +7,22 @@
             "changes": []
         },
         {
+            "type": "org.gradle.api.artifacts.result.ResolvedArtifactResult",
+            "member": "Method org.gradle.api.artifacts.result.ResolvedArtifactResult.getAttributes()",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.result.ResolvedArtifactResult",
+            "member": "Method org.gradle.api.artifacts.result.ResolvedArtifactResult.getCapabilities()",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
             "type": "org.gradle.kotlin.dsl.ConfigurationContainerScope",
             "member": "Method org.gradle.kotlin.dsl.ConfigurationContainerScope.getDelegate$kotlin_dsl()",
             "acceptation": "Not a public API: this is the JVM name of an internal Kotlin member, which encodes the compiler module name as a mangling suffix. Kotlin changed how the default module name is computed (https://youtrack.jetbrains.com/issue/KT-69701), so this suffix is no longer generated.",


### PR DESCRIPTION
Currently to get these for the artifact you need to go through getVariant which returns you a ResolvedVariantResult. However, this is a poor API. A ResolvedVariantResult represents a node in a dependency graph. The attributes and capabilities accessible via ResovledArtifactResult describe the artifacts _derived_ from a variant of a graph, which may have different attributes than the source node itself.

The existing API is confusing, as we expose attribute and capabilities as if they describe a variant when in fact they describe the artifact. The ResolvedVariantResult returned by getVariant is _not_ the variant that produced the artifact set. Even if we wanted to expose that variant on the artifact set, we could not just change the behavior of the existing getVariant method.

So, we expose the necessary information directly on ResolvedVariantResult -- getAttributes and getCapabilties. Eventually, we will deprecated getVariant from ResolvedArtifactResult, but we will need to give time for the community to start using these new methods before doing so

Related: https://github.com/gradle/gradle/issues/30505

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
