### PR TITLE
Add code review guide and gradle-code-review skill

### DIFF
--- a/.agents/code-review.md
+++ b/.agents/code-review.md
@@ -1,0 +1,30 @@
+# Reviewing code
+
+When asked to review a change, diff, branch, or pull request, follow the
+[Code Review guide](../contributing/CodeReview.md). It defines *what* to look
+for (correctness bugs, API-contract violations, edge cases, security) and
+*what* to ignore (style, formatting, and naming).
+It applies to human and AI reviewers alike.
+
+Scope: review everything that will reach the target branch — the commits
+since this branch's fork point, plus uncommitted and untracked changes. If
+the intended range is ambiguous, ask which range to review.
+
+Output: report findings only. Give each as `path:Lstart-Lend`, a short
+description (quoting the offending code or violated rule where useful), and a
+severity (`critical` / `major` / `minor` / `suggestion`). Do not add a summary
+of the change or an overall verdict. If there are no correctness issues, say so
+in one line and stop.
+
+## Tooling notes
+
+A `gradle-code-review` skill under [`.claude/skills/`](../.claude/skills/) wraps
+the guide above with the review mechanics (scope detection, output format). It
+is written in Claude Code's skill format (a `SKILL.md` with frontmatter), but
+its instructions are plain Markdown that any agent can read and follow.
+
+- If your tool supports Claude Code skills, it is discovered automatically —
+  invoke it with `/gradle-code-review`.
+- Otherwise, read the skill's `SKILL.md` and
+  [contributing/CodeReview.md](../contributing/CodeReview.md) directly and follow
+  them by hand.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,8 @@
       "Bash(wc *)",
       "Bash(date *)",
       "Read(.agents/**)",
