### PR TITLE
Drop the 5k full-stack cap under Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
@@ -22,7 +22,7 @@ import static org.gradle.integtests.fixtures.configurationcache.ConfigurationCac
 
 class IsolatedProjectsProblemReportingIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
 
-    def "stops reporting problems at certain limits collecting all stacktraces"() {
+    def "reports problems with locations past the stack-capture cap using bounded captures"() {
         settingsFile """
             include(":a")
         """
@@ -38,6 +38,10 @@ class IsolatedProjectsProblemReportingIntegrationTest extends AbstractIsolatedPr
         then:
         outputContains("Configuration cache entry discarded with 530 problems.")
 
+        // The IP-specific 5000 full-stacktrace cap has been removed: IP now uses the standard 50 full-stack
+        // cap and the cheap bounded location capture past it (#32362). Every problem still resolves to its
+        // line: the first 50 carry a full stacktrace, the rest a bounded capture. Both populate a stacktrace
+        // in the report, so all 530 are still counted as having one and each shows a distinct line.
         problems.assertFailureHasProblems(failure) {
             withProblem("Build file 'build.gradle': line 1: Project ':' cannot access 'Project.version' functionality on another project ':a'")
             withProblem("Build file 'build.gradle': line 10: Project ':' cannot access 'Project.version' functionality on another project ':a'")

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -237,6 +237,10 @@ As a result, the [console](userguide/command_line_interface.html), the [problems
 Run with `--warning-mode=all` to remove the limit and capture a source location for every problem.
 Past the cap, including under `--warning-mode=all` and `fail`, the capture keeps the originating build logic down to the calling script, enough to locate the problem, rather than the full call chain.
 
+Previously, [Isolated Projects](userguide/isolated_projects.html) raised the full stack trace cap to 5000 problems to give early adopters locations on large builds.
+Now that the cheaper location capture covers everything past the cap, that special case is no longer needed: Isolated Projects uses the same 50-problem full stack trace cap as every other mode, and problems past it get the same reduced bounded location.
+This lowers the cost of problem reporting under Isolated Projects with no loss of locations for affected problems.
+
 See the [CLI reference](userguide/command_line_interface.html#sec:command_line_warnings) in the Gradle User Manual for more details.
 
 ### Build authoring improvements

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -761,7 +761,7 @@ Set to `summary` to suppress all warnings and log a summary at the end of the bu
 Set to `none` to suppress all warnings, including the summary at the end of the build.
 +
 In `all` and `fail` modes, Gradle infers a source location for every problem rather than only the first ones.
-Past the stack-capture cap (50 problems by default, 5000 under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>), the trace is reduced to the originating build logic and the calling script (enough to locate the problem) rather than the full call chain.
+Past the stack-capture cap (50 problems), the trace is reduced to the originating build logic and the calling script (enough to locate the problem) rather than the full call chain.
 
 [[sec:rich_console]]
 === Rich console

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationPastCapIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationPastCapIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.problems
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.operations.problems.ProblemUsageProgressDetails
 import spock.lang.Issue
 
@@ -35,7 +34,6 @@ class ProblemLocationPastCapIntegrationTest extends AbstractIntegrationSpec {
 
     def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)
 
-    @ToBeFixedForIsolatedProjects(because = "under Isolated Projects the stack-capture cap is 5000, so the problems fired here stay within it and never reach the bounded path")
     def "problems past the stack-capture cap resolve to the calling script and keep the build-logic frame for warning mode #warningMode"() {
         given:
         // A compiled helper (build logic, not a script) reports the problem. The bounded capture must see

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
@@ -19,7 +19,6 @@ package org.gradle.internal.problems;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
-import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.code.UserCodeSource;
 import org.gradle.internal.problems.failure.Failure;
@@ -48,7 +47,6 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
     private static final ProblemStream.StackTraceTransformer NO_OP = new CopyStackTraceTransFormer();
 
     private static final int MAX_STACKTRACE_COUNT = 50;
-    private static final int ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT = 5000;
 
     // Budget for bounded location captures past the cap: capping the count keeps the stack walk cost
     // bounded and negligible at scale. Builds with more distinct call sites lose locations past it.
@@ -66,14 +64,9 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
         FailureFactory failureFactory,
         ProblemLocationAnalyzer locationAnalyzer,
         UserCodeApplicationContext userCodeContext,
-        BuildModelParameters buildModelParameters,
         BoundedCallerStackCapturer boundedCallerStackCapturer
     ) {
-        this(failureFactory, locationAnalyzer, userCodeContext, getMaxStackTraces(buildModelParameters), MAX_BOUNDED_CAPTURES, boundedCallerStackCapturer);
-    }
-
-    private static int getMaxStackTraces(BuildModelParameters buildModelParameters) {
-        return buildModelParameters.isIsolatedProjects() ? ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT : MAX_STACKTRACE_COUNT;
+        this(failureFactory, locationAnalyzer, userCodeContext, MAX_STACKTRACE_COUNT, MAX_BOUNDED_CAPTURES, boundedCallerStackCapturer);
     }
 
     @VisibleForTesting
@@ -152,7 +145,14 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
         @Override
         public ProblemDiagnostics forCurrentCaller(Supplier<? extends Throwable> exceptionFactory) {
-            return locationFromStackTrace(getImplicitThrowable(exceptionFactory), false, true, NO_OP);
+            Throwable supplied = capturer.captureSupplied(exceptionFactory);
+            if (supplied != null) {
+                // Within the full budget: keep the supplied throwable as the problem's exception.
+                return locationFromStackTrace(supplied, false, true, NO_OP);
+            }
+            // Past the full budget: infer a location from a cheap bounded capture, but never surface it as
+            // the exception (a supplied throwable must be preserved or dropped, never replaced by a bounded one).
+            return locationFromStackTrace(capturer.captureBoundedFallback(), false, false, NO_OP);
         }
 
         @Override
@@ -163,11 +163,6 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
         @Nullable
         private Throwable getImplicitCallerThrowable() {
             return capturer.captureCaller();
-        }
-
-        @Nullable
-        private Throwable getImplicitThrowable(Supplier<? extends Throwable> factory) {
-            return capturer.captureSupplied(factory);
         }
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/StackTraceCapturer.java
@@ -41,16 +41,32 @@ final class StackTraceCapturer {
         if (remainingFull.getAndDecrement() > 0) {
             return new Exception();
         }
-        if (remainingBounded.getAndDecrement() > 0) {
-            return boundedCallerStackCapturer.captureCallerStack();
-        }
-        return null;
+        return captureBoundedFallback();
     }
 
+    /**
+     * Captures the caller-supplied throwable while the full budget lasts, or {@code null} once it is spent.
+     *
+     * <p>A supplied throwable is kept as the problem's exception, so it must never be replaced by a bounded
+     * capture. Past the full budget the caller should fall back to {@link #captureBoundedFallback()}, which
+     * yields a location-only throwable that must not be surfaced as the exception.</p>
+     */
     @Nullable
     Throwable captureSupplied(Supplier<? extends Throwable> factory) {
         if (remainingFull.getAndDecrement() > 0) {
             return factory.get();
+        }
+        return null;
+    }
+
+    /**
+     * Captures a cheap bounded throwable used to infer a location only (never kept as the exception), while
+     * the bounded budget lasts, or {@code null} once it is spent. Spends only the bounded budget.
+     */
+    @Nullable
+    Throwable captureBoundedFallback() {
+        if (remainingBounded.getAndDecrement() > 0) {
+            return boundedCallerStackCapturer.captureCallerStack();
         }
         return null;
     }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/StackTraceCapturerTest.groovy
@@ -59,7 +59,26 @@ class StackTraceCapturerTest extends Specification {
         results[2] == null
         results[3] == null
 
+        // captureSupplied never substitutes a bounded capture for a supplied throwable; the bounded fallback
+        // past the full budget is the caller's responsibility, via captureBoundedFallback.
         0 * boundedCapturer.captureCallerStack()
+    }
+
+    def "captureBoundedFallback spends only the bounded budget, then captures nothing"() {
+        given:
+        def boundedException = new Exception()
+        def capturer = new StackTraceCapturer(2, 2, boundedCapturer)
+
+        when:
+        // The full budget is untouched: captureBoundedFallback only ever spends the bounded budget.
+        def results = (1..3).collect { capturer.captureBoundedFallback() }
+
+        then:
+        results[0].is(boundedException)
+        results[1].is(boundedException)
+        results[2] == null
+
+        2 * boundedCapturer.captureCallerStack() >> boundedException
     }
 
     def "captureCaller with an unbounded bounded budget keeps capturing past the full cap"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/problems/DefaultProblemDiagnosticsFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/problems/DefaultProblemDiagnosticsFactoryTest.groovy
@@ -104,6 +104,52 @@ class DefaultProblemDiagnosticsFactoryTest extends Specification {
         diagnostics5.stack.empty
     }
 
+    def "supplied exception path falls back to a location-only bounded capture past the full cap"() {
+        given:
+        // 1 full capture, then a bounded budget of 2.
+        def cappedFactory = new DefaultProblemDiagnosticsFactory(DefaultFailureFactory.withDefaultClassifier(), locationAnalyzer, userCodeContext, 1, 2, boundedCallerStackCapturer)
+        def stream = cappedFactory.newStream()
+        def suppliedException = new Exception("supplied")
+        def supplier = Stub(Supplier) {
+            get() >> suppliedException
+        }
+        def boundedThrowable = new Exception()
+
+        when:
+        // Within the full budget: the supplied exception is kept and surfaced.
+        def withinCap = stream.forCurrentCaller(supplier)
+
+        then:
+        withinCap.exception == suppliedException
+        0 * boundedCallerStackCapturer.captureCallerStack()
+
+        when:
+        // Past the full budget: a bounded capture provides the location, but it is never kept as the exception.
+        def pastCap = stream.forCurrentCaller(supplier)
+
+        then:
+        pastCap.exception == null
+        !pastCap.stack.empty
+        1 * boundedCallerStackCapturer.captureCallerStack() >> boundedThrowable
+    }
+
+    def "supplied exception path stops capturing once the bounded budget is spent"() {
+        given:
+        // 1 full capture, then a bounded budget of 2, then no capture at all.
+        def cappedFactory = new DefaultProblemDiagnosticsFactory(DefaultFailureFactory.withDefaultClassifier(), locationAnalyzer, userCodeContext, 1, 2, boundedCallerStackCapturer)
+        def stream = cappedFactory.newStream()
+        def supplier = Stub(Supplier) {
+            get() >> new Exception("supplied")
+        }
+
+        when:
+        // 1 supplied (full) + 2 bounded fallbacks + 1 past both budgets.
+        4.times { stream.forCurrentCaller(supplier) }
+
+        then:
+        2 * boundedCallerStackCapturer.captureCallerStack() >> null
+    }
+
     def "stops capturing bounded stacks once the bounded budget is spent"() {
         given:
         // 2 full captures, then a bounded budget of 3, then no capture at all.


### PR DESCRIPTION
> **Spike / draft.** Implements the follow-up agreed in #32362 and the related Slack thread: now that the cheap bounded location capture has landed (#38127, #38251), drop the Isolated-Projects-specific 5000 full-stack-trace cap.

### Why
PR #30028 raised the full stack-trace capture cap from 50 to **5000** under Isolated Projects, as a corner-cutting way to give early adopters source locations on large builds. The number was arbitrary (loosely inspired by the CC 4096 problem-count cap).

Since then, #38127 and #38251 added a cheap **bounded** location capture: past the full-stack cap, a bounded `StackWalker` walk infers the source location (keeping the originating build logic down to the calling script, dropping the runtime frames) at negligible cost. That makes the 5000 full-stack cap redundant — it only forces expensive full captures where a bounded capture yields the same location.

### What changes
- Remove `ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT = 5000` and the `isIsolatedProjects()` branch in `DefaultProblemDiagnosticsFactory`. IP now uses the standard **50** full-stack cap + the bounded location capture past it, like every other mode.
- The supplied-exception path (`forCurrentCaller(Supplier)`) past the full cap now also falls back to a location-only bounded capture, but **never** surfaces that bounded throwable as the problem's exception — a supplied throwable is preserved or dropped, never replaced. Factored out as `StackTraceCapturer.captureBoundedFallback()`.

**Behaviour under IP:**
- Problems 1–50: full trace (unchanged).
- Problems 51–2050: previously full trace (up to 5000), now bounded trace + location.
- Problems 2051+: no inferred location (same as non-IP); `--warning-mode=all`/`fail` still lifts the bounded budget so every problem gets a location.

No public API change. The within-cap behaviour is unchanged.

### Tests
- `IsolatedProjectsProblemReportingIntegrationTest` — rewritten for the bounded-past-50 contract (530 problems still all resolve to their line).
- `ProblemLocationPastCapIntegrationTest` — `@ToBeFixedForIsolatedProjects` removed; now exercises the bounded path under IP too.
- `DefaultProblemDiagnosticsFactoryTest` / `StackTraceCapturerTest` — cover the supplied-exception bounded fallback and budget exhaustion.

### Notes
- The CC problem-count caps (`maxCollectedProblems = 4096`, `configurationCacheMaxProblems = 512`) are a different axis (how many problems are reported, not per-problem trace cost) and are untouched.
- Out of scope (separate follow-ups per the thread): raising/removing the 2000 bounded budget; a knob to force full traces; the `largeAndroidBuild` IDE-sync regression.

Follow-up to #32362.
