### PR TITLE
Documentation infrastructure Update: Clean up build logic for docs

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -60,6 +60,7 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
         extension.getGradleVersion().convention(project.provider(() -> project.getVersion().toString()));
+        extension.getGradleVersion8().convention("8.14.5");
 
         project.apply(target -> target.plugin("org.asciidoctor.jvm.convert"));
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -59,6 +59,7 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
         applyConventions(project, tasks, objects, layout, extension);
 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
+        extension.getGradleVersion().convention(project.provider(() -> project.getVersion().toString()));
 
         project.apply(target -> target.plugin("org.asciidoctor.jvm.convert"));
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -23,7 +23,6 @@ import org.asciidoctor.gradle.jvm.AsciidoctorTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.VersionCatalog;
 import org.gradle.api.artifacts.VersionCatalogsExtension;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
@@ -79,9 +78,13 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
     }
 
     private void configureAsciidoctorJ(Project project, TaskContainer tasks) {
-        VersionCatalog buildLibs = project.getExtensions().getByType(VersionCatalogsExtension.class).named("buildLibs");
         AsciidoctorJExtension asciidoctorj = project.getExtensions().getByType(AsciidoctorJExtension.class);
-        asciidoctorj.setVersion(buildLibs.findVersion("asciidoctor").get().getRequiredVersion());
+        VersionCatalogsExtension catalogs = project.getExtensions().findByType(VersionCatalogsExtension.class);
+        if (catalogs != null) {
+            catalogs.find("buildLibs")
+                .flatMap(catalog -> catalog.findVersion("asciidoctor"))
+                .ifPresent(version -> asciidoctorj.setVersion(version.getRequiredVersion()));
+        }
         asciidoctorj.getModules().getPdf().setVersion("2.3.23");
         // TODO: gif are not supported in pdfs, see also https://github.com/gradle/gradle/issues/24193
         // TODO: tables are not handled properly in pdfs

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -18,9 +18,13 @@ package gradlebuild.docs;
 
 import gradlebuild.basics.PublicApi;
 import gradlebuild.basics.PublicKotlinDslApi;
+import org.asciidoctor.gradle.jvm.AsciidoctorJExtension;
+import org.asciidoctor.gradle.jvm.AsciidoctorTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.artifacts.VersionCatalogsExtension;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.Usage;
@@ -38,6 +42,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> {
 
@@ -55,15 +60,39 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
 
+        project.apply(target -> target.plugin("org.asciidoctor.jvm.convert"));
+
         project.apply(target -> target.plugin(GradleReleaseNotesPlugin.class));
         project.apply(target -> target.plugin(GradleJavadocsPlugin.class));
         project.apply(target -> target.plugin(GradleKotlinDslReferencePlugin.class));
         project.apply(target -> target.plugin(GradleDslReferencePlugin.class));
         project.apply(target -> target.plugin(GradleUserManualPlugin.class));
 
+        configureAsciidoctorJ(project, tasks);
+
         addUtilityTasks(project, tasks, extension);
 
         checkDocumentation(tasks, extension);
+    }
+
+    private void configureAsciidoctorJ(Project project, TaskContainer tasks) {
+        VersionCatalog buildLibs = project.getExtensions().getByType(VersionCatalogsExtension.class).named("buildLibs");
+        AsciidoctorJExtension asciidoctorj = project.getExtensions().getByType(AsciidoctorJExtension.class);
+        asciidoctorj.setVersion(buildLibs.findVersion("asciidoctor").get().getRequiredVersion());
+        asciidoctorj.getModules().getPdf().setVersion("2.3.23");
+        // TODO: gif are not supported in pdfs, see also https://github.com/gradle/gradle/issues/24193
+        // TODO: tables are not handled properly in pdfs
+        asciidoctorj.getFatalWarnings().add(Pattern.compile(
+            "^(?!GIF image format not supported|dropping cells from incomplete row detected end of table|.*Asciidoctor PDF does not support table cell content that exceeds the height of a single page).*"
+        ));
+
+        tasks.withType(AsciidoctorTask.class).configureEach(task -> {
+            AsciidoctorJExtension taskDoctorj = task.getExtensions().getByType(AsciidoctorJExtension.class);
+            taskDoctorj.docExtensions(
+                project.getDependencies().create(project.project(":docs-asciidoctor-extensions")),
+                project.getDependencies().create(project.files("src/main/resources"))
+            );
+        });
     }
 
     private void applyConventions(Project project, TaskContainer tasks, ObjectFactory objects, ProjectLayout layout, GradleDocumentationExtension extension) {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -62,7 +62,6 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
         extension.getGradleVersion().convention(project.provider(() -> project.getVersion().toString()));
-        extension.getGradleVersion8().convention("8.14.5");
 
         project.apply(target -> target.plugin("org.asciidoctor.jvm.convert"));
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -18,6 +18,7 @@ package gradlebuild.docs;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import gradlebuild.basics.BuildEnvironmentKt;
 import gradlebuild.basics.PublicApi;
 import gradlebuild.basics.PublicKotlinDslApi;
 import org.asciidoctor.gradle.jvm.AsciidoctorJExtension;
@@ -65,7 +66,7 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
         extension.getGradleVersion().convention(project.provider(() -> project.getVersion().toString()));
         extension.getGradleVersion8().convention(
-            getProviders().fileContents(project.getRootProject().getLayout().getProjectDirectory().file("released-versions.json"))
+            getProviders().fileContents(BuildEnvironmentKt.releasedVersionsFile(project))
                 .getAsText()
                 .map(GradleBuildDocumentationPlugin::findLatestGradle8Version)
         );

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -16,6 +16,8 @@
 
 package gradlebuild.docs;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import gradlebuild.basics.PublicApi;
 import gradlebuild.basics.PublicKotlinDslApi;
 import org.asciidoctor.gradle.jvm.AsciidoctorJExtension;
@@ -62,6 +64,11 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
 
         extension.getQuickFeedback().convention(getProviders().gradleProperty("quickDocs").map(x -> true).orElse(false));
         extension.getGradleVersion().convention(project.provider(() -> project.getVersion().toString()));
+        extension.getGradleVersion8().convention(
+            getProviders().fileContents(project.getRootProject().getLayout().getProjectDirectory().file("released-versions.json"))
+                .getAsText()
+                .map(GradleBuildDocumentationPlugin::findLatestGradle8Version)
+        );
 
         project.apply(target -> target.plugin("org.asciidoctor.jvm.convert"));
 
@@ -76,6 +83,17 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
         addUtilityTasks(project, tasks, extension);
 
         checkDocumentation(tasks, extension);
+    }
+
+    private static String findLatestGradle8Version(String releasedVersionsJson) {
+        JsonObject root = JsonParser.parseString(releasedVersionsJson).getAsJsonObject();
+        for (var element : root.getAsJsonArray("finalReleases")) {
+            String version = element.getAsJsonObject().get("version").getAsString();
+            if (version.startsWith("8.")) {
+                return version;
+            }
+        }
+        throw new IllegalStateException("No 8.x release found in released-versions.json");
     }
 
     private void configureAsciidoctorJ(Project project, TaskContainer tasks) {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -39,9 +39,11 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.process.CommandLineArgumentProvider;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> {
@@ -185,8 +187,9 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
             task.getInputs().file(extension.getReleaseNotes().getRenderedDocumentation()).withPropertyName("releaseNotes").withPathSensitivity(PathSensitivity.NONE);
 
             task.getInputs().property("systemProperties", Collections.emptyMap());
-            // TODO: This breaks the provider
-            task.systemProperty("org.gradle.docs.releasenotes.rendered", extension.getReleaseNotes().getRenderedDocumentation().get().getAsFile());
+            task.getJvmArgumentProviders().add((CommandLineArgumentProvider) () -> List.of(
+                "-Dorg.gradle.docs.releasenotes.rendered=" + extension.getReleaseNotes().getRenderedDocumentation().get().getAsFile()
+            ));
         });
     }
 }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -23,6 +23,7 @@ import org.asciidoctor.gradle.jvm.AsciidoctorTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.VersionCatalog;
 import org.gradle.api.artifacts.VersionCatalogsExtension;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
