### PR TITLE
Skip TestNG 7.6+ on Java versions below 11

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
@@ -40,6 +40,8 @@ class TestNGCoverage {
 
     private static final String LAST_BEFORE_NEW_EXECUTOR_API = '7.5' // Last version with setExecutorFactoryClass(String)
 
+    private static final String FIRST_REQUIRING_JDK_11 = '7.6' // TestNG 7.6.0 dropped Java 8 support and requires JDK 11+
+
     public static final Set<String> ALL_VERSIONS = [
         '5.12.1', // Newest version without TestNG#setConfigFailurePolicy method (Added in 5.13)
         FIXED_ILLEGAL_ACCESS,
@@ -65,6 +67,9 @@ class TestNGCoverage {
         } else if (javaVersion < JavaVersion.VERSION_1_7) {
             // 6.8.21 was the last version to compile to JDK 5 bytecode. Afterwards (6.9.4) TestNG compiled to JDK 7 bytecode.
             return versions.findAll { VersionNumber.parse(it) <= VersionNumber.parse('6.8.21')}
+        } else if (javaVersion < JavaVersion.VERSION_11) {
+            // TestNG 7.6.0 and later require JDK 11+, so they cannot run on Java 8/9/10.
+            return versions.findAll { VersionNumber.parse(it) < VersionNumber.parse(FIRST_REQUIRING_JDK_11) }
         } else {
             return versions
         }


### PR DESCRIPTION
### Context

`TestNGJavaVersionIntegrationTest.can run test on java 8` was failing in `AllVersionsIntegMultiVersion` CI for TestNG `7.10.2`:

```
Could not resolve org.testng:testng:7.10.2.
  > Dependency resolution is looking for a library compatible with JVM runtime version 8,
    but 'org.testng:testng:7.10.2' is only compatible with JVM runtime version 11 or newer.
```

TestNG 7.6.0 dropped Java 8 support and requires JDK 11+, and `7.10.2` is the `NEWEST` version in the multi-version coverage matrix. The compatibility filter in `TestNGCoverage.testNgVersionsSupportedByJdk` only special-cased Java 16+ (needs ≥ 5.14.6) and Java < 7 (needs ≤ 6.8.21); for Java 8/9/10 it fell through to returning *all* versions. As a result `supportsJavaVersion('7.10.2', 8)` wrongly returned `true`, the `Assume` guard did not skip the case, and the test attempted an impossible dependency resolution.

This change excludes TestNG ≥ 7.6 when running on Java versions below 11, so the unsupported combinations are correctly skipped (matching how `7.5`, the last Java-8-compatible TestNG, still runs).

Verified on a branch build of `Gradle_Master_Check_AllVersionsIntegMultiVersion_33_bucket2`: 1829 passed, 0 failed (the `7.10.2 + java 8` case is now ignored).

