### PR TITLE
Update Documentation: Document ArtifactView reselection to prevent confusion

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/advanced/artifact_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/advanced/artifact_resolution.adoc
@@ -397,3 +397,5 @@ As expected, the `apiProductionElements` variant is selected along with the `pro
 ----
 include::{snippetsPath}/reference/dependency-management/advanced/artifactViews-simple/tests/artifactview-attributes.out[]
 ----
+
+TIP: Variant reselection operates on the components already in the resolved graph and does not follow `available-at` pointers in Gradle Module Metadata. See <<../controlling-dependency-resolution/artifact_views.adoc#sec:performing_variant_reselection, Performing variant reselection>> for details and a recommended workaround.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
@@ -82,6 +82,14 @@ include::{snippetsPath}/reference/dependency-management/controlling-dependency-r
 When this API is used, the attributes used for variant reselection are specified solely by the `ArtifactView.getAttributes()` method.
 The graph resolution attributes specified on the configuration are completely ignored during variant reselection.
 
+[NOTE]
+====
+Variant reselection operates on the components already present in the resolved graph: it re-picks a variant of each component in place.
+It does not re-run graph resolution.
+As a result, variants that delegate to a different component via an `available-at` pointer in Gradle Module Metadata are not followed, and the artifacts of the pointed-at component do not appear in the view.
+To resolve such variants, declare a separate `Configuration` whose request attributes already select them.
+====
+
 [[sec:performing_lenient_artifact_selection]]
 == 2. Performing lenient artifact selection and resolution
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
@@ -164,6 +164,95 @@ class ArtifactVariantReselectionIntegrationTest extends AbstractIntegrationSpec 
         succeeds(":resolve")
     }
 
+    def "withVariantReselection does not follow available-at pointers, since variant reselection picks variants only from components already in the graph"() {
+        // 'foo:a:1.0' has an "original" variant with its own file and a "reselected" variant
+        // that delegates (via available-at) to 'foo:a-reselected:1.0'.
+        // 'foo:b:1.0' has two variants, both with their own files.
+        //
+        // A configuration whose request attributes already select the "reselected" variant
+        // triggers full graph resolution. Graph resolution follows the available-at pointer,
+        // adding foo:a-reselected:1.0 to the graph; that component's artifact appears in the
+        // result.
+        //
+        // An ArtifactView built on a configuration that requested the "original" variant and
+        // reselects via withVariantReselection() does NOT re-run graph resolution. It picks a
+        // different variant of each component already in the graph. The "reselected" variant of
+        // foo:a:1.0 is an external variant with no files of its own; since reselection cannot
+        // follow the available-at pointer, foo:a-reselected:1.0 never enters the result and the
+        // view returns only foo:b:1.0's reselected artifact.
+        given:
+        mavenRepo.module("foo", "a", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("originalElements", [attr: "original"]) {
+                artifact("a-1.0.jar")
+            }
+            .variant("reselectedElements", [attr: "reselected"]) {
+                availableAt("../../a-reselected/1.0/a-reselected-1.0.module", "foo", "a-reselected", "1.0")
+            }
+            .publish()
+
+        mavenRepo.module("foo", "a-reselected", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("reselectedElements", [attr: "reselected"]) {
+                artifact("a-reselected-1.0.jar")
+            }
+            .publish()
+
+        mavenRepo.module("foo", "b", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("originalElements", [attr: "original"]) {
+                artifact("b-1.0.jar")
+            }
+            .variant("reselectedElements", [attr: "reselected"]) {
+                artifact("b-1.0.jar")
+            }
+            .publish()
+
+        buildFile << """
+            def attr = Attribute.of("attr", String)
+
+            repositories { maven { url = "${mavenRepo.uri}" } }
+
+            configurations {
+                originalDependency {
+                    canBeConsumed = false
+                    attributes { attribute(attr, "original") }
+                }
+                reselectedDependency {
+                    canBeConsumed = false
+                    attributes { attribute(attr, "reselected") }
+                }
+            }
+
+            dependencies {
+                originalDependency "foo:a:1.0"
+                originalDependency "foo:b:1.0"
+                reselectedDependency "foo:a:1.0"
+                reselectedDependency "foo:b:1.0"
+            }
+
+            task resolve {
+                def reselectedConfFiles = configurations.reselectedDependency.incoming.files
+                def reselectedViewFiles = configurations.originalDependency.incoming.artifactView {
+                    withVariantReselection()
+                    attributes { attribute(attr, "reselected") }
+                }.files
+                doLast {
+                    // Full graph resolution follows the available-at pointer.
+                    assert reselectedConfFiles*.name.toSet() == ["a-reselected-1.0.jar", "b-1.0.jar"].toSet()
+                    // Variant reselection does not: the foo:a-reselected:1.0 artifact is absent.
+                    assert reselectedViewFiles*.name.toSet() == ["b-1.0.jar"].toSet()
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
     private static String multiFeatureProducer() {
         """
             plugins {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
@@ -113,8 +113,15 @@ public interface ArtifactView extends HasAttributes {
         /**
          * When invoked, this view will disregard existing attributes of its parent configuration and re-resolve the artifacts
          * using only the attributes in the view's attribute container.
+         * <p>
+         * This behavior cannot be unset on a particular view once this method is invoked.
          *
-         * <p>This behavior cannot be unset on a particular view once this method is invoked.
+         * @apiNote Reselection operates on the components already present in the resolved graph: it picks a
+         * different variant of each component selected by the original graph resolution. It does not re-run
+         * graph resolution. As a consequence, variants that delegate to a different component via an
+         * {@code available-at} pointer in Gradle Module Metadata are not followed, and the artifacts of the
+         * pointed-at component do not appear in the view. To resolve such variants, declare a separate
+         * {@link Configuration} whose request attributes already select them.
          *
          * @since 7.5
          */

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -114,6 +114,9 @@ class VariantMetadataSpec {
 
     void availableAt(String url, String group, String name, String version) {
         availableAt = new AvailableAtSpec(url, group, name, version)
+        // An available-at variant cannot declare files; suppress the default artifact list
+        // that AbstractMavenModule.publishModuleMetadata() would otherwise inject.
         noArtifacts = true
+        useDefaultArtifacts = false
     }
 }


### PR DESCRIPTION
Variant reselection via `ArtifactView.withVariantReselection()` operates on the already resolved graph and does not re-run full graph resolution. Consequently, `available-at` pointers are not followed when reselecting variants.

This commit adds documentation to both the API Javadoc and the user guide to clearly state this limitation and provide guidance. An integration test is added to demonstrate this specific behavior, and the `VariantMetadataSpec` is updated to correctly model `available-at` variants in tests.