@@ -78,14 +79,10 @@ public abstract class GradleBuildDocumentationPlugin implements Plugin<Project> 
     }
 
     private void configureAsciidoctorJ(Project project, TaskContainer tasks) {
+        VersionCatalog buildLibs = project.getExtensions().getByType(VersionCatalogsExtension.class).named("buildLibs");
         AsciidoctorJExtension asciidoctorj = project.getExtensions().getByType(AsciidoctorJExtension.class);
-        VersionCatalogsExtension catalogs = project.getExtensions().findByType(VersionCatalogsExtension.class);
-        if (catalogs != null) {
-            catalogs.find("buildLibs")
-                .flatMap(catalog -> catalog.findVersion("asciidoctor"))
-                .ifPresent(version -> asciidoctorj.setVersion(version.getRequiredVersion()));
-        }
-        asciidoctorj.getModules().getPdf().setVersion("2.3.23");
+        asciidoctorj.setVersion(buildLibs.findVersion("asciidoctor").get().getRequiredVersion());
+        asciidoctorj.getModules().getPdf().setVersion(buildLibs.findVersion("asciidoctorPdf").get().getRequiredVersion());
         // TODO: gif are not supported in pdfs, see also https://github.com/gradle/gradle/issues/24193
         // TODO: tables are not handled properly in pdfs
         asciidoctorj.getFatalWarnings().add(Pattern.compile(

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
@@ -139,4 +139,10 @@ public abstract class GradleDocumentationExtension {
      *
      */
     public abstract Property<Boolean> getQuickFeedback();
+
+    /**
+     * The Gradle version this documentation describes. Used in Asciidoctor attributes
+     * (e.g. {@code gradleVersion} and the {@code https://docs.gradle.org/<version>} URLs).
+     */
+    public abstract Property<String> getGradleVersion();
 }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
@@ -145,4 +145,10 @@ public abstract class GradleDocumentationExtension {
      * (e.g. {@code gradleVersion} and the {@code https://docs.gradle.org/<version>} URLs).
      */
     public abstract Property<String> getGradleVersion();
+
+    /**
+     * The latest Gradle 8.x patch version, derived from {@code released-versions.json}.
+     * Surfaced as the {@code gradleVersion8} Asciidoctor attribute for upgrade-guide back-references.
+     */
+    public abstract Property<String> getGradleVersion8();
 }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
@@ -145,10 +145,4 @@ public abstract class GradleDocumentationExtension {
      * (e.g. {@code gradleVersion} and the {@code https://docs.gradle.org/<version>} URLs).
      */
     public abstract Property<String> getGradleVersion();
-
-    /**
-     * The latest Gradle 8.x version referenced from the documentation. Used as the
-     * {@code gradleVersion8} Asciidoctor attribute for back-references to the 8.x line.
-     */
-    public abstract Property<String> getGradleVersion8();
 }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
@@ -145,4 +145,10 @@ public abstract class GradleDocumentationExtension {
      * (e.g. {@code gradleVersion} and the {@code https://docs.gradle.org/<version>} URLs).
      */
     public abstract Property<String> getGradleVersion();
+
+    /**
+     * The latest Gradle 8.x version referenced from the documentation. Used as the
+     * {@code gradleVersion8} Asciidoctor attribute for back-references to the 8.x line.
+     */
+    public abstract Property<String> getGradleVersion8();
 }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
@@ -60,7 +60,7 @@ public class GradleReleaseNotesPlugin implements Plugin<Project> {
             task.getOutputEncoding().convention(Charset.defaultCharset().name());
 
             task.getMarkdownFile().convention(extension.getReleaseNotes().getMarkdownFile());
-            task.getDestinationFile().convention(extension.getStagingRoot().file("release-notes/raw.html"));
+            task.getDestinationFile().convention(extension.getReleaseNotes().getStagingRoot().file("raw.html"));
         });
 
         TaskProvider<DecorateReleaseNotes> releaseNotesPostProcess = tasks.register("releaseNotes", DecorateReleaseNotes.class, task -> {
@@ -84,7 +84,7 @@ public class GradleReleaseNotesPlugin implements Plugin<Project> {
             replacementTokens.put("version", moduleIdentity.getVersion().map(GradleVersion::getVersion));
             replacementTokens.put("baseVersion", moduleIdentity.getVersion().map(v -> v.getBaseVersion().getVersion()));
 
-            task.getDestinationFile().convention(extension.getStagingRoot().file("release-notes/release-notes.html"));
+            task.getDestinationFile().convention(extension.getReleaseNotes().getStagingRoot().file("release-notes.html"));
         });
 
         tasks.register("checkContributorsInReleaseNotes", CheckContributorsInReleaseNotes.class);
@@ -104,6 +104,7 @@ public class GradleReleaseNotesPlugin implements Plugin<Project> {
         });
 
         extension.releaseNotes(releaseNotes -> {
+            releaseNotes.getStagingRoot().convention(extension.getStagingRoot().dir("release-notes"));
             releaseNotes.getMarkdownFile().convention(extension.getSourceRoot().file("release/notes.md"));
             releaseNotes.getRenderedDocumentation().convention(releaseNotesPostProcess.flatMap(DecorateReleaseNotes::getDestinationFile));
             releaseNotes.getBaseCssFile().convention(extension.getSourceRoot().file("css/base.css"));

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -169,8 +169,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
 
             // TODO: This breaks if the version is changed later.
             attributes.put("gradleVersion", project.getVersion().toString());
-            attributes.put("gradleVersion90", "9.0.0");
-            attributes.put("gradleVersion8", "8.14.4");
+            attributes.put("gradleVersion8", "8.14.5");
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
         });

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -160,8 +160,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             // TODO: This breaks the provider
             attributes.put("javaApi", extension.getJavadocs().getJavaApi().get().toString());
             attributes.put("jdkDownloadUrl", "https://jdk.java.net/");
-            // TODO: This is coupled to extension.getJavadocs().getJavaApi()
-            attributes.put("javadocReferenceUrl", "https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html");
+            attributes.put("javadocReferenceUrl", extension.getJavadocs().getJavadocReferenceUrl().get().toString());
             // TODO: This is coupled to extension.getJavadocs().getJavaApi()
             attributes.put("minJdkVersion", "17");
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -214,8 +214,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             task.setDescription("Generates HTML single-page user manual.");
             configureForUserGuideSinglePage(task, extension);
             task.outputOptions(options -> options.setBackends(singletonList("html5")));
-            // TODO: This breaks the provider
-            task.setOutputDir(extension.getUserManual().getStagingRoot().dir("render-single-html").get().getAsFile());
+            task.getOutputDirProperty().set(extension.getUserManual().getStagingRoot().dir("render-single-html"));
         });
 
         TaskProvider<AsciidoctorTask> userguideMultiPage = tasks.register("userguideMultiPage", AsciidoctorTask.class, task -> {
@@ -231,10 +230,8 @@ public class GradleUserManualPlugin implements Plugin<Project> {
                 patternSet.exclude("snippets/**/*.adoc");
             });
 
-            // TODO: This breaks the provider
-            task.setSourceDir(extension.getUserManual().getStagedDocumentation().get().getAsFile());
-            // TODO: This breaks the provider
-            task.setOutputDir(extension.getUserManual().getStagingRoot().dir("render-multi").get().getAsFile());
+            task.getSourceDirProperty().set(extension.getUserManual().getStagedDocumentation());
+            task.getOutputDirProperty().set(extension.getUserManual().getStagingRoot().dir("render-multi"));
 
             Map<String, Object> attributes = new HashMap<>();
             attributes.put("icons", "font");
@@ -281,8 +278,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
 
         task.sources(patternSet -> patternSet.include("userguide_single.adoc"));
 
-        // TODO: This breaks the provider
-        task.setSourceDir(extension.getUserManual().getStagedDocumentation().get().getAsFile());
+        task.getSourceDirProperty().set(extension.getUserManual().getStagedDocumentation());
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("toc", "macro");

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -167,6 +167,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("docsUrl", "https://docs.gradle.org");
 
             attributes.put("gradleVersion", (Callable<String>) extension.getGradleVersion()::get);
+            attributes.put("gradleVersion8", (Callable<String>) extension.getGradleVersion8()::get);
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
         });

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -168,7 +168,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("docsUrl", "https://docs.gradle.org");
 
             attributes.put("gradleVersion", (Callable<String>) () -> extension.getGradleVersion().get());
-            attributes.put("gradleVersion8", "8.14.5");
+            attributes.put("gradleVersion8", (Callable<String>) () -> extension.getGradleVersion8().get());
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
         });

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -167,8 +167,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("antManual", "https://ant.apache.org/manual");
             attributes.put("docsUrl", "https://docs.gradle.org");
 
-            // TODO: This breaks if the version is changed later.
-            attributes.put("gradleVersion", project.getVersion().toString());
+            attributes.put("gradleVersion", (Callable<String>) () -> extension.getGradleVersion().get());
             attributes.put("gradleVersion8", "8.14.5");
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
@@ -213,7 +212,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
 
         TaskProvider<AsciidoctorTask> userguideSinglePageHtml = tasks.register("userguideSinglePageHtml", AsciidoctorTask.class, task -> {
             task.setDescription("Generates HTML single-page user manual.");
-            configureForUserGuideSinglePage(task, extension, project);
+            configureForUserGuideSinglePage(task, extension);
             task.outputOptions(options -> options.setBackends(singletonList("html5")));
             // TODO: This breaks the provider
             task.setOutputDir(extension.getUserManual().getStagingRoot().dir("render-single-html").get().getAsFile());
@@ -275,7 +274,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
         });
     }
 
-    private void configureForUserGuideSinglePage(AsciidoctorTask task, GradleDocumentationExtension extension, Project project) {
+    private void configureForUserGuideSinglePage(AsciidoctorTask task, GradleDocumentationExtension extension) {
         task.setGroup("documentation");
         task.dependsOn(extension.getUserManual().getStagedDocumentation());
         task.onlyIf(t -> !extension.getQuickFeedback().get());
@@ -289,11 +288,9 @@ public class GradleUserManualPlugin implements Plugin<Project> {
         attributes.put("toc", "macro");
         attributes.put("toclevels", 2);
 
-        // TODO: This breaks if version is changed later
-        String versionUrl = DOCS_GRADLE_ORG + project.getVersion();
-        attributes.put("groovyDslPath", versionUrl + "/dsl");
-        attributes.put("javadocPath", versionUrl + "/javadoc");
-        attributes.put("kotlinDslPath", versionUrl + "/kotlin-dsl");
+        attributes.put("groovyDslPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/dsl");
+        attributes.put("javadocPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/javadoc");
+        attributes.put("kotlinDslPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/kotlin-dsl");
         // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
         attributes.put("samples-dir", (Callable<File>) () -> extension.getUserManual().getStagedDocumentation().get().getAsFile());
         task.attributes(attributes);

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -143,7 +143,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
 
             // TODO: Break the paths assumed here
             Map<String, Object> attributes = new HashMap<>();
-            attributes.put("stylesdir", (Callable<String>) () -> stylesDir.get().getAsFile().getAbsolutePath());
+            attributes.put("stylesdir", (Callable<String>) stylesDir.map(d -> d.getAsFile().getAbsolutePath())::get);
             attributes.put("stylesheet", "manual.css");
             attributes.put("doctype", "book");
             attributes.put("imagesdir", "img");
@@ -158,15 +158,15 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("encoding", "utf-8");
             attributes.put("idprefix", "");
             attributes.put("website", "https://gradle.org");
-            attributes.put("javaApi", (Callable<String>) () -> extension.getJavadocs().getJavaApi().get().toString());
+            attributes.put("javaApi", (Callable<String>) extension.getJavadocs().getJavaApi().map(uri -> uri.toString())::get);
             attributes.put("jdkDownloadUrl", "https://jdk.java.net/");
-            attributes.put("javadocReferenceUrl", (Callable<String>) () -> extension.getJavadocs().getJavadocReferenceUrl().get().toString());
-            attributes.put("minJdkVersion", (Callable<String>) () -> extension.getJavadocs().getMinJdkVersion().get().toString());
+            attributes.put("javadocReferenceUrl", (Callable<String>) extension.getJavadocs().getJavadocReferenceUrl().map(uri -> uri.toString())::get);
+            attributes.put("minJdkVersion", (Callable<String>) extension.getJavadocs().getMinJdkVersion().map(v -> v.toString())::get);
 
             attributes.put("antManual", "https://ant.apache.org/manual");
             attributes.put("docsUrl", "https://docs.gradle.org");
 
-            attributes.put("gradleVersion", (Callable<String>) () -> extension.getGradleVersion().get());
+            attributes.put("gradleVersion", (Callable<String>) extension.getGradleVersion()::get);
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
         });
@@ -240,7 +240,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("javadocPath", "../javadoc");
             attributes.put("kotlinDslPath", "../kotlin-dsl");
             // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
-            attributes.put("samples-dir", (Callable<File>) () -> extension.getUserManual().getStagedDocumentation().get().getAsFile());
+            attributes.put("samples-dir", (Callable<File>) extension.getUserManual().getStagedDocumentation().getAsFile()::get);
             task.attributes(attributes);
         });
 
@@ -282,11 +282,11 @@ public class GradleUserManualPlugin implements Plugin<Project> {
         attributes.put("toc", "macro");
         attributes.put("toclevels", 2);
 
-        attributes.put("groovyDslPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/dsl");
-        attributes.put("javadocPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/javadoc");
-        attributes.put("kotlinDslPath", (Callable<String>) () -> DOCS_GRADLE_ORG + extension.getGradleVersion().get() + "/kotlin-dsl");
+        attributes.put("groovyDslPath", (Callable<String>) extension.getGradleVersion().map(v -> DOCS_GRADLE_ORG + v + "/dsl")::get);
+        attributes.put("javadocPath", (Callable<String>) extension.getGradleVersion().map(v -> DOCS_GRADLE_ORG + v + "/javadoc")::get);
+        attributes.put("kotlinDslPath", (Callable<String>) extension.getGradleVersion().map(v -> DOCS_GRADLE_ORG + v + "/kotlin-dsl")::get);
         // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
-        attributes.put("samples-dir", (Callable<File>) () -> extension.getUserManual().getStagedDocumentation().get().getAsFile());
+        attributes.put("samples-dir", (Callable<File>) extension.getUserManual().getStagedDocumentation().getAsFile()::get);
         task.attributes(attributes);
     }
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -167,7 +167,6 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("docsUrl", "https://docs.gradle.org");
 
             attributes.put("gradleVersion", (Callable<String>) () -> extension.getGradleVersion().get());
-            attributes.put("gradleVersion8", (Callable<String>) () -> extension.getGradleVersion8().get());
             attributes.put("snippetsPath", "snippets");
             task.attributes(attributes);
         });

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -37,10 +37,12 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.ysb33r.grolifant.api.core.jvm.ExecutionMode;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -141,8 +143,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
 
             // TODO: Break the paths assumed here
             Map<String, Object> attributes = new HashMap<>();
