### PR TITLE
Report configuration cache warn mode through Problems API

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMa
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheParallelOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheReadOnlyOption
+import org.gradle.integtests.fixtures.problems.ReceivedProblem
 import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatureIntegrationTest
 
 abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigurationCacheOptInFeatureIntegrationTest {
@@ -48,6 +49,13 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
 
     void configurationCacheRunLenient(String... tasks) {
         run(WARN_PROBLEMS_CLI_OPT, *CLI_OPTIONS, *tasks)
+        if (isProblemsApiCheckEnabled()) {
+            consumeWarnModeProblem()
+        }
+    }
+
+    protected ReceivedProblem consumeWarnModeProblem() {
+        return findReceivedProblem { it.fqid.endsWith(":configuration-cache-warn-mode") }
     }
 
     void configurationCacheFails(String... tasks) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOp
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
 
 import static org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption.Value.WARN
+import org.gradle.api.problems.Severity
 
 
 class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
@@ -61,6 +62,30 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
 
         then:
         fixture.assertStateLoaded()
+    }
+
+    def "configuration cache warn mode is reported through the Problems API"() {
+        given:
+        buildFile "task ok {}"
+        enableProblemsApiCheck()
+
+        when:
+        run("ok", "--configuration-cache", "--configuration-cache-problems=warn")
+
+        then:
+        receivedProblems.size() == 1
+
+        verifyAll(receivedProblem) {
+            fqid == 'validation:configuration-cache:configuration-cache-warn-mode'
+
+            contextualLabel == 'Configuration Cache warn mode is ENABLED. ' +
+                'Configuration Cache problems are being ignored. ' +
+                'Build outputs may be incorrect and the build may crash unexpectedly. ' +
+                'Use this only to discover configuration cache problems. ' +
+                'Do not use this to produce artifacts.'
+
+            definition.severity == Severity.WARNING
+        }
     }
 
     def "can enable with a property in gradle user home gradle.properties"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -66,24 +66,13 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
 
     def "configuration cache warn mode is reported through the Problems API"() {
         given:
-        buildFile "task ok {}"
         enableProblemsApiCheck()
 
         when:
-        run("ok", "--configuration-cache", "--configuration-cache-problems=warn")
+        run("help", "--configuration-cache", "--configuration-cache-problems=warn")
 
         then:
-        receivedProblems.size() == 1
-
-        verifyAll(receivedProblem) {
-            fqid == 'validation:configuration-cache:configuration-cache-warn-mode'
-
-            contextualLabel == 'Configuration Cache warn mode is ENABLED. ' +
-                'Configuration Cache problems are being ignored. ' +
-                'Build outputs may be incorrect and the build may crash unexpectedly. ' +
-                'Use this only to discover configuration cache problems. ' +
-                'Do not use this to produce artifacts.'
-
+        verifyAll(consumeWarnModeProblem()) {
             definition.severity == Severity.WARNING
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -49,8 +49,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         }
 
         and:
-        verifyAll(receivedProblem(0)) {
-            fqid == REGISTRATION_UNSUPPORTED
+        verifyAll(findReceivedProblem { it.fqid == REGISTRATION_UNSUPPORTED }) {
             contextualLabel == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.severity == Severity.WARNING
             definition.documentationLink.url.endsWith("/userguide/configuration_cache_requirements.html#config_cache:requirements:build_listeners")
@@ -65,7 +64,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         configurationCacheRunLenient 'run', "-D${StartParameterBuildOptions.ConfigurationCacheRecreateOption.PROPERTY_NAME}=true"
 
         then:
-        verifyAll(receivedProblem) {
+        verifyAll(findReceivedProblem { it.fqid == REGISTRATION_UNSUPPORTED }) {
             fqid == REGISTRATION_UNSUPPORTED
             contextualLabel == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.severity == Severity.WARNING
@@ -88,10 +87,10 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
 
         when:
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, "-D$MAX_PROBLEMS_GRADLE_PROP=0", 'run'
+        consumeWarnModeProblem()
 
         then:
-        verifyAll(receivedProblem) {
-            fqid == REGISTRATION_UNSUPPORTED
+        verifyAll(findReceivedProblem { it.fqid == REGISTRATION_UNSUPPORTED }) {
             contextualLabel == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.severity == Severity.WARNING
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -81,6 +81,14 @@ val isolatedProjectsDangerouslyIgnoreProblemsSentences = listOf(
     "Do not use this to produce artifacts."
 )
 
+val configurationCacheWarnModeSentences = listOf(
+    "Configuration Cache warn mode is ENABLED.",
+    "Configuration Cache problems are being ignored.",
+    "Build outputs may be incorrect and the build may crash unexpectedly.",
+    "Use this only to discover configuration cache problems.",
+    "Do not use this to produce artifacts."
+)
+
 
 private
 val isolatedProjectsDangerouslyIgnoreProblemsDocumentation =
@@ -364,6 +372,21 @@ class ConfigurationCacheProblems(
     }
 
     private
+    fun reportConfigurationCacheWarnMode() {
+        val message = configurationCacheWarnModeSentences.joinToString(" ")
+        problemsService.internalReporter.internalCreate {
+            id(
+                "configuration-cache-warn-mode",
+                "Configuration Cache warn mode is enabled",
+                configCacheValidation
+            )
+            contextualLabel(message)
+        }.also {
+            problemsService.internalReporter.report(it)
+        }
+    }
+
+    private
     fun ProblemSpec.documentOfProblem(problem: PropertyProblem) {
         problem.documentationSection?.let {
             documentedAt(Documentation.userManual(it.page, it.anchor).url)
@@ -496,6 +519,10 @@ class ConfigurationCacheProblems(
             if (isIsolatedProjectsDangerouslyIgnoreProblems) {
                 logger.warn(isolatedProjectsDangerouslyIgnoreProblemsBanner())
                 reportDangerouslyIgnoringProblems()
+            }
+
+            if (isWarningMode) {
+                reportConfigurationCacheWarnMode()
             }
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -83,9 +83,9 @@ val isolatedProjectsDangerouslyIgnoreProblemsSentences = listOf(
 
 val configurationCacheWarnModeSentences = listOf(
     "Configuration Cache warn mode is ENABLED.",
-    "Configuration Cache problems are being ignored.",
+    "Configuration Cache constraint violations are being ignored.",
     "Build outputs may be incorrect and the build may crash unexpectedly.",
-    "Use this only to discover configuration cache problems.",
+    "Use this only to discover configuration cache incompatibilities.",
     "Do not use this to produce artifacts."
 )
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -859,6 +859,19 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
     }
 
     /**
+     * Returns the first received problem that matches the given criteria and marks it as validated.
+     * The validation should only verify the contextual attributes of the received problem, as the problem definition is checked at the end of each test (see {@see KnownProblemIds}).
+     * Fails if no problem matches the condition.
+     *
+     * @see #receivedProblem(int)
+     */
+    protected ReceivedProblem findReceivedProblem(Closure<ReceivedProblem> criteria) {
+        def found = getReceivedProblems().findIndexOf { it?.collect(criteria) }
+        assert found >= 0 : "No problems match the criteria"
+        return receivedProblem(found)
+    }
+
+    /**
      * Generates a `repositories` block pointing to the standard maven repo fixture.
      *
      * This is often required for running with configuration cache enabled, as

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -55,6 +55,7 @@ import org.opentest4j.AssertionFailedError
 import spock.lang.Specification
 
 import java.nio.file.Files
+import java.util.function.Predicate
 import java.util.regex.Pattern
 
 import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.DEFAULT_TIMEOUT_SECONDS
@@ -865,10 +866,10 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
      *
      * @see #receivedProblem(int)
      */
-    protected ReceivedProblem findReceivedProblem(Closure<ReceivedProblem> criteria) {
-        def found = getReceivedProblems().findIndexOf { it?.collect(criteria) }
-        assert found >= 0 : "No problems match the criteria"
-        return receivedProblem(found)
+    protected ReceivedProblem findReceivedProblem(Predicate<ReceivedProblem> criteria) {
+        def index = getReceivedProblems().findIndexOf { it && criteria.test(it) }
+        assert index >= 0: "No received problem matches the given criteria"
+        return receivedProblem(index)
     }
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -172,6 +172,7 @@ class KnownProblemIds {
         'validation:configuration-cache:cannot-serialize-object-of-type-org-gradle-api-defaulttask-a-subtype-of-org-gradle-api-task-as-these-are-not-supported-with-the-configuration-cache': ['cannot serialize object of type \'org.gradle.api.DefaultTask\', a subtype of \'org.gradle.api.Task\', as these are not supported with the configuration cache.'],
         // Dynamic fqid until the CC class-encoding failure path emits a stable problem ID.
         'validation:configuration-cache:class-.*-cannot-be-encoded-because.*': ['(?s)Class .* cannot be encoded because.*'],
+        'validation:configuration-cache:configuration-cache-warn-mode': ['Configuration Cache warn mode is enabled'],
         'validation:missing-java-toolchain-plugin': ['Using task ValidatePlugins without applying the Java Toolchain plugin'],
         'validation:invalid-java-toolchain': ["Running task ValidatePlugins with Java Toolchain lower than ${SupportedJavaVersions.MINIMUM_DAEMON_JAVA_VERSION}"],
 


### PR DESCRIPTION
Fixes #38290

Report Configuration Cache warn mode through the Problems API.

When `org.gradle.configuration-cache.problems=warn` (or the equivalent command-line option) is used, Gradle now emits a Problems API warning describing the implications of running in warn mode.

This aligns Configuration Cache warn mode more closely with the existing Isolated Projects `dangerously-ignore-problems` mode, making it more visible that problems are being ignored and that build results may be unreliable.

Also adds integration test coverage and registers the new problem identifier.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `core/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew :core:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
