### PR TITLE
Add Best Practice: Clarity on logger acquisition

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -993,3 +993,69 @@ NOTE: Remember that the goal of Incubating features is to put them in users' han
 === Tags
 
 <<tags_reference.adoc#tag:upgrades,`#upgrades`>>
+
+[[obtain_loggers_via_logging_get_logger]]
+== Obtain Loggers via `Logging.getLogger(Class)` outside of Tasks
+
+Always obtain a link:{javadocPath}/org/gradle/api/logging/Logger.html[`Logger`] by calling `Logging.getLogger(MyClass.class)` from inside each non-`Task` class that logs — plugins, build services, project extensions, and any other helper class — rather than reusing `project.logger` or `script.logger`.
+Inside a `Task`, use the inherited link:https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] instead.
+
+=== Explanation
+
+A logger obtained via `Logging.getLogger(MyClass.class)` is named after the class that owns it.
+A logger obtained from `Project` or `Script` is named after that Gradle type and is shared by every class that reaches it that way.
+Obtaining a class-named logger is what makes log output traceable to the code that produced it.
+
+`Task` is an exception to this rule as link:https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] already returns a named logger for the task.
+
+Reaching for the `Project`-associated logger carries additional problems:
+
+- `project.logger` accessed during task execution is not compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>>, causing the same problems as noted in <<best_practices_tasks.adoc#dont_access_project_instance_inside_task,Don't access a `Project` instance during Task Execution>>.
+- A `Plugin`'s constructor has no access to `Project` either; `Project` only arrives via `apply(Project)`, so a static class-scoped logger is the only option for logging from a plugin constructor.
+- A `BuildService` has no access to `Project` at all, so `project.logger` is not reachable from inside one.
+
+Constructor-injecting a `Logger` is also not supported.
+`Logger` is not among the <<service_injection.adoc#services_for_injection,services available for injection>> into Gradle-managed types (plugins, build services).
+For a `BuildService` this surfaces as the runtime error `Services of type Logger are not available for injection into instances of type BuildService.`.
+`BuildServiceParameters` cannot carry a `Logger` either, since the concrete logger implementation is not serializable for the Configuration Cache.
+
+NOTE: Inline build scripts (`build.gradle(.kts)`) should use the script-scoped `logger` directly if there is no class to attach a static logger to.
+This recommendation applies to code in compiled classes: `buildSrc`, convention plugins, included builds, and published plugins.
+
+The `org.gradle.api.logging.Logger` interface extends `org.slf4j.Logger`, so you keep the full SLF4J API plus Gradle's `LIFECYCLE` and `QUIET` levels.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *Injecting `Logger` into a `BuildService`*: Fails at task execution time with `Services of type Logger are not available for injection into instances of type BuildService`.
+<2> *Using `project.logger` from a plugin*: Yields a logger named for `Project`, not for the plugin class. The same pattern cannot be used in the plugin's constructor at all, since `Project` is not available there.
+<3> *Declaring a static `Logging.getLogger(MyTask.class)` inside a task*: Works, but is unnecessary. `Task.getLogger()` (inherited as `getLogger()`) already returns a class-named logger for the task type.
+<4> *Reading `project.logger` inside a task action*: Works without the Configuration Cache, but fails as soon as the cache is enabled because accessing `Task.project` at execution time is unsupported.
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy",files="build.gradle[tags=do-this]"]
+====
+
+<1> *Build service logger*: A `private static final` `Logger` named after `GreetingService`. No injection required; works regardless of how the service is registered..
+<2> *Plugin logger*: A `private static final` `Logger` named after `GreetingPlugin`. Accessible from any context, including the plugin's constructor.
+<3> *Task uses the inherited `getLogger()`*: `Task.getLogger()` already returns a logger named for the task type. No static field needed.
+
+=== References
+
+- <<logging.adoc#logging,Logging>>
+- <<build_services.adoc#build_services,Shared Build Services>>
+- <<service_injection.adoc#services_for_injection,Services Available for Injection>>
+- <<configuration_cache.adoc#config_cache,Configuration Cache>>
+
+=== Tags
+
+<<tags_reference.adoc#tag:tasks,`#tasks`>>, <<tags_reference.adoc#tag:plugins,`#plugins`>>, <<tags_reference.adoc#tag:logging,`#logging`>>

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -998,7 +998,7 @@ NOTE: Remember that the goal of Incubating features is to put them in users' han
 == Obtain Loggers via `Logging.getLogger(Class)` outside of Tasks
 
 Always obtain a link:{javadocPath}/org/gradle/api/logging/Logger.html[`Logger`] by calling `Logging.getLogger(MyClass.class)` from inside each non-`Task` class that logs — plugins, build services, project extensions, and any other helper class — rather than reusing `project.logger` or `script.logger`.
