### PR TITLE
Support threadPoolFactoryClass configuration on TestNG >= 7.10

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -190,6 +190,24 @@ The new `TestFailureDetails.isFrameworkFailure()` predicate exposes this distinc
 
 See the [Test logging](userguide/java_testing.html#sec:test_logging) section in the Gradle User Manual for more details.
 
+#### TestNG `threadPoolFactoryClass` works with TestNG 7.10 and later
+TestNG 7.10 replaced its thread-pool factory setter (`setExecutorFactoryClass(String)`) with a new API (`setExecutorServiceFactory(IExecutorServiceFactory)`). This release adds support for thread pool factories implementing this API on supporting TestNG versions.
+
+Gradle now detects which API the runtime TestNG version exposes and handles it accordingly:
+
+- On TestNG 7.10 and later, the configured class must implement `org.testng.IExecutorServiceFactory`.
+- On TestNG 7.0 through 7.9, the configured class must implement `org.testng.thread.IExecutorFactory`.
+
+The test task configuration remains unchanged — only the interface the user-supplied class must implement differs across TestNG versions:
+
+```kotlin
+tasks.named<Test>("test") {
+    useTestNG {
+        threadPoolFactoryClass = "com.example.MyExecutorServiceFactory"
+    }
+}
+```
+
 ### CLI, logging, and problem reporting
 Gradle provides an intuitive [command-line interface](userguide/command_line_interface.html), detailed [logs](userguide/logging.html), and a structured [problems report](userguide/reporting_problems.html#sec:generated_html_report) that helps developers quickly identify and resolve build issues.
 

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
@@ -182,7 +182,28 @@ public class TestNGTestRunner {
         }
     }
 
+    /**
+     * The setter for the thread pool factory has a different signature depending on TestNG version.
+     * This method uses reflection to detect the API and calls the version with the correct signature.
+     *
+     * TestNG >= 7.10 uses {@code setExecutorServiceFactory(IExecutorServiceFactory)}.
+     * TestNG 7.0–7.9 uses {@code setExecutorFactoryClass(String)}.
+     */
     private void setThreadPoolFactoryClass(TestNG testNg, String threadPoolFactoryClass) {
+        try {
+            Class<?> factoryInterface = Class.forName("org.testng.IExecutorServiceFactory", false, applicationClassLoader);
+            Class<?> factoryClass = applicationClassLoader.loadClass(threadPoolFactoryClass);
+            if (!factoryInterface.isAssignableFrom(factoryClass)) {
+                throw new InvalidUserDataException(String.format(
+                    "The thread pool factory class '%s' does not implement org.testng.IExecutorServiceFactory.", threadPoolFactoryClass));
+            }
+            Object factoryInstance = JavaReflectionUtil.newInstance(factoryClass);
+            JavaMethod.of(TestNG.class, Object.class, "setExecutorServiceFactory", factoryInterface).invoke(testNg, factoryInstance);
+            return;
+        } catch (ClassNotFoundException e) {
+            // New API not available, fall through to legacy API
+        }
+
         try {
             JavaMethod.of(TestNG.class, Object.class, "setExecutorFactoryClass", String.class).invoke(testNg, threadPoolFactoryClass);
         } catch (org.gradle.internal.reflect.NoSuchMethodException e) {

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
@@ -190,9 +190,21 @@ public class TestNGTestRunner {
      * TestNG 7.0–7.9 uses {@code setExecutorFactoryClass(String)}.
      */
     private void setThreadPoolFactoryClass(TestNG testNg, String threadPoolFactoryClass) {
+        Class<?> factoryInterface;
         try {
-            Class<?> factoryInterface = Class.forName("org.testng.IExecutorServiceFactory", false, applicationClassLoader);
-            Class<?> factoryClass = applicationClassLoader.loadClass(threadPoolFactoryClass);
+            factoryInterface = Class.forName("org.testng.IExecutorServiceFactory", false, applicationClassLoader);
+        } catch (ClassNotFoundException e) {
+            factoryInterface = null;
+        }
+
+        if (factoryInterface != null) {
+            Class<?> factoryClass;
+            try {
+                factoryClass = applicationClassLoader.loadClass(threadPoolFactoryClass);
+            } catch (ClassNotFoundException e) {
+                throw new InvalidUserDataException(String.format(
+                    "Could not load thread pool factory class '%s'.", threadPoolFactoryClass));
+            }
             if (!factoryInterface.isAssignableFrom(factoryClass)) {
                 throw new InvalidUserDataException(String.format(
                     "The thread pool factory class '%s' does not implement org.testng.IExecutorServiceFactory.", threadPoolFactoryClass));
@@ -200,8 +212,6 @@ public class TestNGTestRunner {
             Object factoryInstance = JavaReflectionUtil.newInstance(factoryClass);
             JavaMethod.of(TestNG.class, Object.class, "setExecutorServiceFactory", factoryInterface).invoke(testNg, factoryInstance);
             return;
-        } catch (ClassNotFoundException e) {
-            // New API not available, fall through to legacy API
         }
 
         try {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.util.internal.VersionNumber
 
 class TestNGCoverage {
-    final static String NEWEST = '7.5'
+    final static String NEWEST = '7.10.2'
 
     private static final String FIXED_ILLEGAL_ACCESS = '5.14.6' // Oldest version to support JDK 16+ without explicit --add-opens
 
@@ -38,6 +38,8 @@ class TestNGCoverage {
     private static final String BEFORE_BROKEN_PRESERVE_ORDER = '6.1.1' // Latest version before introduction of cbeust/testng#639 bug
     private static final String FIXED_BROKEN_PRESERVE_ORDER = '6.9.4'  // Fixes cbeust/testng#639 for preserve-order
 
+    private static final String LAST_BEFORE_NEW_EXECUTOR_API = '7.5' // Last version with setExecutorFactoryClass(String)
+
     public static final Set<String> ALL_VERSIONS = [
         '5.12.1', // Newest version without TestNG#setConfigFailurePolicy method (Added in 5.13)
         FIXED_ILLEGAL_ACCESS,
@@ -45,6 +47,7 @@ class TestNGCoverage {
         FIXED_BROKEN_PRESERVE_ORDER,
         BROKEN_ICLASS_LISTENER,
         FIXED_ICLASS_LISTENER,
+        LAST_BEFORE_NEW_EXECUTOR_API,
         NEWEST
       ]
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/28955")
+class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can configure threadPoolFactoryClass with TestNG 7.10+ (new IExecutorServiceFactory API)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.10.2'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.CustomExecutorServiceFactory'
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/CustomExecutorServiceFactory.java") << """
+            package org.gradle.test;
+
+            import java.util.concurrent.BlockingQueue;
+            import java.util.concurrent.ExecutorService;
+            import java.util.concurrent.ThreadFactory;
+            import java.util.concurrent.ThreadPoolExecutor;
+            import java.util.concurrent.TimeUnit;
+
+            public class CustomExecutorServiceFactory implements org.testng.IExecutorServiceFactory {
+                @Override
+                public ExecutorService create(
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        ThreadFactory threadFactory) {
+                    return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPass() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "can configure threadPoolFactoryClass with TestNG 7.5 (legacy setExecutorFactoryClass API)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.5'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.CustomExecutorFactory'
+                }
+            }
+        """
+
+        // For the old API, we use reflection-based delegation to avoid
+        // compiling against complex internal TestNG classes.
+        file("src/test/java/org/gradle/test/CustomExecutorFactory.java") << """
+            package org.gradle.test;
+
+            import org.testng.thread.IExecutorFactory;
+            import org.testng.thread.ITestNGThreadPoolExecutor;
+            import org.testng.thread.IThreadWorkerFactory;
+            import org.testng.IDynamicGraph;
+            import org.testng.ISuite;
+            import org.testng.ITestNGMethod;
+
+            import java.util.Comparator;
+            import java.util.concurrent.BlockingQueue;
+            import java.util.concurrent.TimeUnit;
+
+            public class CustomExecutorFactory implements IExecutorFactory {
+                @Override
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                public ITestNGThreadPoolExecutor newSuiteExecutor(
+                        String name,
+                        IDynamicGraph<ISuite> graph,
+                        IThreadWorkerFactory<ISuite> factory,
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        Comparator<ISuite> comparator) {
+                    try {
+                        Class clazz = Class.forName("org.testng.internal.thread.graph.TestNGThreadPoolExecutor");
+                        return (ITestNGThreadPoolExecutor) clazz.getConstructors()[0].newInstance(
+                            name, graph, factory, corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, comparator);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                public ITestNGThreadPoolExecutor newTestMethodExecutor(
+                        String name,
+                        IDynamicGraph<ITestNGMethod> graph,
+                        IThreadWorkerFactory<ITestNGMethod> factory,
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        Comparator<ITestNGMethod> comparator) {
+                    try {
+                        Class clazz = Class.forName("org.testng.internal.thread.graph.TestNGThreadPoolExecutor");
+                        return (ITestNGThreadPoolExecutor) clazz.getConstructors()[0].newInstance(
+                            name, graph, factory, corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, comparator);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPass() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
@@ -31,8 +31,11 @@ class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
                 testImplementation 'org.testng:testng:7.10.2'
             }
             test {
+                systemProperty 'factoryMarkerFile', new File(layout.buildDirectory.asFile.get(), 'factory-invoked.marker').absolutePath
                 useTestNG {
                     threadPoolFactoryClass = 'org.gradle.test.CustomExecutorServiceFactory'
+                    parallel = 'methods'
+                    threadCount = 2
                 }
             }
         """
@@ -40,6 +43,8 @@ class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
         file("src/test/java/org/gradle/test/CustomExecutorServiceFactory.java") << """
             package org.gradle.test;
 
+            import java.io.File;
+            import java.io.IOException;
             import java.util.concurrent.BlockingQueue;
             import java.util.concurrent.ExecutorService;
             import java.util.concurrent.ThreadFactory;
@@ -55,7 +60,57 @@ class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
                         TimeUnit unit,
                         BlockingQueue<Runnable> workQueue,
                         ThreadFactory threadFactory) {
+                    String markerPath = System.getProperty("factoryMarkerFile");
+                    if (markerPath != null) {
+                        File marker = new File(markerPath);
+                        marker.getParentFile().mkdirs();
+                        try {
+                            marker.createNewFile();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
                     return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPassOne() {
+                    assert true;
+                }
+
+                @Test
+                public void testPassTwo() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        file("build/factory-invoked.marker").assertExists()
+    }
+
+    def "fails with informative error when threadPoolFactoryClass cannot be loaded (TestNG 7.10+)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.10.2'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.DoesNotExist'
                 }
             }
         """
@@ -74,10 +129,52 @@ class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        succeeds("test")
+        fails("test")
 
         then:
-        noExceptionThrown()
+        failure.assertHasCause("Could not load thread pool factory class 'org.gradle.test.DoesNotExist'.")
+    }
+
+    def "fails with informative error when threadPoolFactoryClass does not implement IExecutorServiceFactory (TestNG 7.10+)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.10.2'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.NotAFactory'
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/NotAFactory.java") << """
+            package org.gradle.test;
+
+            public class NotAFactory {
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPass() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        fails("test")
+
+        then:
+        failure.assertHasCause("The thread pool factory class 'org.gradle.test.NotAFactory' does not implement org.testng.IExecutorServiceFactory.")
     }
 
     def "can configure threadPoolFactoryClass with TestNG 7.5 (legacy setExecutorFactoryClass API)"() {

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -404,9 +404,12 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
 
     /**
      * Sets a custom threadPoolExecutorFactory class.
-     * This should be a fully qualified class name and the class should implement org.testng.IExecutorFactory
-     * More details in https://github.com/testng-team/testng/pull/2042
-     * Requires TestNG 7.0 or higher
+     * This should be a fully qualified class name of a class with a public no-arg constructor.
+     * For TestNG 7.10 and above, the class should implement {@code org.testng.IExecutorServiceFactory}.
+     * For TestNG 7.0 through 7.9, the class should implement {@code org.testng.thread.IExecutorFactory}.
+     * More details in <a href="https://github.com/testng-team/testng/pull/2042">testng#2042</a>
+     * and <a href="https://github.com/testng-team/testng/pull/3095">testng#3095</a>.
+     * Requires TestNG 7.0 or higher.
      * @since 8.7
      */
     @Incubating


### PR DESCRIPTION

Fixes https://github.com/gradle/gradle/issues/28955
Supersedes #37249 

### Context
TestNG changed its thread pool factory class API in TestNG 7.10.  This updates Gradle to support classes conforming to the new API.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
