### PR TITLE
Make Kotlin DSL accessor hash order-independent

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinDslModelChecker.groovy
@@ -21,7 +21,6 @@ import java.nio.file.Paths
 import org.gradle.tooling.model.kotlin.dsl.EditorReport
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
-import spock.lang.Issue
 
 import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkModel
 
@@ -49,8 +48,8 @@ class KotlinDslModelChecker {
 
     static void checkKotlinDslScriptModel(KotlinDslScriptModel actual, KotlinDslScriptModel expected) {
         checkModel(actual, expected, [
-            { withNormalizedAccessorHash(it.classPath) },
-            { withNormalizedAccessorHash(it.sourcePath) },
+            { it.classPath },
+            { it.sourcePath },
             { it.implicitImports },
             [{ it.editorReports }, { a, e -> checkEditorReport(a, e) }],
             // Stack-trace strings legitimately differ between IP and non-IP runs
@@ -90,19 +89,5 @@ class KotlinDslModelChecker {
                 { it.column },
             ]]
         ])
-    }
-
-    // replaces `kotlin-dsl/accessors/*hash*/` with `kotlin-dsl/accessors/<hash>`
-    @Issue("https://github.com/gradle/gradle/issues/37719")
-    private static List<File> withNormalizedAccessorHash(List<File> paths) {
-        final String accessorPathPrefix = "kotlin-dsl" + File.separator + "accessors" + File.separator
-        paths.collect { File f ->
-            int idx = f.path.indexOf(accessorPathPrefix)
-            if (idx < 0) {
-                return f
-            }
-            int hashEnd = f.path.indexOf(File.separator, idx + accessorPathPrefix.length())
-            return new File(f.path.substring(0, idx + accessorPathPrefix.length()) + "<hash>" + f.path.substring(hashEnd))
-        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -699,6 +699,17 @@ fun classLoaderScopeOf(scriptTarget: Any) = when (scriptTarget) {
 }
 
 
+/**
+ * Computes the hash that identifies [schema] for accessor caching.
+ *
+ * The hash is independent of the order in which entries appear within each schema category: every
+ * category is sorted before hashing. This is required because the schema is collected from live,
+ * mutable containers whose iteration order is not stable across configuration modes. For example,
+ * tasks come from `DefaultTaskCollection.getCollectionSchema()` as realized-then-pending, so a task
+ * realized under one mode but not another (`test` is realized by Isolated Projects' project-metadata
+ * serialization, but stays lazy otherwise) shifts position. Without order-independence the same
+ * schema would yield different accessor `<hash>` directories.
+ */
 fun hashCodeFor(schema: TypedProjectSchema): HashCode = Hashing.newHasher().run {
     putAll(schema.extensions)
     putAll(schema.tasks)
@@ -719,10 +730,6 @@ fun Hasher.putConfigurationEntries(configurations: List<ConfigurationEntry<Strin
 
 private
 fun Hasher.putAll(entries: List<ProjectSchemaEntry<SchemaType>>) {
-    // Sort before hashing so the identity is independent of schema collection order.
-    // Task entries come from DefaultTaskCollection.getCollectionSchema() as
-    // realized-then-pending, so a task realized under one mode but not another (e.g. `test`
-    // realized by IP's project-metadata serialization) reorders the list. See gradle/gradle#37719.
     putInt(entries.size)
     entries
         .sortedWith(compareBy({ it.target.kotlinString }, { it.name }, { it.type.kotlinString }))

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -719,30 +719,40 @@ fun Hasher.putConfigurationEntries(configurations: List<ConfigurationEntry<Strin
 
 private
 fun Hasher.putAll(entries: List<ProjectSchemaEntry<SchemaType>>) {
+    // Sort before hashing so the identity is independent of schema collection order.
+    // Task entries come from DefaultTaskCollection.getCollectionSchema() as
+    // realized-then-pending, so a task realized under one mode but not another (e.g. `test`
+    // realized by IP's project-metadata serialization) reorders the list. See gradle/gradle#37719.
     putInt(entries.size)
-    entries.forEach { entry ->
-        putString(entry.target.kotlinString)
-        putString(entry.name)
-        putString(entry.type.kotlinString)
-    }
+    entries
+        .sortedWith(compareBy({ it.target.kotlinString }, { it.name }, { it.type.kotlinString }))
+        .forEach { entry ->
+            putString(entry.target.kotlinString)
+            putString(entry.name)
+            putString(entry.type.kotlinString)
+        }
 }
 
 private fun Hasher.putContainerElementFactoryEntries(entries: List<ContainerElementFactoryEntry<SchemaType>>) {
     putInt(entries.size)
-    entries.forEach { entry ->
-        putString(entry.factoryName)
-        putString(entry.containerReceiverType.kotlinString)
-        putString(entry.publicType.kotlinString)
-    }
+    entries
+        .sortedWith(compareBy({ it.factoryName }, { it.containerReceiverType.kotlinString }, { it.publicType.kotlinString }))
+        .forEach { entry ->
+            putString(entry.factoryName)
+            putString(entry.containerReceiverType.kotlinString)
+            putString(entry.publicType.kotlinString)
+        }
 }
 
 private fun Hasher.putProjectFeatureEntries(entries: List<ProjectFeatureEntry<SchemaType>>) {
     putInt(entries.size)
-    entries.forEach { entry ->
-        putString(entry.featureName)
-        putString(entry.ownDefinitionType.kotlinString)
-        putString(entry.targetDefinitionType.kotlinString)
-    }
+    entries
+        .sortedWith(compareBy({ it.featureName }, { it.ownDefinitionType.kotlinString }, { it.targetDefinitionType.kotlinString }))
+        .forEach { entry ->
+            putString(entry.featureName)
+            putString(entry.ownDefinitionType.kotlinString)
+            putString(entry.targetDefinitionType.kotlinString)
+        }
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaHashCodeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaHashCodeTest.kt
@@ -73,6 +73,69 @@ class ProjectSchemaHashCodeTest : TestWithClassPath() {
     }
 
     @Test
+    fun `hash code is task order insensitive`() {
+
+        assertThat(
+            hashCodeFor(
+                tasks = listOf(
+                    entry<TaskContainer, DefaultTask>("assemble"),
+                    entry<TaskContainer, Delete>("clean")
+                )
+            ),
+            equalTo(
+                hashCodeFor(
+                    tasks = listOf(
+                        entry<TaskContainer, Delete>("clean"),
+                        entry<TaskContainer, DefaultTask>("assemble")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `hash code is extension order insensitive`() {
+
+        assertThat(
+            hashCodeFor(
+                extensions = listOf(
+                    entry<TaskContainer, DefaultTask>("foo"),
+                    entry<TaskContainer, Delete>("bar")
+                )
+            ),
+            equalTo(
+                hashCodeFor(
+                    extensions = listOf(
+                        entry<TaskContainer, Delete>("bar"),
+                        entry<TaskContainer, DefaultTask>("foo")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `hash code is container element order insensitive`() {
+
+        assertThat(
+            hashCodeFor(
+                containerElements = listOf(
+                    entry<TaskContainer, DefaultTask>("assemble"),
+                    entry<TaskContainer, Delete>("clean")
+                )
+            ),
+            equalTo(
+                hashCodeFor(
+                    containerElements = listOf(
+                        entry<TaskContainer, Delete>("clean"),
+                        entry<TaskContainer, DefaultTask>("assemble")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun `hash code takes container element names into account`() {
 
         assertThat(


### PR DESCRIPTION
## Problem

The Kotlin DSL accessor workspace identity (the `kotlin-dsl/accessors/<hash>/` directory) is `hashCodeFor(schema) + DCL flag + classpath fingerprint`. `hashCodeFor` hashed `tasks`/`extensions`/`containerElements`/`containerElementFactories`/`projectFeatures` **in schema-collection order**, while only `configurations` were sorted.

Task entries come from `DefaultTaskCollection.getCollectionSchema()` as `realized(sorted) ++ pending(registration order)` — **not** name-sorted. So the order depends on which tasks are realized vs still-lazy when the schema is read.

## Root cause (#37719), traced

Under Isolated Projects, CC project-metadata serialization realizes a task that non-IP leaves lazy:

```
ProjectMetadataController.write → writeVariantArtifactSets        (IP-only)
  → LocalVariantMetadata.getArtifacts()
  → DefaultIvyArtifactName.forPublishArtifact → DecoratingPublishArtifact.getName
  → LazyPublishArtifact.getName() → DefaultProperty → FlatMapProvider
  → TaskCreatingProvider.tryCreate → realizes `test`
```

Realizing `test` moves it from the registration-ordered pending tail into the sorted realized block, so the task list — and therefore the schema hash and the accessor directory — differs between IP and non-IP. (This is precisely the issue's "test task moves position".) Verified by instrumenting `GenerateProjectAccessors.identify()`: across modes the `classpathFp` and the *sorted* schema hash were identical; only the *list-order* schema hash differed, and the differing category was the task list.

## Fix

Sort each entry list before hashing (mirroring the existing `configurations` handling). The accessor identity is now independent of realization/collection order. With the hash stable, the `withNormalizedAccessorHash` workaround in `KotlinDslModelChecker` is removed; adds order-insensitivity unit tests for tasks, extensions, and container elements.

This is a one-time accessor-cache invalidation (hash values change), after which accessors regenerate normally.

## Why removing the normalization is safe — and why we still want the sort

The parity tests pass on master today only **because** `withNormalizedAccessorHash` masks the differing `<hash>` segment. The relevant finding is that they also pass **without** that normalization — but only since `b7844f3557d` (an unrelated #37942 fix), which added a per-`ClassLoaderScope` accessor cache that snapshots the schema on first computation, before the IP realization above happens. In other words, the underlying IP/non-IP divergence is no longer observable, so the normalization is now dead weight and can be dropped.

That masking is **incidental and timing-dependent**, though: `getCollectionSchema()` is still realized-then-pending, `hashCodeFor` still hashed in list order, and `test` is still force-realized under IP. If the first accessor computation ever moves after the metadata write, the divergence returns. So we sort the hash inputs to fix the identity directly (robust regardless of realization timing), and removing the normalizer restores real regression coverage — a future divergence now fails the parity tests instead of being silently normalized away.

## Verification

- `ProjectSchemaHashCodeTest` — 10/10 (incl. 3 new order-insensitivity tests)
- `kotlin-dsl-tooling-builders:test` — 11/11; `AccessorsClassPathModelCrossVersionSpec` — 9/9
- IP KotlinDsl parity suites with the normalizer removed — 24 tests, 0 failures (1 pre-existing skip): `…KotlinDslIntegrationTest`, `…CompositeBuildIntegrationTest`, `…BrokenScriptsIntegrationTest`
- Confirmed by bisect that **without** the normalization the composite suite fails at `09dfe47f47d` and passes from `b7844f3557d` onward, isolating the incidental masking commit.

Closes #37719.