### PR TITLE
Fix margin marker leaking into generated Kotlin DSL ERROR-deprecation accessors

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -106,7 +106,7 @@ internal fun maybeDeprecationAnnotations(deprecation: Deprecated?): String {
         DeprecationLevel.ERROR -> """
         |@Suppress("DEPRECATION_ERROR")
         |        ${deprecatedAnnotation(deprecation)}
-        """.trimIndent() + "\n        "
+        """.trimMargin() + "\n        "
 
         DeprecationLevel.HIDDEN -> ""
     }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/CodeGeneratorDeprecationAnnotationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/CodeGeneratorDeprecationAnnotationTest.kt
@@ -1,0 +1,54 @@
+package org.gradle.kotlin.dsl.accessors
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.startsWith
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+
+class CodeGeneratorDeprecationAnnotationTest {
+
+    @Test
+    fun `#maybeDeprecationAnnotations renders nothing without a deprecation`() {
+        assertThat(
+            maybeDeprecationAnnotations(null),
+            equalTo("")
+        )
+    }
+
+    @Test
+    fun `#maybeDeprecationAnnotations renders WARNING level without margin markers`() {
+        assertThat(
+            maybeDeprecationAnnotations(Deprecated(message = "Just don't", level = DeprecationLevel.WARNING)),
+            equalTo("@Suppress(\"deprecation\")\n        @Deprecated(\"Just don't\", level = DeprecationLevel.WARNING)\n        ")
+        )
+    }
+
+    @Test
+    fun `#maybeDeprecationAnnotations renders ERROR level without margin markers`() {
+        val annotations = maybeDeprecationAnnotations(Deprecated(message = "Just don't", level = DeprecationLevel.ERROR))
+
+        // The bug left the raw `|` margin markers in the output, producing invalid Kotlin.
+        assertThat(
+            annotations,
+            startsWith("@Suppress(\"DEPRECATION_ERROR\")\n")
+        )
+        assertThat(
+            annotations,
+            equalTo("@Suppress(\"DEPRECATION_ERROR\")\n        @Deprecated(\"Just don't\", level = DeprecationLevel.ERROR)\n        ")
+        )
+    }
+
+    @Test
+    fun `#maybeDeprecationAnnotations ERROR matches WARNING formatting modulo the suppress string`() {
+        val warning = maybeDeprecationAnnotations(Deprecated(message = "Just don't", level = DeprecationLevel.WARNING))
+        val error = maybeDeprecationAnnotations(Deprecated(message = "Just don't", level = DeprecationLevel.ERROR))
+
+        assertThat(
+            error
+                .replace("DEPRECATION_ERROR", "deprecation")
+                .replace("DeprecationLevel.ERROR", "DeprecationLevel.WARNING"),
+            equalTo(warning)
+        )
+    }
+}


### PR DESCRIPTION
Introduced in
* #33585 