### PR TITLE
Deprecate internal `BuildLayout` and `SettingsLocation`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -32,11 +32,11 @@ import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.ProjectDescriptorInternal
 import org.gradle.initialization.SettingsState
-import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.file.PathToFileResolver
+import org.gradle.internal.initialization.BuildLocation
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resource.TextFileResourceLoader
 import org.gradle.internal.service.CloseableServiceRegistry
@@ -178,7 +178,7 @@ class DefaultConfigurationCacheHost internal constructor(
 
         private
         fun settingsDir() =
-            service<BuildLayout>().settingsDir
+            service<BuildLocation>().buildRootDirectory
 
         private
         fun getProjectDescriptor(parentPath: Path?): ProjectDescriptorInternal? =

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
@@ -17,7 +17,6 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.StartParameterInternal
-import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
 import org.gradle.internal.buildoption.DefaultInternalOptions
@@ -30,6 +29,7 @@ import org.gradle.internal.encryption.EncryptionConfiguration
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hasher
 import org.gradle.internal.hash.Hashing
+import org.gradle.internal.initialization.BuildLocation
 import org.gradle.internal.initialization.layout.BuildTreeLocations
 import org.gradle.internal.scripts.DefaultScriptFileResolver
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -252,7 +252,7 @@ class ConfigurationCacheKeyTest {
         val internalOptions = DefaultInternalOptions(mapOf())
         return ConfigurationCacheKey(
             ConfigurationCacheStartParameter(
-                BuildTreeLocations(BuildLayout(file("root"), null, DefaultScriptFileResolver())),
+                BuildTreeLocations(BuildLocation(file("root"), null, DefaultScriptFileResolver())),
                 startParameter,
                 internalOptions,
                 BuildModelParametersProvider.parameters(RunTasksRequirements(startParameter), internalOptions),

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -88,7 +88,7 @@ object BuildServices : ServiceRegistrationProvider {
 
     private
     fun BuildLayoutFactory.settingsDir(gradle: GradleInternal): File =
-        getLayoutFor(gradle.startParameter.toBuildLayoutConfiguration()).settingsDir
+        locationFor(gradle.startParameter.toBuildLayoutConfiguration()).buildRootDirectory
 }
 
 internal object ProjectServices : ServiceRegistrationProvider {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -151,7 +151,7 @@ object BuildServices : ServiceRegistrationProvider {
     // e.g. init scripts or scripts for included builds
     // we need to compute the root directory from the start parameters
     private fun BuildLayoutFactory.getBuildTreeRootDir(startParameter: StartParameterInternal): Path =
-        getLayoutFor(startParameter.toBuildLayoutConfiguration()).rootDirectory
+        locationFor(startParameter.toBuildLayoutConfiguration()).buildRootDirectory
             .toPath().toAbsolutePath().normalize()
 
     @Provides

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/internal/GradleDistRepoDescriptorLocator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/internal/GradleDistRepoDescriptorLocator.kt
@@ -93,7 +93,7 @@ class GradleDistRepoDescriptorLocator(
     private
     fun rootBuildDir() =
         // project.gradle.root.settings may not be available, so we need to compute the root directory from the start parameters
-        BuildLayoutFactory().getLayoutFor((project.gradle as GradleInternal).root.startParameter.toBuildLayoutConfiguration()).rootDirectory
+        BuildLayoutFactory().locationFor((project.gradle as GradleInternal).root.startParameter.toBuildLayoutConfiguration()).buildRootDirectory
 
     private
     fun findStandardCustomBasePath(customUri: URI): String? {

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/SettingsLocation.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/SettingsLocation.java
@@ -15,27 +15,31 @@
  */
 package org.gradle.initialization;
 
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.scripts.ScriptResolutionResult;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
-import java.util.Optional;
 
+/**
+ * @implNote Despite not being part of the public API, this service is known to have been used by users.
+ * So we treat its removal as a breaking change.
+ * @deprecated Instead, use {@link org.gradle.api.file.BuildLayout#getSettingsDirectory()} for settings or {@link org.gradle.api.file.ProjectLayout#getSettingsDirectory()} for project.
+ */
+@Deprecated
 public class SettingsLocation {
-    private final File settingsDir;
-    @Nullable
-    private final ScriptResolutionResult settingsFileResolution;
 
-    public SettingsLocation(File settingsDir, @Nullable ScriptResolutionResult settingsFileResolution) {
-        this.settingsDir = settingsDir;
-        this.settingsFileResolution = settingsFileResolution;
+    protected final BuildLocation buildLocation;
+
+    public SettingsLocation(BuildLocation buildLocation) {
+        this.buildLocation = buildLocation;
     }
 
     /**
      * Returns the settings directory. Never null.
      */
     public File getSettingsDir() {
-        return settingsDir;
+        return buildLocation.getBuildRootDirectory();
     }
 
     /**
@@ -43,7 +47,7 @@ public class SettingsLocation {
      */
     @Nullable
     public ScriptResolutionResult getSettingsFileResolution() {
-        return settingsFileResolution;
+        return buildLocation.getSettingsFileResolution();
     }
 
     /**
@@ -51,9 +55,6 @@ public class SettingsLocation {
      */
     @Nullable
     public File getSettingsFile() {
-        return Optional
-            .ofNullable(settingsFileResolution)
-            .map(ScriptResolutionResult::getSelectedCandidate)
-            .orElse(null);
+        return buildLocation.getSettingsFile();
     }
 }

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/layout/BuildLayout.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/layout/BuildLayout.java
@@ -15,46 +15,37 @@
  */
 package org.gradle.initialization.layout;
 
-import org.gradle.initialization.SettingsLocation;
-import org.gradle.internal.initialization.BuildLogicFiles;
-import org.gradle.internal.scripts.ScriptFileResolver;
-import org.gradle.internal.scripts.ScriptResolutionResult;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
+/**
+ * @implNote Despite not being part of the public API, this service is known to have been used by users.
+ * So we treat its removal as a breaking change.
+ * @deprecated Instead, use {@link org.gradle.api.file.BuildLayout#getSettingsDirectory()} for settings or {@link org.gradle.api.file.ProjectLayout#getSettingsDirectory()} for project.
+ */
+@Deprecated
 @ServiceScope(Scope.Build.class)
-public class BuildLayout extends SettingsLocation {
-    private final ScriptFileResolver scriptFileResolver;
+@SuppressWarnings("deprecation")
+public class BuildLayout extends org.gradle.initialization.SettingsLocation {
 
-    /**
-     * Creates a new build layout.
-     *
-     * @param rootDirectory the root directory of the build
-     * @param settingsFileResolution the settings file resolution result. {@code null} means explicitly no settings.
-     * A non-null value can be a non-existent file, which is semantically equivalent to an empty file.
-     * @param scriptFileResolver the script file resolver
-     */
-    public BuildLayout(File rootDirectory, @Nullable ScriptResolutionResult settingsFileResolution, ScriptFileResolver scriptFileResolver) {
-        super(rootDirectory, settingsFileResolution);
-        this.scriptFileResolver = scriptFileResolver;
+    public BuildLayout(BuildLocation buildLocation) {
+        super(buildLocation);
     }
 
     /**
      * Was a build definition found?
      */
     public boolean isBuildDefinitionMissing() {
-        return getSettingsFile() != null &&
-            !getSettingsFile().exists() &&
-            !scriptFileResolver.resolveScriptFile(getRootDirectory(), BuildLogicFiles.BUILD_FILE_BASENAME).isScriptFound();
+        return buildLocation.isBuildDefinitionMissing();
     }
 
     /**
      * Returns the root directory of the build, is never null.
      */
     public File getRootDirectory() {
-        return getSettingsDir();
+        return buildLocation.getBuildRootDirectory();
     }
 }

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.initialization.layout;
 
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.initialization.BuildLogicFiles;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.ScriptFileResolver;
@@ -42,30 +43,52 @@ public class BuildLayoutFactory {
     }
 
     /**
-     * Determines the layout of the build, given a current directory and some other configuration.
+     * Determines the location of the build, given a current directory and some other configuration.
      */
-    public BuildLayout getLayoutFor(File currentDir, boolean shouldSearchUpwards) {
+    public BuildLocation locationFor(File currentDir, boolean shouldSearchUpwards) {
         boolean searchUpwards = shouldSearchUpwards && !isBuildSrc(currentDir);
-        BuildLayout layout = searchUpwards ? findLayoutRecursively(currentDir) : findLayout(currentDir);
-        return layout != null ? layout : getLayoutWithDefaultSettingsFile(currentDir);
+        BuildLocation location = searchUpwards ? findLocationRecursively(currentDir) : findLocation(currentDir);
+        return location != null ? location : getLocationWithDefaultSettingsFile(currentDir);
+    }
+
+    /**
+     * Determines the location of the build, given a current directory and some other configuration.
+     */
+    public BuildLocation locationFor(BuildLayoutConfiguration configuration) {
+        if (configuration.isUseEmptySettings()) {
+            return location(configuration.getCurrentDir(), null);
+        }
+        return locationFor(configuration.getCurrentDir(), configuration.isSearchUpwards());
     }
 
     /**
      * Determines the layout of the build, given a current directory and some other configuration.
+     *
+     * @deprecated Use {@link #locationFor(File, boolean)} instead. {@link BuildLayout} is a deprecated service.
      */
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    public BuildLayout getLayoutFor(File currentDir, boolean shouldSearchUpwards) {
+        return new BuildLayout(locationFor(currentDir, shouldSearchUpwards));
+    }
+
+    /**
+     * Determines the layout of the build, given a current directory and some other configuration.
+     *
+     * @deprecated Use {@link #locationFor(BuildLayoutConfiguration)} instead. {@link BuildLayout} is a deprecated service.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public BuildLayout getLayoutFor(BuildLayoutConfiguration configuration) {
-        if (configuration.isUseEmptySettings()) {
-            return layout(configuration.getCurrentDir(), null);
-        }
-        return getLayoutFor(configuration.getCurrentDir(), configuration.isSearchUpwards());
+        return new BuildLayout(locationFor(configuration));
     }
 
     @Nullable
-    private BuildLayout findLayoutRecursively(File dir) {
+    private BuildLocation findLocationRecursively(File dir) {
         while (dir != null) {
-            BuildLayout layout = findLayout(dir);
-            if (layout != null) {
-                return layout;
+            BuildLocation location = findLocation(dir);
+            if (location != null) {
+                return location;
             }
             dir = dir.getParentFile();
         }
@@ -73,25 +96,25 @@ public class BuildLayoutFactory {
     }
 
     @Nullable
-    private BuildLayout findLayout(File dir) {
+    private BuildLocation findLocation(File dir) {
         ScriptResolutionResult resolutionResult = scriptFileResolver.resolveScriptFile(dir, BuildLogicFiles.SETTINGS_FILE_BASENAME);
         if (resolutionResult.isScriptFound()) {
-            return layout(dir, resolutionResult);
+            return location(dir, resolutionResult);
         } else {
             return null;
         }
     }
 
-    private BuildLayout getLayoutWithDefaultSettingsFile(File dir) {
+    private BuildLocation getLocationWithDefaultSettingsFile(File dir) {
         ScriptResolutionResult resolution = ScriptResolutionResult.fromSingleFile(
             BuildLogicFiles.SETTINGS_FILE_BASENAME,
             FileUtils.canonicalize(new File(dir, BuildLogicFiles.DEFAULT_SETTINGS_FILE))
         );
-        return layout(dir, resolution);
+        return location(dir, resolution);
     }
 
-    private BuildLayout layout(File rootDir, @Nullable ScriptResolutionResult settingsFileResolution) {
-        return new BuildLayout(rootDir, settingsFileResolution, scriptFileResolver);
+    private BuildLocation location(File rootDir, @Nullable ScriptResolutionResult settingsFileResolution) {
+        return new BuildLocation(rootDir, settingsFileResolution, scriptFileResolver);
     }
 
     private static boolean isBuildSrc(File dir) {

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/BuildLocation.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/BuildLocation.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.initialization;
+
+import org.gradle.internal.scripts.ScriptFileResolver;
+import org.gradle.internal.scripts.ScriptResolutionResult;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * Location of a build on the file system, represented by its {@link #getBuildRootDirectory() root directory}.
+ * <p>
+ * This is the internal companion to the build-tree-scoped {@code BuildTreeLocations} service.
+ * It is the non-deprecated replacement for the {@code org.gradle.initialization.layout.BuildLayout}
+ * and {@code org.gradle.initialization.SettingsLocation} services, which are deprecated because they
+ * are easily mistaken for the public {@link org.gradle.api.file.BuildLayout} service.
+ *
+ * @see org.gradle.internal.initialization.layout.BuildTreeLocations
+ */
+@ServiceScope(Scope.Build.class)
+public class BuildLocation {
+
+    private final File buildRootDirectory;
+    @Nullable
+    private final ScriptResolutionResult settingsFileResolution;
+    private final ScriptFileResolver scriptFileResolver;
+
+    /**
+     * Creates a new build location.
+     *
+     * @param buildRootDirectory the root directory of the build
+     * @param settingsFileResolution the settings file resolution result. {@code null} means explicitly no settings.
+     * A non-null value can resolve to a non-existent file, which is semantically equivalent to an empty file.
+     * @param scriptFileResolver the script file resolver
+     */
+    public BuildLocation(File buildRootDirectory, @Nullable ScriptResolutionResult settingsFileResolution, ScriptFileResolver scriptFileResolver) {
+        this.buildRootDirectory = buildRootDirectory;
+        this.settingsFileResolution = settingsFileResolution;
+        this.scriptFileResolver = scriptFileResolver;
+    }
+
+    /**
+     * Root directory of the build.
+     * <p>
+     * It is the same as the settings directory.
+     * <p>
+     * Note that this directory can technically differ from the {@code Project.rootDir}, because the latter is mutable
+     * during settings via the {@code ProjectDescriptor} of the root project.
+     */
+    public File getBuildRootDirectory() {
+        return buildRootDirectory;
+    }
+
+    /**
+     * Returns the resolution result for the settings file, or {@code null} when using "empty settings".
+     */
+    @Nullable
+    public ScriptResolutionResult getSettingsFileResolution() {
+        return settingsFileResolution;
+    }
+
+    /**
+     * Settings script file or {@code null} when using "empty settings".
+     * <p>
+     * When not null, the file might not exist on disk, in which case it is treated as a file with empty contents.
+     */
+    @Nullable
+    public File getSettingsFile() {
+        return Optional
+            .ofNullable(settingsFileResolution)
+            .map(ScriptResolutionResult::getSelectedCandidate)
+            .orElse(null);
+    }
+
+    /**
+     * Was a build definition found?
+     */
+    public boolean isBuildDefinitionMissing() {
+        File settingsFile = getSettingsFile();
+        return settingsFile != null &&
+            !settingsFile.exists() &&
+            !scriptFileResolver.resolveScriptFile(buildRootDirectory, BuildLogicFiles.BUILD_FILE_BASENAME).isScriptFound();
+    }
+}

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/layout/BuildTreeLocations.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/layout/BuildTreeLocations.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.initialization.layout;
 
-import org.gradle.initialization.layout.BuildLayout;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -30,10 +30,10 @@ import java.io.File;
 @ServiceScope(Scope.BuildSession.class)
 public class BuildTreeLocations {
 
-    private final BuildLayout rootBuildLayout;
+    private final BuildLocation rootBuildLocation;
 
-    public BuildTreeLocations(BuildLayout rootBuildLayout) {
-        this.rootBuildLayout = rootBuildLayout;
+    public BuildTreeLocations(BuildLocation rootBuildLocation) {
+        this.rootBuildLocation = rootBuildLocation;
     }
 
     /**
@@ -45,13 +45,13 @@ public class BuildTreeLocations {
      * via the <code>ProjectDescriptor</code> of the root project.
      */
     public File getBuildTreeRootDirectory() {
-        return rootBuildLayout.getRootDirectory();
+        return rootBuildLocation.getBuildRootDirectory();
     }
 
     /**
-     * Layout of the root build.
+     * Location of the root build.
      */
-    public BuildLayout getRootBuildLayout() {
-        return rootBuildLayout;
+    public BuildLocation getRootBuildLocation() {
+        return rootBuildLocation;
     }
 }

--- a/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/package-info.java
+++ b/platforms/core-runtime/build-discovery-impl/src/main/java/org/gradle/internal/initialization/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@org.jspecify.annotations.NullMarked
+package org.gradle.internal.initialization;

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/buildprocess/execution/BuildSessionLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/buildprocess/execution/BuildSessionLifecycleBuildActionExecutor.java
@@ -18,10 +18,10 @@ package org.gradle.internal.buildprocess.execution;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildRequestContext;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildtree.BuildActionRunner;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.CrossBuildSessionParameters;
@@ -87,8 +87,8 @@ public class BuildSessionLifecycleBuildActionExecutor implements BuildActionExec
      */
     private File getUserActionRootDirectory(StartParameterInternal startParameter) {
         BuildLayoutFactory buildLayoutFactory = globalServices.get(BuildLayoutFactory.class);
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(startParameter.toBuildLayoutConfiguration());
-        return layout.getRootDirectory().getAbsoluteFile();
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(startParameter.toBuildLayoutConfiguration());
+        return buildLocation.getBuildRootDirectory().getAbsoluteFile();
     }
 
     private static class ActionImpl implements Function<BuildSessionContext, BuildActionResult> {

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -138,7 +138,7 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
 
         // Caveat: when adding new manually created services ensure to close them if required, since the service registry does not manage them
         // Ensure rootDirectory is absolute, as it may be relative when the Tooling API is invoked with a relative project directory
-        File rootDirectory = buildLayoutFactory.getLayoutFor(buildLayoutConfiguration).getRootDirectory().getAbsoluteFile();
+        File rootDirectory = buildLayoutFactory.locationFor(buildLayoutConfiguration).getBuildRootDirectory().getAbsoluteFile();
         FileResolver fileResolver = new BaseDirFileResolver(rootDirectory);
         CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
         DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -20,12 +20,12 @@ import org.gradle.api.Project;
 import org.gradle.initialization.BuildLayoutParametersBuildOptions;
 import org.gradle.initialization.ParallelismBuildOptions;
 import org.gradle.initialization.StartParameterBuildOptions;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildconfiguration.DaemonJvmPropertiesDefaults;
 import org.gradle.internal.buildoption.BuildOption;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 import org.gradle.launcher.configuration.AllProperties;
 import org.gradle.launcher.configuration.BuildLayoutResult;
@@ -89,13 +89,13 @@ public class LayoutToPropertiesConverter {
     }
 
     private void configureFromBuildDir(BuildLayoutResult layoutResult, Map<String, String> result) {
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(layoutResult.toLayoutConfiguration());
-        maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(layoutResult.toLayoutConfiguration());
+        maybeConfigureFrom(new File(buildLocation.getBuildRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }
 
     private void configureFromDaemonJVMProperties(BuildLayoutResult layoutResult, Map<String, String> result) {
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(layoutResult.toLayoutConfiguration());
-        configureFrom(new File(layout.getRootDirectory(), DaemonJvmPropertiesDefaults.DAEMON_JVM_PROPERTIES_FILE), result);
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(layoutResult.toLayoutConfiguration());
+        configureFrom(new File(buildLocation.getBuildRootDirectory(), DaemonJvmPropertiesDefaults.DAEMON_JVM_PROPERTIES_FILE), result);
     }
 
     private void configureFrom(File propertiesFile, Map<String, String> result) {

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -127,6 +127,18 @@ Update your `gradle.properties` and command-line invocations to the new names.
 
 See the <<isolated_projects.adoc#sec:enable, Enabling Isolated Projects>> section in the Gradle User Manual for the recommended setup.
 
+[[deprecate-internal-buildlayout]]
+==== Usage of internal `BuildLayout` and `SettingsLocation` services is now deprecated
+
+The internal services `org.gradle.initialization.layout.BuildLayout` and `org.gradle.initialization.SettingsLocation` are deprecated.
+Because these classes do not make it explicit that they are not part of the Gradle API, they can be mistaken for the public link:{javadocPath}/org/gradle/api/file/BuildLayout.html[`org.gradle.api.file.BuildLayout`] service.
+Injecting them is now deprecated, and their removal is scheduled for Gradle 10.
+
+If you need the settings directory in the context of a `Project` plugin,
+then use the public link:{javadocPath}/org/gradle/api/file/ProjectLayout.html[`ProjectLayout.settingsDirectory`] service.
+If you need it in the context of a `Settings` plugin,
+then use the public link:{javadocPath}/org/gradle/api/file/BuildLayout.html[`org.gradle.api.file.BuildLayout.settingsDirectory`] service (note the different package).
+
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier
 

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/settings.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.initialization.layout.BuildLayout
-
 rootProject.name = "services"
 
 // tag::build-layout[]

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -162,7 +162,7 @@ public class ProjectBuilderImpl {
         final ServiceRegistry globalServices = getGlobalServices();
 
         BuildRequestMetaData buildRequestMetaData = new DefaultBuildRequestMetaData(Time.currentTimeMillis());
-        File userActionRootDir = globalServices.get(BuildLayoutFactory.class).getLayoutFor(startParameter.toBuildLayoutConfiguration()).getRootDirectory();
+        File userActionRootDir = globalServices.get(BuildLayoutFactory.class).locationFor(startParameter.toBuildLayoutConfiguration()).getBuildRootDirectory();
         CrossBuildSessionState crossBuildSessionState = new CrossBuildSessionState(globalServices, startParameter, userActionRootDir);
         GradleUserHomeScopeServiceRegistry userHomeServices = userHomeServicesOf(globalServices);
         BuildSessionState buildSessionState = new BuildSessionState(userHomeServices, crossBuildSessionState, startParameter, buildRequestMetaData, ClassPath.EMPTY, new DefaultBuildCancellationToken(), buildRequestMetaData.getClient(), new NoOpBuildEventConsumer());

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionConfigurationUtil.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionConfigurationUtil.java
@@ -51,10 +51,10 @@ public class ConnectionConfigurationUtil {
     }
 
     public static File determineRootDir(ConnectionParameters connectionParameters) {
-        return new BuildLayoutFactory().getLayoutFor(
+        return new BuildLayoutFactory().locationFor(
             connectionParameters.getProjectDir(),
             connectionParameters.isSearchUpwards() != null ? connectionParameters.isSearchUpwards() : true
-        ).getRootDirectory();
+        ).getBuildRootDirectory();
     }
 
     public static File determineRealUserHomeDir(ConnectionParameters connectionParameters) {

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -16,10 +16,10 @@
 package org.gradle.tooling.internal.consumer;
 
 import org.gradle.initialization.BuildCancellationToken;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.time.Clock;
 import org.gradle.tooling.BuildCancelledException;
@@ -50,8 +50,8 @@ public class DistributionFactory {
      * Returns the default distribution to use for the specified project.
      */
     public Distribution getDefaultDistribution(File projectDir, boolean searchUpwards) {
-        BuildLayout layout = new BuildLayoutFactory().getLayoutFor(projectDir, searchUpwards);
-        WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory());
+        BuildLocation buildLocation = new BuildLayoutFactory().locationFor(projectDir, searchUpwards);
+        WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(buildLocation.getBuildRootDirectory());
         if (wrapper.getDistribution() != null) {
             return new ZippedDistribution(wrapper.getConfiguration(), clock);
         }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.initialization.BuildCancellationToken
-import org.gradle.initialization.layout.BuildLayout
 import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.Actions
 import org.gradle.internal.build.BuildAddedListener
@@ -41,6 +40,7 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeServices
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.exception.ExceptionAnalyser
+import org.gradle.internal.initialization.BuildLocation
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -105,15 +105,15 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def buildController = buildController()
         services.add(buildController)
         def rootDir = tmpDir.createDir("root")
-        def rootBuildLayout = Mock(BuildLayout) {
-            rootDirectory >> rootDir
+        def rootBuildLocation = Mock(BuildLocation) {
+            buildRootDirectory >> rootDir
         }
 
         when:
         def rootBuild = registry.createRootBuild(buildDefinition)
 
         then:
-        1 * buildLayoutFactory.getLayoutFor(_) >> rootBuildLayout
+        1 * buildLayoutFactory.locationFor(_) >> rootBuildLocation
         1 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
             notifiedBuild = addedBuild
         }
@@ -349,15 +349,15 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     private BuildLifecycleController buildController(SettingsInternal settings, GradleInternal gradle) {
         def buildController = Stub(BuildLifecycleController)
         def services = Stub(ServiceRegistry)
-        def buildLayout = Stub(BuildLayout)
+        def buildLocation = Stub(BuildLocation)
 
         _ * buildController.gradle >> gradle
         if (settings != null) {
             _ * gradle.settings >> settings
         }
         _ * gradle.services >> services
-        _ * services.get(BuildLayout) >> buildLayout
-        _ * buildLayout.rootDirectory >> tmpDir.file("root-dir")
+        _ * services.get(BuildLocation) >> buildLocation
+        _ * buildLocation.buildRootDirectory >> tmpDir.file("root-dir")
         _ * services.get(PublicBuildPath) >> Stub(PublicBuildPath)
 
         return buildController

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
@@ -93,6 +93,30 @@ class BuildLayoutIntegrationTest extends AbstractIntegrationSpec {
         outputContains("settings source file: " + buildB.settingsFile.absolutePath + ".")
     }
 
+    def "injecting internal #serviceName is deprecated"() {
+        buildFile """
+            abstract class SomePlugin implements Plugin<Project> {
+                @Inject
+                abstract ${serviceClass.name} getService()
+
+                void apply(Project p) {
+                    getService()
+                }
+            }
+
+            apply plugin: SomePlugin
+        """
+
+        executer.expectDocumentedDeprecationWarning("Injecting 'org.gradle.initialization.layout.BuildLayout' or 'org.gradle.initialization.SettingsLocation' service has been deprecated. This is scheduled to be removed in Gradle 10. These classes are not part of the public API. Instead 'org.gradle.api.file.BuildLayout.settingsDirectory' in settings plugins or 'ProjectLayout.settingsDirectory' in project plugins. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-internal-buildlayout")
+
+        expect:
+        run "help"
+
+        where:
+        serviceClass << [org.gradle.initialization.layout.BuildLayout, org.gradle.initialization.SettingsLocation]
+        serviceName = serviceClass.simpleName
+    }
+
     def "locations are as expected in buildSrc settings"() {
         settingsFile """
         // just a marker file

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/BuildScopeCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/BuildScopeCacheDir.java
@@ -19,9 +19,9 @@ package org.gradle.cache.internal;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleUserHomeDirProvider;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.initialization.BuildLocation;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,18 +33,18 @@ public class BuildScopeCacheDir {
 
     public BuildScopeCacheDir(
         GradleUserHomeDirProvider userHomeDirProvider,
-        BuildLayout buildLayout,
+        BuildLocation buildLocation,
         StartParameter startParameter
     ) {
         if (startParameter.getProjectCacheDir() != null) {
             // Use explicitly requested build scoped cache dir
             cacheDir = startParameter.getProjectCacheDir();
-        } else if (!buildLayout.getRootDirectory().getName().equals(SettingsInternal.BUILD_SRC) && buildLayout.isBuildDefinitionMissing()) {
+        } else if (!buildLocation.getBuildRootDirectory().getName().equals(SettingsInternal.BUILD_SRC) && buildLocation.isBuildDefinitionMissing()) {
             // No build definition, use a cache dir in the user home directory to avoid generating garbage in the root directory
-            cacheDir = new File(userHomeDirProvider.getGradleUserHomeDirectory(), UNDEFINED_BUILD + Hashing.hashString(buildLayout.getRootDirectory().getAbsolutePath()));
+            cacheDir = new File(userHomeDirProvider.getGradleUserHomeDirectory(), UNDEFINED_BUILD + Hashing.hashString(buildLocation.getBuildRootDirectory().getAbsolutePath()));
         } else {
             // Use the .gradle directory in the build root directory
-            cacheDir = new File(buildLayout.getRootDirectory(), ".gradle");
+            cacheDir = new File(buildLocation.getBuildRootDirectory(), ".gradle");
         }
         if (cacheDir.exists() && !cacheDir.isDirectory()) {
             throw UncheckedException.throwAsUncheckedException(new IOException(String.format("Cache directory '%s' exists and is not a directory.", cacheDir)), true);

--- a/subprojects/core/src/main/java/org/gradle/features/internal/initialization/SharedModelDefaultsSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/features/internal/initialization/SharedModelDefaultsSettingsProcessor.java
@@ -21,9 +21,9 @@ import org.gradle.api.initialization.internal.SharedModelDefaultsInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
-import org.gradle.initialization.SettingsLocation;
 import org.gradle.initialization.SettingsProcessor;
 import org.gradle.initialization.SettingsState;
+import org.gradle.internal.initialization.BuildLocation;
 
 public class SharedModelDefaultsSettingsProcessor implements SettingsProcessor {
     private final SettingsProcessor delegate;
@@ -33,8 +33,8 @@ public class SharedModelDefaultsSettingsProcessor implements SettingsProcessor {
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
-        SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
+    public SettingsState process(GradleInternal gradle, BuildLocation buildLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
+        SettingsState state = delegate.process(gradle, buildLocation, buildRootClassLoaderScope, startParameter);
         SettingsInternal settings = state.getSettings();
         ((SharedModelDefaultsInternal)settings.getDefaults()).processRegistrations();
         return state;

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
@@ -19,6 +19,7 @@ package org.gradle.initialization;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
@@ -42,11 +43,11 @@ public class BuildOperationSettingsProcessor implements SettingsProcessor {
     }
 
     @Override
-    public SettingsState process(final GradleInternal gradle, final SettingsLocation settingsLocation, final ClassLoaderScope buildRootClassLoaderScope, final StartParameterInternal startParameter) {
+    public SettingsState process(final GradleInternal gradle, final BuildLocation buildLocation, final ClassLoaderScope buildRootClassLoaderScope, final StartParameterInternal startParameter) {
         return buildOperationRunner.call(new CallableBuildOperation<SettingsState>() {
             @Override
             public SettingsState call(BuildOperationContext context) {
-                SettingsState state = settingsProcessor.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
+                SettingsState state = settingsProcessor.process(gradle, buildLocation, buildRootClassLoaderScope, startParameter);
                 context.setResult(RESULT);
                 return state;
             }
@@ -64,12 +65,12 @@ public class BuildOperationSettingsProcessor implements SettingsProcessor {
 
                         @Override
                         public String getSettingsDir() {
-                            return settingsLocation.getSettingsDir().getAbsolutePath();
+                            return buildLocation.getBuildRootDirectory().getAbsolutePath();
                         }
 
                         @Override
                         public String getSettingsFile() {
-                            File settingsFile = settingsLocation.getSettingsFile();
+                            File settingsFile = buildLocation.getSettingsFile();
                             return settingsFile != null ? settingsFile.getPath() : null;
                         }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -34,7 +34,6 @@ import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.buildsrc.BuildSrcDetector;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.build.BuildIncluder;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -42,6 +41,7 @@ import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.deprecation.Documentation;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.initialization.BuildLogicFiles;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -184,9 +184,9 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
     }
 
     private void loadGradlePropertiesForBuild(GradleInternal gradle) {
-        SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(gradle.getStartParameter().toBuildLayoutConfiguration());
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(gradle.getStartParameter().toBuildLayoutConfiguration());
         BuildIdentifier buildId = gradle.getOwner().getBuildIdentifier();
-        gradlePropertiesController.loadGradleProperties(buildId, settingsLocation.getSettingsDir(), true);
+        gradlePropertiesController.loadGradleProperties(buildId, buildLocation.getBuildRootDirectory(), true);
     }
 
     @SuppressWarnings("MixedMutabilityReturnType")
@@ -205,10 +205,10 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
 
     private SettingsState findAndLoadSettings(GradleInternal gradle) {
         StartParameterInternal startParameter = gradle.getStartParameter();
-        BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(startParameter.toBuildLayoutConfiguration());
-        if (buildLayout.getSettingsFileResolution() != null) {
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(startParameter.toBuildLayoutConfiguration());
+        if (buildLocation.getSettingsFileResolution() != null) {
             ScriptResolutionResultReporter reporter = new ScriptResolutionResultReporter(problems.getReporter());
-            reporter.reportResolutionProblemsOf(buildLayout.getSettingsFileResolution());
+            reporter.reportResolutionProblemsOf(buildLocation.getSettingsFileResolution());
         }
 
         SettingsState state;
@@ -219,7 +219,7 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
             spec = ProjectSpecs.forStartParameter(startParameter, state.getSettings());
         } else {
             logger.debug("Loading build definition for build: '{}'", gradle.getIdentityPath());
-            state = findSettingsAndLoadIfAppropriate(gradle, startParameter, buildLayout, gradle.getClassLoaderScope());
+            state = findSettingsAndLoadIfAppropriate(gradle, startParameter, buildLocation, gradle.getClassLoaderScope());
             SettingsInternal settings = state.getSettings();
             spec = ProjectSpecs.forStartParameter(startParameter, settings);
             if (useEmptySettings(spec, settings, startParameter)) {
@@ -278,8 +278,8 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
         StartParameterInternal noSearchParameter = startParameter.newInstance();
         noSearchParameter.useEmptySettings();
         noSearchParameter.doNotSearchUpwards();
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(noSearchParameter.toBuildLayoutConfiguration());
-        return findSettingsAndLoadIfAppropriate(gradle, noSearchParameter, layout, classLoaderScope);
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(noSearchParameter.toBuildLayoutConfiguration());
+        return findSettingsAndLoadIfAppropriate(gradle, noSearchParameter, buildLocation, classLoaderScope);
     }
 
     /**
@@ -290,15 +290,15 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
     private SettingsState findSettingsAndLoadIfAppropriate(
         GradleInternal gradle,
         StartParameterInternal startParameter,
-        BuildLayout buildLayout,
+        BuildLocation buildLocation,
         ClassLoaderScope classLoaderScope
     ) {
-        ScriptResolutionResult resolutionResult = buildLayout.getSettingsFileResolution();
+        ScriptResolutionResult resolutionResult = buildLocation.getSettingsFileResolution();
         if (resolutionResult != null) {
             new ScriptResolutionResultReporter(problems.getReporter()).reportResolutionProblemsOf(resolutionResult);
         }
 
-        SettingsState state = settingsProcessor.process(gradle, buildLayout, classLoaderScope, startParameter);
+        SettingsState state = settingsProcessor.process(gradle, buildLocation, classLoaderScope, startParameter);
         validate(state.getSettings());
         return state;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
 import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.ServiceRegistry;
 
 public class RootBuildCacheControllerSettingsProcessor implements SettingsProcessor {
@@ -43,8 +44,8 @@ public class RootBuildCacheControllerSettingsProcessor implements SettingsProces
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
-        SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
+    public SettingsState process(GradleInternal gradle, BuildLocation buildLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
+        SettingsState state = delegate.process(gradle, buildLocation, buildRootClassLoaderScope, startParameter);
         process(gradle);
         return state;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -25,6 +25,7 @@ import org.gradle.configuration.ScriptPlugin;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.groovy.scripts.TextResourceScriptSource;
 import org.gradle.internal.composite.BuildIncludeListener;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.resource.TextFileResourceLoader;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
@@ -58,13 +59,13 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
     @Override
     public SettingsState process(
         GradleInternal gradle,
-        SettingsLocation settingsLocation,
+        BuildLocation buildLocation,
         ClassLoaderScope baseClassLoaderScope,
         StartParameterInternal startParameter
     ) {
         Timer settingsProcessingClock = Time.startTimer();
-        TextResourceScriptSource settingsScript = new TextResourceScriptSource(textFileResourceLoader.loadFile("settings file", settingsLocation.getSettingsFile()));
-        SettingsState state = settingsFactory.createSettings(gradle, settingsLocation.getSettingsDir(), settingsScript, gradleProperties, startParameter, baseClassLoaderScope);
+        TextResourceScriptSource settingsScript = new TextResourceScriptSource(textFileResourceLoader.loadFile("settings file", buildLocation.getSettingsFile()));
+        SettingsState state = settingsFactory.createSettings(gradle, buildLocation.getBuildRootDirectory(), settingsScript, gradleProperties, startParameter, baseClassLoaderScope);
 
         SettingsInternal settings = state.getSettings();
         gradle.getBuildListenerBroadcaster().beforeSettings(settings);

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.initialization.BuildLocation;
 
 public class SettingsEvaluatedCallbackFiringSettingsProcessor implements SettingsProcessor {
 
@@ -30,8 +31,8 @@ public class SettingsEvaluatedCallbackFiringSettingsProcessor implements Setting
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
-        SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
+    public SettingsState process(GradleInternal gradle, BuildLocation buildLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
+        SettingsState state = delegate.process(gradle, buildLocation, buildRootClassLoaderScope, startParameter);
         SettingsInternal settings = state.getSettings();
         gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
         settings.preventFromFurtherMutation();

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsProcessor.java
@@ -19,6 +19,7 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -32,7 +33,7 @@ public interface SettingsProcessor {
      */
     SettingsState process(
         GradleInternal gradle,
-        SettingsLocation settingsLocation,
+        BuildLocation buildLocation,
         ClassLoaderScope buildRootClassLoaderScope,
         StartParameterInternal startParameter
     );

--- a/subprojects/core/src/main/java/org/gradle/initialization/internal/settings/StartParameterMutationReportingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/internal/settings/StartParameterMutationReportingSettingsProcessor.java
@@ -20,10 +20,10 @@ import kotlin.Unit;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
-import org.gradle.initialization.SettingsLocation;
 import org.gradle.initialization.SettingsProcessor;
 import org.gradle.initialization.SettingsState;
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
+import org.gradle.internal.initialization.BuildLocation;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -43,11 +43,11 @@ public class StartParameterMutationReportingSettingsProcessor implements Setting
     }
 
     @Override
-    public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
+    public SettingsState process(GradleInternal gradle, BuildLocation buildLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
         // Evaluate settings first, then register the listener: mutating the start parameter up to and
         // during settings evaluation (init scripts, the settings script, settingsEvaluated callbacks) is
         // allowed; only mutations after this point are violations.
-        SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
+        SettingsState state = delegate.process(gradle, buildLocation, buildRootClassLoaderScope, startParameter);
         startParameter.setMutationListener(methodSignature ->
             problems.report(factory ->
                 factory.problem(null, messageBuilder -> {

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ResolvedBuildLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ResolvedBuildLayout.java
@@ -18,6 +18,7 @@ package org.gradle.initialization.layout;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.cache.scopes.BuildScopedCacheBuilderFactory;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -29,12 +30,12 @@ import java.io.File;
 @ServiceScope(Scope.Build.class)
 public class ResolvedBuildLayout {
     private final GradleInternal gradle;
-    private final BuildLayout buildLayout;
+    private final BuildLocation buildLocation;
     private final BuildScopedCacheBuilderFactory cacheBuilderFactory;
 
-    public ResolvedBuildLayout(GradleInternal gradle, BuildLayout buildLayout, BuildScopedCacheBuilderFactory cacheBuilderFactory) {
+    public ResolvedBuildLayout(GradleInternal gradle, BuildLocation buildLocation, BuildScopedCacheBuilderFactory cacheBuilderFactory) {
         this.gradle = gradle;
-        this.buildLayout = buildLayout;
+        this.buildLocation = buildLocation;
         this.cacheBuilderFactory = cacheBuilderFactory;
     }
 
@@ -61,7 +62,7 @@ public class ResolvedBuildLayout {
      * in that settings script.</p>
      */
     public boolean isBuildDefinitionMissing() {
-        boolean isNoBuildDefinitionFound = buildLayout.isBuildDefinitionMissing();
+        boolean isNoBuildDefinitionFound = buildLocation.isBuildDefinitionMissing();
         boolean isCurrentDirNotPartOfContainingBuild = gradle.getSettings().getSettingsScript().getResource().getLocation().getFile() == null;
         return isNoBuildDefinitionFound || isCurrentDirNotPartOfContainingBuild;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -21,10 +21,10 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
 import org.gradle.initialization.IncludedBuildSpec;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.buildtree.BuildTreeServices;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
@@ -148,7 +148,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
 
     @Override
     public File getBuildRootDir() {
-        return getBuildServices().get(BuildLayout.class).getRootDirectory();
+        return getBuildServices().get(BuildLocation.class).getBuildRootDirectory();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLayoutValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLayoutValidator.java
@@ -21,9 +21,9 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.BuildClientMetaData;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.exceptions.FailureResolutionAware;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -53,8 +53,8 @@ public class BuildLayoutValidator {
     }
 
     public void validate(StartParameterInternal startParameter) {
-        BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(startParameter.toBuildLayoutConfiguration());
-        if (!buildLayout.isBuildDefinitionMissing()) {
+        BuildLocation buildLocation = buildLayoutFactory.locationFor(startParameter.toBuildLayoutConfiguration());
+        if (!buildLocation.isBuildDefinitionMissing()) {
             // All good
             return;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.flow.FlowScope;
 import org.gradle.api.initialization.SharedModelDefaults;
 import org.gradle.api.internal.BuildDefinition;
@@ -181,7 +182,6 @@ import org.gradle.initialization.TaskExecutionPreparer;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.buildsrc.BuildSrcBuildListenerFactory;
 import org.gradle.initialization.buildsrc.BuildSrcProjectConfigurationAction;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ResolvedBuildLayout;
 import org.gradle.internal.actor.ActorFactory;
@@ -212,6 +212,7 @@ import org.gradle.internal.composite.BuildIncludeListener;
 import org.gradle.internal.composite.DefaultBuildIncluder;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.execution.BuildOutputCleanupRegistry;
@@ -222,6 +223,7 @@ import org.gradle.internal.execution.WorkExecutionTracker;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.managed.ManagedObjectRegistry;
 import org.gradle.internal.instrumentation.reporting.PropertyUpgradeReportConfig;
@@ -265,6 +267,8 @@ import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 import org.gradle.tooling.provider.model.internal.ToolingModelProjectDependencyListener;
 
 import java.util.List;
+
+import static java.lang.String.format;
 
 /**
  * Contains the services for a single build invocation inside a build tree.
@@ -357,17 +361,30 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     @Provides
     protected BuildScopedCacheBuilderFactory createBuildScopedCacheBuilderFactory(
         GradleUserHomeDirProvider userHomeDirProvider,
-        BuildLayout buildLayout,
+        BuildLocation buildLocation,
         StartParameter startParameter,
         UnscopedCacheBuilderFactory unscopedCacheBuilderFactory
     ) {
-        BuildScopeCacheDir cacheDir = new BuildScopeCacheDir(userHomeDirProvider, buildLayout, startParameter);
+        BuildScopeCacheDir cacheDir = new BuildScopeCacheDir(userHomeDirProvider, buildLocation, startParameter);
         return new DefaultBuildScopedCacheBuilderFactory(cacheDir.getDir(), unscopedCacheBuilderFactory);
     }
 
     @Provides
-    protected BuildLayout createBuildLocations(BuildLayoutFactory buildLayoutFactory, BuildDefinition buildDefinition) {
-        return buildLayoutFactory.getLayoutFor(buildDefinition.getStartParameter().toBuildLayoutConfiguration());
+    protected BuildLocation createBuildLocation(BuildLayoutFactory buildLayoutFactory, BuildDefinition buildDefinition) {
+        return buildLayoutFactory.locationFor(buildDefinition.getStartParameter().toBuildLayoutConfiguration());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Provides
+    protected org.gradle.initialization.layout.BuildLayout createBuildLayout(BuildLocation buildLocation) {
+        // TODO: Remove the deprecated services in Gradle 10, see https://github.com/gradle/gradle/issues/31969
+        DeprecationLogger.deprecateAction(format("Injecting '%s' or '%s' service", org.gradle.initialization.layout.BuildLayout.class.getName(), org.gradle.initialization.SettingsLocation.class.getName()))
+            .withContext("These classes are not part of the public API.")
+            .withAdvice(format("Instead '%s.settingsDirectory' in settings plugins or '%s.settingsDirectory' in project plugins.", org.gradle.api.file.BuildLayout.class.getName(), ProjectLayout.class.getSimpleName()))
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecate-internal-buildlayout")
+            .nagUser();
+        return new org.gradle.initialization.layout.BuildLayout(buildLocation);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
@@ -38,7 +38,6 @@ import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.deployment.internal.PendingChangesManager;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.initialization.GradleUserHomeDirProvider;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.build.BuildLayoutValidator;
@@ -47,6 +46,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.initialization.layout.BuildTreeLocations;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.InMemoryCacheFactory;
@@ -97,8 +97,8 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
 
     @Provides
     BuildTreeLocations createBuildTreeLocations(BuildLayoutFactory buildLayoutFactory, StartParameter startParameter) {
-        BuildLayout rootBuildLayout = buildLayoutFactory.getLayoutFor(((StartParameterInternal) startParameter).toBuildLayoutConfiguration());
-        return new BuildTreeLocations(rootBuildLayout);
+        BuildLocation rootBuildLocation = buildLayoutFactory.locationFor(((StartParameterInternal) startParameter).toBuildLayoutConfiguration());
+        return new BuildTreeLocations(rootBuildLocation);
     }
 
     @Provides
@@ -114,7 +114,7 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
         BuildOperationRunner buildOperationRunner,
         StartParameter startParameter
     ) {
-        BuildScopeCacheDir cacheDir = new BuildScopeCacheDir(userHomeDirProvider, buildTreeLocations.getRootBuildLayout(), startParameter);
+        BuildScopeCacheDir cacheDir = new BuildScopeCacheDir(userHomeDirProvider, buildTreeLocations.getRootBuildLocation(), startParameter);
         return new ProjectCacheDir(cacheDir.getDir(), buildOperationRunner, deleter);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -73,10 +73,10 @@ import org.gradle.api.tasks.util.internal.PatternSetFactory;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.initialization.BuildLocation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
@@ -363,10 +363,10 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides({ProjectLayout.class, TaskFileVarFactory.class})
     DefaultProjectLayout createProjectLayout(
-        BuildLayout buildLayout, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory,
+        BuildLocation buildLocation, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory,
         FilePropertyFactory filePropertyFactory, PatternSetFactory patternSetFactory, PropertyHost propertyHost, FileFactory fileFactory
     ) {
-        File settingsDir = buildLayout.getSettingsDir();
+        File settingsDir = buildLocation.getBuildRootDirectory();
         File projectDir = project.getProjectDir();
         return new DefaultProjectLayout(settingsDir, projectDir, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost, fileCollectionFactory, filePropertyFactory, fileFactory);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.internal.initialization.BuildLocation
 import org.gradle.internal.operations.BuildOperationMetadata
 import org.gradle.internal.operations.TestBuildOperationRunner
 import spock.lang.Specification
@@ -29,7 +30,7 @@ class BuildOperationSettingsProcessorTest extends Specification {
     def buildOperationRunner = new TestBuildOperationRunner()
     def settingsProcessor = Mock(SettingsProcessor)
     def gradleInternal = Mock(GradleInternal)
-    def settingsLocation = Mock(SettingsLocation)
+    def buildLocation = Mock(BuildLocation)
     def buildOperationScriptPlugin = new BuildOperationSettingsProcessor(settingsProcessor, buildOperationRunner)
     def classLoaderScope = Mock(ClassLoaderScope)
     def startParameter = Mock(StartParameterInternal)
@@ -42,10 +43,10 @@ class BuildOperationSettingsProcessorTest extends Specification {
         settings()
 
         when:
-        buildOperationScriptPlugin.process(gradleInternal, settingsLocation, classLoaderScope, startParameter)
+        buildOperationScriptPlugin.process(gradleInternal, buildLocation, classLoaderScope, startParameter)
 
         then:
-        1 * settingsProcessor.process(gradleInternal, settingsLocation, classLoaderScope, startParameter) >> state
+        1 * settingsProcessor.process(gradleInternal, buildLocation, classLoaderScope, startParameter) >> state
     }
 
     def "exposes build operation with settings configuration result"() {
@@ -54,10 +55,10 @@ class BuildOperationSettingsProcessorTest extends Specification {
         def contextualizedName = "Contextualized display name"
 
         when:
-        buildOperationScriptPlugin.process(gradleInternal, settingsLocation, classLoaderScope, startParameter)
+        buildOperationScriptPlugin.process(gradleInternal, buildLocation, classLoaderScope, startParameter)
 
         then:
-        1 * settingsProcessor.process(gradleInternal, settingsLocation, classLoaderScope, startParameter) >> state
+        1 * settingsProcessor.process(gradleInternal, buildLocation, classLoaderScope, startParameter) >> state
         1 * gradleInternal.contextualize("Evaluate settings") >> contextualizedName
 
         and:
@@ -73,7 +74,7 @@ class BuildOperationSettingsProcessorTest extends Specification {
     private void settings() {
         _ * state.settings >> settingsInternal
         _ * settingsInternal.gradle >> gradleInternal
-        _ * settingsLocation.settingsDir >> rootDir
-        _ * settingsLocation.settingsFile >> new File("settings.gradle")
+        _ * buildLocation.buildRootDirectory >> rootDir
+        _ * buildLocation.settingsFile >> new File("settings.gradle")
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsPreparerTest.groovy
@@ -26,11 +26,11 @@ import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.api.plugins.internal.HelpBuiltInCommand
 import org.gradle.buildinit.plugins.internal.action.InitBuiltInCommand
 import org.gradle.groovy.scripts.ScriptSource
-import org.gradle.initialization.layout.BuildLayout
 import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.build.BuildIncluder
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.initialization.BuildLocation
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.scripts.ScriptFileResolver
@@ -47,7 +47,7 @@ class DefaultSettingsPreparerTest extends Specification {
 
     private projectRootDir = tmpDir.testDirectory
 
-    private mockBuildLayout = new BuildLayout(projectRootDir, null, Stub(ScriptFileResolver))
+    private mockBuildLocation = new BuildLocation(projectRootDir, null, Stub(ScriptFileResolver))
     private classLoaderScope = Stub(ClassLoaderScope)
     private startParameterInternal = new StartParameterInternal()
     private gradle = Stub(GradleInternal) {
@@ -61,8 +61,8 @@ class DefaultSettingsPreparerTest extends Specification {
     private projectDescriptorRegistry = Stub(ProjectDescriptorRegistry) {
         getAllProjects() >> Collections.singleton(Stub(ProjectDescriptorInternal) {
             getPath() >> ":"
-            getProjectDir() >> mockBuildLayout.settingsDir
-            getBuildFile() >> new File(mockBuildLayout.settingsDir, "build.gradle")
+            getProjectDir() >> mockBuildLocation.buildRootDirectory
+            getBuildFile() >> new File(mockBuildLocation.buildRootDirectory, "build.gradle")
         })
     }
 
@@ -72,7 +72,7 @@ class DefaultSettingsPreparerTest extends Specification {
     private settingsProcessor = Stub(SettingsProcessor) {
         // When we process, we're interested in retaining the start parameter in
         // the resulting state, so we can test it, so create a new mock and configure it
-        process(gradle, mockBuildLayout, classLoaderScope, _) >> { g, settingsLocation, cls, startParameter ->
+        process(gradle, mockBuildLocation, classLoaderScope, _) >> { g, buildLocation, cls, startParameter ->
             def resultSettings = Stub(SettingsInternal) {
                 getProjectRegistry() >> projectDescriptorRegistry
                 getSettingsScript() >> Stub(ScriptSource) { getDisplayName() >> "foo" }
@@ -96,7 +96,7 @@ class DefaultSettingsPreparerTest extends Specification {
         settingsProcessor,
         Stub(BuildStateRegistry),
         Stub(ProjectStateRegistry),
-        Stub(BuildLayoutFactory) { getLayoutFor(_) >> mockBuildLayout },
+        Stub(BuildLayoutFactory) { locationFor(_) >> mockBuildLocation },
         Stub(GradlePropertiesController),
         Stub(BuildIncluder),
         Stub(InitScriptHandler),
@@ -123,7 +123,7 @@ class DefaultSettingsPreparerTest extends Specification {
 
     def "preparing settings for the init task uses new empty settings"() {
         given:
-        startParameterInternal.setCurrentDir(mockBuildLayout.settingsDir)
+        startParameterInternal.setCurrentDir(mockBuildLocation.buildRootDirectory)
         startParameterInternal.setTaskNames(["init"])
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -39,11 +39,10 @@ class BuildLayoutFactoryTest extends Specification {
         def settingsFile = currentDir.createFile(settingsFilename)
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == settingsFile
-        !layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, true)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == settingsFile
+        !location.buildDefinitionMissing
 
         where:
         settingsFilename << TEST_CASES
@@ -60,11 +59,10 @@ class BuildLayoutFactoryTest extends Specification {
         currentDir.mkdirs()
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == new File(currentDir, "settings.gradle") // this is the current behaviour
-        layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, true)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == new File(currentDir, "settings.gradle") // this is the current behaviour
+        location.buildDefinitionMissing
 
         cleanup: "temporary tree"
         tmpDir.deleteDir()
@@ -81,11 +79,10 @@ class BuildLayoutFactoryTest extends Specification {
         tmpDir.createFile(settingsFilename)
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == subDir
-        layout.settingsDir == subDir
-        layout.settingsFile == settingsFile
-        !layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, true)
+        location.buildRootDirectory == subDir
+        location.settingsFile == settingsFile
+        !location.buildDefinitionMissing
 
         where:
         settingsFilename << TEST_CASES
@@ -102,11 +99,10 @@ class BuildLayoutFactoryTest extends Specification {
         tmpDir.createFile(settingsFilename)
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == settingsFile
-        !layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, true)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == settingsFile
+        !location.buildDefinitionMissing
 
         where:
         settingsFilename << TEST_CASES
@@ -122,11 +118,10 @@ class BuildLayoutFactoryTest extends Specification {
         tmpDir.createFile(settingsFilename)
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, false)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == new File(currentDir, "settings.gradle") // this is the current behaviour
-        layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, false)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == new File(currentDir, "settings.gradle") // this is the current behaviour
+        location.buildDefinitionMissing
 
         where:
         settingsFilename << TEST_CASES
@@ -143,11 +138,10 @@ class BuildLayoutFactoryTest extends Specification {
         def currentDir = tmpDir.newFolder("sub", "current")
 
         expect:
-        def layout = locator.getLayoutFor(currentDir, true)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == FileUtils.canonicalize(new File(currentDir, "settings.gradle"))
-        layout.buildDefinitionMissing
+        def location = locator.locationFor(currentDir, true)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == FileUtils.canonicalize(new File(currentDir, "settings.gradle"))
+        location.buildDefinitionMissing
 
         cleanup:
         tmpDir.delete()
@@ -165,11 +159,10 @@ class BuildLayoutFactoryTest extends Specification {
         def config = startParameter.toBuildLayoutConfiguration()
 
         expect:
-        def layout = locator.getLayoutFor(config)
-        layout.rootDirectory == currentDir
-        layout.settingsDir == currentDir
-        layout.settingsFile == new File(currentDir, settingsFilename) // this is the current behaviour
-        !layout.buildDefinitionMissing
+        def location = locator.locationFor(config)
+        location.buildRootDirectory == currentDir
+        location.settingsFile == new File(currentDir, settingsFilename) // this is the current behaviour
+        !location.buildDefinitionMissing
 
         where:
         settingsFilename << TEST_CASES

--- a/testing/architecture-test/src/changes/archunit-store/classes-in-generic-packages.txt
+++ b/testing/architecture-test/src/changes/archunit-store/classes-in-generic-packages.txt
@@ -260,4 +260,5 @@ Class <org.gradle.internal.Transformers> is in a generic package in (Transformer
 Class <org.gradle.internal.TriAction> is in a generic package in (TriAction.java:0)
 Class <org.gradle.internal.Try> is in a generic package in (Try.java:0)
 Class <org.gradle.internal.UncheckedException> is in a generic package in (UncheckedException.java:0)
+Class <org.gradle.internal.initialization.BuildLocation> is in a generic package in (BuildLocation.java:0)
 Class <org.gradle.internal.initialization.BuildLogicFiles> is in a generic package in (BuildLogicFiles.java:0)


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/31969

The internal services `org.gradle.initialization.layout.BuildLayout` and `org.gradle.initialization.SettingsLocation` are easily mistaken for the public `org.gradle.api.file.BuildLayout`: there is no hard public/internal API boundary, so they surface in IDE auto-completion and plugins have injected them by mistake.

This PR **deprecates injecting** either service. The deprecation is documented (upgrade guide section `deprecate-internal-buildlayout`) and removal is scheduled for Gradle 10.

### Approach

Rather than reproduce the larger rename/extract refactor from the original (now-outdated) #34421, this change targets only the deprecation effect:

- A new non-deprecated internal service `BuildLocation` (in `org.gradle.internal.initialization`) is introduced as a companion to `BuildTreeLocations`. It carries the build root directory, the settings file resolution, and `isBuildDefinitionMissing()`.
- `BuildLayoutFactory` gains `locationFor(...)` returning `BuildLocation`; the old `getLayoutFor(...)` is deprecated.
- All **internal** call sites are migrated to `BuildLocation`, so Gradle's own code no longer depends on the deprecated types.
- `BuildScopeServices` now provides `BuildLocation` cleanly, and provides the deprecated `BuildLayout` via a dedicated factory that emits the deprecation warning. The warning therefore fires only when **user code** injects `BuildLayout`/`SettingsLocation`.
- `BuildLayout`/`SettingsLocation` remain functional, now delegating to `BuildLocation`, and are marked `@Deprecated`.

### Tests

- `BuildLayoutIntegrationTest` gains a parameterized feature asserting the documented deprecation warning fires when either `BuildLayout` or `SettingsLocation` is injected (the latter resolves to the same provider via assignability, confirming a single nag provider suffices).
- Existing unit tests migrated to the new types.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things