-Inside a `Task`, use the inherited link:https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] instead.
+Inside a `Task`, use the inherited link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] instead.
 
 === Explanation
 
@@ -1006,7 +1006,7 @@ A logger obtained via `Logging.getLogger(MyClass.class)` is named after the clas
 A logger obtained from `Project` or `Script` is named after that Gradle type and is shared by every class that reaches it that way.
 Obtaining a class-named logger is what makes log output traceable to the code that produced it.
 
-`Task` is an exception to this rule as link:https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] already returns a named logger for the task.
+`Task` is an exception to this rule as link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] already returns a named logger for the task.
 
 Reaching for the `Project`-associated logger carries additional problems:
 
@@ -1045,7 +1045,7 @@ include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-do
 include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy",files="build.gradle[tags=do-this]"]
 ====
 
-<1> *Build service logger*: A `private static final` `Logger` named after `GreetingService`. No injection required; works regardless of how the service is registered..
+<1> *Build service logger*: A `private static final` `Logger` named after `GreetingService`. No injection required; works regardless of how the service is registered.
 <2> *Plugin logger*: A `private static final` `Logger` named after `GreetingPlugin`. Accessible from any context, including the plugin's constructor.
 <3> *Task uses the inherited `getLogger()`*: `Task.getLogger()` already returns a logger named for the task type. No static field needed.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -1006,7 +1006,9 @@ A logger obtained via `Logging.getLogger(MyClass.class)` is named after the clas
 A logger obtained from `Project` or `Script` is named after that Gradle type and is shared by every class that reaches it that way.
 Obtaining a class-named logger is what makes log output traceable to the code that produced it.
 
-`Task` is an exception to this rule as link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] already returns a named logger for the task.
+`Task` is an exception to this rule.
+link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:logger[`Task.getLogger()`] returns a logger whose underlying name is `org.gradle.api.Task` (shared across all tasks), but Gradle wraps it with per-task build-operation context, so console output is attributed to the specific task automatically.
+Use it inside tasks without adding a class-named static field, unless you also need the concrete task class name to appear in raw log output or external log processors.
 
 Reaching for the `Project`-associated logger carries additional problems:
 
@@ -1035,7 +1037,7 @@ include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-av
 
 <1> *Injecting `Logger` into a `BuildService`*: Fails at task execution time with `Services of type Logger are not available for injection into instances of type BuildService`.
 <2> *Using `project.logger` from a plugin*: Yields a logger named for `Project`, not for the plugin class. The same pattern cannot be used in the plugin's constructor at all, since `Project` is not available there.
-<3> *Declaring a static `Logging.getLogger(MyTask.class)` inside a task*: Works, but is unnecessary. `Task.getLogger()` (inherited as `getLogger()`) already returns a class-named logger for the task type.
+<3> *Declaring a static `Logging.getLogger(MyTask.class)` inside a task*: Works, but is redundant for typical Gradle usage. `Task.getLogger()` (inherited as `getLogger()`) provides task attribution through build-operation context, so console output is grouped under the correct task heading without a separate field.
 <4> *Reading `project.logger` inside a task action*: Works without the Configuration Cache, but fails as soon as the cache is enabled because accessing `Task.project` at execution time is unsupported.
 
 ==== Do This Instead