-            // TODO: This breaks the provider
-            attributes.put("stylesdir", stylesDir.get().getAsFile().getAbsolutePath());
+            attributes.put("stylesdir", (Callable<String>) () -> stylesDir.get().getAsFile().getAbsolutePath());
             attributes.put("stylesheet", "manual.css");
             attributes.put("doctype", "book");
             attributes.put("imagesdir", "img");
@@ -157,10 +158,9 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("encoding", "utf-8");
             attributes.put("idprefix", "");
             attributes.put("website", "https://gradle.org");
-            // TODO: This breaks the provider
-            attributes.put("javaApi", extension.getJavadocs().getJavaApi().get().toString());
+            attributes.put("javaApi", (Callable<String>) () -> extension.getJavadocs().getJavaApi().get().toString());
             attributes.put("jdkDownloadUrl", "https://jdk.java.net/");
-            attributes.put("javadocReferenceUrl", extension.getJavadocs().getJavadocReferenceUrl().get().toString());
+            attributes.put("javadocReferenceUrl", (Callable<String>) () -> extension.getJavadocs().getJavadocReferenceUrl().get().toString());
             // TODO: This is coupled to extension.getJavadocs().getJavaApi()
             attributes.put("minJdkVersion", "17");
 
@@ -246,8 +246,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("javadocPath", "../javadoc");
             attributes.put("kotlinDslPath", "../kotlin-dsl");
             // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
