### PR TITLE
WIP Deprecate legacy org.gradle.unsafe.configuration-cache properties

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -103,6 +103,9 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
 
     def "can enable configuration cache using incubating and final property variants"() {
         given:
+        if (deprecatedProperty) {
+            executer.expectDocumentedDeprecationWarning(expectedDeprecationMessage(deprecatedProperty, replacementProperty))
+        }
         buildFile """
         task check {
             assert gradle.startParameter.configurationCache.get() == ${ccOn}
@@ -123,22 +126,30 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
         }
 
         where:
-        task    | ccOn  | problemsAs| maxProblems   | quiet | recreate  | debug | options
-        "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache.problems=warn"]
-        "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.configuration-cache.max-problems=100"]
-        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.internal.configuration-cache.quiet=true"]
-        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.internal.configuration-cache.recreate-cache=true"]
-        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.internal.configuration-cache.debug=true"]
-        "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache-problems=warn"]
-        "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.max-problems=100"]
-        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.quiet=true"]
-        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.unsafe.configuration-cache.recreate-cache=true"]
-        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.unsafe.configuration-cache.debug=true"]
-        "check" | true  | _         | _             | _     | _         | _     | ["--configuration-cache"]
-        "check" | true  | _         | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache=true"]
-        "check" | true  | _         | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache=true"]
-        "check" | false | _         | _             | _     | _         | _     | ["--no-configuration-cache"]
-        "check" | false | _         | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache=false"]
-        "check" | false | _         | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache=false"]
+        task    | ccOn  | problemsAs| maxProblems   | quiet | recreate  | debug | options                                                              | deprecatedProperty                                       | replacementProperty
+        "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache.problems=warn"]                   | null                                                     | null
+        "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.configuration-cache.max-problems=100"]                | null                                                     | null
+        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.internal.configuration-cache.quiet=true"]             | null                                                     | null
+        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.internal.configuration-cache.recreate-cache=true"]    | null                                                     | null
+        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.internal.configuration-cache.debug=true"]             | null                                                     | null
+        "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache-problems=warn"]            | "org.gradle.unsafe.configuration-cache-problems"         | "org.gradle.configuration-cache.problems"
+        "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.max-problems=100"]         | "org.gradle.unsafe.configuration-cache.max-problems"     | "org.gradle.configuration-cache.max-problems"
+        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.quiet=true"]               | "org.gradle.unsafe.configuration-cache.quiet"            | "org.gradle.internal.configuration-cache.quiet"
+        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.unsafe.configuration-cache.recreate-cache=true"]      | "org.gradle.unsafe.configuration-cache.recreate-cache"   | "org.gradle.internal.configuration-cache.recreate-cache"
+        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.unsafe.configuration-cache.debug=true"]               | "org.gradle.unsafe.configuration-cache.debug"            | "org.gradle.internal.configuration-cache.debug"
+        "check" | true  | _         | _             | _     | _         | _     | ["--configuration-cache"]                                            | null                                                     | null
+        "check" | true  | _         | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache=true"]                            | null                                                     | null
+        "check" | true  | _         | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache=true"]                     | "org.gradle.unsafe.configuration-cache"                  | "org.gradle.configuration-cache"
+        "check" | false | _         | _             | _     | _         | _     | ["--no-configuration-cache"]                                         | null                                                     | null
+        "check" | false | _         | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache=false"]                           | null                                                     | null
+        "check" | false | _         | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache=false"]                    | "org.gradle.unsafe.configuration-cache"                  | "org.gradle.configuration-cache"
+    }
+
+    private static String expectedDeprecationMessage(String deprecatedProperty, String replacementProperty) {
+        "The ${deprecatedProperty} system property has been deprecated. " +
+            "This is scheduled to be removed in Gradle 10. " +
+            "Please use the ${replacementProperty} system property instead. " +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_unsafe_configuration_cache_properties"
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -97,6 +97,15 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
 
     def "shows no promo message when #ccSwitch is given in command-line"() {
         given:
+        if (ccSwitch.contains(ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME)) {
+            executer.expectDocumentedDeprecationWarning(
+                "The ${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME} system property has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Please use the ${ConfigurationCacheOption.PROPERTY_NAME} system property instead. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_unsafe_configuration_cache_properties"
+            )
+        }
         buildFile """
             tasks.register("greet") { doLast { println("Hello") } }
         """

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/AbstractBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/AbstractBuildOption.java
@@ -105,6 +105,7 @@ public abstract class AbstractBuildOption<T, V extends CommandLineOptionConfigur
         if (deprecatedProperty != null) {
             value = properties.get(deprecatedProperty);
             if (value != null) {
+                DeprecatedBuildOptionUsageRegistry.record(deprecatedProperty, property);
                 return new OptionValue<String>(value, Origin.forGradleProperty(deprecatedProperty));
             }
         }

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/BooleanBuildOption.java
@@ -35,6 +35,10 @@ public abstract class BooleanBuildOption<T> extends AbstractBuildOption<T, Boole
         this(property, (String) null);
     }
 
+    public BooleanBuildOption(String property, String deprecatedProperty) {
+        super(property, deprecatedProperty);
+    }
+
     public BooleanBuildOption(String property, BooleanCommandLineOptionConfiguration... commandLineOptionConfigurations) {
         this(property, null, commandLineOptionConfigurations);
     }

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedBuildOptionUsageRegistry.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedBuildOptionUsageRegistry.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Process-wide collector for {@link BuildOption} reads that took the deprecated property
+ * branch. Populated by {@link AbstractBuildOption#getFromProperties}, drained later by code
+ * that has access to {@code DeprecationLogger} (the {@code build-option} module intentionally
+ * does not depend on logging).
+ */
+public final class DeprecatedBuildOptionUsageRegistry {
+
+    private static final Set<DeprecatedUsage> RECORDED = new LinkedHashSet<>();
+
+    private DeprecatedBuildOptionUsageRegistry() {
+    }
+
+    public static synchronized void record(String deprecatedProperty, String replacementProperty) {
+        RECORDED.add(new DeprecatedUsage(deprecatedProperty, replacementProperty));
+    }
+
+    public static synchronized Set<DeprecatedUsage> drain() {
+        Set<DeprecatedUsage> snapshot = new LinkedHashSet<>(RECORDED);
+        RECORDED.clear();
+        return snapshot;
+    }
+
+    public static final class DeprecatedUsage {
+        private final String deprecatedProperty;
+        private final String replacementProperty;
+
+        public DeprecatedUsage(String deprecatedProperty, String replacementProperty) {
+            this.deprecatedProperty = deprecatedProperty;
+            this.replacementProperty = replacementProperty;
+        }
+
+        public String getDeprecatedProperty() {
+            return deprecatedProperty;
+        }
+
+        public String getReplacementProperty() {
+            return replacementProperty;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DeprecatedUsage)) {
+                return false;
+            }
+            DeprecatedUsage other = (DeprecatedUsage) o;
+            return deprecatedProperty.equals(other.deprecatedProperty)
+                && replacementProperty.equals(other.replacementProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(deprecatedProperty, replacementProperty);
+        }
+    }
+}

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/ListBuildOption.java
@@ -18,6 +18,7 @@ package org.gradle.internal.buildoption;
 
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,20 +32,28 @@ import java.util.Map;
 public abstract class ListBuildOption<T> extends AbstractBuildOption<T, CommandLineOptionConfiguration> {
 
     public ListBuildOption(String property) {
-        super(property);
+        this(property, (String) null);
+    }
+
+    public ListBuildOption(String property, String deprecatedProperty) {
+        super(property, deprecatedProperty);
     }
 
     public ListBuildOption(String property, CommandLineOptionConfiguration... commandLineOptionConfigurations) {
-        super(property, commandLineOptionConfigurations);
+        this(property, null, commandLineOptionConfigurations);
+    }
+
+    public ListBuildOption(@Nullable String property, @Nullable String deprecatedProperty, CommandLineOptionConfiguration... commandLineOptionConfigurations) {
+        super(property, deprecatedProperty, commandLineOptionConfigurations);
     }
 
     @Override
     public void applyFromProperty(Map<String, String> properties, T settings) {
-        String value = properties.get(property);
-
+        OptionValue<String> propertyValue = getFromProperties(properties);
+        String value = propertyValue.getValue();
         if (value != null) {
             String[] splitValues = value.split("\\s*,\\s*");
-            applyTo(Arrays.asList(splitValues), settings, Origin.forGradleProperty(property));
+            applyTo(Arrays.asList(splitValues), settings, propertyValue.getOrigin());
         }
     }
 
@@ -65,5 +74,5 @@ public abstract class ListBuildOption<T> extends AbstractBuildOption<T, CommandL
         }
     }
 
-    public abstract void applyTo(List<String> values, T settings, Origin origin);
+    public abstract void applyTo(List<String> values, T settings, @Nullable Origin origin);
 }

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/StringBuildOption.java
@@ -18,6 +18,7 @@ package org.gradle.internal.buildoption;
 
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 
@@ -29,19 +30,27 @@ import java.util.Map;
 public abstract class StringBuildOption<T> extends AbstractBuildOption<T, CommandLineOptionConfiguration> {
 
     public StringBuildOption(String property) {
-        super(property);
+        this(property, (String) null);
+    }
+
+    public StringBuildOption(String property, String deprecatedProperty) {
+        super(property, deprecatedProperty);
     }
 
     public StringBuildOption(String property, CommandLineOptionConfiguration... commandLineOptionConfigurations) {
-        super(property, commandLineOptionConfigurations);
+        this(property, null, commandLineOptionConfigurations);
+    }
+
+    public StringBuildOption(@Nullable String property, @Nullable String deprecatedProperty, CommandLineOptionConfiguration... commandLineOptionConfigurations) {
+        super(property, deprecatedProperty, commandLineOptionConfigurations);
     }
 
     @Override
     public void applyFromProperty(Map<String, String> properties, T settings) {
-        String value = properties.get(property);
-
+        OptionValue<String> propertyValue = getFromProperties(properties);
+        String value = propertyValue.getValue();
         if (value != null) {
-            applyTo(value, settings, Origin.forGradleProperty(property));
+            applyTo(value, settings, propertyValue.getOrigin());
         }
     }
 
@@ -62,5 +71,5 @@ public abstract class StringBuildOption<T> extends AbstractBuildOption<T, Comman
         }
     }
 
-    public abstract void applyTo(String value, T settings, Origin origin);
+    public abstract void applyTo(String value, T settings, @Nullable Origin origin);
 }

--- a/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedBuildOptionUsageRegistryTest.groovy
+++ b/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedBuildOptionUsageRegistryTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption
+
+import spock.lang.Specification
+
+class DeprecatedBuildOptionUsageRegistryTest extends Specification {
+
+    private static final String NEW_PROPERTY = 'org.gradle.test.new'
+    private static final String OLD_PROPERTY = 'org.gradle.test.old'
+
+    def setup() {
+        DeprecatedBuildOptionUsageRegistry.drain()
+    }
+
+    def cleanup() {
+        DeprecatedBuildOptionUsageRegistry.drain()
+    }
+
+    def "boolean option reading from deprecated property records usage and reading from new property does not"() {
+        given:
+        def option = new BooleanOption(NEW_PROPERTY, OLD_PROPERTY)
+
+        when:
+        option.applyFromProperty([(NEW_PROPERTY): 'true'], new Settings())
+
+        then:
+        DeprecatedBuildOptionUsageRegistry.drain().isEmpty()
+
+        when:
+        option.applyFromProperty([(OLD_PROPERTY): 'true'], new Settings())
+        def recorded = DeprecatedBuildOptionUsageRegistry.drain()
+
+        then:
+        recorded.size() == 1
+        recorded[0].deprecatedProperty == OLD_PROPERTY
+        recorded[0].replacementProperty == NEW_PROPERTY
+    }
+
+    def "string option honours deprecated property name and records usage"() {
+        given:
+        def option = new StringOption(NEW_PROPERTY, OLD_PROPERTY)
+        def settings = new Settings()
+
+        when:
+        option.applyFromProperty([(OLD_PROPERTY): 'hello'], settings)
+
+        then:
+        settings.value == 'hello'
+        DeprecatedBuildOptionUsageRegistry.drain()*.deprecatedProperty == [OLD_PROPERTY]
+    }
+
+    def "list option honours deprecated property name and records usage"() {
+        given:
+        def option = new ListOption(NEW_PROPERTY, OLD_PROPERTY)
+        def settings = new Settings()
+
+        when:
+        option.applyFromProperty([(OLD_PROPERTY): 'a,b'], settings)
+
+        then:
+        settings.list == ['a', 'b']
+        DeprecatedBuildOptionUsageRegistry.drain()*.deprecatedProperty == [OLD_PROPERTY]
+    }
+
+    def "integer option records usage when deprecated property is read"() {
+        given:
+        def option = new IntegerOption(NEW_PROPERTY, OLD_PROPERTY)
+
+        when:
+        option.applyFromProperty([(OLD_PROPERTY): '42'], new Settings())
+
+        then:
+        DeprecatedBuildOptionUsageRegistry.drain()*.deprecatedProperty == [OLD_PROPERTY]
+    }
+
+    def "duplicate usages are deduplicated"() {
+        given:
+        def option = new BooleanOption(NEW_PROPERTY, OLD_PROPERTY)
+
+        when:
+        option.applyFromProperty([(OLD_PROPERTY): 'true'], new Settings())
+        option.applyFromProperty([(OLD_PROPERTY): 'false'], new Settings())
+
+        then:
+        DeprecatedBuildOptionUsageRegistry.drain().size() == 1
+    }
+
+    def "new property takes precedence so deprecated usage is not recorded"() {
+        given:
+        def option = new BooleanOption(NEW_PROPERTY, OLD_PROPERTY)
+
+        when:
+        option.applyFromProperty([(NEW_PROPERTY): 'true', (OLD_PROPERTY): 'true'], new Settings())
+
+        then:
+        DeprecatedBuildOptionUsageRegistry.drain().isEmpty()
+    }
+
+    static class Settings {
+        String value
+        List<String> list
+        int intValue
+        boolean booleanValue
+    }
+
+    static class BooleanOption extends BooleanBuildOption<Settings> {
+        BooleanOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(boolean value, Settings settings, Origin origin) {
+            settings.booleanValue = value
+        }
+    }
+
+    static class StringOption extends StringBuildOption<Settings> {
+        StringOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(String value, Settings settings, Origin origin) {
+            settings.value = value
+        }
+    }
+
+    static class ListOption extends ListBuildOption<Settings> {
+        ListOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(List<String> values, Settings settings, Origin origin) {
+            settings.list = values
+        }
+    }
+
+    static class IntegerOption extends IntegerBuildOption<Settings> {
+        IntegerOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(int value, Settings settings, Origin origin) {
+            settings.intValue = value
+        }
+    }
+}

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -26,6 +26,7 @@ import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.buildtree.BuildTreeLifecycleListener;
+import org.gradle.internal.deprecation.BuildOptionDeprecations;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.invocation.BuildAction;
@@ -92,6 +93,7 @@ public class RootBuildLifecycleBuildActionExecutor {
             StartParameterInternal startParameter = action.getStartParameter();
             try {
                 initDeprecationLogging(startParameter);
+                BuildOptionDeprecations.nagAboutDeprecatedBuildOptionProperties(startParameter);
                 maybeNagOnDeprecatedJavaRuntimeVersion();
                 RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(startParameter, null));
                 return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/BuildOptionDeprecations.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/internal/deprecation/BuildOptionDeprecations.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.deprecation;
+
+import org.gradle.StartParameter;
+import org.gradle.initialization.StartParameterBuildOptions;
+import org.gradle.internal.buildoption.BuildOption;
+import org.gradle.internal.buildoption.DeprecatedBuildOptionUsageRegistry;
+import org.gradle.internal.buildoption.DeprecatedBuildOptionUsageRegistry.DeprecatedUsage;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Drains the global {@link DeprecatedBuildOptionUsageRegistry} and emits a deprecation warning
+ * for each recorded usage of a {@link BuildOption}'s {@code deprecatedProperty}. Also re-scans
+ * the start parameter's command-line {@code -D} entries so the warning fires when the launcher
+ * and daemon are different JVMs (the registry only catches the launcher-side conversion).
+ *
+ * <p>The {@code -D} scan only sees properties the user passed on the command line. Deprecated
+ * names set via {@code gradle.properties} reach the build through a different channel and rely
+ * on the in-process registry path; cross-JVM coverage for that case would need explicit
+ * propagation through the build action wire format.
+ */
+public class BuildOptionDeprecations {
+
+    public static void nagAboutDeprecatedBuildOptionProperties(StartParameter startParameter) {
+        for (DeprecatedUsage usage : collectDeprecatedUsages(startParameter)) {
+            DeprecationLogger.deprecateSystemProperty(usage.getDeprecatedProperty())
+                .replaceWith(usage.getReplacementProperty())
+                .willBeRemovedInGradle10()
+                .withUpgradeGuideSection(9, "deprecated_unsafe_configuration_cache_properties")
+                .nagUser();
+        }
+    }
+
+    private static Set<DeprecatedUsage> collectDeprecatedUsages(StartParameter startParameter) {
+        Set<DeprecatedUsage> usages = new LinkedHashSet<>(DeprecatedBuildOptionUsageRegistry.drain());
+        Map<String, String> systemPropertiesArgs = startParameter.getSystemPropertiesArgs();
+        for (BuildOption<?> option : new StartParameterBuildOptions().getAllOptions()) {
+            String deprecatedProperty = option.getDeprecatedProperty();
+            String replacementProperty = option.getProperty();
+            if (deprecatedProperty == null || replacementProperty == null) {
+                continue;
+            }
+            if (systemPropertiesArgs.containsKey(deprecatedProperty)) {
+                usages.add(new DeprecatedUsage(deprecatedProperty, replacementProperty));
+            }
+        }
+        return usages;
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -127,6 +127,37 @@ Update your `gradle.properties` and command-line invocations to the new names.
 
 See the <<isolated_projects.adoc#sec:enable, Enabling Isolated Projects>> section in the Gradle User Manual for the recommended setup.
 
+[[deprecated_unsafe_configuration_cache_properties]]
+==== Deprecation of `org.gradle.unsafe.configuration-cache*` properties
+
+The legacy `org.gradle.unsafe.configuration-cache*` Gradle properties (and their equivalent `-D` system properties) were replaced in Gradle 8.1 by official names without the `unsafe` segment.
+The legacy names have continued to work as silent aliases since then; they are now deprecated and will be removed in Gradle 10.
+
+Replace each legacy name with its current equivalent:
+
+[%header,cols="2*"]
+|===
+| Legacy property | Replacement
+
+| `org.gradle.unsafe.configuration-cache`
+| `org.gradle.configuration-cache`
+
+| `org.gradle.unsafe.configuration-cache-problems`
+| `org.gradle.configuration-cache.problems`
+
+| `org.gradle.unsafe.configuration-cache.max-problems`
+| `org.gradle.configuration-cache.max-problems`
+
+| `org.gradle.unsafe.configuration-cache.debug`
+| `org.gradle.internal.configuration-cache.debug`
+
+| `org.gradle.unsafe.configuration-cache.quiet`
+| `org.gradle.internal.configuration-cache.quiet`
+
+| `org.gradle.unsafe.configuration-cache.recreate-cache`
+| `org.gradle.internal.configuration-cache.recreate-cache`
+|===
+
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier
 


### PR DESCRIPTION
## Why

The legacy `org.gradle.unsafe.configuration-cache*` Gradle properties (and their `-D` system property equivalents) were replaced in Gradle 8.1 by names without the `unsafe` segment, but have continued to work as silent aliases since then. This PR makes their use emit a deprecation warning so the aliases can be removed in Gradle 10.

## What

- **`build-option`**: `BuildOption` gains a `deprecatedProperty` notion. Reads that fall back to the deprecated name are recorded in a process-wide `DeprecatedBuildOptionUsageRegistry`. `BooleanBuildOption`, `StringBuildOption`, and `ListBuildOption` get `deprecatedProperty` constructors; String/List reads now route through `getFromProperties` so the deprecated names resolve and the value `Origin` is preserved.
- **`start-parameter`**: New `BuildOptionDeprecations` drains the registry and additionally re-scans the start parameter's command-line `-D` args (covering the split launcher/daemon JVM case), nagging once per deprecated usage.
- **`launcher`**: `RootBuildLifecycleBuildActionExecutor` invokes the nagging at build startup.
- **Docs**: New deprecation section in `upgrading_version_9.adoc` with a legacy → replacement table.
- **Tests**: Unit tests for the registry across boolean/string/list/integer options (dedup, new-property precedence); CC integration tests assert the warning fires for the `unsafe.*` variants.

## Reviewing

Draft — opening for early feedback / CI.
