### PR TITLE
Make console detection resilient to handle-query failures

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
@@ -43,11 +43,11 @@ public class NativePlatformConsoleDetector implements ConsoleDetector {
             return null;
         }
 
-        boolean isStdoutATerminal = terminals.isTerminal(Stdout);
-        boolean isStderrATerminal = terminals.isTerminal(Stderr);
-        boolean disableUnicodeSupportDetection = isWindowsWithNonUnicodeCodePage();
-
         try {
+            boolean isStdoutATerminal = terminals.isTerminal(Stdout);
+            boolean isStderrATerminal = terminals.isTerminal(Stderr);
+            boolean disableUnicodeSupportDetection = isWindowsWithNonUnicodeCodePage();
+
             if (isStdoutATerminal) {
                 return new NativePlatformConsoleMetaData(isStdoutATerminal, isStderrATerminal, terminals.getTerminal(Stdout), disableUnicodeSupportDetection);
             } else if (isStderrATerminal) {
@@ -57,7 +57,8 @@ public class NativePlatformConsoleDetector implements ConsoleDetector {
             }
         } catch (NativeException ex) {
             // if a native terminal exists but cannot be resolved, use dumb terminal settings
-            // this can happen if a terminal is in use that does not have its terminfo installed
+            // this can happen if a terminal is in use that does not have its terminfo installed,
+            // or if the output stream's handle cannot be queried (e.g. a redirected stdout on Windows)
             return null;
         }
     }

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetectorTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetectorTest.groovy
@@ -118,4 +118,16 @@ class NativePlatformConsoleDetectorTest extends Specification {
         where:
         terminal << [Terminals.Output.Stdout, Terminals.Output.Stderr]
     }
+
+    def "returns null when failing to detect whether #terminal is a terminal"() {
+        given:
+        // e.g. a redirected stdout on Windows whose handle information cannot be queried
+        terminals.isTerminal(terminal) >> { throw new NativeException("could not get handle file information") }
+
+        expect:
+        detector.console == null
+
+        where:
+        terminal << [Terminals.Output.Stdout, Terminals.Output.Stderr]
+    }
 }


### PR DESCRIPTION
## Why

`HelpModelIntegrationTest.can fetch model via build action` fails on Windows in NoDaemon CI ([build 114528222](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_13_bucket23/114528222)) with:

```
net.rubygrapefruit.platform.NativeException: Could not determine if Stdout is a console: could not get handle file information (errno 1)
    at WindowsTerminals.isTerminal
    at NativePlatformConsoleDetector.getConsole(NativePlatformConsoleDetector.java:46)
    at HelpRenderer.consoleWidth(HelpRenderer.java:106)
    at HelpBuilder.buildAll
```

`HelpRenderer.consoleWidth()` (added in 275c251f47a, "Respect terminal column length if available") calls `ConsoleDetector.getConsole()`. `HelpBuilder` runs this **inside the build process serving a tooling-API request**. In no-daemon mode on Windows, that process's stdout is a redirected handle, so `WindowsTerminals.isTerminal(Stdout)` can't query the handle and throws `NativeException`.

`NativePlatformConsoleDetector.getConsole()` already had a `catch (NativeException)` whose stated purpose is exactly this ("if a native terminal exists but cannot be resolved, use dumb terminal settings"), but the `isTerminal()` probes that actually throw were sitting **outside** the `try` block, so the exception leaked and crashed the build action.

## What

- Move the `isTerminal()` / unicode-codepage probes inside the existing `try` block in `NativePlatformConsoleDetector`, so a probe failure falls through to returning `null` (no console → `HelpRenderer` uses `Integer.MAX_VALUE`, i.e. no wrapping). Root-cause fix; restores the method's documented contract for all callers.
- Add two regression cases to `NativePlatformConsoleDetectorTest` covering `isTerminal(Stdout/Stderr)` throwing.

## Verification

The Windows-native crash isn't reproducible on macOS, so verification is via the mock-based unit test exercising the exact leak path: `:native:test --tests NativePlatformConsoleDetectorTest` → 10/10 green.