### PR TITLE
Restore --non-interactive flag instead of --interactive/--no-interactive

### DIFF
--- a/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
+++ b/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
@@ -45,8 +45,7 @@ Logging:
 Console:
   --console                          Specifies which type of console output to generate. Supported values are 'plain', 'colored', 'auto' (default), 'rich', or 'verbose'.
   --console-unicode                  Specifies which character types are allowed in the console output. Supported values are 'auto' (default), 'disable', or 'enable'.
-  --interactive                      Allow Gradle to prompt the user for input on the console. [incubating]
-  --no-interactive                   Do not do interactive prompting. [incubating]
+  --non-interactive                  Do not do interactive prompting. [incubating]
 
 Configuration:
   --gradle-user-home, -g             Specifies the Gradle user home directory. Default is ~/.gradle.

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -27,10 +27,10 @@ import org.gradle.cli.OptionCategory;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.buildoption.AbstractBuildOption;
 import org.gradle.internal.buildoption.BooleanBuildOption;
-import org.gradle.internal.buildoption.BooleanCommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.BuildOptionSet;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 import org.gradle.util.internal.TextUtil;
@@ -51,7 +51,8 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         new WarningsOption(),
         new ConsoleOption(),
         new ConsoleUnicodeOption(),
-        new InteractiveOption()
+        new InteractiveOption(),
+        new NonInteractiveOption()
     );
 
     @Override
@@ -248,11 +249,10 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
 
     @NullMarked
     public static class InteractiveOption extends BooleanBuildOption<LoggingConfiguration> {
-        public static final String LONG_OPTION = "interactive";
         public static final String GRADLE_PROPERTY = "org.gradle.console.interactive";
 
         public InteractiveOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create(LONG_OPTION, "Allow Gradle to prompt the user for input on the console.", "Do not do interactive prompting.").incubating());
+            super(GRADLE_PROPERTY);
         }
 
         @Override
