### PR TITLE
Suggest resolutions for capability conflict failures

### DIFF
--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/incompatible-variants/tests/runtimeClasspath.out
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/incompatible-variants/tests/runtimeClasspath.out
@@ -32,9 +32,13 @@ project ':producer'
       - Could not resolve project ':producer'.
           - Module 'org.gradle.demo:producer' has been rejected:
                Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project ':producer'' (postgresSupportRuntimeElements)]
+          - Capability conflicts are explained in more detail at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sub:capabilities.
+          - Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sec:selecting-between-candidates.
       - Could not resolve project ':producer'.
           - Module 'org.gradle.demo:producer' has been rejected:
                Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project ':producer'' (mysqlSupportRuntimeElements)]
+          - Capability conflicts are explained in more detail at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sub:capabilities.
+          - Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sec:selecting-between-candidates.
 
 project ':producer'
 \--- runtimeClasspath

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
@@ -3,6 +3,8 @@ log4j:log4j:1.2.16 FAILED
       - Could not resolve log4j:log4j:1.2.16.
           - Module 'log4j:log4j' has been rejected:
                Cannot select module with conflict on capability 'log4j:log4j:1.2.16' also provided by ['org.slf4j:log4j-over-slf4j:1.7.10' (compile)]
+          - Capability conflicts are explained in more detail at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sub:capabilities.
+          - Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sec:selecting-between-candidates.
 
 log4j:log4j:1.2.16 FAILED
 \--- org.apache.zookeeper:zookeeper:3.4.9
@@ -13,6 +15,8 @@ org.slf4j:log4j-over-slf4j:1.7.10 FAILED
       - Could not resolve org.slf4j:log4j-over-slf4j:1.7.10.
           - Module 'org.slf4j:log4j-over-slf4j' has been rejected:
                Cannot select module with conflict on capability 'log4j:log4j:1.7.10' also provided by ['log4j:log4j:1.2.16' (compile)]
+          - Capability conflicts are explained in more detail at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sub:capabilities.
+          - Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at https://docs.gradle.org/0.0.0/userguide/component_capabilities.html#sec:selecting-between-candidates.
 
 org.slf4j:log4j-over-slf4j:1.7.10 FAILED
 \--- compileClasspath

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -84,6 +84,34 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
             }
         }
     }
+
+    def "demonstrate multiple selected variants with the same capabilities failure"() {
+        multipleSelectedVariantsWithSameCapabilities.prepare()
+
+        expect:
+        fails "forceResolution"
+
+        and: "Has error output"
+        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
+        failure.assertHasCause("Could not resolve root project 'test'.")
+        assertFullMessageCorrect("""     Required by:
+         root project 'test'
+      > Module 'org.example:test' has been rejected:
+           Cannot select module with conflict on capability 'org:example:test-nonconflicting' also provided by ['root project 'test'' (c2)]""")
+
+        and: "Helpful resolutions are provided"
+        assertSuggestsViewingDocs("Capability conflicts are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/component_capabilities.html#sub:capabilities.")
+        assertSuggestsViewingDocs("Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at https://docs.gradle.org/${GradleVersion.current().version}/userguide/component_capabilities.html#sec:selecting-between-candidates.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-version-satisfies'
+            additionalData.asMap['requestTarget'] == "org.example:test"
+            additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_VERSION_SATISFIES.name()
+            additionalData.asMap['problemDisplayName'] == "No version satisfies the constraints"
+        }
+    }
     // endregion Component Selection failures
 
     // region Variant Selection failures

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -628,33 +628,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         true    || true          | false
         false   || false         | true
     }
-
-
-    def "demonstrate multiple selected variants with the same capabilities failure"() {
-        multipleSelectedVariantsWithSameCapabilities.prepare()
-
-        expect:
-        fails "forceResolution" // Graph validation failure is not a failure currently handled by the ResolutionFailureHandler
-
-        and: "Has error output"
-        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project 'test'.")
-        assertFullMessageCorrect("""     Required by:
-         root project 'test'
-      > Module 'org.example:test' has been rejected:
-           Cannot select module with conflict on capability 'org:example:test-nonconflicting' also provided by ['root project 'test'' (c2)]""")
-
-        // TODO: No helpful resolutions are provided in this case
-
-        and: "Problems are reported"
-        verifyAll(receivedProblem(0)) {
-            fqid == 'dependency-variant-resolution:no-version-satisfies'
-            additionalData.asMap['requestTarget'] == "org.example:test"
-            additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_VERSION_SATISFIES.name()
-            additionalData.asMap['problemDisplayName'] == "No version satisfies the constraints"
-        }
-    }
     // endregion other tests
 
     // region error showcase

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -106,10 +106,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
-            fqid == 'dependency-variant-resolution:no-version-satisfies'
+            fqid == 'dependency-variant-resolution:capability-conflict'
             additionalData.asMap['requestTarget'] == "org.example:test"
