### PR TITLE
Improve error message for ambiguity caused by capabilities that differ only by version

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -629,39 +629,86 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeImplemented("this should NOT be a failure, the distinct capabilities required should make selection unambiguous")
-    def "requireCapability() has no effect"() {
-        requireCapabilityHasNoEffect.prepare()
+    // This test fails with an artifact ambiguity error if you remove --configuration-cache and un-comment the artifact type registry entry for color=yellow
+    @ToBeImplemented("this SHOULD be a failure, the choice of artifact transforms IS ambiguous")
+    def "multiple possible artifact transforms should cause an error but dont"() {
+        settingsKotlinFile.text = """
+            rootProject.name = "producer"
+        """
+        buildFile.text = """
+            plugins {
+                id("base")
+            }
+
+            def artifactType = Attribute.of('artifactType', String)
+            def color = Attribute.of("color", String)
+
+            abstract class VariantArtifactTransform1 implements TransformAction<org.gradle.api.artifacts.transform.TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def output = outputs.file("transformed1-" + inputArtifact.get().asFile.name)
+                    output << "transformed1"
+                }
+            }
+
+            abstract class VariantArtifactTransform2 implements TransformAction<org.gradle.api.artifacts.transform.TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def output = outputs.file("transformed2-" + inputArtifact.get().asFile.name)
+                    output << "transformed2"
+                }
+            }
+
+            file("foo").text = "hello"
+            task doZip(type: Zip) {
+                from(file("foo"))
+            }
+
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes {
+                        attribute(artifactType, "jar")
+                    }
+                }
+            }
+
+            dependencies {
+                deps files(file("foo.zip")) {
+                    builtBy doZip
+                }
+
+                registerTransform(VariantArtifactTransform1) {
+                    from.attribute(artifactType, 'zip')
+                    from.attribute(color, 'yellow')
+                    to.attribute(artifactType, 'jar')
+                    to.attribute(color, 'red')
+                }
+
+                registerTransform(VariantArtifactTransform2) {
+                    from.attribute(artifactType, 'zip')
+                    from.attribute(color, 'yellow')
+                    to.attribute(artifactType, 'jar')
+                    to.attribute(color, 'blue')
+                }
+            }
+
+            task resolve {
+                def files = configurations.res.incoming.files
+                doLast {
+                    println files.files*.name
+                }
+            }
+        """
 
         expect:
-        assertResolutionFailsAsExpected(requireCapabilityHasNoEffect)
-
-        and: "Has error output"
-        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project ':producer'")
-        assertFullMessageCorrect("""The consumer was configured to find attribute 'custom' with value 'a1'. However we cannot choose between the following variants of project ':producer':""")
-        assertFullMessageCorrect("""The consumer was configured to find attribute 'custom' with value 'a2'. However we cannot choose between the following variants of project ':producer':""")
-
-        and: "Helpful resolutions are provided"
-        assertSuggestsViewingDocs("Ambiguity errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-ambiguity.")
-        assertSuggestsReviewingAlgorithm()
-
-        and: "Problems are reported"
-        verifyAll(receivedProblem(0)) {
-            fqid == 'dependency-variant-resolution:ambiguous-variants'
-            additionalData.asMap['requestTarget'] == "project ':producer'"
-            additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_VARIANTS.name()
-            additionalData.asMap['problemDisplayName'] == "Multiple variants exist that would match the request"
-        }
-        verifyAll(receivedProblem(1)) {
-            fqid == 'dependency-variant-resolution:ambiguous-variants'
-            additionalData.asMap['requestTarget'] == "project ':producer'"
-            additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_VARIANTS.name()
-            additionalData.asMap['problemDisplayName'] == "Multiple variants exist that would match the request"
-        }
+        succeeds("resolve", '--configuration-cache')
     }
-
     // endregion other tests
 
     // region error showcase
@@ -741,7 +788,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
     private final Demonstration ambiguousArtifactVariants = new Demonstration("Ambiguous artifact variants", ArtifactSelectionException.class, AmbiguousArtifactsFailure.class, this.&setupAmbiguousArtifactsFailureForProject)
 
     private final Demonstration multipleSelectedVariantsWithSameCapabilities = new Demonstration("Multiple selected variants with the same capabilities", VariantSelectionByAttributesException.class, ConfigurationNotCompatibleFailure.class, this.&setupMultipleConfigurationsWithSameCapabilities)
-    private final Demonstration requireCapabilityHasNoEffect = new Demonstration("requireCapability() has no effect", VariantSelectionByAttributesException.class, AmbiguousVariantsFailure.class, this.&setupRequireCapabilityHasNoEffect)
 
     private final Demonstration incompatibleArtifactVariants = new Demonstration("Incompatible graph variants", GraphValidationException.class, IncompatibleMultipleNodesValidationFailure.class, this.&setupIncompatibleMultipleNodesValidationFailureForProject)
 
@@ -761,8 +807,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         ambiguousArtifactVariants,
 
         incompatibleArtifactVariants,
-        multipleSelectedVariantsWithSameCapabilities,
-        requireCapabilityHasNoEffect
+        multipleSelectedVariantsWithSameCapabilities
     ]
     // endregion error showcase
 
