### PR TITLE
Recommend DependencyFactory in deprecation message

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependenciesExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependenciesExtensions.kt
@@ -99,7 +99,7 @@ class DependenciesExtensions {
  * @since 8.0
  */
 @Suppress("DEPRECATION")
-@Deprecated("Use single-string notation instead")
+@Deprecated("Use single-string notation or DependencyFactory instead")
 fun Dependencies.module(group: String?, name: String, version: String?): ExternalModuleDependency = module(group, name, version)
 
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -42,7 +42,7 @@ import org.gradle.kotlin.dsl.support.uncheckedCast
  * @see [DependencyHandler.create]
  */
 @Suppress("DEPRECATION")
-@Deprecated("Use single-string notation instead")
+@Deprecated("Use single-string notation or DependencyFactory instead")
 fun DependencyHandler.create(
     group: String,
     name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -105,7 +105,7 @@ private constructor(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     operator fun String.invoke(
         group: String,
         name: String,
@@ -132,7 +132,7 @@ private constructor(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     inline operator fun String.invoke(
         group: String,
         name: String,
@@ -241,7 +241,7 @@ private constructor(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     operator fun Configuration.invoke(
         group: String,
         name: String,
@@ -267,7 +267,7 @@ private constructor(
      * @since 8.3
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     operator fun NamedDomainObjectProvider<Configuration>.invoke(
         group: String,
         name: String,
@@ -295,7 +295,7 @@ private constructor(
     @JvmName("invokeDependencyScope")
     @Incubating
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
@@ -322,7 +322,7 @@ private constructor(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     inline operator fun Configuration.invoke(
         group: String,
         name: String,
@@ -351,7 +351,7 @@ private constructor(
      * @since 8.3
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     inline operator fun NamedDomainObjectProvider<Configuration>.invoke(
         group: String,
         name: String,
@@ -383,7 +383,7 @@ private constructor(
     @JvmName("invokeDependencyScope")
     @Incubating
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -124,7 +124,7 @@ open class ScriptHandlerScope(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     fun DependencyHandler.classpath(
         group: String,
         name: String,
@@ -152,7 +152,7 @@ open class ScriptHandlerScope(
      * @see [DependencyHandler.add]
      */
     @Suppress("DEPRECATION")
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     inline fun DependencyHandler.classpath(
         group: String,
         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -428,7 +428,7 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                      * @see [DependencyHandler.create]
                      * @see [DependencyHandler.add]
                      */
-                    @Deprecated("Use single-string notation instead")
+                    @Deprecated("Use single-string notation or DependencyFactory instead")
                     fun DependencyHandler.`$kotlinIdentifier`(
                         group: String,
                         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -73,7 +73,7 @@ fun addConfiguredDependencyTo(
 
 
 @Suppress("LongParameterList", "DEPRECATION")
-@Deprecated("Use single-string notation instead")
+@Deprecated("Use single-string notation or DependencyFactory instead")
 fun addExternalModuleDependencyTo(
     dependencyHandler: DependencyHandler,
     targetConfiguration: String,
@@ -97,7 +97,7 @@ fun addExternalModuleDependencyTo(
     dependencyHandler.add(targetConfiguration, it)
 }
 
-@Deprecated("Use single-string notation instead")
+@Deprecated("Use single-string notation or DependencyFactory instead")
 fun externalModuleDependencyFor(
     dependencyHandler: DependencyHandler,
     group: String,

--- a/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
@@ -122,7 +122,7 @@
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     fun DependencyHandler.`api`(
         group: String,
         name: String,
@@ -288,7 +288,7 @@
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
-    @Deprecated("Use single-string notation instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead")
     fun DependencyHandler.`compile`(
         group: String,
         name: String,

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
@@ -477,11 +477,11 @@ class TestSuitesKotlinDSLDependenciesIntegrationTest extends AbstractIntegration
         """
 
         expect: 'we will request an incorrect dependency'
-        executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"org.apache.commons:commons-lang3:3.11:com.google.guava:guava:30.1.1-jre\". Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
+        executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation (\"org.apache.commons:commons-lang3:3.11:com.google.guava:guava:30.1.1-jre\") or DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         succeeds 'checkConfiguration'
 
         and: 'and not be able to run the suite, failing at resolution time'
-        executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"org.apache.commons:commons-lang3:3.11:com.google.guava:guava:30.1.1-jre\". Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
+        executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation (\"org.apache.commons:commons-lang3:3.11:com.google.guava:guava:30.1.1-jre\") or DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         fails suiteName
         result.assertHasErrorOutput("Could not resolve all files for configuration ':${suiteName}CompileClasspath'.")
         result.assertHasErrorOutput("Could not find org.apache.commons:commons-lang3:3.11:com.google.guava:guava:30.1.1-jre:.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
@@ -846,7 +846,7 @@ class MultiStringDependencyNotationIntegrationTest extends AbstractIntegrationSp
         if (suggestion == null) {
             executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         } else {
-            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"${suggestion}\". Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
+            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation (\"${suggestion}\") or DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
@@ -64,7 +64,7 @@ public class DependencyMapNotationConverter<T> extends MapNotationConverter<T> {
             }
 
             deprecation = deprecation
-                .withAdvice("Please use single-string notation instead: \"" + suggestedNotation + "\".");
+                .withAdvice("Please use single-string notation (\"" + suggestedNotation + "\") or DependencyFactory instead.");
         }
 
         deprecation.willBecomeAnErrorInGradle10()

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
@@ -137,7 +137,7 @@ public interface Dependencies {
         String suggestedNotation = (group == null ? "" : group)  + ":" + name + (version == null ? "" : ":" + version);
 
         DeprecationLogger.deprecateAction("Declaring dependencies using multi-string notation")
-            .withAdvice("Please use single-string notation instead: \"" + suggestedNotation + "\".")
+            .withAdvice("Please use single-string notation (\"" + suggestedNotation + "\") or DependencyFactory instead.")
             .willBecomeAnErrorInGradle10()
             .withUpgradeGuideSection(9, "dependency_multi_string_notation")
             .nagUser();

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/artifacts/dsl/DependencyCollectorDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/artifacts/dsl/DependencyCollectorDslIntegrationTest.groovy
@@ -134,7 +134,7 @@ abstract class DependencyCollectorDslIntegrationTest extends AbstractIntegration
 
         when:
         if (expression.contains("module(")) {
-            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"org.example:foo:1.0\". Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
+            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation (\"org.example:foo:1.0\") or DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         }
         succeeds("help")
 
@@ -310,7 +310,7 @@ abstract class DependencyCollectorDslIntegrationTest extends AbstractIntegration
 
         when:
         if (expression.contains("module(")) {
-            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"org.example:foo:1.0\". Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
+            executer.expectDocumentedDeprecationWarning("Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation (\"org.example:foo:1.0\") or DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation")
         }
         succeeds("help")
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.internal.ToolingApiGradleExecutor
-import org.gradle.util.GradleVersion
 import org.junit.Rule
 
 /**
@@ -125,9 +124,6 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
         } else {
             throw new UnsupportedOperationException("Unsupported operating system: ${OperatingSystem.current().name}")
         }
-        runner.maybeExpectLegacyDeprecationWarning(
-            "Declaring dependencies using multi-string notation has been deprecated. This will fail with an error in Gradle 10. Please use single-string notation instead: \"com.google.protobuf:protoc:4.29.2:${protobufClassifier}@exe\". Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#dependency_multi_string_notation"
-        )
 
         runner
     }


### PR DESCRIPTION
In addition to suggesting using a single string notation, also recommend using DependencyFactory. The upgrade guide section already recommends DependencyFactory if you don't want to concat strings

Fixes https://github.com/gradle/gradle/issues/35085

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