@@ -1047,7 +1049,7 @@ include::sample[dir="snippets/best-practices/obtainLoggersViaLoggingGetLogger-do
 
 <1> *Build service logger*: A `private static final` `Logger` named after `GreetingService`. No injection required; works regardless of how the service is registered.
 <2> *Plugin logger*: A `private static final` `Logger` named after `GreetingPlugin`. Accessible from any context, including the plugin's constructor.
-<3> *Task uses the inherited `getLogger()`*: `Task.getLogger()` already returns a logger named for the task type. No static field needed.
+<3> *Task uses the inherited `getLogger()`*: `Task.getLogger()` returns a logger named `org.gradle.api.Task`, but Gradle wraps it with per-task build-operation context so console output is attributed to the specific task. No static field needed.
 
 === References
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
@@ -52,6 +52,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_general.adoc#do_not_use_gradle_properties_in_subprojects,Do not use gradle.properties in subprojects>> | General | 9.2.0
 | <<best_practices_general.adoc#avoid_after_evaluate,Avoid afterEvaluate>> | General | 9.6.0
 | <<best_practices_general.adoc#consider_use_of_incubating_apis_carefully,Consider use of `@Incubating` APIs carefully>> | General | 9.7.0
+| <<best_practices_general.adoc#obtain_loggers_via_logging_get_logger,Obtain Loggers via Logging.getLogger(Class) outside of Tasks>> | General | 9.8.0
 
 | <<best_practices_structuring_builds.adoc#modularize_builds,Modularize Your Builds>> | Structuring Builds | 9.0.0
 | <<best_practices_structuring_builds.adoc#no_source_in_root,Do Not Put Source Files in the Root Project>> | Structuring Builds | 9.0.0

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
@@ -35,6 +35,9 @@ Here you can find a brief explanation of all the tags used in the best practices
 [[tag:inputs-and-outputs]]
 `#inputs-and-outputs`:: Items that are related to Gradle <<writing_tasks_intermediate.adoc#task_inputs_and_outputs,task inputs and outputs>>, the annotations used to declare them, and their proper use.
 
+[[tag:logging]]
+`#logging` :: Items that are related to producing <<logging.adoc#logging,log output>> from Gradle code (tasks, plugins, build services, and helper classes), including how loggers are obtained and named.
+
 [[tag:plugins]]
 `#plugins` :: Items that explain the proper way to <<plugins.adoc#custom_plugins,write plugins>> in Gradle, and common footguns involved in plugin authoring.
 

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/groovy/build.gradle
@@ -1,0 +1,53 @@
+// tag::avoid-this[]
+import javax.inject.Inject
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+abstract class GreetingService implements BuildService<BuildServiceParameters.None> {
+    @Inject
+    abstract Logger getLogger()  // <1>
+
+    void greet(String name) {
+        getLogger().lifecycle("Hello, {}!", name)
+    }
+}
+
+abstract class GreetingPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.logger.lifecycle("Applying GreetingPlugin")  // <2>
+
+        def service =
+            project.gradle.sharedServices.registerIfAbsent("greeting", GreetingService) {}
+
+        project.tasks.register("greet", PluginGreetingTask) {
+            it.service = service
+            it.usesService(service)
+        }
+    }
+}
+
+abstract class PluginGreetingTask extends DefaultTask {
+    private static final Logger LOGGER = Logging.getLogger(PluginGreetingTask)  // <3>
+
+    @Internal
+    abstract Property<GreetingService> getService()
+
+    @Input
+    abstract Property<String> getGreeting()
+
+    @TaskAction
+    void run() {
+        project.logger.lifecycle("Greeting from task: ${greeting.get()}")  // <4>
+        service.get().greet(greeting.get())
+    }
+}
+
+apply plugin: GreetingPlugin
+
+tasks.named("greet", PluginGreetingTask) {
+    greeting = "world"
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "obtain-loggers-via-logging-get-logger-avoid"

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,52 @@
+// tag::avoid-this[]
+import javax.inject.Inject
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+
+abstract class GreetingService : BuildService<BuildServiceParameters.None> {
+    @get:Inject
+    abstract val logger: Logger  // <1>
+
+    fun greet(name: String) {
+        logger.lifecycle("Hello, {}!", name)
+    }
+}
+
+abstract class GreetingPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.logger.lifecycle("Applying GreetingPlugin")  // <2>
+
+        val service =
+            project.gradle.sharedServices.registerIfAbsent("greeting", GreetingService::class) {}
+
+        project.tasks.register<PluginGreetingTask>("greet") {
+            this.service = service
+            usesService(service)
+        }
+    }
+}
+
+abstract class PluginGreetingTask : DefaultTask() {
+    companion object {
+        private val logger = Logging.getLogger(PluginGreetingTask::class.java)  // <3>
+    }
+
+    @get:Internal
+    abstract val service: Property<GreetingService>
+
+    @get:Input
+    abstract val greeting: Property<String>
+
+    @TaskAction
+    fun run() {
+        project.logger.lifecycle("Greeting from task: ${greeting.get()}")  // <4>
+        service.get().greet(greeting.get())
+    }
+}
+
+apply<GreetingPlugin>()
+
+tasks.named<PluginGreetingTask>("greet") {
+    greeting = "world"
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "obtain-loggers-via-logging-get-logger-avoid"

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/tests/obtainLoggersViaLoggingGetLogger-avoid.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/tests/obtainLoggersViaLoggingGetLogger-avoid.sample.conf
@@ -1,0 +1,5 @@
+executable: gradle
+args: greet --no-configuration-cache
+expect-failure: true
+expected-output-file: obtainLoggersViaLoggingGetLogger.out
+allow-additional-output: true

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/tests/obtainLoggersViaLoggingGetLogger.out
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-avoid/tests/obtainLoggersViaLoggingGetLogger.out
@@ -1,0 +1,1 @@
+> Services of type Logger are not available for injection into instances of type BuildService.

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy/build.gradle
@@ -1,0 +1,51 @@
+// tag::do-this[]
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+abstract class GreetingService implements BuildService<BuildServiceParameters.None> {
+    private static final Logger LOGGER = Logging.getLogger(GreetingService)  // <1>
+
+    void greet(String name) {
+        LOGGER.lifecycle("Hello, {}!", name)
+    }
+}
+
+abstract class GreetingPlugin implements Plugin<Project> {
+    private static final Logger LOGGER = Logging.getLogger(GreetingPlugin)  // <2>
+
+    @Override
+    void apply(Project project) {
+        LOGGER.lifecycle("Applying GreetingPlugin")
+
+        def service =
+            project.gradle.sharedServices.registerIfAbsent("greeting", GreetingService) {}
+
+        project.tasks.register("greet", PluginGreetingTask) {
+            it.service = service
+            it.usesService(service)
+        }
+    }
+}
+
+abstract class PluginGreetingTask extends DefaultTask {
+    @Internal
+    abstract Property<GreetingService> getService()
+
+    @Input
+    abstract Property<String> getGreeting()
+
+    @TaskAction
+    void run() {
+        logger.lifecycle("Greeting from task: {}", greeting.get())  // <3>
+        service.get().greet(greeting.get())
+    }
+}
+
+apply plugin: GreetingPlugin
+
+tasks.named("greet", PluginGreetingTask) {
+    greeting = "world"
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "obtain-loggers-via-logging-get-logger-do"

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/kotlin/build.gradle.kts
@@ -1,0 +1,51 @@
+// tag::do-this[]
+import org.gradle.api.logging.Logging
+
+abstract class GreetingService : BuildService<BuildServiceParameters.None> {
+    companion object {
+        private val logger = Logging.getLogger(GreetingService::class.java)  // <1>
+    }
+
+    fun greet(name: String) {
+        logger.lifecycle("Hello, {}!", name)
+    }
+}
+
+abstract class GreetingPlugin : Plugin<Project> {
+    companion object {
+        private val logger = Logging.getLogger(GreetingPlugin::class.java)  // <2>
+    }
+
+    override fun apply(project: Project) {
+        logger.lifecycle("Applying GreetingPlugin")
+
+        val service =
+            project.gradle.sharedServices.registerIfAbsent("greeting", GreetingService::class) {}
+
+        project.tasks.register<PluginGreetingTask>("greet") {
+            this.service = service
+            usesService(service)
+        }
+    }
+}
+
+abstract class PluginGreetingTask : DefaultTask() {
+    @get:Internal
+    abstract val service: Property<GreetingService>
+
+    @get:Input
+    abstract val greeting: Property<String>
+
+    @TaskAction
+    fun run() {
+        logger.lifecycle("Greeting from task: {}", greeting.get())  // <3>
+        service.get().greet(greeting.get())
+    }
+}
+
+apply<GreetingPlugin>()
+
+tasks.named<PluginGreetingTask>("greet") {
+    greeting = "world"
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "obtain-loggers-via-logging-get-logger-do"

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/tests/obtainLoggersViaLoggingGetLogger-do.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/tests/obtainLoggersViaLoggingGetLogger-do.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: greet
+expected-output-file: obtainLoggersViaLoggingGetLogger.out
+allow-additional-output: true

--- a/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/tests/obtainLoggersViaLoggingGetLogger.out
+++ b/platforms/documentation/docs/src/snippets/best-practices/obtainLoggersViaLoggingGetLogger-do/tests/obtainLoggersViaLoggingGetLogger.out
@@ -1,0 +1,6 @@
+> Task :greet
+Greeting from task: world
+Hello, world!
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed


### PR DESCRIPTION
This new guideline ensures loggers in plugins, build services, and extensions are properly named and compatible with the Configuration Cache. It explains how to correctly obtain `Logger` instances via `Logging.getLogger(Class)` and clarifies why `project.logger` and `Logger` injection should be avoided.

`./gradlew docs:docsTest --tests "*snippet-best-practices-obtain*"`