### PR TITLE
Show failures from unattachedEdges when necessary, to prevent confusing serialization failures from surfacing

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -32,56 +32,6 @@ import spock.lang.Issue
  * file more appropriate for the feature they are testing.
  */
 class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
-
-    @NotYetImplemented
-    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1283947029")
-    def "resolution result represents failure to resolve dynamic selected module version when platform has constraint on that module"() {
-        mavenRepo.module("test", "module1", "11.1.0.1").publish()
-
-        settingsFile << "include 'plat'"
-        file("plat/build.gradle") << """
-            plugins {
-                id("java-platform")
-            }
-
-            dependencies {
-                constraints {
-                    api "test:module1:11.1.0.1"
-                }
-            }
-        """
-
-        buildFile << """
-            plugins {
-                id("jvm-ecosystem")
-            }
-
-            configurations {
-                dependencyScope("implementation")
-                resolvable("runtimeClasspath") {
-                    extendsFrom implementation
-                }
-            }
-
-            tasks.register('resolve') {
-                def root = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
-                doLast {
-                    println root.get()
-                }
-            }
-
-            ${mavenTestRepository()}
-
-            dependencies {
-                implementation 'test:module1:11.2.0.+'
-                implementation platform(project(":plat"))
-            }
-        """
-
-        expect:
-        succeeds("resolve")
-    }
-
     @NotYetImplemented
     @Issue("https://github.com/gradle/gradle/issues/22326")
     def "capability conflict skip"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
@@ -202,4 +202,65 @@ class DependencyConstraintsBugsIntegrationTest extends AbstractHttpDependencyRes
             }
         }
     }
+
+    def "throwing eachDependency rule on a coordinate carrying only a phantom constraint surfaces the rule's exception"() {
+        // Reproduces this scenario:
+        //   producer: declares a constraint on org:foo:1.1, but does not depend on org:foo
+        //   app: depends on producer and on org:foo:1.0; registers an eachDependency rule that throws
+        //        whenever it sees a non-1.1 version of org:foo
+        //
+        // The throwing rule fires on org:foo:1.0. Historically the rule's exception
+        // was swallowed and the build failed with a confusing internal error referencing the
+        // binary store and an EdgeState with no target component. The rule's own exception should
+        // be surfaced as the resolution failure cause.
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "1.1").publish()
+
+        createDirs("producer", "app")
+        settingsFile << """
+            rootProject.name = 'test'
+            include 'producer', 'app'
+        """
+
+        file("producer/build.gradle") << """
+            plugins { id 'java-library' }
+            dependencies {
+                constraints {
+                    api 'org:foo:1.1'
+                }
+            }
+        """
+
+        file("app/build.gradle") << """
+            plugins { id 'java' }
+            repositories {
+                maven { url = "${mavenRepo.uri}" }
+            }
+            dependencies {
+                implementation project(':producer')
+                implementation 'org:foo:1.0'
+            }
+            configurations.all {
+                resolutionStrategy.eachDependency { details ->
+                    if (details.requested.group == 'org' && details.requested.name == 'foo'
+                        && !(details.requested.version ?: '').startsWith('1.1')) {
+                        throw new org.gradle.api.GradleException("enforced version check failed for foo:\${details.requested.version}")
+                    }
+                }
+            }
+            tasks.register('resolveRuntime') {
+                def files = configurations.runtimeClasspath
+                doLast { files.files }
+            }
+        """
+
+        when:
+        fails ':app:resolveRuntime'
+
+        then:
+        failure.assertHasCause("enforced version check failed for foo:1.0")
+        failure.assertHasNoCause("Problems writing to Binary store")
+        failure.assertHasNoCause("No target component for edge")
+    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/PlatformResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/PlatformResolveIntegrationTest.groovy
@@ -714,6 +714,54 @@ class PlatformResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         //Shape of the graph is not checked as bug was failing resolution altogether
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1283947029")
+    def "resolution result represents failure to resolve dynamic selected module version when platform has constraint on that module"() {
+        mavenRepo.module("test", "module1", "11.1.0.1").publish()
+
+        settingsFile << "\ninclude 'plat'"
+        file("plat/build.gradle") << """
+            plugins {
+                id("java-platform")
+            }
+
+            dependencies {
+                constraints {
+                    api "test:module1:11.1.0.1"
+                }
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id("jvm-ecosystem")
+            }
+
+            configurations {
+                dependencyScope("implementation")
+                resolvable("runtimeClasspath") {
+                    extendsFrom implementation
+                }
+            }
+
+            tasks.register('resolve') {
+                def root = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    println root.get()
+                }
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation 'test:module1:11.2.0.+'
+                implementation platform(project(":plat"))
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
     String mavenHttpRepo() {
         """
             repositories {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -266,11 +266,21 @@ class EdgeState implements DependencyGraphEdge {
             }
 
             // If we couldn't attach to any nodes, try to inherit any failures that hard edges have
-            // encountered during selection.
+            // encountered during selection. Failures may originate either from target variant
+            // selection (targetNodeSelectionFailure) or from selector resolution itself - for
+            // example when a throwing eachDependency/substitution rule fired on the requested
+            // coordinate and prevented a component from ever being selected.
             if (targetNodes.isEmpty()) {
                 for (EdgeState unattachedEdge : targetComponent.getModule().getUnattachedEdges()) {
-                    if (!unattachedEdge.isConstraint() && unattachedEdge.targetNodeSelectionFailure != null) {
-                        this.targetNodeSelectionFailure = unattachedEdge.targetNodeSelectionFailure;
+                    if (unattachedEdge.isConstraint()) {
+                        continue;
+                    }
+                    ModuleVersionResolveException targetNodeFailure = unattachedEdge.targetNodeSelectionFailure;
+                    if (targetNodeFailure == null && unattachedEdge.selector != null) {
+                        targetNodeFailure = unattachedEdge.selector.getFailure();
+                    }
+                    if (targetNodeFailure != null) {
+                        this.targetNodeSelectionFailure = targetNodeFailure;
                         return;
                     }
                 }


### PR DESCRIPTION
Previously, `eachDependency` rule exceptions were swallowed when applied to a dependency coordinate introduced solely via a "phantom constraint" from a producer. This led to cryptic internal errors instead of surfacing the rule's specific failure.

This change ensures that exceptions thrown by such rules are correctly propagated as the root cause of resolution failure.

## Details

In `EdgeState.calculateTargetNodes()`, the constraint-edge fallback at lines 270-277 previously inherited a failure from a sibling unattached hard edge **only** when that edge's `targetNodeSelectionFailure` was non-`null`.

When a throwing eachDependency/substitution rule fired on the hard edge's coordinate, the resulting ModuleVersionResolveException lived only on `selector.failure`, the constraint edge's fallback found nothing to inherit, the constraint edge ended up with `getFailure() == null` and `targetNodes.isEmpty()`.  During serialization, this inconsistent state was rejected with an `IllegalStateException` wrapped as a confusing "Problems writing to Binary store" message.

The fix widens the fallback to also consult `unattachedEdge.selector.getFailure()` when `targetNodeSelectionFailure` is `null`, so the constraint edge now adopts the rule's exception as its own `targetNodeSelectionFailure`, `getFailure()` returns non-`null`, the serializer takes the failure path instead, and the user's actual "enforced version check failed for foo:1.0" exception surfaces as the resolution failure.