-      "mcp__ide__getDiagnostics"
+      "mcp__ide__getDiagnostics",
+      "Bash(.claude/skills/gradle-code-review/gradle-code-review.sh:*)"
     ],
     "deny": [
       "Bash(git push *)"

--- a/.claude/skills/gradle-code-review/SKILL.md
+++ b/.claude/skills/gradle-code-review/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: gradle-code-review
+description: The code review workflow for this Gradle repository. Use whenever the user asks to review code, perform/do a code review, review a change, diff, branch, or PR, or check changes before they reach the target branch. Prefer this over any generic code-review skill when working in this repo.
+---
+
+# Code Review
+
+Apply the repository's review judgement — the source of truth for *what* to
+look for and *what* to ignore is **`contributing/CodeReview.md`**.
+
+All git access goes through the companion script **`gradle-code-review.sh`**, so only
+that one script needs execute permission — never call `git` directly. It is
+read-only and exposes:
+
+- `.claude/skills/gradle-code-review/gradle-code-review.sh scope [TARGET_REF]` — summary of what is in scope
+- `.claude/skills/gradle-code-review/gradle-code-review.sh diff  [TARGET_REF]` — full review diff (committed + working tree)
+- `.claude/skills/gradle-code-review/gradle-code-review.sh log   PATH [TARGET_REF]` — commit history with patches for a path
+- `.claude/skills/gradle-code-review/gradle-code-review.sh blame PATH` — `git blame` for a path
+
+**Always invoke it by exactly that repo-relative path** — Bash runs from the
+repo root, so it resolves — and do **not** rewrite it to an absolute path. The
+project permission rule allows the relative form; an absolute path would not
+match it and would trigger a prompt.
+
+`TARGET_REF` is auto-detected when omitted — the base branch of an open PR for
+the current branch (via `gh`), else the canonical remote's default branch. Pass
+it explicitly only to override (e.g. `origin/release`); `scope` prints which
+target it used and how it was chosen.
+
+The actual analysis is delegated to a **sub-agent with a fresh context
+window** so that reading the diff and the touched files does not fill up this
+session's context. This session only resolves scope, launches the sub-agent,
+and relays its findings.
+
+## Step 1 — Resolve scope (this session)
+
+Run `.claude/skills/gradle-code-review/gradle-code-review.sh scope <target>` to see the
+target branch, fork point, the commits since it, the files changed, and whether
+the working tree is dirty.
+
+The principle: **everything that will reach the target branch needs review** —
+the commits since the fork point plus any uncommitted/untracked changes. Some
+commits may already have been pushed and reviewed, so the intended range can
+be narrower.
+
+**If scope is ambiguous — or it's unclear whether to include uncommitted work
+— ask the user which range to review before continuing.** (This must happen
+here: the sub-agent cannot ask questions.) End this step knowing the target
+ref and whether uncommitted work is in scope.
+
+## Step 2 — Delegate the analysis to a fresh-context sub-agent
+
+Launch one sub-agent (Agent tool) to perform the review in its own context.
+Give it a self-contained prompt containing:
+
+- The scope from step 1: the target ref, and whether uncommitted/untracked
+  changes are in scope.
+- Instructions to gather the change via the companion script — run
+  `.claude/skills/gradle-code-review/gradle-code-review.sh diff <target>` for the full
+  diff, and `gradle-code-review.sh log <path> <target>` / `gradle-code-review.sh blame <path>`
+  for historical context on subtle code. It must not call `git` directly.
+- An instruction to **read `contributing/CodeReview.md` first** and apply its
+  focus areas and exclusions, plus any relevant `CLAUDE.md` files and
+  `contributing/` guides.
+- The read-only constraint: only the companion script, Read, Glob, and Grep —
+  do not build, type-check, or modify code (CI handles build signal
+  separately).
+- The output contract below — the sub-agent must return **only** the
+  findings, not its intermediate reading or reasoning and not a summary of
+  the change, so this session's context stays small.
+
+Do not read the diff or the touched files in this session yourself — that is
+the sub-agent's job, and doing it here defeats the purpose.
+
+The Agent tool call returns the sub-agent's findings directly as its result;
+use that return value — there is nothing to wait or poll for.
+
+## Step 3 — Relay the findings (this session)
+
+Present the sub-agent's findings to the user verbatim (lightly formatted).
+Each finding:
+
+- **`path:Lstart-Lend`** from the repo root
+  (e.g. `platforms/jvm/scala/.../ScalaForkOptions.java:L40-L52`),
+- a clear description — quoting the offending code or including relevant data
+  flow paths, preconditions, unexpected sideeffects,
+- a severity: `critical` / `major` / `minor` / `suggestion`.
+
+Output findings only — no preamble, no summary of the change, no overall
+verdict or wrap-up. If the sub-agent found no correctness issues, report a
+single line that there is nothing to report and stop — do not invent findings
+or pad the output.

--- a/.claude/skills/gradle-code-review/gradle-code-review.sh
+++ b/.claude/skills/gradle-code-review/gradle-code-review.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 the original authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Companion script for the gradle-code-review skill.
+#
+# All git access the review needs goes through here, so the skill only
+# requires permission to run this one script rather than each individual
+# git command. Read-only: it never mutates the repo.
+#
+# Usage:
+#   gradle-code-review.sh scope [TARGET_REF]         Summary of what is in scope
+#   gradle-code-review.sh diff  [TARGET_REF]         Full review diff (committed + working tree + untracked)
+#   gradle-code-review.sh log   PATH [TARGET_REF]    Commit history with patches for a path
+#   gradle-code-review.sh blame PATH                 git blame for a path (full file, intentionally unscoped)
+#
+# TARGET_REF is the branch the change is destined for on gradle/gradle
+# (github.com). That remote is located by URL, so its name need not be
+# "origin". When TARGET_REF is omitted it is detected as:
+#   1. the base branch of an open PR for the current branch (via `gh`), if any;
+#   2. otherwise the inferred fork parent among the likely integration
+#      branches — master, release, then release<N>x (newest first) — chosen by
+#      which one HEAD actually forked from (the most recent merge-base);
+#      candidate order only breaks ties.
+# The review range is <merge-base(TARGET_REF, HEAD)>..HEAD — everything since
+# the fork point, plus (for `diff`) uncommitted and untracked changes.
+set -euo pipefail
+
+# Run git with a fixed configuration so the output does not depend on the
+# user's global/local git config (custom log formats, external diff/pager
+# tools, colouring, prefix styles, …). Every git invocation below goes
+# through this wrapper; per-command flags (--no-ext-diff, --no-textconv,
+# explicit --pretty) cover the knobs that cannot be forced via -c.
+git() {
+  command git \
+    -c core.pager=cat \
+    -c color.ui=false \
+    -c diff.external= \
+    -c diff.mnemonicPrefix=false \
+    -c diff.noprefix=false \
+    -c diff.relative=false \
+    -c log.showSignature=false \
+    -c log.decorate=false \
+    -c format.pretty=medium \
+    -c status.relativePaths=false \
+    -c blame.showEmail=false \
+    -c blame.showRoot=false \
+    "$@"
+}
+
+usage() {
+  # Print the header comment block as usage, minus the shebang line.
+  grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+}
+
+# --- Target-branch detection -------------------------------------------------
+
+has_remote() { git remote get-url "$1" >/dev/null 2>&1; }
+
+# Remote whose URL points at github.com/gradle/gradle, regardless of its name
+# (matches git@github.com:gradle/gradle.git and https://github.com/gradle/gradle).
+gradle_remote() {
+  local name url
+  while read -r name url; do
+    if [[ "$url" =~ github\.com[:/]gradle/gradle(\.git)?/?$ ]]; then
+      printf '%s' "$name"; return
+    fi
+  done < <(git remote -v | awk '$3 == "(fetch)" { print $1, $2 }')
+}
+
+# Fallback when no remote is clearly gradle/gradle: upstream, else origin, else
+# the first configured remote.
+fallback_remote() {
+  local r
+  for r in upstream origin; do has_remote "$r" && { printf '%s' "$r"; return; }; done
+  git remote | head -n1
+}
+
+# The remote we treat as the gradle/gradle target repository.
+target_remote() {
+  local r; r="$(gradle_remote)"
+  [[ -n "$r" ]] && { printf '%s' "$r"; return; }
+  fallback_remote
+}
+
+# Map a plain branch name (e.g. a PR base) to a tracking ref, preferring the
+# target remote, then any remote, then a local branch.
+resolve_branch_ref() {
+  local name="$1" r
+  for r in "$(target_remote)" upstream origin $(git remote); do
+    [[ -n "$r" ]] || continue
+    if git rev-parse --verify --quiet "refs/remotes/$r/$name" >/dev/null; then
+      printf '%s' "$r/$name"; return
+    fi
+  done
+  git rev-parse --verify --quiet "refs/heads/$name" >/dev/null && { printf '%s' "$name"; return; }
+  printf '%s' "$name"   # last resort: let base_for validate/fail with context
+}
+
+# Ordered candidate target refs on the target remote: master, release, then
+# release<N>x (newest first). Only existing branches are emitted.
+candidate_targets() {
+  local remote="$1" c
+  for c in master release; do
+    git rev-parse --verify --quiet "refs/remotes/$remote/$c" >/dev/null && printf '%s\n' "$remote/$c"
+  done
+  # release<N>x, sorted by N descending (portable: prefix number, numeric sort).
+  git for-each-ref --format='%(refname:short)' "refs/remotes/$remote/release*" \
+    | sed "s#^$remote/##" \
+    | grep -E '^release[0-9]+x$' \
+    | sed -E 's/^release([0-9]+)x$/\1 &/' \
+    | sort -k1,1 -nr \
+    | awk -v R="$remote" '{ print R"/"$2 }'
+}
+
+# Print "<ref>\t<source>" for the detected target, or nothing.
+detect_target() {
+  # 1) Definitive: the base branch of an open PR for the current branch.
+  if command -v gh >/dev/null 2>&1; then
+    local base_ref
+    base_ref="$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || true)"
+    if [[ -n "$base_ref" ]]; then
+      printf '%s\t%s' "$(resolve_branch_ref "$base_ref")" "open PR base branch"
+      return
+    fi
+  fi
+
+  # 2) No PR: infer the fork parent. Among the candidates, the branch HEAD
+  #    forked from is the one whose merge-base with HEAD is the most recent
+  #    commit; ties fall to candidate order (master > release > newer release<N>x).
+  local remote; remote="$(target_remote)"
+  [[ -n "$remote" ]] || return
+
+  local best="" best_base="" cand mb
+  while IFS= read -r cand; do
+    mb="$(git merge-base "$cand" HEAD 2>/dev/null || true)"
+    [[ -n "$mb" ]] || continue
+    if [[ -z "$best" ]]; then
+      best="$cand"; best_base="$mb"
+    elif [[ "$mb" != "$best_base" ]] && git merge-base --is-ancestor "$best_base" "$mb"; then
+      best="$cand"; best_base="$mb"
+    fi
+  done < <(candidate_targets "$remote")
+
+  [[ -n "$best" ]] && printf '%s\t%s' "$best" "inferred fork parent (no PR)"
+}
+
+# Resolve the effective target from an optional explicit argument, setting the
+# globals `target` and `target_source`. Errors out if nothing can be resolved.
+target=""
+target_source=""
+resolve() {
+  local explicit="${1:-}" out
+  if [[ -n "$explicit" ]]; then
+    target="$explicit"; target_source="explicit argument"; return
+  fi
+  out="$(detect_target)"
+  if [[ -z "$out" ]]; then
+    echo "gradle-code-review.sh: could not auto-detect a target branch (no open PR, and no candidate branch found on the gradle/gradle remote). Pass TARGET_REF explicitly, e.g. 'scope upstream/master'." >&2
+    exit 2
+  fi
+  target="${out%%$'\t'*}"
+  target_source="${out#*$'\t'} (auto-detected)"
+}
+
+base_for() {
+  local target="${1:-}"
+  git rev-parse --verify --quiet "$target^{commit}" >/dev/null || {
+    echo "gradle-code-review.sh: unknown target ref '$target' — fetch it or pass the correct branch (e.g. origin/master)" >&2
+    exit 2
+  }
+  git merge-base "$target" HEAD || {
+    echo "gradle-code-review.sh: could not determine a merge base with '$target' (no common ancestor with HEAD?)" >&2
+    exit 2
+  }
+}
+
+# --- Commands ----------------------------------------------------------------
+
+cmd="${1:-}"
+[[ -n "$cmd" ]] || { usage >&2; exit 2; }
+shift
+
+case "$cmd" in
+  scope)
+    resolve "${1:-}"
+    base="$(base_for "$target")"
+    echo "Target branch : $target [$target_source]"
+    echo "Fork point    : $base"
+    echo
+    echo "== Commits since fork point =="
+    git log --no-decorate --abbrev=12 --pretty=tformat:'%h %s' "$base"..HEAD
+    echo
+    echo "== Files changed (committed) =="
+    git diff --no-ext-diff --stat=200 "$base"..HEAD
+    echo
+    echo "== Working tree (uncommitted) =="
+    if [[ -n "$(git status --porcelain)" ]]; then
+      git status --porcelain
+    else
+      echo "clean"
+    fi
+    ;;
+
+  diff)
+    resolve "${1:-}"
+    base="$(base_for "$target")"
+    echo "### Committed changes ($base..HEAD, target $target)"
+    git diff --no-ext-diff --no-textconv "$base"..HEAD
+    echo
+    echo "### Uncommitted changes (working tree vs HEAD)"
+    git diff --no-ext-diff --no-textconv HEAD
+    echo
+    echo "### Untracked files (shown as new-file additions)"
+    if [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
+      echo "none"
+    else
+      # Diff each untracked file against the empty file so its full content
+      # is shown as an addition. --no-index reports differences with exit 1,
+      # which is expected here, so swallow it. Read-only: nothing is staged.
+      while IFS= read -r -d '' f; do
+        printf '\n--- new file: %s\n' "$f"
+        git diff --no-ext-diff --no-textconv --no-index -- /dev/null "$f" || true
+      done < <(git ls-files --others --exclude-standard -z)
+    fi
+    ;;
+
+  log)
+    path="${1:?PATH required}"
+    resolve "${2:-}"
+    base="$(base_for "$target")"
+    git log -p --no-ext-diff --no-textconv --pretty=medium "$base"..HEAD -- "$path"
+    ;;
+
+  blame)
+    path="${1:?PATH required}"
+    git blame -- "$path"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent Instructions
+
+Guidance for AI coding agents of any vendor working in the Gradle repository.
+Human contributors should start from [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Before you start
+
+- Follow the contributor guidelines in [CONTRIBUTING.md](CONTRIBUTING.md),
+  including its [Code change guidelines](CONTRIBUTING.md#code-change-guidelines)
+  and the topical guides under [`contributing/`](contributing/).
+
+## Reviewing code
+
+When asked to review a change, diff, branch, or pull request, follow the
+[Code Review guide](contributing/CodeReview.md). It defines *what* to look
+for (correctness bugs, API-contract violations, edge cases, security) and
+*what* to ignore (style, formatting, and naming).
+It applies to human and AI reviewers alike.
+
+Scope: review everything that will reach the target branch — the commits
+since this branch's fork point, plus uncommitted and untracked changes. If
+the intended range is ambiguous, ask which range to review.
+
+Output: report findings only. Give each as `path:Lstart-Lend`, a short
+description (quoting the offending code or violated rule where useful), and a
+severity (`critical` / `major` / `minor` / `suggestion`). Do not add a summary
+of the change or an overall verdict. If there are no correctness issues, say so
+in one line and stop.
+
+## Tooling notes
+
+A `gradle-code-review` skill under [`.claude/skills/`](.claude/skills/) wraps
+the guide above with the review mechanics (scope detection, output format). It
+is written in Claude Code's skill format (a `SKILL.md` with frontmatter), but
+its instructions are plain Markdown that any agent can read and follow.
+
+- If your tool supports Claude Code skills, it is discovered automatically —
+  invoke it with `/gradle-code-review`.
+- Otherwise, read the skill's `SKILL.md` and
+  [contributing/CodeReview.md](contributing/CodeReview.md) directly and follow
+  them by hand.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,37 +5,8 @@ Human contributors should start from [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Before you start
 
-- Follow the contributor guidelines in [CONTRIBUTING.md](CONTRIBUTING.md),
-  including its [Code change guidelines](CONTRIBUTING.md#code-change-guidelines)
-  and the topical guides under [`contributing/`](contributing/).
-
-## Reviewing code
-
-When asked to review a change, diff, branch, or pull request, follow the
-[Code Review guide](contributing/CodeReview.md). It defines *what* to look
-for (correctness bugs, API-contract violations, edge cases, security) and
-*what* to ignore (style, formatting, and naming).
-It applies to human and AI reviewers alike.
-
-Scope: review everything that will reach the target branch — the commits
-since this branch's fork point, plus uncommitted and untracked changes. If
-the intended range is ambiguous, ask which range to review.
-
-Output: report findings only. Give each as `path:Lstart-Lend`, a short
-description (quoting the offending code or violated rule where useful), and a
-severity (`critical` / `major` / `minor` / `suggestion`). Do not add a summary
-of the change or an overall verdict. If there are no correctness issues, say so
-in one line and stop.
-
-## Tooling notes
-
-A `gradle-code-review` skill under [`.claude/skills/`](.claude/skills/) wraps
-the guide above with the review mechanics (scope detection, output format). It
-is written in Claude Code's skill format (a `SKILL.md` with frontmatter), but
-its instructions are plain Markdown that any agent can read and follow.
-
-- If your tool supports Claude Code skills, it is discovered automatically —
-  invoke it with `/gradle-code-review`.
-- Otherwise, read the skill's `SKILL.md` and
-  [contributing/CodeReview.md](contributing/CodeReview.md) directly and follow
-  them by hand.
+- Follow the [code change guidelines](CONTRIBUTING.md#code-change-guidelines) as well as the relevant topical contributing guidelines:
+  - For information about how to to add suggestions to error messages, see [ErrorMessages.md](contributing/ErrorMessages.md).
+  - For JavaDoc style guidelines, see [JavadocStyleGuide.md](contributing/JavadocStyleGuide.md).
+  - For guidelines on nullability and related annotations, see [Nullability.md](contributing/Nullability.md).
+  - For information on writing tests for Gradle, see [Testing.md](contributing/Testing.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Project Instructions
+
+Always read and follow [AGENTS.md](AGENTS.md) for any work in this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,7 @@ Code contributions should follow these guidelines to maximize the chance of them
 * Add Javadoc for new methods and classes, following the [Javadoc Style Guide](contributing/JavadocStyleGuide.md). Javadoc is *required* for new public, top-level types.
 * For new features, the feature should be mentioned in the [Release Notes](platforms/documentation/docs/src/docs/release/notes.md).
 * Use American English spelling in code, comments, and documentation (e.g., "color" not "colour", "initialize" not "initialise"). See [ADR-0009](architecture/standards/0009-use-american-english.md) for details.
+* When reviewing changes - or preparing your own for review — follow the [Code Review guide](contributing/CodeReview.md).
 
 Your code needs to run on [all versions of Java that Gradle supports](platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc) and across all supported operating systems (macOS, Windows, Linux). The Gradle CI system will verify this, but here are some pointers that will avoid surprises:
 

--- a/contributing/CodeReview.md
+++ b/contributing/CodeReview.md
@@ -1,0 +1,12 @@
+# Code Review Guide
+
+## What to look for
+
+- Correctness bugs and logic errors
+- API contract violations or misuse
+- Edge cases and error-handling gaps
+- Security concerns
+
+## What NOT to report
+
+- Style nits, formatting, or naming conventions.


### PR DESCRIPTION
- Add contributing/CodeReview.md — a vendor-neutral guide for what to look for and what to ignore in a correctness review, for humans and AI tools alike.
- Add AGENTS.md and CLAUDE.md directing agents of any vendor to the guide.
- Add a gradle-code-review Claude Code skill that resolves review scope, delegates analysis to a fresh-context sub-agent, and relays findings only.
- Add a read-only companion script routing all git access through one command: pins git config for stable output, shows untracked file content, and auto-detects the target branch (open PR base, else fork parent).
- Allow the companion script to run without per-command prompts (.claude/settings.json).