### PR TITLE
Fix issue with configureEach realizing pending elements

### DIFF
--- a/platforms/core-configuration/domain-object-collections/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/platforms/core-configuration/domain-object-collections/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -203,7 +203,11 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         while (iterator.hasNext()) {
             // only create an intermediate collection if there's something to copy
             if (copied == null) {
-                copied = new ArrayList<>(estimatedSize());
+                // Don't size the copy with estimatedSize(): it realizes pending elements (size() on a
+                // collection provider resolves its value), which would make configureEach eager. This copy
+                // only ever holds the realized elements yielded by iteratorNoFlush(), so a default-capacity
+                // list is correct and keeps configureEach lazy, as documented.
+                copied = new ArrayList<>();
             }
             copied.add(iterator.next());
         }

--- a/platforms/core-configuration/domain-object-collections/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/platforms/core-configuration/domain-object-collections/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal
 
 import groovy.test.NotYetImplemented
 import org.gradle.util.TestUtil
+import spock.lang.Issue
 
 class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<CharSequence> {
     DefaultDomainObjectSet<CharSequence> set = new DefaultDomainObjectSet<CharSequence>(CharSequence, callbackActionDecorator)
@@ -87,6 +88,23 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
 
         then:
         result == [value]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36951")
+    def "configureEach does not realize pending elements added via addAllLater when an eager element is present"() {
+        given:
+        def pending = TestUtil.objectFactory().listProperty(CharSequence)
+        pending.value(TestUtil.providerFactory().provider { throw new RuntimeException("pending provider realized too early") })
+        set.addAllLater(pending)
+        // configureEach is documented as lazy: registering it must not realize pending providers.
+        set.configureEach { } // first call stays lazy because no eager element exists yet
+        set.add(a) // mix in an eager element
+
+        when:
+        set.configureEach { } // second call must remain lazy and not realize the pending provider
+
+        then:
+        noExceptionThrown()
     }
 
     interface Subtype extends CharSequence {}

--- a/platforms/core-configuration/domain-object-collections/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/platforms/core-configuration/domain-object-collections/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -96,12 +96,13 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
         def pending = TestUtil.objectFactory().listProperty(CharSequence)
         pending.value(TestUtil.providerFactory().provider { throw new RuntimeException("pending provider realized too early") })
         set.addAllLater(pending)
-        // configureEach is documented as lazy: registering it must not realize pending providers.
-        set.configureEach { } // first call stays lazy because no eager element exists yet
+        // configureEach is documented as lazy: registering it must never realize pending providers,
+        // whether registered before or after an eager element is present.
+        set.configureEach { } // registered with no eager element present
         set.add(a) // mix in an eager element
 
         when:
-        set.configureEach { } // second call must remain lazy and not realize the pending provider
+        set.configureEach { } // registered with an eager element present; must still stay lazy
 
         then:
         noExceptionThrown()

--- a/platforms/core-configuration/domain-object-collections/src/testFixtures/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/platforms/core-configuration/domain-object-collections/src/testFixtures/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -871,7 +871,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.configureEach(action)
 
         then:
-        _ * providerOfIterable.size() >> 2
+        // configureEach must not query the provider's size: doing so realizes pending elements (see gradle/gradle#36951)
+        0 * providerOfIterable.size()
         1 * action.execute(a)
         1 * action.execute(b)
         1 * action.execute(c)


### PR DESCRIPTION
Fixes #36951

### Context

`DomainObjectCollection.configureEach` is [documented as lazy](https://docs.gradle.org/current/javadoc/org/gradle/api/DomainObjectCollection.html#configureEach(org.gradle.api.Action)) and registering a `configureEach` action should not realize elements that were added lazily via `addAllLater`. However, once a collection also contained at least one *eager* element, calling `configureEach` realized every pending `addAllLater` collection provider.

Root cause: DefaultDomainObjectCollection.configureEach iterates with the no-flush iterator (correctly yielding only realized elements), but presized its temporary copy list with estimatedSize(). estimatedSize() sums size() over all inserted elements, and size() on a pending collection provider resolves the provider value, realizing it. The asymmetry in the reproducer is that the presize is only reached once the no-flush iterator is non-empty, i.e. once at least one eager element exists.

Fix: the copy only ever holds the realized elements yielded by iteratorNoFlush(), so it is sized with a default-capacity ArrayList instead of estimatedSize(). This keeps configureEach lazy without changing the estimatedSize() contract or the eager all() / whenObjectAdded path (which iterates the flushing iterator and is legitimately eager).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
