### PR TITLE
Deprecate KDSL multi-string dependency functions in bytecode

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/DeprecationInAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/DeprecationInAccessorsIntegrationTest.kt
@@ -68,7 +68,7 @@ class DeprecationInAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
             pluginId,
             """
                 @file:Suppress("deprecation")
-                
+
                 import com.example.DeprecatedJavaExt
                 import com.example.DeprecatedJavaTask
 
@@ -105,6 +105,41 @@ class DeprecationInAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
                 |    val TaskContainer.`myTask`: TaskProvider<com.example.DeprecatedJavaTask>
                 """.trimMargin()
             )
+        }
+    }
+
+    @Test
+    fun `multi-string dependency declaration accessors are deprecated at compile time`() {
+        withBuildScript(
+            """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation("group", "name", "version")
+            }
+            """
+        )
+
+        // Declaring the dependency at configuration time also triggers the runtime multi-string deprecation warning.
+        executer.expectDocumentedDeprecationWarning(
+            "Declaring dependencies using multi-string notation has been deprecated. " +
+                "This will fail with an error in Gradle 10. " +
+                "Please use single-string notation (\"group:name:version\") or DependencyFactory instead. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_multi_string_notation"
+        )
+
+        build("help").apply {
+            assertTrue("Expected a compile-time deprecation warning on the multi-string accessor usage, output was:\n$output") {
+                output.lines().any {
+                    it.startsWith("w: ") &&
+                        it.contains("build.gradle.kts:") &&
+                        it.contains("implementation") &&
+                        it.endsWith("is deprecated. Use single-string notation or DependencyFactory instead.")
+                }
+            }
         }
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -410,103 +410,120 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                 "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Lorg/gradle/api/provider/ProviderConvertible;Lorg/gradle/api/Action;)V"
             )
         ),
