### PR TITLE
Add mailmap entry for myself

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -24,6 +24,8 @@ Hans Dockter <hans@gradle.com> <hans@gradle.biz>
 Hans Dockter <hans@gradle.com> <hd@hd-desktop.(none)>
 Hans Dockter <hans@gradle.com> <mail@dockter.biz>
 Hans Dockter <hans@gradle.com> U-WIN-T79U3J3QLBC\Hans Dockter <Hans Dockter@WIN-T79U3J3QLBC.(none)>
+Justin Van Dort <jvandort@gradle.com>
+Justin Van Dort <jvandort@gradle.com> <justinvandort@gmail.com>
 Lari Hotari <lari.hotari@gradle.com> <lari.hotari@gradleware.com>
 Lari Hotari <lari.hotari@gradle.com> <lari@hotari.net>
 Lari Hotari <lari.hotari@gradle.com> <lhotari@users.noreply.github.com>


### PR DESCRIPTION
- Adds a single entry to map my personal email to my work email
- Format names to use a Unicode Non-breaking space (U+00A0) to trick IntelliJ blame to print my name as 'Van Dort' in the blame UI instead of 'Dort'.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