-            // TODO: This breaks the provider
-            attributes.put("samples-dir", extension.getUserManual().getStagedDocumentation().get().getAsFile()); // TODO:
+            attributes.put("samples-dir", (Callable<File>) () -> extension.getUserManual().getStagedDocumentation().get().getAsFile());
             task.attributes(attributes);
         });
 
@@ -296,8 +295,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
         attributes.put("javadocPath", versionUrl + "/javadoc");
         attributes.put("kotlinDslPath", versionUrl + "/kotlin-dsl");
         // Used by SampleIncludeProcessor from `gradle/dotorg-docs`
-        // TODO: This breaks the provider
-        attributes.put("samples-dir", extension.getUserManual().getStagedDocumentation().get().getAsFile()); // TODO:
+        attributes.put("samples-dir", (Callable<File>) () -> extension.getUserManual().getStagedDocumentation().get().getAsFile());
         task.attributes(attributes);
     }
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -161,8 +161,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             attributes.put("javaApi", (Callable<String>) () -> extension.getJavadocs().getJavaApi().get().toString());
             attributes.put("jdkDownloadUrl", "https://jdk.java.net/");
             attributes.put("javadocReferenceUrl", (Callable<String>) () -> extension.getJavadocs().getJavadocReferenceUrl().get().toString());