@@ -263,6 +263,23 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         @Override
         public void applyTo(boolean value, LoggingConfiguration settings, Origin origin) {
             settings.setInteractive(value);
+        }
+    }
+
+    @NullMarked
+    public static class NonInteractiveOption extends EnabledOnlyBooleanBuildOption<LoggingConfiguration> {
+        public NonInteractiveOption() {
+            super(null, CommandLineOptionConfiguration.create("non-interactive", "Do not do interactive prompting.").incubating());
+        }
+
+        @Override
+        protected OptionCategory getCategory() {
+            return OptionCategory.CONSOLE;
+        }
+
+        @Override
+        public void applyTo(LoggingConfiguration settings, Origin origin) {
+            settings.setInteractive(false);
         }
     }
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -22,7 +22,7 @@ We recommend upgrading to Gradle @version@.
 
 This release improves [Configuration Cache](#configuration-cache-improvements) hit rates by precisely tracking project properties supplied through system properties and environment variables.
 
-The [CLI, logging, and problem reporting](#cli-logging-and-problem-reporting) gains a `--no-interactive` option (and `org.gradle.console.interactive` property) to disable interactive prompts when running Gradle in automated environments, support for the `NO_COLOR` environment variable to suppress color output, and sortable columns in HTML test reports.
+The [CLI, logging, and problem reporting](#cli-logging-and-problem-reporting) gains a `--non-interactive` option (and `org.gradle.console.interactive` property) to disable interactive prompts when running Gradle in automated environments, support for the `NO_COLOR` environment variable to suppress color output, and sortable columns in HTML test reports.
 
 [Build authoring](#build-authoring-improvements) includes an important deprecation: implicit property and method lookup in parent projects now emits a warning and will be removed in Gradle 10. A new `NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS` feature preview lets you adopt the Gradle 10 behavior early once related deprecations are addressed.
 
@@ -135,7 +135,7 @@ See the [Reading System Properties and Environment Variables](userguide/configur
 Gradle provides an intuitive [command-line interface](userguide/command_line_interface.html), detailed [logs](userguide/logging.html), and a structured [problems report](userguide/reporting_problems.html#sec:generated_html_report) that helps developers quickly identify and resolve build issues.
 
 #### Non-interactive mode
-Gradle now supports a `--no-interactive` [command-line](userguide/command_line_interface.html) option, and a corresponding `org.gradle.console.interactive` [Gradle property](userguide/build_environment.html#sec:gradle_configuration_properties), to disable all interactive console prompting.
+Gradle now supports a `--non-interactive` [command-line](userguide/command_line_interface.html) option, and a corresponding `org.gradle.console.interactive` [Gradle property](userguide/build_environment.html#sec:gradle_configuration_properties), to disable all interactive console prompting.
 This is useful for running Gradle in automated environments such as CI pipelines, scripts, and AI agents where no user input is available.
 
 See the [Non-interactive mode](userguide/command_line_interface.html#sec:non_interactive) section in the Gradle User Manual for more information.

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -14,7 +14,7 @@
 
 [[command_line_interface]]
 = Command-Line Interface
-:keywords: cli, clean, check, projects, tasks, rerun-tasks, continue, build-cache, no-build-cache, configuration-cache, no-configuration-cache, configuration-cache-problems, configure-on-demand, no-configure-on-demand, max-workers, parallel, no-parallel, priority, profile, scan, watch-fs, no-watch-fs, help, version, show-version, full-stacktrace, stacktrace, org.gradle.debug, org.gradle.debug.host, org.gradle.debug.port, org.gradle.debug.server, org.gradle.debug.suspend, project-cache-dir, system-prop, init-script, project-prop, org.gradle.jvmargs, org.gradle.java.home, gradle-user-home, dependency-verification, write-verification-metadata, refresh-keys, export-keys, include-build, offline, refresh-dependencies, dry-run, continuous, write-locks, update-locks , no-rebuild, org.gradle.warning.mode, warning-mode, no-problems-report, problems-report, org.gradle.console, console, interactive, no-interactive, org.gradle.console.interactive, org.gradle.logging.level, quiet, warn, info, debug, daemon, no-daemon, foreground, status, stop, org.gradle.daemon.idletimeout, exclude-task, distribution-type, gradle-distribution-url, gradle-distribution-sha256-sum, gradle-version
+:keywords: cli, clean, check, projects, tasks, rerun-tasks, continue, build-cache, no-build-cache, configuration-cache, no-configuration-cache, configuration-cache-problems, configure-on-demand, no-configure-on-demand, max-workers, parallel, no-parallel, priority, profile, scan, watch-fs, no-watch-fs, help, version, show-version, full-stacktrace, stacktrace, org.gradle.debug, org.gradle.debug.host, org.gradle.debug.port, org.gradle.debug.server, org.gradle.debug.suspend, project-cache-dir, system-prop, init-script, project-prop, org.gradle.jvmargs, org.gradle.java.home, gradle-user-home, dependency-verification, write-verification-metadata, refresh-keys, export-keys, include-build, offline, refresh-dependencies, dry-run, continuous, write-locks, update-locks , no-rebuild, org.gradle.warning.mode, warning-mode, no-problems-report, problems-report, org.gradle.console, console, non-interactive, org.gradle.console.interactive, org.gradle.logging.level, quiet, warn, info, debug, daemon, no-daemon, foreground, status, stop, org.gradle.daemon.idletimeout, exclude-task, distribution-type, gradle-distribution-url, gradle-distribution-sha256-sum, gradle-version
 
 The command-line interface is the **primary method of interacting with Gradle**.
 
@@ -860,15 +860,12 @@ A <<build_environment.adoc#sec:gradle_configuration_properties,Gradle property>>
 == Non-interactive mode
 
 By default, Gradle may prompt the user for input on the console when an interactive terminal is available.
-You can disable all interactive prompting by using the `--no-interactive` command-line option, or by setting the `org.gradle.console.interactive` <<build_environment.adoc#sec:gradle_configuration_properties,Gradle property>> to `false` (for example in `gradle.properties`, `GRADLE_OPTS`, or via `-D`).
+You can disable all interactive prompting by using the `--non-interactive` command-line option, or by setting the `org.gradle.console.interactive` <<build_environment.adoc#sec:gradle_configuration_properties,Gradle property>> to `false` (for example in `gradle.properties`, `GRADLE_OPTS`, or via `-D`).
 
 When interactive prompting is disabled, Gradle uses default values instead of prompting.
 This is useful for running Gradle in automated environments such as CI pipelines, scripts, and AI agents.
 
-`--interactive` (default)::
-Allow Gradle to prompt the user for input on the console. _(incubating)_
-
-`--no-interactive`::
+`--non-interactive`::
 Do not prompt for user input. _(incubating)_
 
 [[sec:task_options]]

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitInteractiveIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitInteractiveIntegrationTest.groovy
@@ -475,21 +475,21 @@ class BuildInitInteractiveIntegrationTest extends AbstractInteractiveInitIntegra
         ScriptDslFixture.of(BuildInitDsl.KOTLIN, targetDir, null).assertGradleFilesGenerated("app")
     }
 
-    def "use defaults when run from an interactive session with --no-interactive and no options"() {
+    def "use defaults when run from an interactive session with --non-interactive and no options"() {
         when:
         closeInteractiveExecutor(
-            startInteractiveExecutorWithTasks("--no-interactive", "init")
+            startInteractiveExecutorWithTasks("--non-interactive", "init")
         )
 
         then:
         ScriptDslFixture.of(BuildInitDsl.KOTLIN, targetDir, null).assertGradleFilesGenerated()
     }
 
-    def "use defaults when run from an interactive session with --no-interactive and not enough options"() {
+    def "use defaults when run from an interactive session with --non-interactive and not enough options"() {
         when:
         closeInteractiveExecutor(
             startInteractiveExecutorWithTasks(
-                "--no-interactive",
+                "--non-interactive",
                 "init",
                 "--type", "basic",
                 "--dsl", "kotlin",
@@ -500,11 +500,11 @@ class BuildInitInteractiveIntegrationTest extends AbstractInteractiveInitIntegra
         ScriptDslFixture.of(BuildInitDsl.KOTLIN, targetDir, null).assertGradleFilesGenerated()
     }
 
-    def "use defaults when run from an interactive session with --no-interactive and all options"() {
+    def "use defaults when run from an interactive session with --non-interactive and all options"() {
         when:
         closeInteractiveExecutor(
             startInteractiveExecutorWithTasks(
-                "--no-interactive",
+                "--non-interactive",
                 "init",
                 "--type", "basic",
                 "--dsl", "kotlin",

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/UserInputHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/UserInputHandlingIntegrationTest.groovy
@@ -199,12 +199,12 @@ class UserInputHandlingIntegrationTest extends AbstractUserInputHandlerIntegrati
         outputContains("result = <default>")
     }
 
-    def "does not prompt and uses default with --no-interactive"() {
+    def "does not prompt and uses default with --non-interactive"() {
         given:
         interactiveExecution()
 
         when:
-        def gradleHandle = executer.withArgument("--no-interactive").withTasks("askYesNo").start()
+        def gradleHandle = executer.withArgument("--non-interactive").withTasks("askYesNo").start()
         writeToStdInAndClose(gradleHandle, EOF)
         result = gradleHandle.waitForFinish()
 


### PR DESCRIPTION
PR #38301 introduced --interactive/--no-interactive to toggle interactive console prompting. Following review, restore the original --non-interactive flag (shipped in 9.6.0), now marked incubating, and drop the newly added --interactive/--no-interactive flags.

The org.gradle.console.interactive Gradle property (true/false) remains as the property-based control, and the incubating isInteractive/setInteractive API is unchanged.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
