### PR TITLE
Support javaVersion and Groovy 6 properties for groovydoc #33659 #38359

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -114,7 +114,7 @@ Beta and RC versions may or may not work.
 [[groovy_compatibility]]
 == Groovy
 
-Gradle is tested with Groovy 1.5.8 through 5.0.2.
+Gradle is tested with Groovy 1.5.8 through 6.0.0-alpha-2.
 
 Gradle plugins written in Groovy must use Groovy 4.x for compatibility with Gradle and Groovy DSL build scripts.
 

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
@@ -80,8 +80,8 @@ class AntWorkerMemoryLeakIntegrationTest extends AbstractIntegrationSpec {
             case 1, 2 -> '0.24.1'
             default -> "3.6.0" + switch (groovyVersionNumber.major) {
                 case 3 -> ""
-                // Temporary override as there is no CodeNarc release for Groovy 5.0 yet
-                case 5 -> "-groovy-4.0"
+                // Temporary override as there is no CodeNarc release for Groovy 5.0 or 6.0 yet
+                case 5, 6 -> "-groovy-4.0"
                 default -> "-groovy-${groovyVersionNumber.major}.${groovyVersionNumber.minor}"
             }
         }

--- a/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
+++ b/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.internal.ant.AntWorkAction;
 import org.gradle.util.internal.VersionNumber;
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
@@ -60,6 +61,20 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
         putIfNotNull(args, "doctitle", parameters.getDocTitle().getOrNull());
         putIfNotNull(args, "header", parameters.getHeader().getOrNull());
         putIfNotNull(args, "footer", parameters.getFooter().getOrNull());
+        // javaVersion (passed to JavaParser) was added to the Groovydoc Ant task in Groovy 4.0.27.
+        if (isAtLeast(version, "4.0.27")) {
+            putIfNotNull(args, "javaVersion", parameters.getJavaVersion().getOrNull());
+        }
+        // The following options were added to the Groovydoc Ant task in Groovy 6.0.0.
+        if (isAtLeast(version, "6.0.0")) {
+            args.put("showInternal", parameters.getShowInternal().get());
+            args.put("noIndex", parameters.getNoIndex().get());
+            args.put("noDeprecatedList", parameters.getNoDeprecatedList().get());
+            args.put("noHelp", parameters.getNoHelp().get());
+            putIfNotNull(args, "syntaxHighlighter", parameters.getSyntaxHighlighter().getOrNull());
+            putIfNotNull(args, "theme", parameters.getTheme().getOrNull());
+            putIfNotNull(args, "preLanguage", parameters.getPreLanguage().getOrNull());
+        }
         putIfNotNull(args, "overview", parameters.getOverview().getOrNull());
 
         ant.taskdef("groovydoc", "org.codehaus.groovy.ant.Groovydoc");
@@ -72,6 +87,13 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
                         "href", link.getUrl()
                     )
                 );
+            }
+            // Additional stylesheets are configured via nested <addStylesheet file="..."/> elements,
+            // available in the Groovydoc Ant task since Groovy 6.0.0.
+            if (isAtLeast(version, "6.0.0")) {
+                for (File stylesheet : parameters.getAdditionalStylesheets().getFiles()) {
+                    ant.createNode("addStylesheet", ImmutableMap.of("file", stylesheet.getAbsolutePath()));
+                }
             }
         });
     }

--- a/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
+++ b/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
@@ -61,10 +61,12 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
         putIfNotNull(args, "doctitle", parameters.getDocTitle().getOrNull());
         putIfNotNull(args, "header", parameters.getHeader().getOrNull());
         putIfNotNull(args, "footer", parameters.getFooter().getOrNull());
+
         // javaVersion (passed to JavaParser) was added to the Groovydoc Ant task in Groovy 4.0.27.
         if (isAtLeast(version, "4.0.27")) {
             putIfNotNull(args, "javaVersion", parameters.getJavaVersion().getOrNull());
         }
+
         // The following options were added to the Groovydoc Ant task in Groovy 6.0.0.
         // Threshold is the first 6.0.0 pre-release so alphas/betas pick up the options while preserving "6.0.0" > "6.0.0-alpha-*".
         if (isAtLeast(version, "6.0.0-alpha-1")) {
@@ -76,6 +78,7 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
             putIfNotNull(args, "theme", parameters.getTheme().getOrNull());
             putIfNotNull(args, "preLanguage", parameters.getPreLanguage().getOrNull());
         }