-            // TODO: This is coupled to extension.getJavadocs().getJavaApi()
-            attributes.put("minJdkVersion", "17");
+            attributes.put("minJdkVersion", (Callable<String>) () -> extension.getJavadocs().getMinJdkVersion().get().toString());
 
             attributes.put("antManual", "https://ant.apache.org/manual");
             attributes.put("docsUrl", "https://docs.gradle.org");

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -21,6 +21,7 @@ import gradlebuild.docs.dsl.source.GenerateDefaultImports;
 import org.asciidoctor.gradle.jvm.AsciidoctorTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.DuplicatesStrategy;
@@ -199,10 +200,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
                 sub.setIncludeEmptyDirs(false);
             });
             task.from(extension.getCssFiles(), sub -> sub.into("css"));
-            task.from(extension.getUserManual().getRoot().dir("img"), sub -> {
-                sub.include("**/*.png", "**/*.gif", "**/*.jpg", "**/*.svg");
-                sub.into("img");
-            });
+            stageUserManualImages(task, extension);
             task.from(extension.getUserManual().getResources());
 
             task.from(generateDocinfo);
@@ -263,11 +261,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             task.from(userguideSinglePageHtml);
             task.from(userguideMultiPage);
             task.into(extension.getUserManual().getStagingRoot().dir("final"));
