### PR TITLE
Update Documentation: Follow up to ResolutionResult CC compatibility

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -85,6 +85,7 @@ Additionally, referencing resolved dependency results directly is disallowed (e.
 Instead, use lazy providers that defer resolution:
 
 * Use a `Provider<ResolvedComponentResult>` from `ResolutionResult.getRootComponent()` for dependency graph metadata.
+* Alternatively, reference the link:{javadocPath}/org/gradle/api/artifacts/result/ResolutionResult.html[`ResolutionResult`] directly. It is Configuration Cache-compatible, so it can be wired into a task input property (for example, a `Property<ResolutionResult>`) and accessed via its full API at execution time.
 * Use `ArtifactCollection.getResolvedArtifacts()`, which returns a `Provider<Set<ResolvedArtifactResult>>`, for artifact metadata and files.
 
 IMPORTANT: The `Provider` returned by `getResolvedArtifacts()` is Configuration Cache-compatible, but the `ResolvedArtifactResult` type itself is *not* serializable. You cannot wire the provider directly into a `SetProperty<ResolvedArtifactResult>` task property. Instead, use `Provider.map()` to extract the data you need (artifact identifiers, variant information, files) into serializable types, and wire those into your task's input properties. See <<artifact_resolution.adoc#sec:resolving_artifacts, Resolving artifacts>> for a complete example of this pattern.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/advanced/graph_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/advanced/graph_resolution.adoc
@@ -472,6 +472,8 @@ include::sample[dir="snippets/reference/dependency-management/advanced/performin
 
 NOTE: This example uses incubating APIs.
 
+`ResolutionResult` is Configuration Cache-compatible, so you can also wire it directly into a task input property if you need access to its full API at execution time.
+
 Running this task, we get the following output:
 
 [source,text]


### PR DESCRIPTION
### Details
This is a Documentation change ONLY. Documentation follow-up to #38273

### Context
  - Related code change: #38273
  - Underlying issue: #26897

### Changes
  - `configuration_cache_requirements.adoc` — In the "Dependency Management Types" section, added a bullet alongside the existing `Provider<ResolvedComponentResult>` recommendation, noting that `ResolutionResult` itself can now be wired into a task input property (e.g., `Property<ResolutionResult>`) and accessed via its full API at execution time.                                                                           
  - `graph_resolution.adoc` — Added a sentence after the worked example pointing out the same capability, so readers exploring the `ResolutionResult` API discover the direct-input path.       

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description                                                                                                               
                                                                                                                                       

