### PR TITLE
Add Best Practice: Build your Published Artifacts Securely

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
@@ -91,6 +91,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_security.adoc#validate_wrapper_checksum,Validate the Gradle Wrapper on every Upgrade>> | Security | 9.3.0
 | <<best_practices_security.adoc#run_gradle_on_external_projects,Do not Run `./gradlew` on Untrusted Projects>> | Security | 9.7.0
 | <<best_practices_security.adoc#builds_should_be_reproducible,Build Output Should Be Byte-for-Byte Reproducible>> | Security | 9.7.0
+| <<best_practices_security.adoc#build-published-artifacts-securely,Build your Published Artifacts Securely>> | Security | 9.7.0
 
 | <<best_practices_testing.adoc#test_custom_types_with_testkit,Test your custom Task and Plugins with TestKit>> | Testing | 9.4.0
 |===

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_security.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_security.adoc
@@ -186,3 +186,38 @@ include::sample[dir="snippets/bestPractices/reproducibleBuilds-do/groovy",files=
 
 <<tags_reference.adoc#tag:publishing,`#publishing`>>, <<tags_reference.adoc#tag:tasks,`#tasks`>>
 
+
+[[build-published-artifacts-securely]]
+== Build your Published Artifacts Securely
+
+When publishing, ensure that artifacts are built in a trusted, reproducible way to protect your link:https://slsa.dev/[software supply chain].
+
+=== Explanation
+
+A project's published artifacts should be <<working_with_files.adoc#sec:reproducible_archives,byte-for-byte reproducible>>; reproducibility is a precondition for everything below.
+Without it, the additional safeguards described here provide no verifiable assurance.
+
+When preparing a project for publishing, also use a secure and isolated build process.
+This both prevents security risks and ensures that the published artifact is a direct and verifiable result of the source code.
+
+==== Don't Do This
+
+Do not use incremental, local, or cached builds when publishing.
+These methods rely on the outputs of previous builds, which can open an attack vector.
+An incremental build might use a leftover artifact from an older, potentially compromised, build.
+Similarly, using a remote build cache or other caching mechanisms can lead to accidental inclusion of outdated or malicious content, resulting in a non-reproducible artifact.
+The build output could then depend on the state of the machine where it ran, undermining the integrity of your software.
+
+==== Do This Instead
+
+Published artifacts should always be built in a trusted, pristine environment.
+The best way to achieve this is to use a fresh, isolated, temporary CI machine.
+This approach, often referred to as *Ephemeral CI*, guarantees that the build starts from a clean slate every time, with no lingering artifacts, caches, or other external state.
+
+NOTE: This guidance is specific to builds that produce published artifacts.
+Gradle's <<build_cache.adoc#build_cache,Build Cache>> and <<configuration_cache.adoc#config_cache,Configuration Cache>> are safe and deterministic when configured correctly, and non-publishing builds should continue to take full advantage of them.
+Avoiding caching for publishing builds is an extra layer of certainty, not a statement that caches are inherently unsafe.
+
+=== Tags
+
+<<tags_reference.adoc#tag:publishing,`#publishing`>>

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
@@ -42,7 +42,7 @@ Here you can find a brief explanation of all the tags used in the best practices
 `#properties` :: Items that explain the proper way to use <<build_environment.adoc#sec:gradle_configuration_properties,Gradle properties>>, and the appropriate usage of using particular properties.
 
 [[tag:publishing]]
-`#publishing` :: Items that explain the proper way to <<publishing_setup.adoc#publishing_components,publish>> Gradle builds.
+`#publishing` :: Items that are related to <<publishing_setup.adoc#publishing_overview,publishing artifacts>> produced by your build to a repository for consumption by others.
 
 [[tag:repositories]]
 `#repositories` :: Items that explain how to declare and use <<declaring_repositories.adoc#three-declaring-repositories,dependency repositories>>.


### PR DESCRIPTION
Splits publishing item from:
- https://github.com/gradle/gradle/pull/38271