### PR TITLE
Sync should empty destination when source becomes empty

### DIFF
--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.Sync.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.Sync.xml
@@ -20,6 +20,10 @@
                 <td>preserve</td>
                 <td><literal>empty</literal></td>
             </tr>
+            <tr>
+                <td>skipWhenSourceIsEmpty</td>
+                <td><literal>true</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,6 +79,16 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
+#### `Sync` now deletes stale outputs when its source becomes empty
+
+Previously, a [`Sync`](javadoc/org/gradle/api/tasks/Sync.html) task with no source files was reported as `NO-SOURCE` and skipped, which left any previously synced files sitting in the destination directory indefinitely.
+
+`Sync` now always runs, even when its source is empty, so that a destination it has already synced into is correctly reconciled with the (now empty) source and stale files are deleted, exactly as `Sync` is documented to do.
+
+To guard against the common misconfiguration where `from` accidentally resolves to nothing (for example, a mistyped path) while `into` points at some pre-existing, unrelated directory, `Sync` only performs this cleanup for a destination it has a recorded history of syncing into before. The very first time a `Sync` task runs against a given destination, an empty source is treated as suspicious, and the task does nothing rather than risk deleting content it never put there.
+
+See the [upgrading guide](userguide/upgrading_version_9.html#sync_runs_when_source_is_empty) for details on this behavior change and how to opt back into the old skip behavior.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -91,6 +91,22 @@ Gradle provides comprehensive support for [JVM languages](userguide/building_jav
 ### Core plugin and plugin authoring enhancements
 Gradle provides a comprehensive plugin system, including built-in [Core Plugins](userguide/plugin_reference.html) for standard tasks and powerful APIs for creating custom plugins.
 
+#### `Sync` can empty its destination when its source is empty
+
+A [`Sync`](dsl/org.gradle.api.tasks.Sync.html) task whose source contains no files and no directories, by default, does not run, so its destination directory is not synchronized. What is left in the destination then depends on whether it is a build-owned directory: if it is, the destination is cleaned up; otherwise it keeps the files the source no longer contains.
+
+Setting the new `skipWhenSourceIsEmpty` property to `false` makes the task run in that case as well, so that an empty source empties the destination directory:
+
+```kotlin
+tasks.named<Sync>("mySync") {
+    skipWhenSourceIsEmpty = false
+}
+```
+
+`Sync` always deletes the entire contents of its destination directory, not only the files it previously copied there. With `skipWhenSourceIsEmpty` disabled, that also happens when the source is empty - including when it is empty by mistake - so disable it only where nothing other than the task writes to the destination, and use `preserve { ... }` to retain anything the task does not manage.
+
+See [Synchronizing from an empty source](userguide/working_with_files.html#sec:sync_task_empty_source) in the user manual for more details.
+
 ### Security and infrastructure
 Gradle provides robust [security features and underlying infrastructure](userguide/security.html) to ensure that builds are secure, reproducible, and easy to maintain.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,16 +79,6 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
-#### `Sync` now deletes stale outputs when its source becomes empty
-
-Previously, a [`Sync`](javadoc/org/gradle/api/tasks/Sync.html) task with no source files was reported as `NO-SOURCE` and skipped, which left any previously synced files sitting in the destination directory indefinitely.
-
-`Sync` now always runs, even when its source is empty, so that a destination it has already synced into is correctly reconciled with the (now empty) source and stale files are deleted, exactly as `Sync` is documented to do.
-
-To guard against the common misconfiguration where `from` accidentally resolves to nothing (for example, a mistyped path) while `into` points at some pre-existing, unrelated directory, `Sync` only performs this cleanup for a destination it has a recorded history of syncing into before. The very first time a `Sync` task runs against a given destination, an empty source is treated as suspicious, and the task does nothing rather than risk deleting content it never put there.
-
-See the [upgrading guide](userguide/upgrading_version_9.html#sync_runs_when_source_is_empty) for details on this behavior change and how to opt back into the old skip behavior.
-
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -15,6 +15,7 @@ We are excited to announce Gradle @version@ (released [@releaseDate@](https://gr
 This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
+[devareddy05](https://github.com/devareddy05).
 
 <!-- 
 Include only their name, impactful features should be called out separately below.

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -485,6 +485,14 @@ It synchronizes the contents of a directory with its source.
 
 This can be useful for doing things such as installing your application, creating an exploded copy of your archives, or maintaining a copy of the project's dependencies.
 
+[NOTE]
+====
+Since Gradle 9.8.0, `Sync` no longer skips when its source is empty.
+If the task has previously synced into its destination, an empty-source run deletes the stale files it wrote there (except anything matched by `preserve { ... }`).
+On the very first run into a destination, an empty source is treated as a no-op, to avoid wiping content the task never wrote.
+See <<upgrading_version_9.adoc#sync_runs_when_source_is_empty, the upgrade guide entry>> for migration guidance.
+====
+
 Here is an example that maintains a copy of the project's runtime dependencies in the `build/libs` directory:
 
 ====

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -487,10 +487,9 @@ This can be useful for doing things such as installing your application, creatin
 
 [NOTE]
 ====
-Since Gradle 9.8.0, `Sync` no longer skips when its source is empty.
-If the task has previously synced into its destination, an empty-source run deletes the stale files it wrote there (except anything matched by `preserve { ... }`).
-On the very first run into a destination, an empty source is treated as a no-op, to avoid wiping content the task never wrote.
-See <<upgrading_version_9.adoc#sync_runs_when_source_is_empty, the upgrade guide entry>> for migration guidance.
+Since Gradle 9.8.0, `Sync` no longer skips when its source is empty; it empties its destination instead, except for anything matched by `preserve { ... }`.
+However, a destination the build does not own and has never synced into is left untouched.
+See <<upgrading_version_9.adoc#sync_runs_when_source_is_empty, the upgrade guide entry>>.
 ====
 
 Here is an example that maintains a copy of the project's runtime dependencies in the `build/libs` directory:

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -494,6 +494,46 @@ include::sample[dir="snippets/reference/gradle-types/sync/groovy",files="build.g
 
 You can also perform the same function in your own tasks with the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:sync(org.gradle.api.Action)[Project.sync(org.gradle.api.Action)] method.
 
+[[sec:sync_task_empty_source]]
+==== Synchronizing from an empty source
+
+A `Sync` task whose source contains no files and no directories does not run, so its destination directory is not synchronized.
+What is left in the destination then depends on whether it is a build-owned directory: if it is, the destination is cleaned up; otherwise it keeps the files the source no longer contains.
+
+Set `skipWhenSourceIsEmpty` to `false` to have the task synchronize its destination even then, so that an empty source empties the destination directory, honoring `preserve { ... }`:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.named<Sync>("mySync") {
+    skipWhenSourceIsEmpty = false
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.named('mySync', Sync) {
+    skipWhenSourceIsEmpty = false
+}
+----
+=====
+====
+
+NOTE: `skipWhenSourceIsEmpty` is an <<feature_lifecycle.adoc#feature_lifecycle,incubating>> feature and is subject to change.
+
+[WARNING]
+====
+`Sync` always deletes the entire contents of its destination directory, not only the files it previously copied there.
+With `skipWhenSourceIsEmpty` disabled, that also happens when the source is empty - including when it is empty by mistake.
+Disable it only where nothing other than this task writes to the destination, and use `preserve { ... }` to retain anything the task does not manage.
+====
+
 [[sec:copying_single_file_example]]
 === Using the `Copy` task
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -337,6 +337,14 @@ If your build requires shared, synchronized state, use <<build_services.adoc#bui
 
 For a complete list of types that are incompatible with the Configuration Cache, see the <<configuration_cache_requirements.adoc#config_cache:requirements:disallowed_types, documentation>>.
 
+[[sync_runs_when_source_is_empty]]
+==== `Sync` task is no longer skipped when its source files are empty
+
+Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving stale files in its destination directory.
+The task now runs even when its sources are empty, ensuring stale outputs are deleted as `Sync` is documented to do.
+
+If you previously relied on the skip behavior, configure your task to short-circuit explicitly with `onlyIf { ... }`.
+
 [[v9_upgrade_to_kotlin_2_3_21]]
 ==== Upgrade to Kotlin 2.3.21
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -217,10 +217,13 @@ If you have custom code that branched on `getParameters() == null` to detect a p
 [[sync_runs_when_source_is_empty]]
 ==== `Sync` task is no longer skipped when its source files are empty
 
-Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving stale files in its destination directory.
-The task now runs even when its sources are empty, ensuring stale outputs are deleted as documented.
+Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
 
-If you previously relied on the skip behavior, configure your task to short-circuit explicitly:
+`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not covered by its `preserve()` filter — exactly as `Sync` is documented to do for any other source change.
+
+As a safety measure, this cleanup only happens for a destination the task has synced into before. The very first execution of a `Sync` task against a given destination directory is left untouched if its source is empty: nothing is deleted, and no assumption is made about pre-existing, unrelated content sitting at that destination.
+
+If you rely on the previous skip behavior for a `Sync` task that has already run against its destination, configure it to short-circuit explicitly:
 ====
 [.multi-language-sample]
 =====

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -77,10 +77,9 @@ If you relied on mutable state surviving a cache hit, move it into a task proper
 
 Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
 
-`Sync` now always runs its copy action, even when its source is empty, and behaves the same way whether or not its destination is owned by Gradle.
-Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not matched by the task's `preserve { ... }` filter.
+`Sync` now always runs its copy action, even when its source is empty, deleting everything in its destination directory that is not matched by the task's `preserve { ... }` filter.
 
-If you rely on the previous skip behavior for a `Sync` task that has already run against a destination not owned by Gradle, configure it to short-circuit explicitly:
+If you rely on the previous skip behavior, configure the task to short-circuit explicitly:
 
 ====
 [.multi-language-sample]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -341,9 +341,31 @@ For a complete list of types that are incompatible with the Configuration Cache,
 ==== `Sync` task is no longer skipped when its source files are empty
 
 Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving stale files in its destination directory.
-The task now runs even when its sources are empty, ensuring stale outputs are deleted as `Sync` is documented to do.
+The task now runs even when its sources are empty, ensuring stale outputs are deleted as documented.
 
-If you previously relied on the skip behavior, configure your task to short-circuit explicitly with `onlyIf { ... }`.
+If you previously relied on the skip behavior, configure your task to short-circuit explicitly:
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.named<Sync>("mySync") {
+    onlyIf { !source.isEmpty }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.named('mySync') {
+    onlyIf { !source.empty }
+}
+----
+=====
+====
 
 [[v9_upgrade_to_kotlin_2_3_21]]
 ==== Upgrade to Kotlin 2.3.21

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -214,6 +214,36 @@ Null-checks against the result are no longer required.
 No source change is needed in typical builds.
 If you have custom code that branched on `getParameters() == null` to detect a parameterless action, replace it with `getParameters() instanceof WorkParameters.None` (or the equivalent `None` type).
 
+[[sync_runs_when_source_is_empty]]
+==== `Sync` task is no longer skipped when its source files are empty
+
+Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving stale files in its destination directory.
+The task now runs even when its sources are empty, ensuring stale outputs are deleted as documented.
+
+If you previously relied on the skip behavior, configure your task to short-circuit explicitly:
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.named<Sync>("mySync") {
+    onlyIf { !source.isEmpty }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.named('mySync') {
+    onlyIf { !source.empty }
+}
+----
+=====
+====
+
 === Feature previews
 
 [[dependency_resolution_ordering]]
@@ -336,36 +366,6 @@ Previously, attempts to serialize these types could fail with exceptions such as
 If your build requires shared, synchronized state, use <<build_services.adoc#build_services, shared build services>>, which are explicitly designed for safe coordination between tasks.
 
 For a complete list of types that are incompatible with the Configuration Cache, see the <<configuration_cache_requirements.adoc#config_cache:requirements:disallowed_types, documentation>>.
-
-[[sync_runs_when_source_is_empty]]
-==== `Sync` task is no longer skipped when its source files are empty
-
-Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving stale files in its destination directory.
-The task now runs even when its sources are empty, ensuring stale outputs are deleted as documented.
-
-If you previously relied on the skip behavior, configure your task to short-circuit explicitly:
-====
-[.multi-language-sample]
-=====
-.build.gradle.kts
-[source,kotlin]
-----
-tasks.named<Sync>("mySync") {
-    onlyIf { !source.isEmpty }
-}
-----
-=====
-[.multi-language-sample]
-=====
-.build.gradle
-[source,groovy]
-----
-tasks.named('mySync') {
-    onlyIf { !source.empty }
-}
-----
-=====
-====
 
 [[v9_upgrade_to_kotlin_2_3_21]]
 ==== Upgrade to Kotlin 2.3.21

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -219,9 +219,7 @@ If you have custom code that branched on `getParameters() == null` to detect a p
 
 Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
 
-`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not covered by its `preserve()` filter — exactly as `Sync` is documented to do for any other source change.
-
-As a safety measure, this cleanup only happens for a destination the task has synced into before. The very first execution of a `Sync` task against a given destination directory is left untouched if its source is empty: nothing is deleted, and no assumption is made about pre-existing, unrelated content sitting at that destination.
+`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not covered by its `preserve()` filter.
 
 If you rely on the previous skip behavior for a `Sync` task that has already run against its destination, configure it to short-circuit explicitly:
 ====

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -77,9 +77,10 @@ If you relied on mutable state surviving a cache hit, move it into a task proper
 
 Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
 
-`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not matched by the task's `preserve { ... }` filter.
+`Sync` now always runs its copy action, even when its source is empty, and behaves the same way whether or not its destination is owned by Gradle.
+Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not matched by the task's `preserve { ... }` filter.
 
-If you rely on the previous skip behavior for a `Sync` task that has already run against its destination, configure it to short-circuit explicitly:
+If you rely on the previous skip behavior for a `Sync` task that has already run against a destination not owned by Gradle, configure it to short-circuit explicitly:
 
 ====
 [.multi-language-sample]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -72,6 +72,40 @@ As a consequence, only the singleton's identity is restored, not any mutable sta
 Previously, each `object` was serialized as a regular bean and rebuilt as a _new_ instance on a cache hit, so `deserialized === TheObject` was `false`.
 If you relied on mutable state surviving a cache hit, move it into a task property or another bean type that is serialized by value.
 
+[[sync_runs_when_source_is_empty]]
+==== `Sync` task is no longer skipped when its source files are empty
+
+Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
+
+`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not matched by the task's `preserve { ... }` filter.
+
+If you rely on the previous skip behavior for a `Sync` task that has already run against its destination, configure it to short-circuit explicitly:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.named<Sync>("mySync") {
+    onlyIf { !source.isEmpty }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.named('mySync') {
+    onlyIf { !source.empty }
+}
+----
+=====
+====
+
+NOTE: `source.isEmpty` counts regular files only. If your source can also be a set of empty directories that you want to trigger the skip, expand the predicate to visit the source file tree and check for any file or directory.
+
 === Deprecations
 
 [[deprecate_implicit_parallel_model_building]]
@@ -213,37 +247,6 @@ Null-checks against the result are no longer required.
 
 No source change is needed in typical builds.
 If you have custom code that branched on `getParameters() == null` to detect a parameterless action, replace it with `getParameters() instanceof WorkParameters.None` (or the equivalent `None` type).
-
-[[sync_runs_when_source_is_empty]]
-==== `Sync` task is no longer skipped when its source files are empty
-
-Previously, a link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] task with no source files was reported as `NO-SOURCE` and skipped, leaving any previously synced files in its destination directory in place indefinitely.
-
-`Sync` now always runs its copy action, even when its source is empty. Once a `Sync` task has successfully synced into a given destination directory at least once, a later run with an empty source deletes stale files from that destination — anything not covered by its `preserve()` filter.
-
-If you rely on the previous skip behavior for a `Sync` task that has already run against its destination, configure it to short-circuit explicitly:
-====
-[.multi-language-sample]
-=====
-.build.gradle.kts
-[source,kotlin]
-----
-tasks.named<Sync>("mySync") {
-    onlyIf { !source.isEmpty }
-}
-----
-=====
-[.multi-language-sample]
-=====
-.build.gradle
-[source,groovy]
-----
-tasks.named('mySync') {
-    onlyIf { !source.empty }
-}
-----
-=====
-====
 
 === Feature previews
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
@@ -29,11 +29,13 @@ import org.gradle.internal.properties.InputFilePropertyType;
 import org.gradle.internal.properties.StaticValue;
 import org.jspecify.annotations.NullMarked;
 
+import java.util.function.BooleanSupplier;
+
 @NullMarked
 public class DefaultTaskInputFilePropertyRegistration extends AbstractTaskFilePropertyRegistration implements TaskInputFilePropertyRegistration {
 
     private final InputFilePropertyType filePropertyType;
-    private boolean skipWhenEmpty;
+    private BooleanSupplier skipWhenEmpty = () -> false;
     private DirectorySensitivity directorySensitivity = DirectorySensitivity.DEFAULT;
     private LineEndingSensitivity lineEndingSensitivity = LineEndingSensitivity.DEFAULT;
     private FileNormalizer normalizer = InputNormalizer.ABSOLUTE_PATH;
@@ -56,11 +58,16 @@ public class DefaultTaskInputFilePropertyRegistration extends AbstractTaskFilePr
 
     @Override
     public boolean isSkipWhenEmpty() {
-        return skipWhenEmpty;
+        return skipWhenEmpty.getAsBoolean();
     }
 
     @Override
-    public TaskInputFilePropertyBuilderInternal skipWhenEmpty(boolean skipWhenEmpty) {
+    public TaskInputFilePropertyBuilderInternal skipWhenEmpty(boolean newValue) {
+        return skipWhenEmpty(() -> newValue);
+    }
+
+    @Override
+    public TaskInputFilePropertyBuilderInternal skipWhenEmpty(BooleanSupplier skipWhenEmpty) {
         this.skipWhenEmpty = skipWhenEmpty;
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskInputFilePropertyBuilderInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskInputFilePropertyBuilderInternal.java
@@ -21,6 +21,8 @@ import org.gradle.api.tasks.TaskInputFilePropertyBuilder;
 import org.gradle.internal.fingerprint.FileNormalizer;
 import org.jspecify.annotations.NullMarked;
 
+import java.util.function.BooleanSupplier;
+
 @NullMarked
 public interface TaskInputFilePropertyBuilderInternal extends TaskInputFilePropertyBuilder, TaskFilePropertyBuilderInternal {
 
@@ -40,6 +42,14 @@ public interface TaskInputFilePropertyBuilderInternal extends TaskInputFilePrope
 
     @Override
     TaskInputFilePropertyBuilderInternal skipWhenEmpty(boolean skipWhenEmpty);
+
+    /**
+     * Same as {@link #skipWhenEmpty(boolean)}, but lazy.
+     * <p>
+     * The supplier may be queried whenever the registered properties are visited, possibly more than once
+     * and as early as the end of the task's configuration.
+     */
+    TaskInputFilePropertyBuilderInternal skipWhenEmpty(BooleanSupplier skipWhenEmpty);
 
     @Override
     TaskInputFilePropertyBuilderInternal optional();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -122,9 +122,10 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
      * Whether this task should be skipped with NO-SOURCE when its source files are empty.
      * {@link Sync} overrides this to always run, since deleting stale outputs is part of its contract.
      *
-     * @since 9.7.0
+     * <p>This is intentionally package-private and not part of the public API: the behavior is a fixed
+     * contract of each task type rather than something builds are meant to reconfigure.
      */
-    protected boolean skipWhenSourceIsEmpty() {
+    boolean skipWhenSourceIsEmpty() {
         return true;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -91,7 +91,7 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
                 .withPropertyName(specPropertyName)
                 .withPathSensitivity(PathSensitivity.RELATIVE)
                 .ignoreEmptyDirectories(false)
-                .skipWhenEmpty(skipWhenSourceIsEmpty());
+                .skipWhenEmpty(shouldSkipWhenSourceIsEmpty());
 
             getInputs().property(specPropertyName + ".destPath", (Callable<String>) () -> resolver.getDestPath().getPathString());
             getInputs().property(specPropertyName + ".caseSensitive", (Callable<Boolean>) spec::isCaseSensitive);
@@ -117,13 +117,9 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
     protected abstract CopyAction createCopyAction();
 
     /**
-     * Whether this task should be skipped with NO-SOURCE when its source files are empty.
-     * {@link Sync} overrides this to always run, since deleting stale outputs is part of its contract.
-     *
-     * <p>This is intentionally package-private and not part of the public API: the behavior is a fixed
-     * contract of each task type rather than something builds are meant to reconfigure.
+     * Whether this task should be skipped when its source files are empty.
      */
-    boolean skipWhenSourceIsEmpty() {
+    /* package */ boolean shouldSkipWhenSourceIsEmpty() {
         return true;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -87,13 +87,11 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
             CopySpecResolver resolver = spec.buildResolverRelativeToParent(parentResolver);
             String specPropertyName = specPropertyNameBuilder.toString();
 
-            TaskInputFilePropertyBuilder source = getInputs().files((Callable<FileTree>) resolver::getSource)
+            getInputs().files((Callable<FileTree>) resolver::getSource)
                 .withPropertyName(specPropertyName)
                 .withPathSensitivity(PathSensitivity.RELATIVE)
-                .ignoreEmptyDirectories(false);
-            if (skipWhenSourceIsEmpty()) {
-                source.skipWhenEmpty();
-            }
+                .ignoreEmptyDirectories(false)
+                .skipWhenEmpty(skipWhenSourceIsEmpty());
 
             getInputs().property(specPropertyName + ".destPath", (Callable<String>) () -> resolver.getDestPath().getPathString());
             getInputs().property(specPropertyName + ".caseSensitive", (Callable<Boolean>) spec::isCaseSensitive);

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -87,11 +87,13 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
             CopySpecResolver resolver = spec.buildResolverRelativeToParent(parentResolver);
             String specPropertyName = specPropertyNameBuilder.toString();
 
-            getInputs().files((Callable<FileTree>) resolver::getSource)
+            TaskInputFilePropertyBuilder source = getInputs().files((Callable<FileTree>) resolver::getSource)
                 .withPropertyName(specPropertyName)
                 .withPathSensitivity(PathSensitivity.RELATIVE)
-                .ignoreEmptyDirectories(false)
-                .skipWhenEmpty();
+                .ignoreEmptyDirectories(false);
+            if (skipWhenSourceIsEmpty()) {
+                source.skipWhenEmpty();
+            }
 
             getInputs().property(specPropertyName + ".destPath", (Callable<String>) () -> resolver.getDestPath().getPathString());
             getInputs().property(specPropertyName + ".caseSensitive", (Callable<Boolean>) spec::isCaseSensitive);
@@ -115,6 +117,16 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
     }
 
     protected abstract CopyAction createCopyAction();
+
+    /**
+     * Whether this task should be skipped with NO-SOURCE when its source files are empty.
+     * {@link Sync} overrides this to always run, since deleting stale outputs is part of its contract.
+     *
+     * @since 9.7.0
+     */
+    protected boolean skipWhenSourceIsEmpty() {
+        return true;
+    }
 
     @Inject
     protected abstract Instantiator getInstantiator();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.internal.file.copy.CopySpecResolver;
 import org.gradle.api.internal.file.copy.CopySpecSource;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.provider.PropertyFactory;
+import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.specs.Spec;
@@ -93,11 +94,12 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
             CopySpecResolver resolver = spec.buildResolverRelativeToParent(parentResolver);
             String specPropertyName = specPropertyNameBuilder.toString();
 
-            getInputs().files((Callable<FileTree>) resolver::getSource)
-                .withPropertyName(specPropertyName)
+            TaskInputFilePropertyBuilderInternal sourceProperty =
+                (TaskInputFilePropertyBuilderInternal) getInputs().files((Callable<FileTree>) resolver::getSource);
+            sourceProperty.withPropertyName(specPropertyName)
                 .withPathSensitivity(PathSensitivity.RELATIVE)
-                .ignoreEmptyDirectories(false)
-                .skipWhenEmpty();
+                .skipWhenEmpty(this::shouldSkipWhenSourceIsEmpty)
+                .ignoreEmptyDirectories(false);
 
             getInputs().property(specPropertyName + ".destPath", (Callable<String>) () -> resolver.getDestPath().getPathString());
             getInputs().property(specPropertyName + ".caseSensitive", (Callable<Boolean>) spec::isCaseSensitive);
@@ -131,6 +133,13 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
      * @since 1.8
      */
     protected abstract CopyAction createCopyAction();
+
+    /**
+     * Whether this task should be skipped when its source files are empty.
+     */
+    /* package */ boolean shouldSkipWhenSourceIsEmpty() {
+        return true;
+    }
 
     @Inject
     protected abstract Instantiator getInstantiator();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -72,6 +72,11 @@ public abstract class Sync extends AbstractCopyTask {
     private final PatternFilterable preserveInDestination = new PatternSet();
 
     @Override
+    protected boolean skipWhenSourceIsEmpty() {
+        return false;
+    }
+
+    @Override
     protected CopyAction createCopyAction() {
         File destinationDir = getDestinationDir();
         if (destinationDir == null) {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -73,7 +73,7 @@ public abstract class Sync extends AbstractCopyTask {
     private final PatternFilterable preserveInDestination = new PatternSet();
 
     @Override
-    boolean skipWhenSourceIsEmpty() {
+    boolean shouldSkipWhenSourceIsEmpty() {
         return false;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -32,6 +32,7 @@ import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Synchronizes the contents of a destination directory with some source directories and files.
@@ -73,6 +74,29 @@ public abstract class Sync extends AbstractCopyTask {
 
     @Override
     boolean skipWhenSourceIsEmpty() {
+        return false;
+    }
+
+    @Override
+    protected void copy() {
+        File destinationDir = getDestinationDir();
+        if (destinationDir != null && getSource().isEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
+            // No source, and no record of ever having synced into this exact destination before: most likely
+            // a misconfigured `from` pointed at an unrelated, pre-existing directory. Do nothing rather than
+            // risk wiping out content this task never put there.
+            setDidWork(false);
+            return;
+        }
+        super.copy();
+    }
+
+    private boolean hasPreviousOutputFilesUnder(File destinationDir) {
+        Path destinationPath = destinationDir.toPath();
+        for (File previousOutputFile : getOutputs().getPreviousOutputFiles()) {
+            if (previousOutputFile.toPath().startsWith(destinationPath)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -72,7 +72,7 @@ public abstract class Sync extends AbstractCopyTask {
     private final PatternFilterable preserveInDestination = new PatternSet();
 
     @Override
-    protected boolean skipWhenSourceIsEmpty() {
+    boolean skipWhenSourceIsEmpty() {
         return false;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -83,15 +83,14 @@ public abstract class Sync extends AbstractCopyTask {
     @Override
     protected void copy() {
         File destinationDir = getDestinationDir();
-        boolean isUntracked = getReasonNotToTrackState().isPresent();
-        if (!isUntracked && destinationDir != null && isSourceEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
+        if (destinationDir != null && isSourceEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
             // No source, and no record of ever having synced into this exact destination before: most likely
             // a misconfigured `from` pointed at an unrelated, pre-existing directory. Do nothing rather than
             // risk wiping out content this task never put there.
             //
-            // Untracked tasks (doNotTrackState()/@UntrackedTask) are exempt: Gradle never records execution
-            // history for them, so "no previous output" would otherwise always be true, permanently disabling
-            // this cleanup. An untracked task already forgoes Gradle's incremental/up-to-date guarantees.
+            // For an untracked task (doNotTrackState()/@UntrackedTask), Gradle never records execution history,
+            // so this condition is always true when the source is empty: such a task never auto-cleans stale
+            // outputs on an empty source, since there is no way to safely tell prior output from unrelated content.
             setDidWork(false);
             return;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -83,24 +83,24 @@ public abstract class Sync extends AbstractCopyTask {
     @Override
     protected void copy() {
         File destinationDir = getDestinationDir();
-        if (destinationDir != null && isSourceEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
-            // No source, and no record of ever having synced into this exact destination before: most likely
-            // a misconfigured `from` pointed at an unrelated, pre-existing directory. Do nothing rather than
-            // risk wiping out content this task never put there.
-            //
-            // For an untracked task (doNotTrackState()/@UntrackedTask), Gradle never records execution history,
-            // so this condition is always true when the source is empty: such a task never auto-cleans stale
-            // outputs on an empty source, since there is no way to safely tell prior output from unrelated content.
-            setDidWork(false);
-            return;
+        if (destinationDir != null && !hasPreviousOutputFilesUnder(destinationDir)) {
+            // performance: check file system contents last
+            if (isSourceEmpty()) {
+                // Empty source and no record of a prior sync into this destination:
+                // possibly a misconfigured source pointing at an unrelated directory, so do nothing rather than
+                // wipe content this task never wrote. (Untracked tasks keep no history, so they always
+                // take this branch on an empty source.)
+                setDidWork(false);
+                return;
+            }
         }
         super.copy();
     }
 
     /**
-     * Whether the source contains no files and no directories, consistent with the source input property's own
-     * {@code ignoreEmptyDirectories(false)} configuration — unlike {@link org.gradle.api.file.FileCollection#isEmpty()},
-     * which only counts regular files and would otherwise treat a source made up solely of empty directories as empty.
+     * Whether the source has no files and no directories. Unlike {@link org.gradle.api.file.FileCollection#isEmpty()},
+     * which counts regular files only, this also counts empty directories (needed to honor
+     * {@code ignoreEmptyDirectories(false)}).
      */
     private boolean isSourceEmpty() {
         MutableBoolean found = new MutableBoolean();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -18,6 +18,8 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.EmptyFileVisitor;
+import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DestinationRootCopySpec;
@@ -25,6 +27,7 @@ import org.gradle.api.internal.file.copy.FileCopyAction;
 import org.gradle.api.internal.file.copy.SyncCopyActionDecorator;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.MutableBoolean;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
@@ -80,14 +83,42 @@ public abstract class Sync extends AbstractCopyTask {
     @Override
     protected void copy() {
         File destinationDir = getDestinationDir();
-        if (destinationDir != null && getSource().isEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
+        boolean isUntracked = getReasonNotToTrackState().isPresent();
+        if (!isUntracked && destinationDir != null && isSourceEmpty() && !hasPreviousOutputFilesUnder(destinationDir)) {
             // No source, and no record of ever having synced into this exact destination before: most likely
             // a misconfigured `from` pointed at an unrelated, pre-existing directory. Do nothing rather than
             // risk wiping out content this task never put there.
+            //
+            // Untracked tasks (doNotTrackState()/@UntrackedTask) are exempt: Gradle never records execution
+            // history for them, so "no previous output" would otherwise always be true, permanently disabling
+            // this cleanup. An untracked task already forgoes Gradle's incremental/up-to-date guarantees.
             setDidWork(false);
             return;
         }
         super.copy();
+    }
+
+    /**
+     * Whether the source contains no files and no directories, consistent with the source input property's own
+     * {@code ignoreEmptyDirectories(false)} configuration — unlike {@link org.gradle.api.file.FileCollection#isEmpty()},
+     * which only counts regular files and would otherwise treat a source made up solely of empty directories as empty.
+     */
+    private boolean isSourceEmpty() {
+        MutableBoolean found = new MutableBoolean();
+        getSource().getAsFileTree().visit(new EmptyFileVisitor() {
+            @Override
+            public void visitFile(FileVisitDetails fileDetails) {
+                found.set(true);
+                fileDetails.stopVisiting();
+            }
+
+            @Override
+            public void visitDir(FileVisitDetails dirDetails) {
+                found.set(true);
+                dirDetails.stopVisiting();
+            }
+        });
+        return !found.get();
     }
 
     private boolean hasPreviousOutputFilesUnder(File destinationDir) {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -88,16 +88,11 @@ public abstract class Sync extends AbstractCopyTask {
     @Override
     protected void copy() {
         File destinationDir = getDestinationDir();
-        if (destinationDir != null && !hasPreviousOutputFilesUnder(destinationDir)) {
-            // performance: check file system contents last
-            if (isSourceEmpty()) {
-                // Empty source and no record of a prior sync into this destination:
-                // possibly a misconfigured source pointing at an unrelated directory, so do nothing rather than
-                // wipe content this task never wrote. (Untracked tasks keep no history, so they always
-                // take this branch on an empty source.)
-                setDidWork(false);
-                return;
-            }
+        if (destinationDir != null && !hasPreviousOutputFilesUnder(destinationDir) && isSourceEmpty()) {
+            // Empty source without history: skip to avoid wiping external files.
+            // Untracked tasks have no history, so they always take this path when empty.
+            setDidWork(false);
+            return;
         }
         super.copy();
     }
@@ -109,18 +104,9 @@ public abstract class Sync extends AbstractCopyTask {
      */
     private boolean isSourceEmpty() {
         MutableBoolean found = new MutableBoolean();
-        getSource().getAsFileTree().visit(new EmptyFileVisitor() {
-            @Override
-            public void visitFile(FileVisitDetails fileDetails) {
-                found.set(true);
-                fileDetails.stopVisiting();
-            }
-
-            @Override
-            public void visitDir(FileVisitDetails dirDetails) {
-                found.set(true);
-                dirDetails.stopVisiting();
-            }
+        getSource().getAsFileTree().visit(fileDetails -> {
+            found.set(true);
+            fileDetails.stopVisiting();
         });
         return !found.get();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.copy.SyncCopyActionDecorator;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.execution.BuildOutputCleanupRegistry;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
@@ -42,11 +43,6 @@ import java.nio.file.Path;
  * This task is like the {@link Copy} task, except the destination directory will only contain the files
  * copied. All files that exist in the destination directory will be deleted before copying files, unless
  * a {@link #preserve(Action)} is specified.
- *
- * <p>
- * Since Gradle 9.8.0, an empty source no longer skips the task: the destination is cleared instead
- * (unless there is no record of a previous sync into that destination, in which case the task does nothing
- * to avoid wiping content it never wrote).
  *
  * <p>
  * Examples:
@@ -86,10 +82,14 @@ public abstract class Sync extends AbstractCopyTask {
     @Override
     protected void copy() {
         File destinationDir = getDestinationDir();
-        if (destinationDir != null && !hasPreviousOutputFilesUnder(destinationDir) && isSourceEmpty()) {
-            // Empty source without history: skip to avoid wiping external files.
-            // Untracked tasks have no history, so they always take this path when empty.
+        if (destinationDir != null
+            && !getBuildOutputCleanupRegistry().isOutputOwnedByBuild(destinationDir)
+            && !hasPreviousOutputFilesUnder(destinationDir)
+            && isSourceEmpty()) {
             setDidWork(false);
+            // we used to skip the task on empty input but no longer do, so, for the sake of safety,
+            // if there is no previous record of syncing into the destination, and it is not build-owned,
+            // don't do anything
             return;
         }
         super.copy();
@@ -191,4 +191,7 @@ public abstract class Sync extends AbstractCopyTask {
 
     @Inject
     protected abstract Deleter getDeleter();
+
+    @Inject
+    protected abstract BuildOutputCleanupRegistry getBuildOutputCleanupRegistry();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.copy.DestinationRootCopySpec;
 import org.gradle.api.internal.file.copy.FileCopyAction;
 import org.gradle.api.internal.file.copy.SyncCopyActionDecorator;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.Deleter;
@@ -73,6 +74,43 @@ import java.io.File;
 public abstract class Sync extends AbstractCopyTask {
 
     private final PatternFilterable preserveInDestination = new PatternSet();
+
+    /**
+     * Creates a new {@code Sync} task.
+     *
+     * @since 9.9.0
+     */
+    @SuppressWarnings("this-escape")
+    public Sync() {
+        getSkipWhenSourceIsEmpty().convention(true);
+    }
+
+    /**
+     * Whether this task is skipped when its source contains no files and no directories.
+     *
+     * <p>
+     * When this is {@code true}, which is the default, a task with an empty source does not run and its
+     * destination directory is not synchronized. What is left in the destination then depends on whether it is
+     * a build-owned directory: if it is, the destination is cleaned up; otherwise it keeps the files
+     * the source no longer contains.
+     *
+     * <p>
+     * When this is {@code false}, the task always runs its copy action, so an empty source empties the
+     * destination. Note that this task always deletes the entire contents of its destination directory, not
+     * only the files it copied there, except for anything matched by {@link #preserve(Action)}; disabling this
+     * extends that to a source that is empty, including one that is empty by mistake.
+     *
+     * @return whether this task is skipped when its source is empty
+     * @since 9.9.0
+     */
+    @Incubating
+    @Input
+    public abstract Property<Boolean> getSkipWhenSourceIsEmpty();
+
+    @Override
+    boolean shouldSkipWhenSourceIsEmpty() {
+        return getSkipWhenSourceIsEmpty().get();
+    }
 
     @Override
     protected CopyAction createCopyAction() {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -18,8 +18,6 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.file.EmptyFileVisitor;
-import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DestinationRootCopySpec;

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -46,6 +46,11 @@ import java.nio.file.Path;
  * a {@link #preserve(Action)} is specified.
  *
  * <p>
+ * Since Gradle 9.8.0, an empty source no longer skips the task: the destination is cleared instead
+ * (unless there is no record of a previous sync into that destination, in which case the task does nothing
+ * to avoid wiping content it never wrote).
+ *
+ * <p>
  * Examples:
  * <pre class='autoTested'>
  *

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -28,6 +28,35 @@ import spock.lang.Issue
 
 class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'deletes stale outputs when source becomes empty'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/foo.txt').exists()
+
+        when:
+        file('source/foo.txt').delete()
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        !file('dest/foo.txt').exists()
+        file('dest').directory
+    }
+
     def 'copies files and removes extra files from destDir'() {
         given:
         defaultSourceFileTree()

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -65,6 +65,112 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         file('dest').directory
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'on its first execution against a destination, an empty source leaves pre-existing unrelated content untouched'() {
+        given:
+        // 'source' is never created, so it resolves to an empty file tree (simulating a misconfigured 'from').
+        file('dest/unrelated.txt').text = 'do not delete me'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        // The task attempts to run (Sync's source is never skip-when-empty), but since there is no record of
+        // this task ever having synced into 'dest' before, the safety guard makes it a no-op: it reports
+        // setDidWork(false), which the engine surfaces as UP-TO-DATE, and 'dest' is left untouched.
+        skipped ':sync'
+        file('dest/unrelated.txt').text == 'do not delete me'
+        file('dest').assertHasDescendants('unrelated.txt')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'Copy task is unaffected and stays NO-SOURCE with stale outputs when source becomes empty'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+
+        buildFile """
+            task copy(type: Copy) {
+                from 'source'
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'copy'
+        file('source/foo.txt').delete()
+        run 'copy'
+
+        then:
+        skipped ':copy'
+        file('dest/foo.txt').exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'deletes stale outputs when a child source dir becomes empty'() {
+        given:
+        file('source/sub/foo.txt').text = 'foo'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/sub/foo.txt').exists()
+
+        when:
+        file('source/sub/foo.txt').delete()
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        !file('dest/sub/foo.txt').exists()
+        file('dest/sub').directory
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'with includeEmptyDirs=false an emptied child source dir is not synced to destination'() {
+        given:
+        file('source/sub/foo.txt').text = 'foo'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                includeEmptyDirs = false
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/sub/foo.txt').exists()
+
+        when:
+        file('source/sub/foo.txt').delete()
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        !file('dest/sub/foo.txt').exists()
+        !file('dest/sub').exists()
+    }
+
     def 'copies files and removes extra files from destDir'() {
         given:
         defaultSourceFileTree()
@@ -133,6 +239,85 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
             'dir1/extraDir/extra.txt',
             'emptyDir'
         )
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'preserved files survive while non-preserved stale files are deleted once the destination has sync history'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+        file('dest').create {
+            preservedDir { file 'keep.txt' }
+        }
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                preserve {
+                    include 'preservedDir/**'
+                }
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/foo.txt').exists()
+        file('dest/preservedDir/keep.txt').exists()
+
+        when:
+        file('source/foo.txt').delete()
+        run 'sync'
+
+        then:
+        // 'dest' has sync history from the previous run, so the safety guard does not apply: the real copy
+        // action runs, honoring the preserve spec. foo.txt is stale (not in the now-empty source, not preserved)
+        // and is deleted, while preservedDir/keep.txt matches the preserve spec and survives.
+        executedAndNotSkipped ':sync'
+        !file('dest/foo.txt').exists()
+        file('dest/preservedDir/keep.txt').exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'preserved files are now retained when the source is fully emptied, regardless of whether the destination is build-managed'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+        file('source/keep.txt').text = 'keep'
+
+        buildFile """
+            apply plugin: 'base'
+            task sync(type: Sync) {
+                from 'source'
+                into layout.buildDirectory.dir('dest')
+                preserve {
+                    include 'keep.txt'
+                }
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        file('build/dest/foo.txt').exists()
+        file('build/dest/keep.txt').exists()
+
+        when:
+        file('source/foo.txt').delete()
+        file('source/keep.txt').delete()
+        run 'sync'
+
+        then:
+        // Previously, a build-managed destination with a fully empty source relied on the engine's preserve-blind
+        // stale-output cleanup, which deleted 'keep.txt' too (a known inconsistency vs. a non-build-managed
+        // destination). Now Sync's source is never skip-when-empty, so it never takes that engine-only cleanup
+        // path: its own copy()/SyncCopyActionDecorator always runs once history exists, and correctly honors
+        // preserve() regardless of build-managed status. keep.txt now survives, matching the non-build-managed case.
+        executedAndNotSkipped ':sync'
+        !file('build/dest/foo.txt').exists()
+        file('build/dest/keep.txt').exists()
     }
 
     def 'only excluding non-preserved files works as expected'() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -55,6 +55,14 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         executedAndNotSkipped ':sync'
         !file('dest/foo.txt').exists()
         file('dest').directory
+
+        when:
+        run 'sync'
+
+        then:
+        skipped ':sync'
+        !file('dest/foo.txt').exists()
+        file('dest').directory
     }
 
     def 'copies files and removes extra files from destDir'() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -91,28 +91,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'Copy task is unaffected and stays NO-SOURCE with stale outputs when source becomes empty'() {
-        given:
-        file('source/foo.txt').text = 'foo'
-
-        buildFile """
-            task copy(type: Copy) {
-                from 'source'
-                into 'dest'
-            }
-        """
-
-        when:
-        run 'copy'
-        file('source/foo.txt').delete()
-        run 'copy'
-
-        then:
-        skipped ':copy'
-        file('dest/foo.txt').exists()
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37597")
     def 'deletes stale outputs when a child source dir becomes empty'() {
         given:
         file('source/sub/foo.txt').text = 'foo'
@@ -281,7 +259,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'preserved files are now retained when the source is fully emptied, regardless of whether the destination is build-managed'() {
+    def 'preserve() is honored when the source is fully emptied, even for a build-managed destination'() {
         given:
         file('source/foo.txt').text = 'foo'
         file('source/keep.txt').text = 'keep'
@@ -310,11 +288,8 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         run 'sync'
 
         then:
-        // Previously, a build-managed destination with a fully empty source relied on the engine's preserve-blind
-        // stale-output cleanup, which deleted 'keep.txt' too (a known inconsistency vs. a non-build-managed
-        // destination). Now Sync's source is never skip-when-empty, so it never takes that engine-only cleanup
-        // path: its own copy()/SyncCopyActionDecorator always runs once history exists, and correctly honors
-        // preserve() regardless of build-managed status. keep.txt now survives, matching the non-build-managed case.
+        // preserve() is honored the same way for a build-managed destination as for any other: keep.txt
+        // survives, while foo.txt is stale (not in the now-empty source, not preserved) and is deleted.
         executedAndNotSkipped ':sync'
         !file('build/dest/foo.txt').exists()
         file('build/dest/keep.txt').exists()

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -91,6 +91,30 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'on its first execution against a destination, an empty source leaves pre-existing unrelated content untouched even for an untracked task'() {
+        given:
+        // 'source' is never created, so it resolves to an empty file tree (simulating a misconfigured 'from').
+        file('dest/unrelated.txt').text = 'do not delete me'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                doNotTrackState('exercising the empty-source guard without execution history')
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        // No execution history for an untracked task means "no previous output", so the guard no-ops via setDidWork(false), surfaced as UP-TO-DATE.
+        skipped ':sync'
+        file('dest/unrelated.txt').text == 'do not delete me'
+        file('dest').assertHasDescendants('unrelated.txt')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
     def 'deletes stale outputs when a child source dir becomes empty'() {
         given:
         file('source/sub/foo.txt').text = 'foo'
@@ -174,9 +198,10 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    // Sync's stale-output cleanup on an empty source applies to untracked tasks too, exactly as it does for a
-    // normal, tracked Sync task.
-    def 'deletes stale outputs when source becomes empty even for an untracked task'() {
+    // An untracked task never accumulates sync history, so stale outputs from a real prior run are not
+    // auto-cleaned when the source later becomes empty -- Gradle has no way to safely tell such output apart
+    // from unrelated content that happens to already be in the destination.
+    def 'does not delete stale outputs when source becomes empty for an untracked task'() {
         given:
         file('source/foo.txt').text = 'foo'
 
@@ -200,9 +225,8 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         run 'sync'
 
         then:
-        executedAndNotSkipped ':sync'
-        !file('dest/foo.txt').exists()
-        file('dest').directory
+        skipped ':sync'
+        file('dest/foo.txt').exists()
     }
 
     def 'copies files and removes extra files from destDir'() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -149,6 +149,62 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         !file('dest/sub').exists()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    // A source made up only of empty directories still counts as real content: Sync creates the corresponding
+    // empty directories in the destination on its first run, consistent with the default includeEmptyDirs = true.
+    def 'a source of only empty directories is synced on first run when includeEmptyDirs is true'() {
+        given:
+        file('source').create {
+            emptyDir {}
+        }
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/emptyDir').directory
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    // Sync's stale-output cleanup on an empty source applies to untracked tasks too, exactly as it does for a
+    // normal, tracked Sync task.
+    def 'deletes stale outputs when source becomes empty even for an untracked task'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                doNotTrackState('exercising the empty-source guard without execution history')
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file('dest/foo.txt').exists()
+
+        when:
+        file('source/foo.txt').delete()
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        !file('dest/foo.txt').exists()
+        file('dest').directory
+    }
+
     def 'copies files and removes extra files from destDir'() {
         given:
         defaultSourceFileTree()

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -28,6 +28,161 @@ import spock.lang.Issue
 
 class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'an empty source when destination is #destDescription and skipWhenSourceIsEmpty is #skipOnEmpty'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+
+        buildFile """
+            // `base` is responsible for registering build-owned locations
+            apply plugin: 'base'
+            task sync(type: Sync) {
+                from 'source'
+                into $into
+                skipWhenSourceIsEmpty = $skipOnEmpty
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file("$destDir/foo.txt").exists()
+
+        when:
+        file('source/foo.txt').delete()
+        run 'sync'
+
+        then:
+        assertSyncOutcome(afterEmptying)
+        assertDestination(destDir, remaining)
+
+        when:
+        run 'sync'
+
+        then:
+        assertSyncOutcome(onRerun)
+        assertDestination(destDir, remaining)
+
+        where:
+        skipOnEmpty | destDescription   | into                                 | destDir     | afterEmptying | onRerun      | remaining
+        true        | 'build-owned'     | 'layout.buildDirectory.dir("out")'   | 'build/out' | 'EXECUTED'    | 'NO-SOURCE'  | null
+        true        | 'non-build-owned' | 'layout.projectDirectory.dir("out")' | 'out'       | 'NO-SOURCE'   | 'NO-SOURCE'  | ['foo.txt']
+        false       | 'build-owned'     | 'layout.buildDirectory.dir("out")'   | 'build/out' | 'EXECUTED'    | 'UP-TO-DATE' | []
+        false       | 'non-build-owned' | 'layout.projectDirectory.dir("out")' | 'out'       | 'EXECUTED'    | 'UP-TO-DATE' | []
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'an empty source with no previous run (skipWhenSourceIsEmpty: #skipOnEmpty)'() {
+        given:
+        // 'source' is never created, so it resolves to an empty file tree (simulating a misconfigured 'from').
+        file('dest/unrelated.txt').text = 'do not delete me'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                skipWhenSourceIsEmpty = $skipOnEmpty
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        assertSyncOutcome(expectedOutcome)
+        assertDestination('dest', remaining)
+
+        where:
+        skipOnEmpty | expectedOutcome | remaining
+        true        | 'NO-SOURCE'     | ['unrelated.txt']
+        false       | 'EXECUTED'      | []
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'an empty source with a destination that does not exist yet (skipWhenSourceIsEmpty: #skipOnEmpty)'() {
+        given:
+        // neither 'source' nor 'dest' is created, so the source resolves to an empty file tree and there is
+        // nothing at all for the task to do
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                skipWhenSourceIsEmpty = $skipOnEmpty
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        assertSyncOutcome(expectedOutcome)
+        assertDestination('dest', remaining)
+
+        where:
+        // not skipping runs the task, which creates its output directory, but the copy action does no work,
+        // so the task is reported as UP-TO-DATE rather than as executed
+        skipOnEmpty | expectedOutcome | remaining
+        true        | 'NO-SOURCE'     | null
+        false       | 'UP-TO-DATE'    | []
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'skipWhenSourceIsEmpty is honored when set after the task has been configured'() {
+        given:
+        // 'source' is never created, so it resolves to an empty file tree. The pre-existing file gives the
+        // task something to do, so that honoring the late assignment shows up as the task running rather
+        // than being skipped as NO-SOURCE. What it does to the destination is covered elsewhere.
+        file('dest/pre-existing.txt').text = 'delete me'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+            }
+
+            tasks.named('sync') {
+                skipWhenSourceIsEmpty = false
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        assertSyncOutcome('EXECUTED')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'disabling skipWhenSourceIsEmpty removes the copy spec from the task source files (skipWhenSourceIsEmpty: #skipOnEmpty)'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+
+        buildFile """
+            task sync(type: Sync) {
+                from 'source'
+                into 'dest'
+                skipWhenSourceIsEmpty = $skipOnEmpty
+            }
+
+            println "sourceFiles=" + tasks.sync.inputs.sourceFiles.files.size()
+            println "inputFiles=" + tasks.sync.inputs.files.files.size()
+        """
+
+        when:
+        run 'help'
+
+        then:
+        outputContains("sourceFiles=$expectedSourceFiles")
+        outputContains("inputFiles=1")
+
+        where:
+        skipOnEmpty | expectedSourceFiles
+        true        | 1
+        false       | 0
+    }
+
     def 'copies files and removes extra files from destDir'() {
         given:
         defaultSourceFileTree()
@@ -96,6 +251,49 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
             'dir1/extraDir/extra.txt',
             'emptyDir'
         )
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37597")
+    def 'preserve is honored when the source is fully emptied and skipWhenSourceIsEmpty is false (destination: #description)'() {
+        given:
+        file('source/foo.txt').text = 'foo'
+        file('source/keep.txt').text = 'keep'
+
+        buildFile """
+            // `base` is responsible for registering build-owned locations
+            apply plugin: 'base'
+            task sync(type: Sync) {
+                from 'source'
+                into $into
+                skipWhenSourceIsEmpty = false
+                preserve {
+                    include 'keep.txt'
+                }
+            }
+        """
+
+        when:
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        file("$destDir/foo.txt").exists()
+        file("$destDir/keep.txt").exists()
+
+        when:
+        file('source/foo.txt').delete()
+        file('source/keep.txt').delete()
+        run 'sync'
+
+        then:
+        executedAndNotSkipped ':sync'
+        !file("$destDir/foo.txt").exists()
+        file("$destDir/keep.txt").exists()
+
+        where:
+        description         | into                                    | destDir
+        'build-owned'       | 'layout.buildDirectory.dir("out")'      | 'build/out'
+        'non-build-owned'   | 'layout.projectDirectory.dir("out")'    | 'out'
     }
 
     def 'only excluding non-preserved files works as expected'() {
@@ -739,6 +937,33 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         file('dest').assertHasDescendants(
             'file1.txt'
         )
+    }
+
+    /**
+     * Asserts the outcome the ':sync' task was reported with: 'EXECUTED', or a skip marker such as
+     * 'NO-SOURCE' or 'UP-TO-DATE'. Both markers report the task as skipped, so the marker itself is
+     * what distinguishes them.
+     */
+    private void assertSyncOutcome(String expectedOutcome) {
+        if (expectedOutcome == 'EXECUTED') {
+            executedAndNotSkipped ':sync'
+        } else {
+            skipped ':sync'
+            outputContains(":sync $expectedOutcome")
+        }
+    }
+
+    /**
+     * Asserts the contents of the destination directory, where {@code null} expects the directory itself not
+     * to exist: the stale-output clean-up deletes it once it is left empty, and a skipped task never creates
+     * it in the first place. The copy action, in contrast, both creates and keeps it.
+     */
+    private void assertDestination(String destDir, List<String> expectedContents) {
+        if (expectedContents == null) {
+            file(destDir).assertDoesNotExist()
+        } else {
+            file(destDir).assertHasDescendants(expectedContents)
+        }
     }
 
     def defaultSourceFileTree() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -29,14 +29,16 @@ import spock.lang.Issue
 class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'deletes stale outputs when source becomes empty'() {
+    def 'deletes stale outputs when source becomes empty (destination: #description)'() {
         given:
         file('source/foo.txt').text = 'foo'
 
         buildFile """
+            // `base` is responsible for registering build-owned locations
+            apply plugin: 'base'
             task sync(type: Sync) {
                 from 'source'
-                into 'dest'
+                into $into
             }
         """
 
@@ -45,7 +47,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
 
         then:
         executedAndNotSkipped ':sync'
-        file('dest/foo.txt').exists()
+        file("$destDir/foo.txt").exists()
 
         when:
         file('source/foo.txt').delete()
@@ -53,16 +55,21 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
 
         then:
         executedAndNotSkipped ':sync'
-        !file('dest/foo.txt').exists()
-        file('dest').directory
+        !file("$destDir/foo.txt").exists()
+        file(destDir).directory
 
         when:
         run 'sync'
 
         then:
         skipped ':sync'
-        !file('dest/foo.txt').exists()
-        file('dest').directory
+        !file("$destDir/foo.txt").exists()
+        file(destDir).directory
+
+        where:
+        description         | into                                    | destDir
+        'build-owned'       | 'layout.buildDirectory.dir("out")'      | 'build/out'
+        'non-build-owned'   | 'layout.projectDirectory.dir("out")'    | 'out'
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
@@ -300,55 +307,17 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'preserved files survive while non-preserved stale files are deleted once the destination has sync history'() {
-        given:
-        file('source/foo.txt').text = 'foo'
-        file('dest').create {
-            preservedDir { file 'keep.txt' }
-        }
-
-        buildFile """
-            task sync(type: Sync) {
-                from 'source'
-                into 'dest'
-                preserve {
-                    include 'preservedDir/**'
-                }
-            }
-        """
-
-        when:
-        run 'sync'
-
-        then:
-        executedAndNotSkipped ':sync'
-        file('dest/foo.txt').exists()
-        file('dest/preservedDir/keep.txt').exists()
-
-        when:
-        file('source/foo.txt').delete()
-        run 'sync'
-
-        then:
-        // 'dest' has sync history from the previous run, so the safety guard does not apply: the real copy
-        // action runs, honoring the preserve spec. foo.txt is stale (not in the now-empty source, not preserved)
-        // and is deleted, while preservedDir/keep.txt matches the preserve spec and survives.
-        executedAndNotSkipped ':sync'
-        !file('dest/foo.txt').exists()
-        file('dest/preservedDir/keep.txt').exists()
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'preserve() is honored when the source is fully emptied, even for a build-managed destination'() {
+    def 'preserve() is honored when the source is fully emptied, once the destination has sync history (destination: #description)'() {
         given:
         file('source/foo.txt').text = 'foo'
         file('source/keep.txt').text = 'keep'
 
         buildFile """
+            // `base` is responsible for registering build-owned locations
             apply plugin: 'base'
             task sync(type: Sync) {
                 from 'source'
-                into layout.buildDirectory.dir('dest')
+                into $into
                 preserve {
                     include 'keep.txt'
                 }
@@ -359,8 +328,9 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         run 'sync'
 
         then:
-        file('build/dest/foo.txt').exists()
-        file('build/dest/keep.txt').exists()
+        executedAndNotSkipped ':sync'
+        file("$destDir/foo.txt").exists()
+        file("$destDir/keep.txt").exists()
 
         when:
         file('source/foo.txt').delete()
@@ -368,11 +338,14 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         run 'sync'
 
         then:
-        // preserve() is honored the same way for a build-managed destination as for any other: keep.txt
-        // survives, while foo.txt is stale (not in the now-empty source, not preserved) and is deleted.
         executedAndNotSkipped ':sync'
-        !file('build/dest/foo.txt').exists()
-        file('build/dest/keep.txt').exists()
+        !file("$destDir/foo.txt").exists()
+        file("$destDir/keep.txt").exists()
+
+        where:
+        description         | into                                    | destDir
+        'build-owned'       | 'layout.buildDirectory.dir("out")'      | 'build/out'
+        'non-build-owned'   | 'layout.projectDirectory.dir("out")'    | 'out'
     }
 
     def 'only excluding non-preserved files works as expected'() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -98,35 +98,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'deletes stale outputs when a child source dir becomes empty'() {
-        given:
-        file('source/sub/foo.txt').text = 'foo'
-
-        buildFile """
-            task sync(type: Sync) {
-                from 'source'
-                into 'dest'
-            }
-        """
-
-        when:
-        run 'sync'
-
-        then:
-        executedAndNotSkipped ':sync'
-        file('dest/sub/foo.txt').exists()
-
-        when:
-        file('source/sub/foo.txt').delete()
-        run 'sync'
-
-        then:
-        executedAndNotSkipped ':sync'
-        !file('dest/sub/foo.txt').exists()
-        file('dest/sub').directory
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37597")
     def 'with includeEmptyDirs=false an emptied child source dir is not synced to destination'() {
         given:
         file('source/sub/foo.txt').text = 'foo'
@@ -283,7 +254,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'preserve() is honored when the source is fully emptied, once the destination has sync history (destination: #description)'() {
+    def 'preserve is honored when the source is fully emptied, once the destination has sync history (destination: #description)'() {
         given:
         file('source/foo.txt').text = 'foo'
         file('source/keep.txt').text = 'keep'

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -89,9 +89,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
         run 'sync'
 
         then:
-        // The task attempts to run (Sync's source is never skip-when-empty), but since there is no record of
-        // this task ever having synced into 'dest' before, the safety guard makes it a no-op: it reports
-        // setDidWork(false), which the engine surfaces as UP-TO-DATE, and 'dest' is left untouched.
         skipped ':sync'
         file('dest/unrelated.txt').text == 'do not delete me'
         file('dest').assertHasDescendants('unrelated.txt')
@@ -128,8 +125,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    // A source made up only of empty directories still counts as real content: Sync creates the corresponding
-    // empty directories in the destination on its first run, consistent with the default includeEmptyDirs = true.
     def 'a source of only empty directories is synced on first run when includeEmptyDirs is true'() {
         given:
         file('source').create {
@@ -140,6 +135,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
+                // includeEmptyDirs = true (default)
             }
         """
 
@@ -152,9 +148,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    // An untracked task never accumulates sync history, so stale outputs from a real prior run are not
-    // auto-cleaned when the source later becomes empty -- Gradle has no way to safely tell such output apart
-    // from unrelated content that happens to already be in the destination.
     def 'does not delete stale outputs when source becomes empty for an untracked task'() {
         given:
         file('source/foo.txt').text = 'foo'

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -95,36 +95,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'with includeEmptyDirs=false an emptied child source dir is not synced to destination'() {
-        given:
-        file('source/sub/foo.txt').text = 'foo'
-
-        buildFile """
-            task sync(type: Sync) {
-                from 'source'
-                into 'dest'
-                includeEmptyDirs = false
-            }
-        """
-
-        when:
-        run 'sync'
-
-        then:
-        executedAndNotSkipped ':sync'
-        file('dest/sub/foo.txt').exists()
-
-        when:
-        file('source/sub/foo.txt').delete()
-        run 'sync'
-
-        then:
-        executedAndNotSkipped ':sync'
-        !file('dest/sub/foo.txt').exists()
-        !file('dest/sub').exists()
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37597")
     def 'a source of only empty directories is synced on first run when includeEmptyDirs is true'() {
         given:
         file('source').create {
@@ -148,15 +118,17 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'does not delete stale outputs when source becomes empty for an untracked task'() {
+    def 'for a task that does not track state, an emptied source #description'() {
         given:
         file('source/foo.txt').text = 'foo'
 
         buildFile """
+            // `base` is responsible for registering build-owned locations
+            apply plugin: 'base'
             task sync(type: Sync) {
                 from 'source'
-                into 'dest'
-                doNotTrackState('exercising the empty-source guard without execution history')
+                into $into
+                doNotTrackState('a task that does not track state keeps no record of previous syncs')
             }
         """
 
@@ -165,15 +137,26 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
 
         then:
         executedAndNotSkipped ':sync'
-        file('dest/foo.txt').exists()
+        file("$destDir/foo.txt").exists()
 
         when:
         file('source/foo.txt').delete()
         run 'sync'
 
         then:
-        skipped ':sync'
-        file('dest/foo.txt').exists()
+        file("$destDir/foo.txt").exists() != destinationEmptied
+
+        and:
+        if (destinationEmptied) {
+            executedAndNotSkipped ':sync'
+        } else {
+            skipped ':sync'
+        }
+
+        where:
+        description                                      | into                                 | destDir     | destinationEmptied
+        'empties a build-owned destination'              | 'layout.buildDirectory.dir("out")'   | 'build/out' | true
+        'leaves a non-build-owned destination untouched' | 'layout.projectDirectory.dir("out")' | 'out'       | false
     }
 
     def 'copies files and removes extra files from destDir'() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -98,30 +98,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableC
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37597")
-    def 'on its first execution against a destination, an empty source leaves pre-existing unrelated content untouched even for an untracked task'() {
-        given:
-        // 'source' is never created, so it resolves to an empty file tree (simulating a misconfigured 'from').
-        file('dest/unrelated.txt').text = 'do not delete me'
-
-        buildFile """
-            task sync(type: Sync) {
-                from 'source'
-                into 'dest'
-                doNotTrackState('exercising the empty-source guard without execution history')
-            }
-        """
-
-        when:
-        run 'sync'
-
-        then:
-        // No execution history for an untracked task means "no previous output", so the guard no-ops via setDidWork(false), surfaced as UP-TO-DATE.
-        skipped ':sync'
-        file('dest/unrelated.txt').text == 'do not delete me'
-        file('dest').assertHasDescendants('unrelated.txt')
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/37597")
     def 'deletes stale outputs when a child source dir becomes empty'() {
         given:
         file('source/sub/foo.txt').text = 'foo'


### PR DESCRIPTION
Sync should not be skipped if inputs are empty, as it should make the destination dir empty as well.  

This (when out of draft) shall supersede #37836, by @devareddy05 (it contains commits by @devareddy05 from that branch).

Issue: #37597

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