+
         putIfNotNull(args, "overview", parameters.getOverview().getOrNull());
 
         ant.taskdef("groovydoc", "org.codehaus.groovy.ant.Groovydoc");

--- a/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
+++ b/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
@@ -66,7 +66,8 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
             putIfNotNull(args, "javaVersion", parameters.getJavaVersion().getOrNull());
         }
         // The following options were added to the Groovydoc Ant task in Groovy 6.0.0.
-        if (isAtLeast(version, "6.0.0")) {
+        // Threshold is the first 6.0.0 pre-release so alphas/betas pick up the options while preserving "6.0.0" > "6.0.0-alpha-*".
+        if (isAtLeast(version, "6.0.0-alpha-1")) {
             args.put("showInternal", parameters.getShowInternal().get());
             args.put("noIndex", parameters.getNoIndex().get());
             args.put("noDeprecatedList", parameters.getNoDeprecatedList().get());
@@ -90,7 +91,7 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
             }
             // Additional stylesheets are configured via nested <addStylesheet file="..."/> elements,
             // available in the Groovydoc Ant task since Groovy 6.0.0.
-            if (isAtLeast(version, "6.0.0")) {
+            if (isAtLeast(version, "6.0.0-alpha-1")) {
                 for (File stylesheet : parameters.getAdditionalStylesheets().getFiles()) {
                     ant.createNode("addStylesheet", ImmutableMap.of("file", stylesheet.getAbsolutePath()));
                 }

--- a/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocParameters.java
+++ b/platforms/jvm/groovydoc-worker/src/main/java/org/gradle/api/internal/tasks/GroovydocParameters.java
@@ -42,6 +42,24 @@ public interface GroovydocParameters extends AntWorkParameters {
 
     Property<String> getFooter();
 
+    Property<String> getJavaVersion();
+
+    Property<Boolean> getShowInternal();
+
+    Property<Boolean> getNoIndex();
+
+    Property<Boolean> getNoDeprecatedList();
+
+    Property<Boolean> getNoHelp();
+
+    Property<String> getSyntaxHighlighter();
+
+    Property<String> getTheme();
+
+    Property<String> getPreLanguage();
+
+    ConfigurableFileCollection getAdditionalStylesheets();
+
     Property<String> getOverview();
 
     Property<GroovydocAccess> getAccess();

--- a/platforms/jvm/language-groovy/build.gradle.kts
+++ b/platforms/jvm/language-groovy/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(projects.groovydocWorker)
     api(projects.javaCompilerWorker)
     api(projects.jvmCompilerWorker)
+    api(projects.jvmServices)
     api(projects.processServices)
     api(projects.languageJava)
     api(projects.languageJvm)
@@ -34,7 +35,6 @@ dependencies {
     api(libs.jspecify)
 
     implementation(projects.classloaders)
-    implementation(projects.jvmServices)
     implementation(projects.fileCollections)
     implementation(projects.fileTemp)
     implementation(projects.logging)

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocGroovy6OptionsIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocGroovy6OptionsIntegrationTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.testing.fixture.GroovyCoverage
+
+import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
+
+/**
+ * Coverage for the Groovydoc options introduced in Groovy 6.0.0
+ * ({@code showInternal}, {@code noIndex}, {@code noDeprecatedList}, {@code noHelp},
+ * {@code syntaxHighlighter}, {@code theme}, {@code preLanguage} and additional stylesheets).
+ *
+ * <p>These options are silently ignored by earlier Groovy versions, so this spec only runs against
+ * Groovy 6.0.0 and later. The current test matrix contains no such version yet, so the spec is
+ * currently skipped; it will activate automatically once a Groovy 6.x release is added to
+ * {@link GroovyCoverage}.</p>
+ */
+@TargetCoverage({ GroovyCoverage.SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS })
+class GroovyDocGroovy6OptionsIntegrationTest extends MultiVersionIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id("groovy")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation "${groovyModuleDependency("groovy", versionNumber)}"
+            }
+        """
+
+        file("src/main/groovy/pkg/Thing.groovy") << """
+            package pkg
+
+            /** A thing. */
+            class Thing {
+                /** Greets. */
+                void greet() {}
+            }
+        """
+    }
+
+    def "can suppress the index, help and deprecated-list pages"() {
+        when:
+        buildFile << """
+            groovydoc {
+                noIndex = true
+                noHelp = true
+                noDeprecatedList = true
+            }
+        """
+
+        run "groovydoc"
+
+        then:
+        // The documented class page is always generated.
+        file('build/docs/groovydoc/pkg/Thing.html').exists()
+        // The suppressed auxiliary pages are not.
+        !file('build/docs/groovydoc/index-all.html').exists()
+        !file('build/docs/groovydoc/help-doc.html').exists()
+        !file('build/docs/groovydoc/deprecated-list.html').exists()
+    }
+
+    def "can add an additional stylesheet to the generated documentation"() {
+        given:
+        file("extra.css") << "/* custom */ body { color: rebeccapurple; }"
+
+        when:
+        buildFile << """
+            groovydoc {
+                additionalStylesheets.from(file("extra.css"))
+            }
+        """
+
+        run "groovydoc"
+
+        then:
+        // The extra stylesheet is copied into the output, preserving its name.
+        file('build/docs/groovydoc/extra.css').text.contains("rebeccapurple")
+    }
+
+    def "accepts theme, syntax highlighter, preLanguage and showInternal options"() {
+        when:
+        buildFile << """
+            groovydoc {
+                theme = "dark"
+                syntaxHighlighter = "prism"
+                preLanguage = "groovy"
+                showInternal = true
+            }
+        """
+
+        then:
+        succeeds "groovydoc"
+        file('build/docs/groovydoc/pkg/Thing.html').exists()
+    }
+
+}

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocGroovy6OptionsIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocGroovy6OptionsIntegrationTest.groovy
@@ -28,9 +28,7 @@ import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependen
  * {@code syntaxHighlighter}, {@code theme}, {@code preLanguage} and additional stylesheets).
  *
  * <p>These options are silently ignored by earlier Groovy versions, so this spec only runs against
- * Groovy 6.0.0 and later. The current test matrix contains no such version yet, so the spec is
- * currently skipped; it will activate automatically once a Groovy 6.x release is added to
- * {@link GroovyCoverage}.</p>
+ * Groovy 6.0.0-alpha-2 and later, as selected by {@link GroovyCoverage#SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS}.</p>
  */
 @TargetCoverage({ GroovyCoverage.SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS })
 class GroovyDocGroovy6OptionsIntegrationTest extends MultiVersionIntegrationSpec {

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocJavaVersionIntegrationTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.testing.fixture.GroovyCoverage
+
+import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
+
+@TargetCoverage({ GroovyCoverage.SUPPORTS_GROOVYDOC_JAVA_VERSION })
+class GroovyDocJavaVersionIntegrationTest extends MultiVersionIntegrationSpec {
+
+    private static final String GROOVY_DOC_NESTED_CLASS_PATTERN = /Thing\.Other/
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id("groovy")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation "${groovyModuleDependency("groovy", versionNumber)}"
+            }
+        """
+
+        // Sealed classes were introduced in Java 17
+        file("src/main/groovy/pkg/Thing.java") << """
+            package pkg;
+
+            public sealed class Thing {
+                public final static class Other extends Thing { }
+            }
+        """
+    }
+
+    def "can provide a java version"() {
+        when:
+        buildFile << """
+            groovydoc {
+              javaVersion = JavaLanguageVersion.of(17)
+            }
+        """
+
+        run "groovydoc"
+
+        then:
+        def text = file('build/docs/groovydoc/pkg/Thing.html').text
+        text =~ GROOVY_DOC_NESTED_CLASS_PATTERN
+    }
+
+}

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.javadoc;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
@@ -31,6 +32,7 @@ import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -44,6 +46,7 @@ import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.jvm.JpmsConfiguration;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.workers.WorkerExecutor;
@@ -163,6 +166,15 @@ public abstract class Groovydoc extends SourceTask {
             parameters.getDocTitle().convention(getDocTitle());
             parameters.getHeader().convention(getHeader());
             parameters.getFooter().convention(getFooter());
+            parameters.getJavaVersion().convention(getJavaVersion().map(version -> "JAVA_" + version.asInt()));
+            parameters.getShowInternal().convention(getShowInternal());
+            parameters.getNoIndex().convention(getNoIndex());
+            parameters.getNoDeprecatedList().convention(getNoDeprecatedList());
+            parameters.getNoHelp().convention(getNoHelp());
+            parameters.getSyntaxHighlighter().convention(getSyntaxHighlighter());
+            parameters.getTheme().convention(getTheme());
+            parameters.getPreLanguage().convention(getPreLanguage());
+            parameters.getAdditionalStylesheets().from(getAdditionalStylesheets());
             parameters.getOverview().convention(getPathToOverview());
             parameters.getAccess().convention(getAccess());
             parameters.getLinks().convention(
@@ -451,6 +463,128 @@ public abstract class Groovydoc extends SourceTask {
      */
     @Input
     public abstract Property<Boolean> getIncludeMainForScripts();
+
+    /**
+     * The Java language version used when parsing Java source files, e.g. {@link JavaLanguageVersion#of(int) JavaLanguageVersion.of(17)}.
+     *
+     * <p>Groovydoc uses the JavaParser library to read Java sources; this controls the source level it assumes,
+     * which is needed for parsing newer Java language constructs (for example, sealed classes require Java 17).
+     * When unset, Groovydoc uses the JavaParser library's own default.</p>
+     *
+     * <p>Only has an effect with Groovy 4.0.27 or later; the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Optional
+    @Input
+    public abstract Property<JavaLanguageVersion> getJavaVersion();
+
+    /**
+     * Whether to include members annotated with {@code groovy.transform.Internal} (per GEP-17) in the generated documentation.
+     *
+     * <p>Defaults to {@code false}, so internal members are hidden. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<Boolean> getShowInternal();
+
+    /**
+     * Whether to suppress generation of the alphabetical index page ({@code index-all.html}) and its nav-bar link.
+     *
+     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<Boolean> getNoIndex();
+
+    /**
+     * Whether to suppress generation of the deprecated-list page ({@code deprecated-list.html}) and its nav-bar link.
+     *
+     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<Boolean> getNoDeprecatedList();
+
+    /**
+     * Whether to suppress generation of the help page ({@code help-doc.html}) and its nav-bar link.
+     *
+     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<Boolean> getNoHelp();
+
+    /**
+     * The client-side syntax highlighter for {@code {@snippet}} and fenced Markdown code blocks.
+     *
+     * <p>Valid values are {@code "prism"} (bundled) or {@code "none"} (default); any other value is treated as {@code "none"}.
+     * Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<String> getSyntaxHighlighter();
+
+    /**
+     * The theme lock mode for the generated documentation.
+     *
+     * <ul>
+     *   <li>{@code "auto"} (default) — emit a {@code prefers-color-scheme} media query so each reader sees their OS preference.</li>
+     *   <li>{@code "light"} — lock the palette to light regardless of OS.</li>
+     *   <li>{@code "dark"} — lock the palette to dark regardless of OS.</li>
+     * </ul>
+     *
+     * <p>Any other value is treated as {@code "auto"}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<String> getTheme();
+
+    /**
+     * The default language id applied to preformatted code blocks in rendered doc comments that carry no {@code class} attribute.
+     *
+     * <p>When set (for example, {@code "groovy"}), a post-pass adds {@code class="language-xxx"} to the opening tag of such
+     * blocks, enabling syntax highlighting for legacy doc-comment code blocks without touching source files. Blocks that
+     * already carry any {@code class} attribute are left alone.</p>
+     *
+     * <p>Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @Optional
+    @Input
+    public abstract Property<String> getPreLanguage();
+
+    /**
+     * Additional stylesheets to copy into the generated documentation alongside the default stylesheet, preserving each file's name.
+     *
+     * <p>Only has an effect with Groovy 6.0.0 or later; the stylesheets are silently ignored with earlier Groovy versions.</p>
+     *
+     * @since 9.7.0
+     */
+    @Incubating
+    @InputFiles
+    @PathSensitive(PathSensitivity.NAME_ONLY)
+    public abstract ConfigurableFileCollection getAdditionalStylesheets();
 
     /**
      * Returns the links to groovydoc/javadoc output at the given URL.

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -466,14 +466,14 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * The Java language version used when parsing Java source files, e.g. {@link JavaLanguageVersion#of(int) JavaLanguageVersion.of(17)}.
-     *
-     * <p>Groovydoc uses the JavaParser library to read Java sources; this controls the source level it assumes,
+     * <p>
+     * Groovydoc uses the JavaParser library to read Java sources; this controls the source level it assumes,
      * which is needed for parsing newer Java language constructs (for example, sealed classes require Java 17).
-     * When unset, Groovydoc uses the JavaParser library's own default.</p>
+     * When unset, Groovydoc uses the JavaParser library's own default.
+     * <p>
+     * Only has an effect with Groovy 4.0.27 or later; the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Only has an effect with Groovy 4.0.27 or later; the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Optional
@@ -482,11 +482,11 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * Whether to include members annotated with {@code groovy.transform.Internal} (per GEP-17) in the generated documentation.
+     * <p>
+     * Defaults to {@code false}, so internal members are hidden. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Defaults to {@code false}, so internal members are hidden. Only has an effect with Groovy 6.0.0 or later;
-     * the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -494,11 +494,11 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * Whether to suppress generation of the alphabetical index page ({@code index-all.html}) and its nav-bar link.
+     * <p>
+     * Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
-     * the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -506,11 +506,11 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * Whether to suppress generation of the deprecated-list page ({@code deprecated-list.html}) and its nav-bar link.
+     * <p>
+     * Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
-     * the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -518,11 +518,11 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * Whether to suppress generation of the help page ({@code help-doc.html}) and its nav-bar link.
+     * <p>
+     * Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Defaults to {@code false}. Only has an effect with Groovy 6.0.0 or later;
-     * the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -530,11 +530,11 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * The client-side syntax highlighter for {@code {@snippet}} and fenced Markdown code blocks.
+     * <p>
+     * Valid values are {@code "prism"} (bundled) or {@code "none"} (default); any other value is treated as {@code "none"}.
+     * Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Valid values are {@code "prism"} (bundled) or {@code "none"} (default); any other value is treated as {@code "none"}.
-     * Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -549,10 +549,10 @@ public abstract class Groovydoc extends SourceTask {
      *   <li>{@code "dark"} — lock the palette to dark regardless of OS.</li>
      * </ul>
      *
-     * <p>Any other value is treated as {@code "auto"}. Only has an effect with Groovy 6.0.0 or later;
-     * the option is silently ignored with earlier Groovy versions.</p>
+     * Any other value is treated as {@code "auto"}. Only has an effect with Groovy 6.0.0 or later;
+     * the option is silently ignored with earlier Groovy versions.
      *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Input
@@ -560,14 +560,14 @@ public abstract class Groovydoc extends SourceTask {
 
     /**
      * The default language id applied to preformatted code blocks in rendered doc comments that carry no {@code class} attribute.
-     *
-     * <p>When set (for example, {@code "groovy"}), a post-pass adds {@code class="language-xxx"} to the opening tag of such
+     * <p>
+     * When set (for example, {@code "groovy"}), a post-pass adds {@code class="language-xxx"} to the opening tag of such
      * blocks, enabling syntax highlighting for legacy doc-comment code blocks without touching source files. Blocks that
-     * already carry any {@code class} attribute are left alone.</p>
+     * already carry any {@code class} attribute are left alone.
+     * <p>
+     * Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.
      *
-     * <p>Only has an effect with Groovy 6.0.0 or later; the option is silently ignored with earlier Groovy versions.</p>
-     *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @Optional
@@ -579,7 +579,7 @@ public abstract class Groovydoc extends SourceTask {
      *
      * <p>Only has an effect with Groovy 6.0.0 or later; the stylesheets are silently ignored with earlier Groovy versions.</p>
      *
-     * @since 9.7.0
+     * @since 9.8.0
      */
     @Incubating
     @InputFiles

--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -31,6 +31,8 @@ class GroovyCoverage {
     static final Map<String, Jvm> ALL_VERSIONS_JVMS
     static final Set<String> ALL_VERSIONS
     static final Set<String> SUPPORTS_GROOVYDOC
+    static final Set<String> SUPPORTS_GROOVYDOC_JAVA_VERSION
+    static final Set<String> SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS
     static final Set<String> SUPPORTS_INDY
     static final Set<String> SUPPORTS_TIMESTAMP
     static final Set<String> SUPPORTS_PARAMETERS
@@ -48,6 +50,10 @@ class GroovyCoverage {
         ALL_VERSIONS = ALL_VERSIONS_JVMS.keySet()
         SUPPORTED_BY_JDK = groovyVersionsSupportedByJdk(JavaVersion.current())
         SUPPORTS_GROOVYDOC = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "1.6.9")
+        // The Groovydoc Ant task gained a javaVersion option (passed to JavaParser) in 4.0.27
+        SUPPORTS_GROOVYDOC_JAVA_VERSION = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "4.0.27")
+        // The Groovydoc Ant task gained showInternal/noIndex/noDeprecatedList/noHelp/syntaxHighlighter/theme/preLanguage/addStylesheet in 6.0.0
+        SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "6.0.0")
         // Indy compilation doesn't work in 2.2.2 and before
         SUPPORTS_INDY = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "2.3.0")
         SUPPORTS_TIMESTAMP = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "2.4.6")

--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -84,7 +84,7 @@ class GroovyCoverage {
 
     private static boolean supportsTargetingJavaVersion(VersionNumber groovyVersion, JavaVersion javaVersion) {
         return switch (groovyVersion.major) {
-            case 6 -> javaVersion <= JavaVersion.VERSION_25
+            case 6 -> javaVersion <= JavaVersion.VERSION_26
             case 5 -> javaVersion <= JavaVersion.VERSION_26
             case 4 -> javaVersion <= JavaVersion.VERSION_25
             case 3 -> javaVersion <= JavaVersion.VERSION_17

--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -25,7 +25,7 @@ import org.gradle.util.internal.VersionNumber
 class GroovyCoverage {
     // NOTE: Update compatibility.adoc when adding new versions of Groovy
     private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8', '3.0.25', '4.0.29']
-    private static final String[] FUTURE = ["5.0.2"]
+    private static final String[] FUTURE = ["5.0.2", "6.0.0-alpha-2"]
 
     static final Set<String> SUPPORTED_BY_JDK
     static final Map<String, Jvm> ALL_VERSIONS_JVMS
@@ -52,8 +52,9 @@ class GroovyCoverage {
         SUPPORTS_GROOVYDOC = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "1.6.9")
         // The Groovydoc Ant task gained a javaVersion option (passed to JavaParser) in 4.0.27
         SUPPORTS_GROOVYDOC_JAVA_VERSION = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "4.0.27")
-        // The Groovydoc Ant task gained showInternal/noIndex/noDeprecatedList/noHelp/syntaxHighlighter/theme/preLanguage/addStylesheet in 6.0.0
-        SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "6.0.0")
+        // The Groovydoc Ant task gained showInternal/noIndex/noDeprecatedList/noHelp/syntaxHighlighter/theme/preLanguage/addStylesheet in 6.0.0.
+        // Bound is the first 6.0.0 pre-release so that alphas match while preserving the invariant that "6.0.0" > "6.0.0-alpha-*".
+        SUPPORTS_GROOVYDOC_GROOVY6_OPTIONS = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "6.0.0-alpha-1")
         // Indy compilation doesn't work in 2.2.2 and before
         SUPPORTS_INDY = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "2.3.0")
         SUPPORTS_TIMESTAMP = VersionCoverage.versionsAtLeast(SUPPORTED_BY_JDK, "2.4.6")
@@ -83,6 +84,7 @@ class GroovyCoverage {
 
     private static boolean supportsTargetingJavaVersion(VersionNumber groovyVersion, JavaVersion javaVersion) {
         return switch (groovyVersion.major) {
+            case 6 -> javaVersion <= JavaVersion.VERSION_25
             case 5 -> javaVersion <= JavaVersion.VERSION_26
             case 4 -> javaVersion <= JavaVersion.VERSION_25
             case 3 -> javaVersion <= JavaVersion.VERSION_17

--- a/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -181,6 +181,12 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
             groovydoc.getIncludeAuthor().convention(false);
             groovydoc.getProcessScripts().convention(true);
             groovydoc.getIncludeMainForScripts().convention(true);
+            groovydoc.getShowInternal().convention(false);
+            groovydoc.getNoIndex().convention(false);
+            groovydoc.getNoDeprecatedList().convention(false);
+            groovydoc.getNoHelp().convention(false);
+            groovydoc.getSyntaxHighlighter().convention("none");
+            groovydoc.getTheme().convention("auto");
         });
     }
 


### PR DESCRIPTION
Fixes:  #33659 #38359

### Context
Gradle Groovydoc support is lagging behind Groovy CLI, Ant, and Maven

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