@@ -772,98 +817,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         settingsKotlinFile << """
             rootProject.name = "example"
-        """
-    }
-
-    private void setupRequireCapabilityHasNoEffect() {
-        settingsKotlinFile << """
-            rootProject.name = "test"
-
-            include("producer");
-        """
-
-        file("producer/build.gradle.kts") << """
-            group = "org.example"
-            version = "1.0"
-            val CUSTOM_ATTRIBUTE = Attribute.of("custom", String::class.java)
-
-            configurations {
-                create("v1") {
-                    isCanBeConsumed = true
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a1")
-                    }
-                    outgoing {
-                        capability("org:example:c1")
-                    }
-                }
-
-                create("v2") {
-                    isCanBeConsumed = true
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a1")
-                    }
-                    outgoing {
-                        capability("org:example:c2")
-                    }
-                }
-
-                create("v3") {
-                    isCanBeConsumed = true
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a2")
-                    }
-                    outgoing {
-                        capability("org:example:c1")
-                    }
-                }
-
-                create("v4") {
-                    isCanBeConsumed = true
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a2")
-                    }
-                    outgoing {
-                        capability("org:example:c2")
-                    }
-                }
-            }
-        """
-
-        buildKotlinFile << """
-            group = "org.example"
-            version = "1.0"
-            val CUSTOM_ATTRIBUTE = Attribute.of("custom", String::class.java)
-
-            configurations {
-                dependencyScope("myDependencies")
-
-                resolvable("resolveMe") {
-                    extendsFrom(configurations.getByName("myDependencies"))
-                }
-            }
-
-            dependencies {
-                add("myDependencies", project(":producer")) {
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a1")
-                    }
-                    capabilities {
-                        requireCapability("org:example:c1")
-                    }
-                }
-
-                add("myDependencies", project(":producer")) {
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, "a2")
-                    }
-                    capabilities {
-                        requireCapability("org:example:c2")
-                    }
-                }
-            }
-
-            ${forceConsumerResolution()}
         """
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -38,7 +38,6 @@ import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariant
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
-import org.gradle.util.internal.ToBeImplemented
 
 /**
  * These tests demonstrate the behavior of the [ResolutionFailureHandler] when a project has various
@@ -627,87 +626,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_VERSION_SATISFIES.name()
             additionalData.asMap['problemDisplayName'] == "No version satisfies the constraints"
         }
-    }
-
-    // This test fails with an artifact ambiguity error if you remove --configuration-cache and un-comment the artifact type registry entry for color=yellow
-    @ToBeImplemented("this SHOULD be a failure, the choice of artifact transforms IS ambiguous")
-    def "multiple possible artifact transforms should cause an error but dont"() {
-        settingsKotlinFile.text = """
-            rootProject.name = "producer"
-        """
-        buildFile.text = """
-            plugins {
-                id("base")
-            }
-
-            def artifactType = Attribute.of('artifactType', String)
-            def color = Attribute.of("color", String)
-
-            abstract class VariantArtifactTransform1 implements TransformAction<org.gradle.api.artifacts.transform.TransformParameters.None> {
-                @InputArtifact
-                abstract Provider<FileSystemLocation> getInputArtifact()
-
-                void transform(TransformOutputs outputs) {
-                    def output = outputs.file("transformed1-" + inputArtifact.get().asFile.name)
-                    output << "transformed1"
-                }
-            }
-
-            abstract class VariantArtifactTransform2 implements TransformAction<org.gradle.api.artifacts.transform.TransformParameters.None> {
-                @InputArtifact
-                abstract Provider<FileSystemLocation> getInputArtifact()
-
-                void transform(TransformOutputs outputs) {
-                    def output = outputs.file("transformed2-" + inputArtifact.get().asFile.name)
-                    output << "transformed2"
-                }
-            }
-
-            file("foo").text = "hello"
-            task doZip(type: Zip) {
-                from(file("foo"))
-            }
-
-            configurations {
-                dependencyScope("deps")
-                resolvable("res") {
-                    extendsFrom(deps)
-                    attributes {
-                        attribute(artifactType, "jar")
-                    }
-                }
-            }
-
-            dependencies {
-                deps files(file("foo.zip")) {
-                    builtBy doZip
-                }
-
-                registerTransform(VariantArtifactTransform1) {
-                    from.attribute(artifactType, 'zip')
-                    from.attribute(color, 'yellow')
-                    to.attribute(artifactType, 'jar')
-                    to.attribute(color, 'red')
-                }
-
-                registerTransform(VariantArtifactTransform2) {
-                    from.attribute(artifactType, 'zip')
-                    from.attribute(color, 'yellow')
-                    to.attribute(artifactType, 'jar')
-                    to.attribute(color, 'blue')
-                }
-            }
-
-            task resolve {
-                def files = configurations.res.incoming.files
-                doLast {
-                    println files.files*.name
-                }
-            }
-        """
-
-        expect:
-        succeeds("resolve", '--configuration-cache')
     }
     // endregion other tests
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -315,4 +315,87 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         ["org:foo", "org:bar"]  | "with capabilities ['org:bar', 'org:foo']"
     }
 
+    def "requireCapability() narrows otherwise-ambiguous variants when capability differs in group or name"() {
+        given:
+        setupVariantsDistinguishedByCapability("org.example:c1:1.0", "org.example:c2:1.0")
+
+        expect:
+        succeeds "forceResolution"
+    }
+
+    def "requireCapability() does not narrow when notations differ only in the version segment, and the error message surfaces the effective selector"() {
+        given:
+        setupVariantsDistinguishedByCapability("org:example:c1", "org:example:c2")
+
+        when:
+        fails "forceResolution"
+
+        then: "the ambiguity is reported with the effective (version-stripped) capability"
+        failure.assertHasErrorOutput("The consumer was configured to find attribute 'custom' with value 'a1' and capability 'org:example'. However we cannot choose between the following variants of project ':producer':")
+
+        and: "the trailer indicates required capability was considered"
+        failure.assertHasErrorOutput("All of them match the consumer attributes and required capability:")
+    }
+
+    private void setupVariantsDistinguishedByCapability(String c1Notation, String c2Notation) {
+        settingsFile << """
+            include("producer")
+        """
+
+        file("producer/build.gradle") << """
+            group = "org.example"
+            version = "1.0"
+
+            def custom = Attribute.of("custom", String)
+
+            configurations {
+                consumable("v1") {
+                    attributes {
+                        attribute(custom, "a1")
+                    }
+                    outgoing {
+                        capability("${c1Notation}")
+                    }
+                }
+                consumable("v2") {
+                    attributes {
+                        attribute(custom, "a1")
+                    }
+                    outgoing {
+                        capability("${c2Notation}")
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            def custom = Attribute.of("custom", String)
+
+            configurations {
+                dependencyScope("myDependencies")
+                resolvable("resolveMe") {
+                    extendsFrom(myDependencies)
+                }
+            }
+
+            dependencies {
+                myDependencies(project(":producer")) {
+                    attributes {
+                        attribute(custom, "a1")
+                    }
+                    capabilities {
+                        requireCapability("${c1Notation}")
+                    }
+                }
+            }
+
+            task forceResolution {
+                def files = configurations.resolveMe.incoming.files
+                doLast {
+                    files.each { println(it) }
+                }
+            }
+        """
+    }
+
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -323,23 +323,28 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds "forceResolution"
     }
 
-    def "requireCapability() does not narrow when notations differ only in the version segment, and the error message surfaces the effective selector"() {
+    def "requireCapability() does NOT narrow when notations differ only in the version segment, and the error message surfaces the effective selector"() {
         given:
-        setupVariantsDistinguishedByCapability("org:example:c1", "org:example:c2")
+        setupVariantsDistinguishedByCapability("group:name:1.0", "group:name:2.0")
 
         when:
         fails "forceResolution"
 
-        then: "the ambiguity is reported with the effective (version-stripped) capability"
-        failure.assertHasErrorOutput("The consumer was configured to find attribute 'custom' with value 'a1' and capability 'org:example'. However we cannot choose between the following variants of project ':producer':")
-
-        and: "the trailer indicates required capability was considered"
-        failure.assertHasErrorOutput("All of them match the consumer attributes and required capability:")
+        then: "the ambiguity is reported with the effective (version-stripped) capability and the trailer indicates required capability was considered"
+        assertFullMessageCorrect("""Required by:
+         root project 'test'
+      > The consumer was configured to find attribute 'custom' with value 'a1' and capability 'group:name'. However we cannot choose between the following variants of project ':producer':
+          - v1
+          - v2
+        All of them match the consumer attributes and required capability:
+          - Variant 'v1' capability 'group:name:1.0' declares attribute 'custom' with value 'a1'
+          - Variant 'v2' capability 'group:name:2.0' declares attribute 'custom' with value 'a1'""")
     }
 
     private void setupVariantsDistinguishedByCapability(String c1Notation, String c2Notation) {
         settingsFile << """
             include("producer")
+            rootProject.name = "test"
         """
 
         file("producer/build.gradle") << """
@@ -398,4 +403,9 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         """
     }
 
+    private void assertFullMessageCorrect(String identifyingFragment) {
+        identifyingFragment.eachLine {
+            failure.assertHasErrorOutput(it.trim())
+        }
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
@@ -29,7 +30,9 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static org.gradle.internal.exceptions.StyledException.style;
 
@@ -77,16 +80,28 @@ public abstract class AmbiguousVariantsFailureDescriber extends AbstractResoluti
         for (ResolutionCandidateAssessor.AssessedCandidate candidate : failure.getCandidates()) {
             ambiguousVariants.put(candidate.getDisplayName(), candidate);
         }
-        if (failure.getRequestedAttributes().isEmpty()) {
+        Set<CapabilitySelector> capabilitySelectors = failure.getCapabilitySelectors();
+        boolean hasAttributes = !failure.getRequestedAttributes().isEmpty();
+        boolean hasCapabilities = !capabilitySelectors.isEmpty();
+        if (!hasAttributes && !hasCapabilities) {
             formatter.node("Cannot choose between the available variants of ");
         } else {
-            String node = "The consumer was configured to find " + describer.describeAttributeSet(failure.getRequestedAttributes().asMap());
-            if (listAvailableVariants) {
-                node = node + ". However we cannot choose between the following variants of ";
-            } else {
-                node = node + ". There are several available matching variants of ";
+            StringBuilder node = new StringBuilder("The consumer was configured to find ");
+            if (hasAttributes) {
+                node.append(describer.describeAttributeSet(failure.getRequestedAttributes().asMap()));
+                if (hasCapabilities) {
+                    node.append(" and ");
+                }
             }
-            formatter.node(node);
+            if (hasCapabilities) {
+                node.append(describeCapabilitySelectors(capabilitySelectors));
+            }
+            if (listAvailableVariants) {
+                node.append(". However we cannot choose between the following variants of ");
+            } else {
+                node.append(". There are several available matching variants of ");
+            }
+            formatter.node(node.toString());
         }
         formatter.append(style(StyledTextOutput.Style.Info, failure.describeRequestTarget()));
         if (listAvailableVariants) {
@@ -95,9 +110,30 @@ public abstract class AmbiguousVariantsFailureDescriber extends AbstractResoluti
                 formatter.node(configuration);
             }
             formatter.endChildren();
-            formatter.node("All of them match the consumer attributes");
+            formatter.node(describeMatchSummary(hasAttributes, capabilitySelectors));
         }
         return ambiguousVariants;
+    }
+
+    private static String describeCapabilitySelectors(Set<CapabilitySelector> selectors) {
+        if (selectors.size() == 1) {
+            return "capability " + selectors.iterator().next().getDisplayName();
+        }
+        return "capabilities [" + selectors.stream()
+            .map(CapabilitySelector::getDisplayName)
+            .sorted()
+            .collect(Collectors.joining(", ")) + "]";
+    }
+
+    private static String describeMatchSummary(boolean hasAttributes, Set<CapabilitySelector> capabilitySelectors) {
+        if (capabilitySelectors.isEmpty()) {
+            return "All of them match the consumer attributes";
+        }
+        String capabilityWord = capabilitySelectors.size() == 1 ? "capability" : "capabilities";
+        if (hasAttributes) {
+            return "All of them match the consumer attributes and required " + capabilityWord;
+        }
+        return "All of them match the required " + capabilityWord;
     }
 
     private void formatUnselectable(


### PR DESCRIPTION
`DefaultSpecificCapabilitySelector` deliberately ignores the version segment when matching, so when two notations collapse to the same selector (for example "org:example" results from both "org:example:1.0" and "org:example:2.0") the capability filter does not distinguish anything. Equivalent corrected coverage now lives in `CapabilitiesLocalComponentIntegrationTest`.
     
The failure message change in this branch also shows the effective version-stripped selector so this failure makes sense.

Fixes one of the issues flagged by:
- https://github.com/gradle/gradle/pull/29543