### PR TITLE
Add write-side mark/commit/rollback to CC serialization

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -709,7 +709,7 @@
   {
     "name": "graph-serialization",
     "path": "platforms/core-configuration/graph-serialization",
-    "unitTests": false,
+    "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -37,8 +37,12 @@ import org.gradle.internal.cc.impl.serialize.DefaultClassDecoder
 import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
 import org.gradle.internal.cc.impl.serialize.DefaultSharedObjectDecoder
 import org.gradle.internal.cc.impl.serialize.DefaultSharedObjectEncoder
+import org.gradle.internal.cc.impl.serialize.EncoderRollback
 import org.gradle.internal.cc.impl.serialize.ParallelStringDecoder
 import org.gradle.internal.cc.impl.serialize.ParallelStringEncoder
+import org.gradle.internal.cc.impl.serialize.SpillingOutputStream
+import org.gradle.internal.cc.impl.serialize.SpoolStore
+import org.gradle.internal.cc.impl.serialize.TempFileSpoolStore
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.hash.HashCode
@@ -74,6 +78,7 @@ import org.gradle.internal.serialize.graph.StringDecoder
 import org.gradle.internal.serialize.graph.StringEncoder
 import org.gradle.internal.serialize.graph.Tracer
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.WriteRollback
 import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readFile
 import org.gradle.internal.serialize.graph.readList
@@ -389,7 +394,17 @@ class DefaultConfigurationCacheIO internal constructor(
         stateFile: ConfigurationCacheStateFile,
         specialEncoders: SpecialEncoders,
         profile: () -> String
-    ) = writeContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::outputStream, profile, specialEncoders)
+    ): Pair<CloseableWriteContext, ConfigurationCacheCodecs> =
+        rollbackableEncoderFor(stateFile.stateType, stateFile::outputStream, spoolStoreFor(stateFile)).let { (encoder, rollback) ->
+            writeContextFor(
+                stateFile.stateFile.name,
+                encoder,
+                loggingTracerFor(profile, encoder),
+                codecs,
+                specialEncoders,
+                rollbackSupport = rollback
+            ) to codecs
+        }
 
     /**
      * @param profile the unique name associated with the output stream for debugging space usage issues
@@ -418,6 +433,44 @@ class DefaultConfigurationCacheIO internal constructor(
             if (isUsingSequentialStringDeduplicationStrategy(stateType)) StringDeduplicatingKryoBackedEncoder(stream)
             else KryoBackedEncoder(stream)
         }
+
+    /**
+     * Like [encoderFor], but interposes a [SpillingOutputStream] so the resulting context can revert
+     * writes via [WriteContext.beginRollbackScope].
+     *
+     * Rollback is offered only for the plain [KryoBackedEncoder]: the sequential string-dedup
+     * encoder keeps an inline string table that is not currently revertible, so it is left without
+     * a rollback handle.
+     */
+    private
+    fun rollbackableEncoderFor(
+        stateType: StateType,
+        outputStream: () -> OutputStream,
+        spoolStore: SpoolStore
+    ): Pair<PositionAwareEncoder, WriteRollback?> =
+        outputStreamFor(stateType, outputStream).let { main ->
+            if (isUsingSequentialStringDeduplicationStrategy(stateType)) {
+                StringDeduplicatingKryoBackedEncoder(main) to null
+            } else {
+                val spilling = SpillingOutputStream(main, spoolStore)
+                val encoder = KryoBackedEncoder(spilling)
+                encoder to EncoderRollback(encoder, spilling)
+            }
+        }
+
+    /**
+     * Spools rolled-back-region overflow into a temporary file next to [stateFile], encrypted to
+     * match the main stream so plaintext never reaches disk.
+     */
+    private
+    fun spoolStoreFor(stateFile: ConfigurationCacheStateFile): SpoolStore {
+        val encryptable = stateFile.stateType.encryptable
+        return TempFileSpoolStore(
+            stateFile.stateFile.file,
+            { if (encryptable) encryptionService.outputStream(it) else it },
+            { if (encryptable) encryptionService.inputStream(it) else it }
+        )
+    }
 
     override fun decoderFor(stateType: StateType, inputStream: () -> InputStream): Decoder =
         inputStreamFor(stateType, inputStream).let { stream ->
@@ -570,7 +623,8 @@ class DefaultConfigurationCacheIO internal constructor(
         tracer: Tracer?,
         codecs: ConfigurationCacheCodecs,
         specialEncoders: SpecialEncoders = SpecialEncoders(),
-        customClassEncoder: ClassEncoder? = null
+        customClassEncoder: ClassEncoder? = null,
+        rollbackSupport: WriteRollback? = null
     ): CloseableWriteContext = DefaultWriteContext(
         name,
         codecs.userTypesCodec(),
@@ -581,7 +635,8 @@ class DefaultConfigurationCacheIO internal constructor(
         tracer,
         problems,
         customClassEncoder ?: classEncoder(),
-        specialEncoders = specialEncoders
+        specialEncoders = specialEncoders,
+        rollbackSupport = rollbackSupport
     )
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/EncoderRollback.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/EncoderRollback.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import org.gradle.internal.serialize.FlushableEncoder
+import org.gradle.internal.serialize.graph.WriteRollback
+
+
+/**
+ * Ties an [encoder] to the [SpillingOutputStream] underneath it to implement byte-level rollback.
+ *
+ * On every boundary the encoder is flushed so its buffered tail reaches the spill before the spill
+ * is committed or dropped. Rolling back flushes the tail into the spool too and then discards the
+ * whole spool, so it never needs to touch the encoder's internal buffer.
+ */
+internal
+class EncoderRollback(
+    private val encoder: FlushableEncoder,
+    private val spilling: SpillingOutputStream
+) : WriteRollback {
+
+    override fun beginScope() {
+        encoder.flush()
+        spilling.beginSpill()
+    }
+
+    override fun commitScope() {
+        encoder.flush()
+        spilling.commit()
+    }
+
+    override fun rollbackScope() {
+        encoder.flush()
+        spilling.rollback()
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/SpillingOutputStream.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/SpillingOutputStream.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.InputStream
+import java.io.OutputStream
+
+
+/**
+ * A transient store for bytes spilled while a rollback scope is open.
+ *
+ * The bytes written to [outputStream] are the same bytes that can later be read back from
+ * [inputStream]. Implementations that persist the spool encrypt on write and decrypt on read, so
+ * that plaintext never reaches disk.
+ */
+internal
+interface Spool : Closeable {
+    fun outputStream(): OutputStream
+
+    fun inputStream(): InputStream
+
+    /**
+     * Releases the spool, deleting any backing storage.
+     */
+    override fun close()
+}
+
+
+/**
+ * Creates a fresh [Spool] for a rollback scope.
+ */
+internal
+fun interface SpoolStore {
+    fun newSpool(): Spool
+}
+
+
+/**
+ * An [OutputStream] that can divert everything written after a [mark][beginSpill] away from the
+ * main destination, so it can later be relayed verbatim ([commit]) or dropped ([rollback]).
+ *
+ * While diverted, bytes are held in a small in-memory buffer and only overflow to a (potentially
+ * encrypted) [Spool] once the buffer is exceeded, so small rollback regions never touch disk.
+ *
+ * Nesting is not supported: [beginSpill] must be balanced by exactly one [commit] or [rollback]
+ * before it can be called again.
+ *
+ * This stream does not own the buffering of its writer (e.g. a Kryo `Output`). The writer must
+ * flush into this stream before [beginSpill] (so pre-mark bytes reach the main destination) and
+ * before [commit] (so the whole region is captured); on [rollback] the writer must instead discard
+ * its own un-flushed tail.
+ */
+internal
+class SpillingOutputStream(
+    private val main: OutputStream,
+    private val spoolStore: SpoolStore,
+    private val bufferSize: Int = DEFAULT_BUFFER_SIZE
+) : OutputStream() {
+
+    private
+    enum class Mode { PASSTHROUGH, BUFFERING, SPILLED }
+
+    private
+    var mode = Mode.PASSTHROUGH
+
+    private
+    var buffer: ByteArrayOutputStream? = null
+
+    private
+    var spool: Spool? = null
+
+    private
+    var spoolSink: OutputStream? = null
+
+    /**
+     * Number of bytes durably written to [main] (pre-mark bytes plus committed regions). Diverted
+     * bytes are not counted until they are committed. Used to report a meaningful write position.
+     */
+    var committedBytes: Long = 0
+        private set
+
+    override fun write(b: Int) {
+        when (mode) {
+            Mode.PASSTHROUGH -> writeToMain(b)
+            Mode.BUFFERING -> {
+                if (buffer!!.size() + 1 > bufferSize) {
+                    overflow()
+                    spoolSink!!.write(b)
+                } else {
+                    buffer!!.write(b)
+                }
+            }
+
+            Mode.SPILLED -> spoolSink!!.write(b)
+        }
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        when (mode) {
+            Mode.PASSTHROUGH -> writeToMain(b, off, len)
+            Mode.BUFFERING -> {
+                if (buffer!!.size() + len > bufferSize) {
+                    overflow()
+                    spoolSink!!.write(b, off, len)
+                } else {
+                    buffer!!.write(b, off, len)
+                }
+            }
+
+            Mode.SPILLED -> spoolSink!!.write(b, off, len)
+        }
+    }
+
+    override fun flush() {
+        when (mode) {
+            Mode.PASSTHROUGH -> main.flush()
+            // Nothing to flush downstream while buffering: the bytes are tentative.
+            Mode.BUFFERING -> Unit
+            Mode.SPILLED -> spoolSink!!.flush()
+        }
+    }
+
+    override fun close() {
+        // The main stream owns the underlying file. Abandon any open spool first.
+        try {
+            spoolSink?.close()
+        } finally {
+            try {
+                spool?.close()
+            } finally {
+                main.close()
+            }
+        }
+    }
+
+    /**
+     * Starts diverting subsequent writes so they can be committed or rolled back.
+     */
+    fun beginSpill() {
+        check(mode == Mode.PASSTHROUGH) { "Already spilling; nested rollback scopes are not supported." }
+        buffer = ByteArrayOutputStream()
+        mode = Mode.BUFFERING
+    }
+
+    /**
+     * Relays everything written since [beginSpill] into [main], in order, then returns to passthrough.
+     */
+    fun commit() {
+        when (mode) {
+            Mode.BUFFERING -> buffer!!.let { writeToMain(it.toByteArray()) }
+            Mode.SPILLED -> {
+                spoolSink!!.close()
+                spoolSink = null
+                spool!!.inputStream().use { relayToMain(it) }
+            }
+
+            Mode.PASSTHROUGH -> error("Not spilling.")
+        }
+        cleanupSpill()
+    }
+
+    /**
+     * Discards everything written since [beginSpill], then returns to passthrough.
+     */
+    fun rollback() {
+        check(mode != Mode.PASSTHROUGH) { "Not spilling." }
+        spoolSink?.close()
+        spoolSink = null
+        cleanupSpill()
+    }
+
+    private
+    fun overflow() {
+        val newSpool = spoolStore.newSpool()
+        val sink = newSpool.outputStream()
+        buffer!!.writeTo(sink)
+        buffer = null
+        spool = newSpool
+        spoolSink = sink
+        mode = Mode.SPILLED
+    }
+
+    private
+    fun cleanupSpill() {
+        spool?.close()
+        spool = null
+        spoolSink = null
+        buffer = null
+        mode = Mode.PASSTHROUGH
+    }
+
+    private
+    fun relayToMain(input: InputStream) {
+        val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(chunk)
+            if (read < 0) break
+            writeToMain(chunk, 0, read)
+        }
+    }
+
+    private
+    fun writeToMain(b: Int) {
+        main.write(b)
+        committedBytes++
+    }
+
+    private
+    fun writeToMain(b: ByteArray) = writeToMain(b, 0, b.size)
+
+    private
+    fun writeToMain(b: ByteArray, off: Int, len: Int) {
+        main.write(b, off, len)
+        committedBytes += len
+    }
+
+    companion object {
+        const val DEFAULT_BUFFER_SIZE = 8 * 1024
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/TempFileSpoolStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/TempFileSpoolStore.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+
+/**
+ * A [SpoolStore] that overflows to a temporary file placed next to the main state file.
+ *
+ * The bytes diverted into the spool are plaintext, so [encrypt]/[decrypt] (mirroring the main
+ * stream's encryption) are applied on write/read to ensure plaintext never reaches disk.
+ *
+ * Spool files are deleted explicitly when the [Spool] is closed; [File.deleteOnExit] is registered
+ * only as a backstop in case an explicit cleanup is missed.
+ */
+internal
+class TempFileSpoolStore(
+    private val mainFile: File,
+    private val encrypt: (OutputStream) -> OutputStream,
+    private val decrypt: (InputStream) -> InputStream
+) : SpoolStore {
+
+    override fun newSpool(): Spool {
+        val dir = mainFile.absoluteFile.parentFile.toPath()
+        Files.createDirectories(dir)
+        val spoolFile = Files.createTempFile(dir, "${mainFile.name}.", ".spool")
+        spoolFile.toFile().deleteOnExit()
+        return TempFileSpool(spoolFile, encrypt, decrypt)
+    }
+}
+
+
+private
+class TempFileSpool(
+    private val file: Path,
+    private val encrypt: (OutputStream) -> OutputStream,
+    private val decrypt: (InputStream) -> InputStream
+) : Spool {
+
+    override fun outputStream(): OutputStream =
+        encrypt(BufferedOutputStream(Files.newOutputStream(file)))
+
+    override fun inputStream(): InputStream =
+        decrypt(BufferedInputStream(Files.newInputStream(file)))
+
+    override fun close() {
+        Files.deleteIfExists(file)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialize/RollbackRoundtripTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialize/RollbackRoundtripTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import org.gradle.internal.extensions.stdlib.useToRun
+import org.gradle.internal.serialize.beans.services.DefaultBeanStateWriterLookup
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.kryo.KryoBackedDecoder
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.FilterInputStream
+import java.io.FilterOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+class RollbackRoundtripTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `commit keeps the region and is byte-identical to writing it directly`() {
+        val withScope = write {
+            writeString("a")
+            val scope = beginRollbackScope()
+            writeString("b")
+            scope.commit()
+            writeString("c")
+        }
+        val direct = write {
+            writeString("a")
+            writeString("b")
+            writeString("c")
+        }
+        assertArrayEquals(direct, withScope)
+        assertEquals(listOf("a", "b", "c"), readStrings(withScope, 3))
+    }
+
+    @Test
+    fun `rollback drops the region and is byte-identical to never writing it`() {
+        val withScope = write {
+            writeString("a")
+            val scope = beginRollbackScope()
+            writeString("b")
+            scope.rollback()
+            writeString("c")
+        }
+        val direct = write {
+            writeString("a")
+            writeString("c")
+        }
+        assertArrayEquals(direct, withScope)
+        assertEquals(listOf("a", "c"), readStrings(withScope, 2))
+    }
+
+    @Test
+    fun `commit relays a region that overflowed the in-memory buffer`() {
+        val long = "a-region-that-exceeds-the-tiny-buffer".repeat(8)
+        val bytes = write(bufferSize = 4) {
+            writeString("a")
+            val scope = beginRollbackScope()
+            writeString(long)
+            scope.commit()
+            writeString("c")
+        }
+        assertEquals(listOf("a", long, "c"), readStrings(bytes, 3))
+    }
+
+    @Test
+    fun `rollback drops a region that overflowed the in-memory buffer`() {
+        val long = "a-region-that-exceeds-the-tiny-buffer".repeat(8)
+        val bytes = write(bufferSize = 4) {
+            writeString("a")
+            val scope = beginRollbackScope()
+            writeString(long)
+            scope.rollback()
+            writeString("c")
+        }
+        assertEquals(listOf("a", "c"), readStrings(bytes, 2))
+    }
+
+    @Test
+    fun `overflow spools to an encrypted temp file and relays it correctly on commit`() {
+        val long = "secret-payload-".repeat(64)
+        val xorKey = 0x5A.toByte()
+        val store = TempFileSpoolStore(
+            tmp.newFile("work.bin"),
+            { XorOutputStream(it, xorKey) },
+            { XorInputStream(it, xorKey) }
+        )
+        val bytes = write(bufferSize = 4, spoolStore = store) {
+            writeString("a")
+            val scope = beginRollbackScope()
+            writeString(long)
+            scope.commit()
+            writeString("c")
+        }
+        assertEquals(listOf("a", long, "c"), readStrings(bytes, 3))
+    }
+
+    @Test
+    fun `supports successive commit and rollback scopes`() {
+        val bytes = write(bufferSize = 4) {
+            writeString("a")
+            beginRollbackScope().also { writeString("keep") }.commit()
+            beginRollbackScope().also { writeString("drop") }.rollback()
+            writeString("b")
+        }
+        assertEquals(listOf("a", "keep", "b"), readStrings(bytes, 3))
+    }
+
+    private
+    fun write(
+        bufferSize: Int = SpillingOutputStream.DEFAULT_BUFFER_SIZE,
+        spoolStore: SpoolStore = InMemorySpoolStore(),
+        block: WriteContext.() -> Unit
+    ): ByteArray {
+        val main = ByteArrayOutputStream()
+        val spilling = SpillingOutputStream(main, spoolStore, bufferSize)
+        val encoder = KryoBackedEncoder(spilling)
+        val context = writeContextForTesting(encoder, EncoderRollback(encoder, spilling))
+        context.useToRun { block() }
+        return main.toByteArray()
+    }
+
+    private
+    fun readStrings(bytes: ByteArray, count: Int): List<String> =
+        KryoBackedDecoder(ByteArrayInputStream(bytes)).let { decoder ->
+            (1..count).map { decoder.readString() }
+        }
+
+    private
+    fun writeContextForTesting(encoder: KryoBackedEncoder, rollback: EncoderRollback) =
+        org.gradle.internal.serialize.graph.DefaultWriteContext(
+            codec = mock<Codec<Any?>>(),
+            encoder = encoder,
+            classEncoder = DefaultClassEncoder(mock()),
+            beanStateWriterLookup = DefaultBeanStateWriterLookup(),
+            isIntegrityCheckEnabled = false,
+            logger = mock(),
+            tracer = null,
+            problemsListener = mock(),
+            rollbackSupport = rollback
+        )
+
+    private
+    class InMemorySpoolStore : SpoolStore {
+        override fun newSpool(): Spool = object : Spool {
+            private val bytes = ByteArrayOutputStream()
+            override fun outputStream(): OutputStream = bytes
+            override fun inputStream(): InputStream = ByteArrayInputStream(bytes.toByteArray())
+            override fun close() = Unit
+        }
+    }
+
+    private
+    class XorOutputStream(out: OutputStream, private val key: Byte) : FilterOutputStream(out) {
+        override fun write(b: Int) = out.write((b.toByte().toInt() xor key.toInt()) and 0xFF)
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            for (i in off until off + len) write(b[i].toInt())
+        }
+    }
+
+    private
+    class XorInputStream(input: InputStream, private val key: Byte) : FilterInputStream(input) {
+        override fun read(): Int {
+            val v = `in`.read()
+            return if (v < 0) v else (v.toByte().toInt() xor key.toInt()) and 0xFF
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val n = `in`.read(b, off, len)
+            for (i in off until off + (if (n < 0) 0 else n)) {
+                b[i] = (b[i].toInt() xor key.toInt()).toByte()
+            }
+            return n
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialize/SpillingOutputStreamTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialize/SpillingOutputStreamTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+class SpillingOutputStreamTest {
+
+    private
+    val main = ByteArrayOutputStream()
+
+    private
+    val spoolStore = RecordingSpoolStore()
+
+    private
+    fun newStream(bufferSize: Int = 16) = SpillingOutputStream(main, spoolStore, bufferSize)
+
+    @Test
+    fun `passes through writes when no scope is open`() {
+        val stream = newStream()
+        stream.write("hello".toByteArray())
+        assertArrayEquals("hello".toByteArray(), main.toByteArray())
+        assertEquals(5L, stream.committedBytes)
+    }
+
+    @Test
+    fun `commit relays buffered bytes in order without touching disk`() {
+        val stream = newStream(bufferSize = 16)
+        stream.write("pre-".toByteArray())
+        stream.beginSpill()
+        stream.write("spilled".toByteArray())
+        stream.commit()
+        stream.write("-post".toByteArray())
+
+        assertArrayEquals("pre-spilled-post".toByteArray(), main.toByteArray())
+        assertEquals(0, spoolStore.created.size) // stayed in memory
+    }
+
+    @Test
+    fun `rollback discards buffered bytes`() {
+        val stream = newStream(bufferSize = 16)
+        stream.write("pre-".toByteArray())
+        stream.beginSpill()
+        stream.write("discarded".toByteArray())
+        stream.rollback()
+        stream.write("post".toByteArray())
+
+        assertArrayEquals("pre-post".toByteArray(), main.toByteArray())
+        assertEquals(0, spoolStore.created.size)
+    }
+
+    @Test
+    fun `commit relays overflowed bytes from the spool in order`() {
+        val stream = newStream(bufferSize = 4)
+        stream.write("pre-".toByteArray())
+        stream.beginSpill()
+        // exceeds the 4-byte buffer, so it overflows to a spool
+        stream.write("a-long-spilled-region".toByteArray())
+        stream.commit()
+        stream.write("-post".toByteArray())
+
+        assertArrayEquals("pre-a-long-spilled-region-post".toByteArray(), main.toByteArray())
+        assertEquals(1, spoolStore.created.size)
+        assertTrue("spool should be closed/deleted after commit", spoolStore.created.single().closed)
+    }
+
+    @Test
+    fun `rollback discards overflowed bytes and deletes the spool`() {
+        val stream = newStream(bufferSize = 4)
+        stream.write("pre-".toByteArray())
+        stream.beginSpill()
+        stream.write("a-long-discarded-region".toByteArray())
+        stream.rollback()
+        stream.write("post".toByteArray())
+
+        assertArrayEquals("pre-post".toByteArray(), main.toByteArray())
+        assertEquals(1, spoolStore.created.size)
+        assertTrue("spool should be closed/deleted after rollback", spoolStore.created.single().closed)
+    }
+
+    @Test
+    fun `committedBytes ignores spilled bytes until commit`() {
+        val stream = newStream(bufferSize = 4)
+        stream.write("abcd".toByteArray())
+        assertEquals(4L, stream.committedBytes)
+
+        stream.beginSpill()
+        stream.write("spilled-region".toByteArray())
+        assertEquals(4L, stream.committedBytes) // tentative bytes not counted
+
+        stream.commit()
+        assertEquals(4L + "spilled-region".length, stream.committedBytes)
+    }
+
+    @Test
+    fun `supports successive scopes after commit and rollback`() {
+        val stream = newStream(bufferSize = 4)
+        stream.beginSpill()
+        stream.write("keep".toByteArray())
+        stream.commit()
+
+        stream.beginSpill()
+        stream.write("drop".toByteArray())
+        stream.rollback()
+
+        stream.beginSpill()
+        stream.write("keep2".toByteArray())
+        stream.commit()
+
+        assertArrayEquals("keepkeep2".toByteArray(), main.toByteArray())
+    }
+
+    @Test
+    fun `beginSpill rejects nesting`() {
+        val stream = newStream()
+        stream.beginSpill()
+        assertThrows(IllegalStateException::class.java) { stream.beginSpill() }
+    }
+
+    @Test
+    fun `commit and rollback require an open scope`() {
+        val stream = newStream()
+        assertThrows(IllegalStateException::class.java) { stream.rollback() }
+        assertThrows(IllegalStateException::class.java) { stream.commit() }
+    }
+
+    private
+    class RecordingSpoolStore : SpoolStore {
+        val created = mutableListOf<RecordingSpool>()
+        override fun newSpool(): Spool = RecordingSpool().also { created.add(it) }
+    }
+
+    private
+    class RecordingSpool : Spool {
+        private val bytes = ByteArrayOutputStream()
+        var closed = false
+            private set
+
+        override fun outputStream(): OutputStream = bytes
+
+        override fun inputStream(): InputStream = ByteArrayInputStream(bytes.toByteArray())
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -236,7 +236,15 @@ class TaskNodeCodec(
     private
     suspend fun WriteContext.writeTaskActions(task: TaskInternal) {
         withVirtualPropertyTrace(TaskVirtualProperty.ACTIONS) {
-            writeCollection(task.taskActions)
+            // Dummy use of the rollback infrastructure to exercise it on the happy path: open a
+            // scope around the action write and always commit (relaying the bytes and replaying any
+            // deferred problems), regardless of whether problems were recorded.
+            val scope = beginRollbackScope()
+            try {
+                writeCollection(task.taskActions)
+            } finally {
+                scope.commit()
+            }
         }
     }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -69,6 +69,18 @@ interface WriteContext : MutableIsolateContext, Encoder {
      * @see ClassEncoder.encodeClassLoader
      */
     fun writeClassLoader(classLoader: ClassLoader?) = Unit
+
+    /**
+     * Opens a scope that can revert everything written after this point.
+     *
+     * The returned scope must be finished with exactly one [WriteRollbackScope.commit] or
+     * [WriteRollbackScope.rollback], in the same coroutine frame and only after the guarded write
+     * has returned or thrown. Nesting is not supported.
+     *
+     * @throws UnsupportedOperationException if this context does not support rollback.
+     */
+    fun beginRollbackScope(): WriteRollbackScope =
+        throw UnsupportedOperationException("This write context does not support rollback.")
 }
 
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -75,7 +75,10 @@ class DefaultWriteContext(
     private
     val classEncoder: ClassEncoder,
 
-    specialEncoders: SpecialEncoders = SpecialEncoders()
+    specialEncoders: SpecialEncoders = SpecialEncoders(),
+
+    private
+    val rollbackSupport: WriteRollback? = null
 
 ) : AbstractIsolateContext<WriteIsolate>(codec, problemsListener, name), CloseableWriteContext, Encoder by encoder {
 
@@ -130,6 +133,66 @@ class DefaultWriteContext(
 
     override fun newIsolate(owner: IsolateOwner): WriteIsolate =
         DefaultWriteIsolate(owner)
+
+    private
+    var currentScope: WriteRollbackScope? = null
+
+    override fun beginRollbackScope(): WriteRollbackScope {
+        val rollback = rollbackSupport
+            ?: throw UnsupportedOperationException("This write context does not support rollback.")
+        check(currentScope == null) { "A rollback scope is already open; nested rollback scopes are not supported." }
+
+        // Only state written inline into this stream needs to be reverted. The current isolate's
+        // identities and the shared identities are such state; circularReferences is self-healing
+        // (paired enter/leave), and side-file dedup (strings, shared objects) is intentionally not
+        // reverted (its definitions live in separate files, so stale entries are harmless orphans).
+        val markedIdentities = buildList {
+            add(sharedIdentities)
+            currentIsolateOrNull?.identities?.let { add(it) }
+        }
+        markedIdentities.forEach { it.mark() }
+
+        val previousListener = currentProblemsListener
+        val buffering = BufferingProblemsListener(previousListener)
+        currentProblemsListener = buffering
+
+        rollback.beginScope()
+
+        return Scope(rollback, markedIdentities, previousListener, buffering).also { currentScope = it }
+    }
+
+    private
+    inner class Scope(
+        private val rollback: WriteRollback,
+        private val markedIdentities: List<WriteIdentities>,
+        private val previousListener: ProblemsListener,
+        private val buffering: BufferingProblemsListener
+    ) : WriteRollbackScope {
+
+        override fun commit() {
+            finish {
+                rollback.commitScope()
+                markedIdentities.forEach { it.discardMark() }
+            }
+            buffering.replay()
+        }
+
+        override fun rollback(): List<PropertyProblem> {
+            finish {
+                rollback.rollbackScope()
+                markedIdentities.forEach { it.restoreToMark() }
+            }
+            return buffering.bufferedProblems()
+        }
+
+        private
+        fun finish(action: () -> Unit) {
+            check(currentScope === this) { "This rollback scope is not the active one." }
+            action()
+            currentProblemsListener = previousListener
+            currentScope = null
+        }
+    }
 }
 
 
@@ -334,11 +397,15 @@ abstract class AbstractIsolateContext<T>(
     private val explicitName: String? = null
 ) : MutableIsolateContext {
 
-    private
+    protected
     var currentProblemsListener: ProblemsListener = problemsListener
 
     private
     var currentIsolate: T? = null
+
+    protected
+    val currentIsolateOrNull: T?
+        get() = currentIsolate
 
     private
     var currentCodec = codec

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Identities.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Identities.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.serialize.graph
 
 import it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 
@@ -27,6 +28,13 @@ class WriteIdentities {
     val instanceIds = Reference2IntOpenHashMap<Any>()
 
     /**
+     * Records the instances registered since [mark] so they can be removed by [restoreToMark].
+     * Non-null only while a rollback scope is active. Nesting is not supported.
+     */
+    private
+    var journal: ObjectArrayList<Any>? = null
+
+    /**
      * Returns `-1` when the instance cannot be found to avoid boxing.
      */
     fun getId(instance: Any): Int =
@@ -35,7 +43,40 @@ class WriteIdentities {
     fun putInstance(instance: Any): Int {
         val id = instanceIds.size
         instanceIds.put(instance, id)
+        journal?.add(instance)
         return id
+    }
+
+    /**
+     * Starts recording newly registered instances so a later [restoreToMark] can undo them.
+     * Must be paired with exactly one [discardMark] (commit) or [restoreToMark] (rollback).
+     */
+    fun mark() {
+        require(journal == null) { "WriteIdentities is already marked; nested rollback scopes are not supported." }
+        journal = ObjectArrayList()
+    }
+
+    /**
+     * Keeps all instances registered since [mark] and stops recording (commit).
+     */
+    fun discardMark() {
+        require(journal != null) { "WriteIdentities is not marked." }
+        journal = null
+    }
+
+    /**
+     * Removes every instance registered since [mark] and stops recording (rollback).
+     *
+     * Ids are assigned densely from [instanceIds]`.size`, so removing exactly the instances added
+     * since the mark restores both the contents and the next id to their state at [mark].
+     */
+    fun restoreToMark() {
+        val recorded = journal
+        require(recorded != null) { "WriteIdentities is not marked." }
+        for (i in recorded.indices.reversed()) {
+            instanceIds.removeInt(recorded[i])
+        }
+        journal = null
     }
 }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/WriteRollback.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/WriteRollback.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import org.gradle.api.Task
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.configuration.problems.StructuredMessageBuilder
+
+
+/**
+ * Byte-level control over a rollback scope, provided by the I/O layer that owns the encoder and its
+ * output. Everything written between [beginScope] and [commitScope] is relayed to the real
+ * destination verbatim; everything written between [beginScope] and [rollbackScope] is discarded.
+ *
+ * Nesting is not supported: [beginScope] must be balanced by exactly one [commitScope] or
+ * [rollbackScope].
+ */
+interface WriteRollback {
+    fun beginScope()
+
+    fun commitScope()
+
+    fun rollbackScope()
+}
+
+
+/**
+ * A rollback scope opened by [WriteContext.beginRollbackScope].
+ *
+ * Must be finished with exactly one [commit] or [rollback], in the same coroutine frame that opened
+ * it and only after the guarded write has returned or thrown (never while it is suspended).
+ */
+interface WriteRollbackScope {
+    /**
+     * Keeps everything written since the scope began and replays the problems that were deferred
+     * during the scope to the enclosing problems listener.
+     */
+    fun commit()
+
+    /**
+     * Discards everything written since the scope began and restores the serialization state to the
+     * point the scope was opened.
+     *
+     * @return the problems that were deferred during the scope, for the caller to inspect and, if
+     * desired, re-report (e.g. collapsed into a single placeholder problem) via the context.
+     */
+    fun rollback(): List<PropertyProblem>
+}
+
+
+/**
+ * A [ProblemsListener] that defers the problems reported to it instead of forwarding, so that
+ * problems discovered during a speculative write are only surfaced once the write is committed
+ * (via [replay]), or are handed back to the caller on rollback (via [bufferedProblems]).
+ *
+ * [onError] is NOT deferred: an error carries control-flow meaning (e.g. the configuration cache
+ * problems listener re-throws [java.io.IOException] to abort serialization), so it is forwarded to
+ * the [delegate] immediately. Deferring it would let the write appear to succeed and only surface
+ * the failure later, during replay, outside the caller's rollback handling.
+ *
+ * Task routing is preserved: a [forIncompatibleTask]/[forTask] listener defers onto the
+ * corresponding scoped listener of the [delegate].
+ */
+class BufferingProblemsListener private constructor(
+    private val delegate: ProblemsListener,
+    private val deferred: MutableList<() -> Unit>,
+    private val problems: MutableList<PropertyProblem>
+) : ProblemsListener {
+
+    constructor(delegate: ProblemsListener) : this(delegate, mutableListOf(), mutableListOf())
+
+    override fun onProblem(problem: PropertyProblem) {
+        problems.add(problem)
+        deferred.add { delegate.onProblem(problem) }
+    }
+
+    override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+        delegate.onError(trace, error, message)
+    }
+
+    override fun onExecutionTimeProblem(problem: PropertyProblem) {
+        problems.add(problem)
+        deferred.add { delegate.onExecutionTimeProblem(problem) }
+    }
+
+    override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener =
+        BufferingProblemsListener(delegate.forIncompatibleTask(trace, reason), deferred, problems)
+
+    override fun forTask(task: Task): ProblemsListener =
+        BufferingProblemsListener(delegate.forTask(task), deferred, problems)
+
+    /**
+     * The problems deferred during the scope, for inspection on rollback.
+     */
+    fun bufferedProblems(): List<PropertyProblem> = problems.toList()
+
+    /**
+     * Forwards all deferred problems to the delegate, preserving order and task routing.
+     */
+    fun replay() {
+        deferred.forEach { it() }
+    }
+}

--- a/platforms/core-configuration/graph-serialization/src/test/kotlin/org/gradle/internal/serialize/graph/BufferingProblemsListenerTest.kt
+++ b/platforms/core-configuration/graph-serialization/src/test/kotlin/org/gradle/internal/serialize/graph/BufferingProblemsListenerTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import org.gradle.api.Task
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.configuration.problems.StructuredMessage
+import org.gradle.internal.configuration.problems.StructuredMessageBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class BufferingProblemsListenerTest {
+
+    private
+    fun problem(message: String) =
+        PropertyProblem(PropertyTrace.Gradle, StructuredMessage.build { text(message) })
+
+    @Test
+    fun `defers problems until replay, preserving order`() {
+        val delegate = RecordingProblemsListener()
+        val listener = BufferingProblemsListener(delegate)
+        val p1 = problem("p1")
+        val p2 = problem("p2")
+
+        listener.onProblem(p1)
+        listener.onProblem(p2)
+
+        assertTrue("problems must not be forwarded before replay", delegate.problems.isEmpty())
+        assertEquals(listOf(p1, p2), listener.bufferedProblems())
+
+        listener.replay()
+        assertEquals(listOf(p1, p2), delegate.problems)
+    }
+
+    @Test
+    fun `defers execution-time problems until replay`() {
+        val delegate = RecordingProblemsListener()
+        val listener = BufferingProblemsListener(delegate)
+        val p = problem("exec")
+
+        listener.onExecutionTimeProblem(p)
+
+        assertTrue(delegate.executionTimeProblems.isEmpty())
+        assertEquals(listOf(p), listener.bufferedProblems())
+
+        listener.replay()
+        assertEquals(listOf(p), delegate.executionTimeProblems)
+    }
+
+    @Test
+    fun `forwards errors to the delegate immediately and does not buffer them`() {
+        val delegate = RecordingProblemsListener()
+        val listener = BufferingProblemsListener(delegate)
+        val error = RuntimeException("boom")
+
+        listener.onError(PropertyTrace.Gradle, error) { text("boom") }
+
+        assertEquals(listOf<Exception>(error), delegate.errors)
+        assertTrue("errors must not be buffered", listener.bufferedProblems().isEmpty())
+    }
+
+    @Test
+    fun `propagates a delegate error rethrow immediately`() {
+        val delegate = RecordingProblemsListener().apply { rethrowErrors = true }
+        val listener = BufferingProblemsListener(delegate)
+        val error = IOException("must abort")
+
+        val thrown = assertThrows(IOException::class.java) {
+            listener.onError(PropertyTrace.Gradle, error) { text("must abort") }
+        }
+        assertSame(error, thrown)
+    }
+
+    @Test
+    fun `replay routes deferred problems through the matching task-scoped delegate`() {
+        val delegate = RecordingProblemsListener()
+        val listener = BufferingProblemsListener(delegate)
+        val p = problem("incompatible")
+
+        val scoped = listener.forIncompatibleTask(PropertyTrace.Gradle, "reason")
+        scoped.onProblem(p)
+
+        // The scoped listener resolves its delegate eagerly, but defers the problem itself.
+        assertEquals(1, delegate.incompatibleChildren.size)
+        assertTrue(delegate.problems.isEmpty())
+        assertTrue(delegate.incompatibleChildren.single().problems.isEmpty())
+
+        listener.replay()
+        assertEquals(listOf(p), delegate.incompatibleChildren.single().problems)
+    }
+
+    private
+    class RecordingProblemsListener : ProblemsListener {
+        val problems = mutableListOf<PropertyProblem>()
+        val executionTimeProblems = mutableListOf<PropertyProblem>()
+        val errors = mutableListOf<Exception>()
+        val incompatibleChildren = mutableListOf<RecordingProblemsListener>()
+        var rethrowErrors = false
+
+        override fun onProblem(problem: PropertyProblem) {
+            problems.add(problem)
+        }
+
+        override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+            errors.add(error)
+            if (rethrowErrors) throw error
+        }
+
+        override fun onExecutionTimeProblem(problem: PropertyProblem) {
+            executionTimeProblems.add(problem)
+        }
+
+        override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener =
+            RecordingProblemsListener().also { incompatibleChildren.add(it) }
+
+        override fun forTask(task: Task): ProblemsListener = this
+    }
+}

--- a/platforms/core-configuration/graph-serialization/src/test/kotlin/org/gradle/internal/serialize/graph/WriteIdentitiesTest.kt
+++ b/platforms/core-configuration/graph-serialization/src/test/kotlin/org/gradle/internal/serialize/graph/WriteIdentitiesTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class WriteIdentitiesTest {
+
+    @Test
+    fun `assigns dense ids in registration order`() {
+        val identities = WriteIdentities()
+        val a = Any()
+        val b = Any()
+
+        assertEquals(0, identities.putInstance(a))
+        assertEquals(1, identities.putInstance(b))
+        assertEquals(0, identities.getId(a))
+        assertEquals(1, identities.getId(b))
+        assertEquals(-1, identities.getId(Any()))
+    }
+
+    @Test
+    fun `restoreToMark removes instances registered since mark and rewinds the id counter`() {
+        val identities = WriteIdentities()
+        val beforeMark = Any()
+        identities.putInstance(beforeMark)
+
+        identities.mark()
+        val sinceMark1 = Any()
+        val sinceMark2 = Any()
+        identities.putInstance(sinceMark1)
+        identities.putInstance(sinceMark2)
+
+        identities.restoreToMark()
+
+        // instances registered since the mark are gone
+        assertEquals(-1, identities.getId(sinceMark1))
+        assertEquals(-1, identities.getId(sinceMark2))
+        // instances registered before the mark keep their ids
+        assertEquals(0, identities.getId(beforeMark))
+        // the next id continues from the mark, as if the rolled-back instances never existed
+        assertEquals(1, identities.putInstance(Any()))
+    }
+
+    @Test
+    fun `discardMark keeps instances registered since mark`() {
+        val identities = WriteIdentities()
+        identities.mark()
+        val instance = Any()
+        assertEquals(0, identities.putInstance(instance))
+
+        identities.discardMark()
+
+        assertEquals(0, identities.getId(instance))
+        assertEquals(1, identities.putInstance(Any()))
+    }
+
+    @Test
+    fun `mark rejects nesting`() {
+        val identities = WriteIdentities()
+        identities.mark()
+        assertThrows(IllegalArgumentException::class.java) { identities.mark() }
+    }
+
+    @Test
+    fun `commit and rollback require an active mark`() {
+        val identities = WriteIdentities()
+        assertThrows(IllegalArgumentException::class.java) { identities.restoreToMark() }
+        assertThrows(IllegalArgumentException::class.java) { identities.discardMark() }
+    }
+}


### PR DESCRIPTION
Introduces a rollback capability for Configuration Cache writes: mark a
position, then either commit everything written since (relayed verbatim)
or roll it back as if it never happened. The reader and on-disk format
are unchanged.

Mechanism (spool-and-relay, write-side only):
- SpillingOutputStream diverts post-mark bytes into a small in-memory
  buffer that overflows to an encrypted sibling temp file, so plaintext
  never reaches disk and small regions never touch disk at all.
- EncoderRollback flushes the encoder at each boundary and drives the
  spill; rollback flushes the tail into the spool and drops it, so the
  Kryo Output internals are untouched.
- WriteContext.beginRollbackScope() journals the inline WriteIdentities
  (current isolate + shared) and swaps in a BufferingProblemsListener
  that defers problems, replaying them on commit or returning them for
  inspection on rollback. circularReferences/PropertyTrace/reentrant
  self-heal on unwind.

The BufferingProblemsListener forwards onError immediately rather than
deferring it: onError carries control-flow meaning (the CC problems
listener re-throws IOException/ConfigurationCacheThrowable to abort
serialization), so deferring it would let a failing write appear to
succeed and surface only during replay.

Rollback is offered only for the plain KryoBackedEncoder path (Work),
not the sequential string-dedup encoder whose inline table is not yet
revertible. Nesting is rejected.

Covered by unit tests for WriteIdentities, SpillingOutputStream and
BufferingProblemsListener, plus a write/read round-trip test.