### PR TITLE
De-incubate project dependency factory methods

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -317,6 +317,11 @@ The following are the features that have been promoted in this Gradle release.
 ### Example promoted
 -->
 
+* [`project()`](javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html#project()) in `DependencyHandler`
+* [`project(String)`](javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html#project(java.lang.String)) in `DependencyHandler`
+* [`createProjectDependency()`](javadoc/org/gradle/api/artifacts/dsl/DependencyFactory.html#createProjectDependency()) in `DependencyFactory`
+* [`createProjectDependency(String)`](javadoc/org/gradle/api/artifacts/dsl/DependencyFactory.html#createProjectDependency(java.lang.String)) in `DependencyFactory`
+
 ## Documentation and training
 
 <!--

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyFactory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.dsl;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -104,7 +103,6 @@ public interface DependencyFactory {
      *
      * @since 9.5.0
      */
-    @Incubating
     ProjectDependency createProjectDependency(String projectPath);
 
     /**
@@ -114,7 +112,6 @@ public interface DependencyFactory {
      *
      * @since 9.5.0
      */
-    @Incubating
     ProjectDependency createProjectDependency();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
@@ -339,7 +338,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 9.5.0
      */
-    @Incubating
     ProjectDependency project();
 
     /**
@@ -351,7 +349,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @since 9.5.0
      * @see org.gradle.api.Project#getPath()
      */
-    @Incubating
     ProjectDependency project(String projectPath);
 
     /**


### PR DESCRIPTION
Promotes DependencyHandler.project(), DependencyHandler.project(String), DependencyFactory.createProjectDependency(), and
DependencyFactory.createProjectDependency(String) out of incubation.

Fixes #38316 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