-        AccessorFragment(
-            source = name.run {
-                """
-                    /**
-                     * Adds a dependency to the '$original' configuration.
-                     *
-                     * @param group the group of the module to be added as a dependency.
-                     * @param name the name of the module to be added as a dependency.
-                     * @param version the optional version of the module to be added as a dependency.
-                     * @param configuration the optional configuration of the module to be added as a dependency.
-                     * @param classifier the optional classifier of the module artifact to be added as a dependency.
-                     * @param ext the optional extension of the module artifact to be added as a dependency.
-                     * @param dependencyConfiguration expression to use to configure the dependency.
-                     * @return The dependency.
-                     *
-                     * @see [DependencyHandler.create]
-                     * @see [DependencyHandler.add]
-                     */
-                    @Deprecated("Use single-string notation or DependencyFactory instead")
-                    fun DependencyHandler.`$kotlinIdentifier`(
-                        group: String,
-                        name: String,
-                        version: String? = null,
-                        configuration: String? = null,
-                        classifier: String? = null,
-                        ext: String? = null,
-                        dependencyConfiguration: Action<ExternalModuleDependency>? = null
-                    ): ExternalModuleDependency = addExternalModuleDependencyTo(
-                        this, "$stringLiteral", group, name, version, configuration, classifier, ext, dependencyConfiguration
-                    )
-                """
-            },
-            bytecode = {
-
-                val methodBody: MethodVisitor.() -> Unit = {
-                    ALOAD(0)
-                    LDC(propertyName)
-                    for (i in 1..7) {
-                        ALOAD(i)
+        run {
+            val deprecation = Deprecated(
+                listOfNotNull(
+                    "Use single-string notation or DependencyFactory instead",
+                    if (config.hasDeclarationDeprecations()) config.getDeclarationDeprecationMessage() else null
+                ).joinToString(". ")
+            )
+            AccessorFragment(
+                source = name.run {
+                    """
+                        /**
+                         * Adds a dependency to the '$original' configuration.
+                         *
+                         * @param group the group of the module to be added as a dependency.
+                         * @param name the name of the module to be added as a dependency.
+                         * @param version the optional version of the module to be added as a dependency.
+                         * @param configuration the optional configuration of the module to be added as a dependency.
+                         * @param classifier the optional classifier of the module artifact to be added as a dependency.
+                         * @param ext the optional extension of the module artifact to be added as a dependency.
+                         * @param dependencyConfiguration expression to use to configure the dependency.
+                         * @return The dependency.
+                         *
+                         * @see [DependencyHandler.create]
+                         * @see [DependencyHandler.add]
+                         */
+                        @Deprecated("${deprecation.message}")
+                        fun DependencyHandler.`$kotlinIdentifier`(
+                            group: String,
+                            name: String,
+                            version: String? = null,
+                            configuration: String? = null,
+                            classifier: String? = null,
+                            ext: String? = null,
+                            dependencyConfiguration: Action<ExternalModuleDependency>? = null
+                        ): ExternalModuleDependency = addExternalModuleDependencyTo(
+                            this, "$stringLiteral", group, name, version, configuration, classifier, ext, dependencyConfiguration
+                        )
+                    """
+                },
+                bytecode = {
+                    val methodBody: MethodVisitor.() -> Unit = {
+                        ALOAD(0)
+                        LDC(propertyName)
+                        for (i in 1..7) {
+                            ALOAD(i)
+                        }
+                        @Suppress("MaxLineLength")
+                        invokeRuntime(
+                            "addExternalModuleDependencyTo",
+                            "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lorg/gradle/api/artifacts/ExternalModuleDependency;"
+                        )
+                        ARETURN()
                     }
-                    @Suppress("MaxLineLength")
-                    invokeRuntime(
-                        "addExternalModuleDependencyTo",
-                        "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lorg/gradle/api/artifacts/ExternalModuleDependency;"
+
+                    publicStaticMethod(signature) {
+                        maybeWithDeprecation(deprecation)
+                        methodBody()
+                    }
+
+                    // Usually, this method would compute the default argument values
+                    // and delegate to the original implementation.
+                    // Here we can simply inline the implementation in both
+                    // methods.
+                    val overload3Defaults = JvmMethodSignature(
+                        "$propertyName\$default",
+                        "(" +
+                            "Lorg/gradle/api/artifacts/dsl/DependencyHandler;" +
+                            "Ljava/lang/String;" +
+                            "Ljava/lang/String;" +
+                            "Ljava/lang/String;" +
+                            "Ljava/lang/String;" +
+                            "Ljava/lang/String;" +
+                            "Ljava/lang/String;" +
+                            "Lorg/gradle/api/Action;" +
+                            "ILjava/lang/Object;" +
+                            ")Lorg/gradle/api/artifacts/ExternalModuleDependency;"
                     )
-                    ARETURN()
-                }
-
-                publicStaticMaybeDeprecatedMethod(signature, config) {
-                    methodBody()
-                }
-
-                // Usually, this method would compute the default argument values
-                // and delegate to the original implementation.
-                // Here we can simply inline the implementation in both
-                // methods.
-                val overload3Defaults = JvmMethodSignature(
-                    "$propertyName\$default",
+                    publicStaticSyntheticMethod(overload3Defaults) {
+                        methodBody()
+                    }
+                },
+                metadata = {
+                    kmPackage.functions += newFunctionOf(
+                        functionAttributes = {
+                            functionFlags()
+                            hasAnnotationsIfDeprecated(deprecation)
+                        },
+                        receiverType = GradleType.dependencyHandler,
+                        returnType = GradleType.externalModuleDependency,
+                        name = propertyName,
+                        valueParameters = listOf(
+                            newValueParameterOf("group", KotlinType.string),
+                            newValueParameterOf("name", KotlinType.string),
+                            newOptionalValueParameterOf("version", KotlinType.string),
+                            newOptionalValueParameterOf("configuration", KotlinType.string),
+                            newOptionalValueParameterOf("classifier", KotlinType.string),
+                            newOptionalValueParameterOf("ext", KotlinType.string),
+                            newOptionalValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency)),
+                        ),
+                        signature = signature
+                    )
+                },
+                signature = JvmMethodSignature(
+                    propertyName,
                     "(" +
                         "Lorg/gradle/api/artifacts/dsl/DependencyHandler;" +
-                        "Ljava/lang/String;" +
-                        "Ljava/lang/String;" +
-                        "Ljava/lang/String;" +
-                        "Ljava/lang/String;" +
-                        "Ljava/lang/String;" +
-                        "Ljava/lang/String;" +
+                        "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;" +
+                        "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;" +
                         "Lorg/gradle/api/Action;" +
-                        "ILjava/lang/Object;" +
-                        ")Lorg/gradle/api/artifacts/ExternalModuleDependency;"
+                        ")" +
+                        "Lorg/gradle/api/artifacts/ExternalModuleDependency;"
                 )
-                publicStaticSyntheticMethod(overload3Defaults) {
-                    methodBody()
-                }
-            },
-            metadata = {
-                kmPackage.functions += newFunctionOf(
-                    functionAttributes = functionFlags,
-                    receiverType = GradleType.dependencyHandler,
-                    returnType = GradleType.externalModuleDependency,
-                    name = propertyName,
-                    valueParameters = listOf(
-                        newValueParameterOf("group", KotlinType.string),
-                        newValueParameterOf("name", KotlinType.string),
-                        newOptionalValueParameterOf("version", KotlinType.string),
-                        newOptionalValueParameterOf("configuration", KotlinType.string),
-                        newOptionalValueParameterOf("classifier", KotlinType.string),
-                        newOptionalValueParameterOf("ext", KotlinType.string),
-                        newOptionalValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency)),
-                    ),
-                    signature = signature
-                )
-            },
-            signature = JvmMethodSignature(
-                propertyName,
-                "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)Lorg/gradle/api/artifacts/ExternalModuleDependency;"
             )
-        ),
+        },
         AccessorFragment(
             source = name.run {
                 """

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -49,6 +49,7 @@ import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyMap
 import org.mockito.kotlin.any
@@ -222,37 +223,56 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             )
 
         val srcDir = newFolder("src")
-        val binDir = newFolder("bin")
 
-        withClassLoaderFor(binDir) {
-            // when:
-            buildAccessorsFromSourceFor(
-                schema,
-                testRuntimeClassPath,
-                srcDir,
-                binDir
-            )
+        val compiledBinDir = newFolder("compiledBin")
+        buildAccessorsFromSourceFor(schema, testRuntimeClassPath, srcDir, compiledBinDir)
 
-            val binaryAccessorsDir = File(binDir, "org/gradle/kotlin/dsl")
+        val generatedBinDir = newFolder("generatedBin")
+        buildAccessorsFor(schema, testRuntimeClassPath, srcDir = newFolder("ignored"), generatedBinDir)
 
-            // then:
-            schema.configurations.forEach { config ->
-                val name = config.target
-                val className = "${name.uppercaseFirstChar()}ConfigurationAccessorsKt"
-                val classFile = File(binaryAccessorsDir, "$className.class")
+        fun checkConfigurationAccessors(classesDir: File) {
+            val accessorsDir = File(classesDir, "org/gradle/kotlin/dsl")
 
-                require(classFile.exists())
+            withClassLoaderFor(classesDir) {
+                schema.configurations.forEach { config ->
+                    val name = config.target
+                    val className = "${name.uppercaseFirstChar()}ConfigurationAccessorsKt"
 
-                loadClass("org.gradle.kotlin.dsl.$className").run {
-                    dependencyHandlerExtensionMethods(name).forEach {
-                        assertEquals(
-                            isDeprecated(it),
-                            config.hasDeclarationDeprecations() || isDeprecatedAccessor(it)
-                        )
+                    require(File(accessorsDir, "$className.class").exists())
+
+                    loadClass("org.gradle.kotlin.dsl.$className").run {
+                        dependencyHandlerExtensionMethods(name).forEach {
+                            val shouldBeDeprecated = config.hasDeclarationDeprecations() || isDeprecatedAccessor(it)
+                            assertEquals(
+                                "The accessor for '${config.target}' should be ${if (shouldBeDeprecated) "" else "not "} deprecated in $classesDir",
+                                shouldBeDeprecated,
+                                isDeprecated(it),
+                            )
+
+                            // The multi-string accessor is always deprecated, advising single-string notation,
+                            // and for a configuration deprecated for declaration it also appends that configuration's
+                            // own declaration-deprecation message.
+                            if (isDeprecatedAccessor(it)) {
+                                val message = deprecationMessageOf(it)!!
+                                assertTrue(
+                                    "The multi-string accessor for '${config.target}' should advise single-string notation in $classesDir, but was: $message",
+                                    message.startsWith("Use single-string notation or DependencyFactory instead")
+                                )
+                                if (config.hasDeclarationDeprecations()) {
+                                    assertTrue(
+                                        "The multi-string accessor for the deprecated configuration '${config.target}' should append its declaration-deprecation message in $classesDir, but was: $message",
+                                        message.contains(". The ${config.target} configuration has been deprecated for dependency declaration.")
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
+
+        checkConfigurationAccessors(compiledBinDir)
+        checkConfigurationAccessors(generatedBinDir)
     }
 
     /**
@@ -265,6 +285,9 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             DependencyHandler::class.java, String::class.java, String::class.java, String::class.java,
             String::class.java, String::class.java, String::class.java, Action::class.java
         )
+
+    private fun deprecationMessageOf(method: Method): String? =
+        method.getAnnotation(Deprecated::class.java)?.message
 
     @Test
     fun `#buildAccessorsFor (default package types)`() {

--- a/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
@@ -288,7 +288,7 @@
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
-    @Deprecated("Use single-string notation or DependencyFactory instead")
+    @Deprecated("Use single-string notation or DependencyFactory instead. The compile configuration has been deprecated for dependency declaration. Please use the 'api' or 'implementation' configuration instead.")
     fun DependencyHandler.`compile`(
         group: String,
         name: String,


### PR DESCRIPTION
Add the missing deprecation in the Kotlin DSL accessors bytecode for multi-string dependency DSL functions, in addition to the deprecation in the generated sources (which were only effective in precompiled scripts but not in regular Kotlin DSL).

Fixes:
* https://github.com/gradle/gradle/issues/35837