### PR TITLE
Surface clear cause for exec stream config error

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.process.ShellScript
 import org.gradle.process.TestJavaMain
 import org.gradle.util.internal.TextUtil
+import spock.lang.Issue
 
 class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
     def "providers.exec can be used during configuration time"() {
@@ -262,6 +263,25 @@ class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("Other script output")
         result.assertTaskScheduled(":printScriptOutput")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/33858")
+    def "providers.exec reports a clear cause when configuring standard streams"() {
+        given:
+        buildFile """
+            providers.exec {
+                standardInput = System.in
+                commandLine("echo")
+            }
+
+            task empty() {}
+        """
+
+        when:
+        fails(":empty")
+
+        then:
+        failure.assertHasCause("Standard streams cannot be configured for exec output provider")
     }
 
     static String cmdToExecConfig(String... args) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpec.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider.sources.process;
 
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.ProcessForkOptions;
 import org.jspecify.annotations.Nullable;
@@ -36,32 +37,32 @@ abstract class ProviderCompatibleBaseExecSpec implements DelegatingBaseExecSpec 
 
     @Override
     public BaseExecSpec setStandardInput(InputStream inputStream) {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override
     public InputStream getStandardInput() {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override
     public BaseExecSpec setStandardOutput(OutputStream outputStream) {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override
     public OutputStream getStandardOutput() {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override
     public BaseExecSpec setErrorOutput(OutputStream outputStream) {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override
     public OutputStream getErrorOutput() {
-        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+        throw new InvalidUserCodeException("Standard streams cannot be configured for exec output provider");
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpecTestBase.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpecTestBase.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider.sources.process
 
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.process.BaseExecSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -131,21 +132,48 @@ abstract class ProviderCompatibleBaseExecSpecTestBase extends Specification {
         when:
         specUnderTest.setStandardInput(new ByteArrayInputStream())
         then:
-        thrown UnsupportedOperationException
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
     }
 
     def "setting output stream is forbidden"() {
         when:
         specUnderTest.setStandardOutput(new ByteArrayOutputStream())
         then:
-        thrown UnsupportedOperationException
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
     }
 
     def "setting error stream is forbidden"() {
         when:
         specUnderTest.setErrorOutput(new ByteArrayOutputStream())
         then:
-        thrown UnsupportedOperationException
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
+    }
+
+    def "getting input stream is forbidden"() {
+        when:
+        specUnderTest.getStandardInput()
+        then:
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
+    }
+
+    def "getting output stream is forbidden"() {
+        when:
+        specUnderTest.getStandardOutput()
+        then:
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
+    }
+
+    def "getting error stream is forbidden"() {
+        when:
+        specUnderTest.getErrorOutput()
+        then:
+        def e = thrown(InvalidUserCodeException)
+        e.message == "Standard streams cannot be configured for exec output provider"
     }
 
     def "spec without working directory doesn't set it on parameters"() {


### PR DESCRIPTION
Fixes #33858

### Context

When a build configures standard streams on a `providers.exec {}` / `providers.javaexec {}` spec, the build fails with a confusing message:

```
* What went wrong:
A problem occurred evaluating root project '...'.
> Could not create provider for value source ProcessOutputValueSource.
```

The actionable cause — `Standard streams cannot be configured for exec output provider` — was only visible with `--stacktrace`.

**Reproducer:**
```groovy
providers.exec {
    standardInput = System.in
    commandLine("echo")
}
```

### Root cause

`ProviderCompatibleBaseExecSpec` threw `UnsupportedOperationException` from its standard-stream getters/setters. That spec is configured inside the action run by `DefaultValueSourceProviderFactory.createProviderOf`, whose `catch (Exception e)` wraps any non-`GradleException` into a generic `GradleException("Could not create provider for value source …", e)`. The default console renderer shows the wrapper's message but collapses the nested `UnsupportedOperationException` cause, hiding the meaningful text.

### Change

Throw `InvalidUserCodeException` (a `GradleException` subtype) instead of `UnsupportedOperationException` from the six standard-stream getters/setters, keeping the message verbatim. Because `createProviderOf` rethrows `GradleException` causes **unwrapped** (`catch (GradleException e) { throw e; }`), the clarifying message now surfaces as the reported failure cause without `--stacktrace`. The exception type is also semantically correct: configuring standard streams here is invalid build-script usage.

No change to the generic `createProviderOf` wrapping path, so there is no blast radius for other value source types.

### Out of scope

Actually *supporting* input-stream / standard-stream configuration on `providers.exec`/`javaexec` (deferred until `ExecSpec` migrates to the Provider API, per the issue discussion). This PR only makes the existing error message visible.

### Tests

- New regression integration test `ProcessOutputProviderIntegrationTest."providers.exec reports a clear cause when configuring standard streams"` (annotated `@Issue`), asserting the clarifying cause is visible in the rendered failure (without `--stacktrace`). Red before the fix, green after, in both forking and configuration-cache variants.
- Updated the three `set*` forbidden-stream unit tests in `ProviderCompatibleBaseExecSpecTestBase` to assert the new exception type and exact message; added three new tests covering the previously-untested `get*` methods.