### PR TITLE
Adjust TaskInputs.files serialization in CC to handle absent better

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
@@ -41,10 +41,9 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
 
             tasks.register("reader") {
                 inputs.files($tasksInput)
-                def inputFiles = inputs.files
                 doLast {
-                    println "names = " + inputFiles.asFileTree.files*.name.sort()
-                    println "contents = " + inputFiles.asFileTree.files.collect { it.text }.sort()
+                    println "names = " + inputs.files.asFileTree.files*.name.sort()
+                    println "contents = " + inputs.files.asFileTree.files.collect { it.text }.sort()
                 }
             }
         """
@@ -83,10 +82,9 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
         file("foo/build.gradle") << """
             tasks.register("consumer") {
                 inputs.files(parent.tasks.getByName('producer'))
-                def inputFiles = inputs.files
                 doLast {
-                    println "names = " + inputFiles.files*.name
-                    println "contents = " + inputFiles.files.collect { it.text }
+                    println "names = " + inputs.files.files*.name
+                    println "contents = " + inputs.files.files.collect { it.text }
                 }
             }
         """

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
@@ -498,6 +498,52 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
     }
 
     @Issue("https://github.com/gradle/gradle/issues/33318")
+    def "can use TaskCollection from withType wrapped in a list as task input"() {
+        buildFile  """
+            abstract class MyTask extends DefaultTask {
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
+                @TaskAction
+                void run() {
+                    outputFile.get().asFile.text = name
+                }
+            }
+
+            tasks.register("task1", MyTask) {
+                outputFile = layout.buildDirectory.file("task1.txt")
+            }
+            tasks.register("task2", MyTask) {
+                outputFile = layout.buildDirectory.file("task2.txt")
+            }
+
+            tasks.register("task3") {
+                def myTasks = tasks.withType(MyTask)
+                dependsOn(myTasks)
+                inputs.files([myTasks])
+                def inputFiles = inputs.files
+                doLast {
+                    println "inputs = " + inputFiles.files*.name.sort()
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun "task3"
+
+        then:
+        result.assertTasksExecuted(":task1", ":task2", ":task3")
+        outputContains("inputs = [task1.txt, task2.txt]")
+
+        when:
+        configurationCacheRun "task3"
+
+        then:
+        result.assertTaskExecuted(":task3")
+        outputContains("inputs = [task1.txt, task2.txt]")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/33318")
     def "can use DomainObjectCollection of Configuration as ad hoc task input"() {
         file("foo.txt").text = "foo"
         file("bar.txt").text = "bar"

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskSerializationIntegrationTest.groovy
@@ -473,11 +473,9 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
 
             tasks.register("task3") {
                 def myTasks = tasks.withType(MyTask)
-                dependsOn(myTasks)
                 inputs.files(myTasks)
-                def inputFiles = inputs.files
                 doLast {
-                    println "inputs = " + inputFiles.files*.name.sort()
+                    println "inputs = " + inputs.files.files*.name.sort()
                 }
             }
         """
@@ -519,11 +517,9 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
 
             tasks.register("task3") {
                 def myTasks = tasks.withType(MyTask)
-                dependsOn(myTasks)
                 inputs.files([myTasks])
-                def inputFiles = inputs.files
                 doLast {
-                    println "inputs = " + inputFiles.files*.name.sort()
+                    println "inputs = " + inputs.files.files*.name.sort()
                 }
             }
         """
@@ -568,7 +564,7 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
                 inputs.files(myConfigs)
                 def inputFiles = inputs.files
                 doLast {
-                    println "inputs = " + inputFiles.files*.name.sort()
+                    println "inputs = " + inputs.files.files*.name.sort()
                 }
             }
         """
@@ -595,9 +591,9 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
             tasks.register("reader") {
                 inputs.file("inputFile.txt").withPropertyName("singleFile")
                 inputs.dir("inputDir").withPropertyName("singleDir")
-                def fileInput = inputs.files.filter { it.name == "inputFile.txt" }
-                def dirInput = inputs.files.filter { it.parentFile?.name == "inputDir" }
                 doLast {
+                    def fileInput = inputs.files.filter { it.name == "inputFile.txt" }
+                    def dirInput = inputs.files.filter { it.parentFile?.name == "inputDir" }
                     println "file = " + fileInput.singleFile.name
                     println "dir contents = " + dirInput.files*.name.sort()
                 }
@@ -639,8 +635,8 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
                 // `selected` exposes DefaultNamedDomainObjectCollection internals (pendingMap) — without the
                 // codec-level wrap this hits ConcurrentModificationException at CC store time.
                 outputs.files(selected)
-                def outFiles = outputs.files
                 doLast {
+                    def outFiles = outputs.files
                     println "outputs = " + outFiles.files*.name.sort()
                 }
             }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCollectionCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCollectionCodec.kt
@@ -32,6 +32,7 @@ import org.gradle.api.internal.file.collections.FailingFileCollection
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.file.collections.ProviderBackedFileCollection
 import org.gradle.api.internal.provider.ProviderInternal
+import org.gradle.api.internal.provider.ProviderResolutionStrategy
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskProvider
@@ -98,7 +99,13 @@ class FileCollectionCodec(
                     is File -> element
                     is SubtractingFileCollectionSpec -> element.left.minus(element.right)
                     is FilteredFileCollectionSpec -> element.collection.filter(element.filter)
-                    is ProviderBackedFileCollectionSpec -> fileCollectionFactory.withResolver(element.resolver).resolving(element.provider)
+                    is ProviderBackedFileCollectionSpec -> fileCollectionFactory.withResolver(element.resolver).run {
+                        val source = element.provider
+                        when (element.resolutionStrategy) {
+                            ProviderResolutionStrategy.ALLOW_ABSENT -> resolvingLeniently(source)
+                            ProviderResolutionStrategy.REQUIRE_PRESENT -> resolving(source)
+                        }
+                    }
                     is FileTree -> element
                     is ResolutionBackedFileCollectionSpec -> ResolutionBackedFileCollection(
                         artifactSetConverter.getSelectedArtifacts(element.elements),
@@ -126,8 +133,11 @@ class FilteredFileCollectionSpec(val collection: FileCollection, val filter: Spe
 
 
 private
-class ProviderBackedFileCollectionSpec(val resolver: PathToFileResolver, val provider: ProviderInternal<*>) :
-    ValueObject
+class ProviderBackedFileCollectionSpec(
+    val resolver: PathToFileResolver,
+    val resolutionStrategy: ProviderResolutionStrategy,
+    val provider: ProviderInternal<*>
+) : ValueObject
 
 
 private
@@ -174,7 +184,7 @@ class CollectingVisitor : AbstractVisitor() {
                 // being referenced from a different task.
                 val provider = fileCollection.provider
                 if (provider !is TaskProvider<*>) {
-                    elements.add(ProviderBackedFileCollectionSpec(fileCollection.resolver, provider))
+                    elements.add(ProviderBackedFileCollectionSpec(fileCollection.resolver, fileCollection.providerResolutionStrategy, provider))
                     false
                 } else {
                     true

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -28,7 +28,9 @@ import org.gradle.api.internal.provider.Providers
 import org.gradle.api.internal.tasks.TaskDestroyablesInternal
 import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal
 import org.gradle.api.internal.tasks.TaskLocalStateInternal
+import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.execution.plan.LocalTaskNode
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.internal.cc.base.serialize.IsolateOwners
@@ -423,13 +425,18 @@ suspend fun WriteContext.writeRegisteredPropertiesOf(task: Task) {
  * mutable internals. This is semantically equivalent to what consumers of `TaskInputs` do at execution time
  * via `FileParameterUtils.resolveInputFileValue`.
  *
+ * One exception are [Provider] values. These are handled specially by the validation logic, so we have to preserve
+ * the shape. And yes, this means that `files(absentProvider)` fails and `files(listOf(absentProvider))` works.
+ * An exception to the exception is [TaskProvider], which it cannot be serialized directly but only inside a file collection.
+ * It is always present, so wrapping it is okay.
+ *
  * Only applied to [InputFilePropertyType.FILES] — [InputFilePropertyType.FILE] and [InputFilePropertyType.DIRECTORY]
  * expect a single path-like value on read, so wrapping in a [FileCollection] would break `inputs.file(...)` /
  * `inputs.dir(...)`.
  */
 private
 fun WriteContext.adaptInputFileValueForSerialization(value: Any?, filePropertyType: InputFilePropertyType): Any? {
-    if (value == null || value is FileCollection || filePropertyType != InputFilePropertyType.FILES) {
+    if (value == null || filePropertyType != InputFilePropertyType.FILES || !needsFileCollectionWrapper(value)) {
         return value
     }
     return isolate.owner.serviceOf<FileCollectionFactory>().resolvingLeniently(value)
@@ -445,10 +452,23 @@ fun WriteContext.adaptInputFileValueForSerialization(value: Any?, filePropertyTy
  */
 private
 fun WriteContext.adaptOutputFileValueForSerialization(value: Any?, filePropertyType: OutputFilePropertyType): Any? {
-    if (value == null || value is FileCollection || filePropertyType == OutputFilePropertyType.FILE || filePropertyType == OutputFilePropertyType.DIRECTORY) {
+    if (value == null || filePropertyType == OutputFilePropertyType.FILE || filePropertyType == OutputFilePropertyType.DIRECTORY || !needsFileCollectionWrapper(value)) {
         return value
     }
     return isolate.owner.serviceOf<FileCollectionFactory>().resolvingLeniently(value)
+}
+
+
+/**
+ * Checks if the input value needs to be wrapped in a file collection to properly serialize.
+ *
+ * [FileCollection]s aren't wrapped as it is pointless.
+ * [Provider]s except [TaskProvider] aren't wrapped because input validation has special handling for them.
+ * [TaskProvider]s must be wrapped because they cannot be serialized directly, and `inputs.files(taskProvider)` is idiomatic.
+ */
+private
+fun needsFileCollectionWrapper(value: Any): Boolean {
+    return value !is FileCollection && (value !is Provider<*> || value is TaskProvider<*>)
 }
 
 

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -70,4 +70,8 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
     public PathToFileResolver getResolver() {
         return resolver;
     }
+
+    public ProviderResolutionStrategy getProviderResolutionStrategy() {
+        return providerResolutionStrategy;
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.api.file
 
+import org.gradle.api.problems.Severity
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.any
 
@@ -194,4 +196,83 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksScheduledInOrder(any(':b:jar', ':b:otherJar'), ':a:doStuff')
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/38330")
+    def "optional runtime input declared via #description with an absent provider source is ignored"() {
+        buildFile """
+            task myTask {
+                $declaration
+
+                doLast {
+                    println("inputs = \${inputs.files.files}")
+                }
+            }
+        """
+
+        when:
+        run "myTask"
+
+        then:
+        executedAndNotSkipped(":myTask")
+
+        where:
+        description                                | declaration
+        "inputs.files(fileProperty)"               | 'inputs.files(objects.fileProperty()).optional().withPropertyName("inputProp")'
+        "inputs.files(fileProperty, fileProperty)" | 'inputs.files([objects.fileProperty()]).withPropertyName("inputProp")'
+        "inputs.file(fileProperty)"                | 'inputs.file(objects.fileProperty()).optional().withPropertyName("inputProp")'
+        "inputs.property(property)"                | 'inputs.property("inputProp", objects.property(String)).optional(true)'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38330")
+    def "required runtime input declared via #description with an absent provider source fails"() {
+        buildFile """
+            task myTask {
+                $declaration
+
+                doLast {
+                    println("inputs = \${inputs.files.files}")
+                }
+            }
+        """
+
+        enableProblemsApiCheck()
+
+        when:
+        fails "myTask"
+
+        then:
+        failure.assertHasDescription("A problem was found with the configuration of task ':myTask' (type 'DefaultTask').")
+        verifyAll(receivedProblem) {
+            severity == Severity.ERROR
+            fqid == 'validation:property-validation:value-not-set'
+            definition.id.displayName == 'Value not set'
+            contextualLabel == "Property 'inputProp' doesn't have a configured value"
+        }
+
+        where:
+        description                  | declaration
+        "inputs.files(fileProperty)" | 'inputs.files(objects.fileProperty()).withPropertyName("inputProp")'
+        "inputs.file(fileProperty)"  | 'inputs.file(objects.fileProperty()).withPropertyName("inputProp")'
+        "inputs.property(property)"  | 'inputs.property("inputProp", objects.property(String))'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38330")
+    def "required runtime input declared via files() with an absent provider in a list source is ignored"() {
+        buildFile """
+            task myTask {
+                inputs.files([objects.fileProperty()]).withPropertyName("inputProp")
+
+                doLast {
+                    println("inputs = \${inputs.files.files}")
+                }
+            }
+        """
+
+        enableProblemsApiCheck()
+
+        when:
+        run "myTask"
+
+        then:
+        outputContains("inputs = []")
+    }
 }


### PR DESCRIPTION
This is all caused by a failure when an optional files() input has an
absent provider as its single source. Without CC, it is allowed, but the
new FileCollection wrapping broke this.

First problem is that CC didn't preserve file collection leniency, so
fingerprinting of the optional property was failing while resolving the
wrapping collection. This commit changes the codec to preserve the
strategy properly.

This uncovered the second issue. Property validation is not
exactly part of the fingerprinting and examines raw values rather than
inputs as a collection. It has special handling for absent providers.
In particular, an absent provider doesn't pass the check if the property
is not optional, but it works when it is wrapped in a file collection or
an Iterable. Thus, our unconditional wrapping tripped it over as it no
longer saw the provider. The fix is to exclude provider from wrapping,
as CC already knows how to handle it.

Confusingly, for users this means that `inputs.files(absent)` works,
while `inputs.files(absent, absent)` doesn't, but this is consistent
with vintage and out of scope for this PR.

Fixes #38330.