-            additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_VERSION_SATISFIES.name()
-            additionalData.asMap['problemDisplayName'] == "No version satisfies the constraints"
+            additionalData.asMap['problemId'] == ResolutionFailureProblemId.CAPABILITY_CONFLICT.name()
+            additionalData.asMap['problemDisplayName'] == "Module rejected due to a capability conflict"
         }
     }
     // endregion Component Selection failures

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -320,7 +320,7 @@ public class DependencyGraphBuilder {
                 } else if (Iterables.any(selected.getNodes(), node -> node.getReplacement() == null)) {
                     for (NodeState node : selected.getNodes()) {
                         if (node.isRejectedForCapabilityConflict()) {
-                            GradleException error = resolutionFailureHandler.nodeRejected(node);
+                            GradleException error = resolutionFailureHandler.nodeRejectedDueToCapabilityConflict(node);
                             node.getIncomingEdges().forEach(edge -> edge.failWith(error));
                         }
                     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
@@ -118,7 +119,6 @@ public class ResolutionFailureHandler {
 
     // region Component Selection failures
     // TODO: Route more of these failures through this handler in order to standardize their description logic
-
     public AbstractResolutionFailureException componentRejected(ComponentState component, List<String> conflictResolutions) {
         AssessedSelection assessedSelection = SelectionReasonAssessor.assessSelection(component.getModule());
         String legacyErrorMsg = component.getRejectedErrorMessage();
@@ -126,13 +126,19 @@ public class ResolutionFailureHandler {
         return describeFailure(failure);
     }
 
-    public AbstractResolutionFailureException nodeRejected(NodeState node) {
+    public AbstractResolutionFailureException nodeRejectedDueToCapabilityConflict(NodeState node) {
         AssessedSelection assessedSelection = SelectionReasonAssessor.assessSelection(node.getComponent().getModule());
         String legacyErrorMsg = node.getRejectedErrorMessage();
-        ModuleRejectedFailure failure = new ModuleRejectedFailure(ResolutionFailureProblemId.NO_VERSION_SATISFIES, assessedSelection, Collections.emptyList(), legacyErrorMsg);
+
+        DocumentationRegistry docs = new DocumentationRegistry();
+        List<String> resolutionFailures = ImmutableList.of(
+            "Capability conflicts are explained in more detail at " + docs.getDocumentationFor("component_capabilities", "sub:capabilities") + ".",
+            "Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at " + docs.getDocumentationFor("component_capabilities", "sec:selecting-between-candidates") + "."
+        );
+
+        ModuleRejectedFailure failure = new ModuleRejectedFailure(ResolutionFailureProblemId.NO_VERSION_SATISFIES, assessedSelection, resolutionFailures, legacyErrorMsg);
         return describeFailure(failure);
     }
-
     // endregion Component Selection failures
 
     // region Variant Selection failures

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.resolution.failure;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
-import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
@@ -129,14 +128,7 @@ public class ResolutionFailureHandler {
     public AbstractResolutionFailureException nodeRejectedDueToCapabilityConflict(NodeState node) {
         AssessedSelection assessedSelection = SelectionReasonAssessor.assessSelection(node.getComponent().getModule());
         String legacyErrorMsg = node.getRejectedErrorMessage();
-
-        DocumentationRegistry docs = new DocumentationRegistry();
-        List<String> resolutionFailures = ImmutableList.of(
-            "Capability conflicts are explained in more detail at " + docs.getDocumentationFor("component_capabilities", "sub:capabilities") + ".",
-            "Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at " + docs.getDocumentationFor("component_capabilities", "sec:selecting-between-candidates") + "."
-        );
-
-        ModuleRejectedFailure failure = new ModuleRejectedFailure(ResolutionFailureProblemId.NO_VERSION_SATISFIES, assessedSelection, resolutionFailures, legacyErrorMsg);
+        ModuleRejectedFailure failure = new ModuleRejectedFailure(ResolutionFailureProblemId.CAPABILITY_CONFLICT, assessedSelection, Collections.emptyList(), legacyErrorMsg);
         return describeFailure(failure);
     }
     // endregion Component Selection failures

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ModuleRejectedFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ModuleRejectedFailureDescriber.java
@@ -16,24 +16,42 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.exception.ComponentSelectionException;
 import org.gradle.internal.component.resolution.failure.type.ModuleRejectedFailure;
 
 import javax.inject.Inject;
+import java.util.List;
 
 /**
  * Abstract base class for implementing {@link ResolutionFailureDescriber}s that
  * describe {@link ModuleRejectedFailure}s.
  */
 public abstract class ModuleRejectedFailureDescriber extends AbstractResolutionFailureDescriber<ModuleRejectedFailure> {
+    private static final String CAPABILITY_CONFLICT_DOCS_ID = "component_capabilities";
+    private static final String CAPABILITY_CONFLICT_DOCS_SECTION = "sub:capabilities";
+    private static final String CAPABILITY_CONFLICT_RESOLUTION_DOCS_SECTION = "sec:selecting-between-candidates";
+
     @Inject
     @Override
     protected abstract DocumentationRegistry getDocumentationRegistry();
 
     @Override
     public AbstractResolutionFailureException describeFailure(ModuleRejectedFailure failure) {
-        return new ComponentSelectionException(failure.getLegacyErrorMsg(), failure, failure.getResolutions());
+        return new ComponentSelectionException(failure.getLegacyErrorMsg(), failure, buildResolutions(failure));
+    }
+
+    private List<String> buildResolutions(ModuleRejectedFailure failure) {
+        if (failure.getProblemId() == ResolutionFailureProblemId.CAPABILITY_CONFLICT) {
+            DocumentationRegistry docs = getDocumentationRegistry();
+            return ImmutableList.of(
+                "Capability conflicts are explained in more detail at " + docs.getDocumentationFor(CAPABILITY_CONFLICT_DOCS_ID, CAPABILITY_CONFLICT_DOCS_SECTION) + ".",
+                "Use 'resolutionStrategy.capabilitiesResolution' to choose between conflicting capability providers, as described at " + docs.getDocumentationFor(CAPABILITY_CONFLICT_DOCS_ID, CAPABILITY_CONFLICT_RESOLUTION_DOCS_SECTION) + "."
+            );
+        }
+        return failure.getResolutions();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ModuleRejectedFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ModuleRejectedFailureDescriber.java
@@ -34,6 +34,6 @@ public abstract class ModuleRejectedFailureDescriber extends AbstractResolutionF
 
     @Override
     public AbstractResolutionFailureException describeFailure(ModuleRejectedFailure failure) {
-        return new ComponentSelectionException(failure.getLegacyErrorMsg(), failure);
+        return new ComponentSelectionException(failure.getLegacyErrorMsg(), failure, failure.getResolutions());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.NullMarked;
 public enum ResolutionFailureProblemId implements Describable {
     // Component Selection failures
     NO_VERSION_SATISFIES("No version satisfies the constraints"),
+    CAPABILITY_CONFLICT("Module rejected due to a capability conflict"),
 
     // Variant Selection failures
     CONFIGURATION_NOT_COMPATIBLE("Configuration selected by name is not compatible"),

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -184,6 +184,7 @@ class KnownProblemIds {
         'dependency-variant-resolution:no-compatible-variants': ['No variants exist that would match the request'],
         'dependency-variant-resolution:no-variants-with-matching-capabilities': ['No variants exist with capabilities that would match the request'],
         'dependency-variant-resolution:no-version-satisfies' : ['No version satisfies the constraints'],
+        'dependency-variant-resolution:capability-conflict' : ['Module rejected due to a capability conflict'],
 
         'dependency-variant-resolution:ambiguous-artifact-transform': ['Multiple artifacts transforms exist that would satisfy the request'],
         'dependency-variant-resolution:no-compatible-artifact': ['No artifacts exist that would match the request'],


### PR DESCRIPTION
When multiple selected variants provide the same capabilities and cause a conflict, the error message now includes helpful documentation links. This guides users on how to understand and resolve such conflicts using `resolutionStrategy.capabilitiesResolution`, improving the user experience.

Fixes one of the issues flagged by:
- https://github.com/gradle/gradle/pull/29543