### PR TITLE
Update docs on reproducible archive defaults

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -265,6 +265,9 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * <p>
      * If <code>false</code> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
      * </p>
+     * <p>
+     * Gradle defaults to <code>false</code> if not set explictly starting Gradle 9.0.0
+     * </p>
      *
      * @return <code>true</code> if file timestamps should be preserved for archive entries
      * @since 3.4
@@ -280,6 +283,9 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * <p>
      * If <code>false</code> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
      * </p>
+     * <p>
+     * Gradle defaults to <code>false</code> if not set explictly starting Gradle 9.0.0
+     * </p>
      *
      * @param preserveFileTimestamps <code>true</code> if file timestamps should be preserved for archive entries
      * @since 3.4
@@ -294,6 +300,9 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Gradle will then walk the directories on disk which are part of this archive in a reproducible order
      * independent of file systems and operating systems.
      * This helps Gradle reliably produce byte-for-byte reproducible archives.
+     * </p>
+     * <p>
+     * Gradle defaults to <code>true</code> if not set explictly starting Gradle 9.0.0
      * </p>
      *
      * @return <code>true</code> if the files should read from disk in a reproducible order.
@@ -311,6 +320,9 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Gradle will then walk the directories on disk which are part of this archive in a reproducible order
      * independent of file systems and operating systems.
      * This helps Gradle reliably produce byte-for-byte reproducible archives.
+     * </p>
+     * <p>
+     * Gradle defaults to <code>true</code> if not set explictly starting Gradle 9.0.0
      * </p>
      *
      * @param reproducibleFileOrder <code>true</code> if the files should read from disk in a reproducible order.


### PR DESCRIPTION
### Context
This is to match the change in Gradle 9.0.0

https://docs.gradle.org/9.0.0/release-notes.html#archive-tasks-produce-reproducible-archives-by-default

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
