### PR TITLE
Update Documentation: fix Groovy plugin documentation sample

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -69,5 +69,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -69,5 +69,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/groovy_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/groovy_plugin.adoc
@@ -29,8 +29,8 @@ Note that if you want to benefit from the <<java_library_plugin.adoc#sec:java_li
 To use the Groovy plugin, include the following in your build script:
 
 ====
-include::sample[dir="snippets/reference/platforms/jvm/quickstart/kotlin",files="build.gradle.kts[tags=use-plugin]"]
-include::sample[dir="snippets/reference/platforms/jvm/quickstart/groovy",files="build.gradle[tags=use-plugin]"]
+include::sample[dir="snippets/reference/platforms/jvm/groovyDependency/kotlin",files="build.gradle.kts[tags=use-plugin]"]
+include::sample[dir="snippets/reference/platforms/jvm/groovyDependency/groovy",files="build.gradle[tags=use-plugin]"]
 ====
 
 [[sec:groovy_tasks]]

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/groovyDependency/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/groovyDependency/groovy/build.gradle
@@ -1,6 +1,8 @@
+// tag::use-plugin[]
 plugins {
     id 'groovy'
 }
+// end::use-plugin[]
 
 repositories {
     mavenCentral()

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/groovyDependency/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/groovyDependency/kotlin/build.gradle.kts
@@ -1,6 +1,8 @@
+// tag::use-plugin[]
 plugins {
     groovy
 }
+// end::use-plugin[]
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fixes #38310

The Groovy plugin documentation referenced the JVM quickstart sample,
which applies the Scala plugin. Added a use-plugin tag to the Groovy
dependency samples and updated the Groovy plugin documentation to use
those snippets instead.