-            // TODO: Eliminate this duplication with the flatten task
-            task.from(extension.getUserManual().getRoot().dir("img"), sub -> {
-                sub.include("**/*.png", "**/*.gif", "**/*.jpg", "**/*.svg");
-                sub.into("img");
-            });
+            stageUserManualImages(task, extension);
             task.from(extension.getUserManual().getRoot().dir("js"), sub -> {
                 sub.include("**/*.js");
                 sub.into("js");
@@ -307,6 +301,13 @@ public class GradleUserManualPlugin implements Plugin<Project> {
         // TODO: This breaks the provider
         attributes.put("samples-dir", extension.getUserManual().getStagedDocumentation().get().getAsFile()); // TODO:
         task.attributes(attributes);
+    }
+
+    private static void stageUserManualImages(CopySpec spec, GradleDocumentationExtension extension) {
+        spec.from(extension.getUserManual().getRoot().dir("img"), sub -> {
+            sub.include("**/*.png", "**/*.gif", "**/*.jpg", "**/*.svg");
+            sub.into("img");
+        });
     }
 
     private void checkXrefLinksInUserManualAreValid(ProjectLayout layout, TaskContainer tasks, GradleDocumentationExtension extension) {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/Javadocs.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/Javadocs.java
@@ -33,6 +33,12 @@ public abstract class Javadocs {
     public abstract Property<URI> getJavaApi();
 
     /**
+     * Minimum JDK version that the documented Gradle distribution targets.
+     * Surfaced as the {@code minJdkVersion} Asciidoctor attribute.
+     */
+    public abstract Property<Integer> getMinJdkVersion();
+
+    /**
      * Link to the documentation for the {@code javadoc} tool, referenced from the user manual.
      */
     public abstract Property<URI> getJavadocReferenceUrl();

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/Javadocs.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/Javadocs.java
@@ -33,6 +33,11 @@ public abstract class Javadocs {
     public abstract Property<URI> getJavaApi();
 
     /**
+     * Link to the documentation for the {@code javadoc} tool, referenced from the user manual.
+     */
+    public abstract Property<URI> getJavadocReferenceUrl();
+
+    /**
      * Package list of the Java API used to generate Javadoc offline
      */
     public abstract DirectoryProperty getJavaPackageListLoc();

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotes.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotes.java
@@ -45,7 +45,10 @@ public abstract class ReleaseNotes {
      */
     public abstract DirectoryProperty getReleaseNotesAssets();
 
-    // TODO: Need staging root property too
+    /**
+     * Intermediate working directory for release notes rendering.
+     */
+    public abstract DirectoryProperty getStagingRoot();
 
     /**
      * The collection of rendered documentation.

--- a/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
+++ b/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
@@ -58,6 +58,12 @@ class FindBrokenInternalLinksTest extends Specification {
             }
         """.stripIndent()
 
+        // `repoRoot()` walks up the tree looking for `version.txt`; `released-versions.json` is the
+        // source for the `gradleVersion8` Asciidoctor attribute. Provide both so the documentation
+        // plugin applies cleanly in this minimal TestKit project.
+        new File(projectDir, "version.txt") << "test"
+        new File(projectDir, "released-versions.json") << '{"finalReleases":[{"version":"8.99.99","buildTime":"20260101000000+0000"}]}'
+
         new File(projectDir, "src/docs/javaPackageList/8").mkdirs()
         new File(projectDir, "src/docs/javaPackageList/8/package-list") << """
         java.lang

--- a/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
+++ b/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
@@ -47,6 +47,17 @@ class FindBrokenInternalLinksTest extends Specification {
             org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
         """.stripIndent()
 
+        new File(projectDir, "settings.gradle") << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    create('buildLibs') {
+                        version('asciidoctor', '3.0.1')
+                        version('asciidoctorPdf', '2.3.23')
+                    }
+                }
+            }
+        """.stripIndent()
+
         new File(projectDir, "src/docs/javaPackageList/8").mkdirs()
         new File(projectDir, "src/docs/javaPackageList/8/package-list") << """
         java.lang

--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -1,6 +1,7 @@
 # some versions are in shared-versions.properties
 [versions]
 asciidoctor = "3.0.1"
+asciidoctorPdf = "2.3.23"
 bytebuddy = "1.18.8"
 checkstyle = "10.25.0"
 develocity = "4.4.3"

--- a/platforms/documentation/docs/README.md
+++ b/platforms/documentation/docs/README.md
@@ -18,6 +18,56 @@ All file paths in this guide are relative to the `docs` project directory unless
 
 ---
 
+## Build Logic
+
+The documentation build is driven by plugins in [`build-logic/documentation/`](../../../build-logic/documentation/).
+The root plugin `gradlebuild.documentation` is applied in [`build.gradle.kts`](build.gradle.kts) and applies the per-document-type sub-plugins below.
+
+### Plugins
+
+| Plugin                           | Responsibility                                                                                                                                                  |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GradleBuildDocumentationPlugin` | Root plugin. Creates the `gradleDocumentation` extension, configures the Asciidoctor toolchain, and applies the sub-plugins.                                    |
+| `GradleReleaseNotesPlugin`       | Converts `notes.md` to HTML.                                                                                                                                    |
+| `GradleUserManualPlugin`         | Registers Asciidoctor tasks for the multi-page and single-page user manual. Also generates the default-imports and API-mapping files used by the DSL reference. |
+| `GradleDslReferencePlugin`       | Generates the Groovy DSL reference from Docbook sources and extracted code doc comments.                                                                        |
+| `GradleKotlinDslReferencePlugin` | Runs Dokka to produce the Kotlin DSL reference.                                                                                                                 |
+| `GradleJavadocsPlugin`           | Generates Javadoc for the full Gradle distribution.                                                                                                             |
+
+### The `gradleDocumentation` extension
+
+The extension is the configuration surface used by `build.gradle.kts`.
+
+Top-level properties:
+
+| Property                    | Purpose                                                                                      |
+|-----------------------------|----------------------------------------------------------------------------------------------|
+| `sourceRoot`                | Root directory of all documentation inputs (defaults to `src/docs`).                         |
+| `stagingRoot`               | Working directory for in-flight rendered output (defaults to `build/working`).               |
+| `documentationRenderedRoot` | Final location of all rendered documentation (defaults to `build/docs`).                     |
+| `gradleVersion`             | Gradle version embedded in the documentation.                                                |
+| `quickFeedback`             | When `true` (via `-PquickDocs`), slow tasks (single-page manual, DSL reference) are skipped. |
+
+The extension also exposes nested configurations for each documentation type:
+
+| Configuration                | Configures                                                                                    |
+|------------------------------|-----------------------------------------------------------------------------------------------|
+| `releaseNotes { ... }`       | Release-notes source and rendered output locations.                                           |
+| `userManual { ... }`         | Staging directories, snippet sources, raw and rendered output paths.                          |
+| `dslReference { ... }`       | Generated metadata file, rendered output location.                                            |
+| `javadocs { ... }`           | `javaApi`, `javadocReferenceUrl`, `minJdkVersion`, `groovyApi`, package-list paths, CSS file. |
+| `kotlinDslReference { ... }` | Dokka configuration and rendered output.                                                      |
+
+### Build flow
+
+1. **Source** — Each documentation type reads from a subdirectory of `src/docs/` (or from generated metadata such as the DSL meta-data file).
+2. **Stage** — The user manual stages flattened `.adoc` sources, snippets, images, and CSS into `build/working/usermanual/raw/` via the `stageUserguideSource` task.
+3. **Render** — Asciidoctor (`userguideMultiPage`, `userguideSinglePageHtml`) and Dokka render the staged sources into `build/working/<doc-type>/render-*/`.
+4. **Publish** — `stageDocs` collects every rendered output into `build/docs/` (multi-page manual under `userguide/`, DSL under `dsl/`, Javadoc under `javadoc/`, Kotlin DSL under `kotlin-dsl/`).
+5. **Consume** — The `gradleFullDocsElements` configuration exposes `build/docs/` as an outgoing artifact for downstream packaging (distribution zips, the `docs.gradle.org` deploy).
+
+---
+
 ## Release Notes
 
 **Source file:** `src/docs/release/notes.md` - authored in [Markdown](https://www.markdownguide.org/)

--- a/platforms/documentation/docs/README.md
+++ b/platforms/documentation/docs/README.md
@@ -46,6 +46,7 @@ Top-level properties:
 | `stagingRoot`               | Working directory for in-flight rendered output (defaults to `build/working`).               |
 | `documentationRenderedRoot` | Final location of all rendered documentation (defaults to `build/docs`).                     |
 | `gradleVersion`             | Gradle version embedded in the documentation.                                                |
+| `gradleVersion8`            | Latest Gradle 8.x patch version, auto-derived from `released-versions.json`.                 |
 | `quickFeedback`             | When `true` (via `-PquickDocs`), slow tasks (single-page manual, DSL reference) are skipped. |
 
 The extension also exposes nested configurations for each documentation type:

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -101,6 +101,7 @@ gradleDocumentation {
     javadocs {
         val jvmVersion = jvmCompile.compilations.named("main").flatMap { it.targetJvmVersion }
         javaApi = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/api/") }
+        javadocReferenceUrl = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/specs/man/javadoc.html") }
         javaPackageListLoc = jvmVersion.map { v -> project.layout.projectDirectory.dir("src/docs/javaPackageList/$v/") }
         groovyApi = libs.versions.groovy.map { v -> project.uri("https://docs.groovy-lang.org/docs/groovy-$v/html/gapi") }
         groovyPackageListSrc = libs.versions.groovy.map { v -> "org.apache.groovy:groovy-all:$v:groovydoc" }

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -99,7 +99,6 @@ jvmCompile {
 
 gradleDocumentation {
     gradleVersion = project.version.toString()
-    gradleVersion8 = "8.14.5"
     javadocs {
         val jvmVersion = jvmCompile.compilations.named("main").flatMap { it.targetJvmVersion }
         javaApi = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/api/") }

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -339,8 +339,7 @@ tasks.named<Test>("docsTest") {
 
 configurations {
     named("gradleFullDocsElements") {
-        // TODO: This breaks the provider
-        outgoing.artifact(project.gradleDocumentation.documentationRenderedRoot.get().asFile) {
+        outgoing.artifact(project.gradleDocumentation.documentationRenderedRoot) {
             builtBy(tasks.named("docs"))
         }
     }

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -99,6 +99,7 @@ jvmCompile {
 
 gradleDocumentation {
     gradleVersion = project.version.toString()
+    gradleVersion8 = "8.14.5"
     javadocs {
         val jvmVersion = jvmCompile.compilations.named("main").flatMap { it.targetJvmVersion }
         javaApi = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/api/") }

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -6,7 +6,6 @@ import gradlebuild.integrationtests.androidhomewarmup.SdkVersion
 import gradlebuild.integrationtests.configureTestSourceSetInIde
 import gradlebuild.integrationtests.model.GradleDistribution
 import java.io.FileFilter
-import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.docs.internal.tasks.CheckLinks
 import org.gradle.docs.samples.internal.tasks.InstallSample
@@ -15,8 +14,6 @@ import org.gradle.internal.os.OperatingSystem
 plugins {
     id("java-library") // Needed for the dependency-analysis plugin. However, we should not need this. This is not a real library.
     id("gradlebuild.internal.java")
-    // TODO: Apply asciidoctor in documentation plugin instead.
-    id("org.asciidoctor.jvm.convert")
     id("gradlebuild.documentation")
     id("org.gradle.samples")
     id("gradlebuild.android-home-warmup")
@@ -98,24 +95,6 @@ dependencies {
 
 jvmCompile {
     addCompilationFrom(sourceSets.docsTest)
-}
-
-asciidoctorj {
-    setVersion(buildLibs.versions.asciidoctor.get())
-    modules.pdf.setVersion("2.3.23")
-    // TODO: gif are not supported in pdfs, see also https://github.com/gradle/gradle/issues/24193
-    // TODO: tables are not handled properly in pdfs
-    fatalWarnings.add(
-        Regex("^(?!GIF image format not supported|dropping cells from incomplete row detected end of table|.*Asciidoctor PDF does not support table cell content that exceeds the height of a single page).*").toPattern()
-    )
-}
-
-tasks.withType<AsciidoctorTask>().configureEach {
-    val doctorj = extensions.getByType<org.asciidoctor.gradle.jvm.AsciidoctorJExtension>()
-    doctorj.docExtensions(
-        project.dependencies.create(project(":docs-asciidoctor-extensions")),
-        project.dependencies.create(files("src/main/resources"))
-    )
 }
 
 gradleDocumentation {

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -103,6 +103,7 @@ gradleDocumentation {
     javadocs {
         val jvmVersion = jvmCompile.compilations.named("main").flatMap { it.targetJvmVersion }
         javaApi = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/api/") }
+        minJdkVersion = jvmVersion
         javadocReferenceUrl = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/specs/man/javadoc.html") }
         javaPackageListLoc = jvmVersion.map { v -> project.layout.projectDirectory.dir("src/docs/javaPackageList/$v/") }
         groovyApi = libs.versions.groovy.map { v -> project.uri("https://docs.groovy-lang.org/docs/groovy-$v/html/gapi") }

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -98,6 +98,7 @@ jvmCompile {
 }
 
 gradleDocumentation {
+    gradleVersion = project.version.toString()
     javadocs {
         val jvmVersion = jvmCompile.compilations.named("main").flatMap { it.targetJvmVersion }
         javaApi = jvmVersion.map { v -> uri("https://docs.oracle.com/en/java/javase/$v/docs/api/") }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -16,7 +16,7 @@
 
 = Upgrading to Gradle 9.0.0
 
-This chapter provides the information you need to migrate your Gradle {gradleVersion8} builds to Gradle 9.0.0.
+This chapter provides the information you need to migrate your Gradle 8.14.5 builds to Gradle 9.0.0.
 For migrating within Gradle 8.x, see the <<upgrading_version_8.adoc#upgrading_version_8, older migration guide>> first.
 
 We recommend the following steps for all users:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -16,7 +16,7 @@
 
 = Upgrading to Gradle 9.0.0
 
-This chapter provides the information you need to migrate your Gradle 8.14.5 builds to Gradle 9.0.0.
+This chapter provides the information you need to migrate your Gradle {gradleVersion8} builds to Gradle 9.0.0.
 For migrating within Gradle 8.x, see the <<upgrading_version_8.adoc#upgrading_version_8, older migration guide>> first.
 
 We recommend the following steps for all users:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -16,7 +16,7 @@
 
 = Upgrading to Gradle 9.0.0
 
-This chapter provides the information you need to migrate your Gradle {gradleVersion8} builds to Gradle {gradleVersion90}.
+This chapter provides the information you need to migrate your Gradle {gradleVersion8} builds to Gradle 9.0.0.
 For migrating within Gradle 8.x, see the <<upgrading_version_8.adoc#upgrading_version_8, older migration guide>> first.
 
 We recommend the following steps for all users:
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins may break with a new major version of Gradle, as these releases can remove public APIs.
 Using the latest version of a plugin increases the likelihood that it is already compatible with the new major Gradle version.
 +
-. Run `gradle :wrapper --gradle-version {gradleVersion90}` to update the project to {gradleVersion90}.
+. Run `gradle :wrapper --gradle-version 9.0.0` to update the project to 9.0.0.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_major_9]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -16,7 +16,7 @@
 
 = Upgrading within Gradle 8.x
 
-This chapter provides the information you need to migrate your Gradle 8.x builds to Gradle 8.14.5.
+This chapter provides the information you need to migrate your Gradle 8.x builds to Gradle {gradleVersion8}.
 For migrating from Gradle 7.x, see the <<upgrading_version_7.adoc#upgrading_version_7, older migration guide>> first.
 
 We recommend the following steps for all users:
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin tries to use a deprecated part of the API.
 +
-. Run `gradle :wrapper --gradle-version 8.14.5` to update the project to 8.14.5.
+. Run `gradle :wrapper --gradle-version {gradleVersion8}` to update the project to {gradleVersion8}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_8.14]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -16,7 +16,7 @@
 
 = Upgrading within Gradle 8.x
 
-This chapter provides the information you need to migrate your Gradle 8.x builds to Gradle {gradleVersion8}.
+This chapter provides the information you need to migrate your Gradle 8.x builds to Gradle 8.14.5.
 For migrating from Gradle 7.x, see the <<upgrading_version_7.adoc#upgrading_version_7, older migration guide>> first.
 
 We recommend the following steps for all users:
@@ -33,7 +33,7 @@ Alternatively, you can run `gradle help --warning-mode=all` to see the deprecati
 Some plugins will break with this new version of Gradle because they use internal APIs that have been removed or changed.
 The previous step will help you identify potential problems by issuing deprecation warnings when a plugin tries to use a deprecated part of the API.
 +
-. Run `gradle :wrapper --gradle-version {gradleVersion8}` to update the project to {gradleVersion8}.
+. Run `gradle :wrapper --gradle-version 8.14.5` to update the project to 8.14.5.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_8.14]]


### PR DESCRIPTION
### Details
This is a Documentation infrastructure change ONLY.

### Context
  Cleans up the documentation build infrastructure by replacing eagerly resolved values with properly lazy-loaded provider wiring and removing 9 long-standing TODOs in the process. Also adds a new **Build Logic** section to the `docs` project's README documenting how the documentation production and build wiring works:

  **Lazy attribute wiring on `AsciidoctorTask`s** — the user-manual attribute maps in `GradleUserManualPlugin` were calling `.get()` on Providers at configuration time, which meant the cached values would silently drift if the underlying Provider changed later. All Asciidoctor attribute Callables now use the `provider::get` (or `provider.map(...)::get`) method-reference pattern, making it visually obvious that resolution is deferred to execution time. The `setSourceDir` / `setOutputDir` calls now go through `getSourceDirProperty()` / `getOutputDirProperty()` so the AsciidoctorTask's own `DirectoryProperty` does the lazy resolution. The `gradleFullDocsElements` outgoing artifact in `build.gradle.kts` is now also wired through its Provider instead of being unwrapped to a `File`.                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                          
  **`gradleVersion` and `minJdkVersion` promoted to extension properties** — both were hardcoded in the plugin. `gradleVersion` captured `project.getVersion()` eagerly at configuration time and is now a `Property<String>` on `GradleDocumentationExtension` with a sensible default convention. `minJdkVersion` is now  
  `Property<Integer>` on the existing `Javadocs` sub-extension, derived from the same `jvmCompile.compilations.main.targetJvmVersion` chain that already feeds `javaApi` and `javadocReferenceUrl` — so the userguide's "JDK version N or higher" line follows the documented JVM target automatically. Both are explicitly set from `platforms/documentation/docs/build.gradle.kts`.                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
  **`gradleVersion8` derived from `released-versions.json`** — was previously hardcoded in the plugin as `"8.14.5"`. Now exposed as `Property<String>` on the documentation extension, with its convention computed by parsing `released-versions.json` at the repo root and picking the first version whose major is `8`. Uses the existing `gradlebuild.basics.BuildEnvironment.releasedVersionsFile(project)` helper (Isolated-Projects safe) and Gson (already on the classpath). The two upgrade-guide `.adoc` files reference the attribute via `{gradleVersion8}` again, so the literal version no longer has to be touched at release time.
                                                                                                                                                                                                                                                                                                                            
  **Asciidoctor and Asciidoctor-PDF versions promoted to the `buildLibs` catalog** — both versions live in `gradle/dependency-management/build.versions.toml` under the `asciidoctor` and `asciidoctorPdf` aliases. `GradleBuildDocumentationPlugin.configureAsciidoctorJ` reads both via strict `buildLibs.findVersion(...).get()` calls so a rename or typo fails loudly. The `FindBrokenInternalLinksTest` fixture provides a matching inline catalog so the plugin applies cleanly in TestKit projects.
                                                                                                                                                                                                                                                                                                                            
  **`test` task system property switched to a `CommandLineArgumentProvider`** — `task.systemProperty("...rendered", provider.get().getAsFile())` stored a `File` at configuration time and bypassed the Provider. Replaced with a `CommandLineArgumentProvider` that resolves the path at task execution time. The existing `inputs.file(provider)` line that handles input-change detection is unaffected.
                                                                                                                                                                                                                                                                                                                            
  **Tidy-ups** — the `javadocReferenceUrl` attribute (added earlier on this branch) and the `samples-dir` attributes were also wrapped in the new method-reference Callable style for consistency. `configureForUserGuideSinglePage` no longer needs a `Project` parameter.                                                 
   
  **README — new "Build Logic" section** — adds a ~50-line section to `platforms/documentation/docs/README.md` describing how the documentation build is structured: the plugin layout in `build-logic/documentation/`, the role of each sub-plugin, the `gradleDocumentation` extension's configuration surface (top-level properties and nested per-doc-type configurations), and the build flow from source → stage → render → publish → consume.     
                                 

### Documentation Checklist
- [ ] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [ ] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [ ] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [ ] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [ ] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [ ] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [ ] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [ ] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [ ] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description