### PR TITLE
Drop deprecated isolated-projects property names

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -27,7 +27,7 @@ class CheckProject(
 
         params {
             if (model.branch.isMaster || model.branch.isExperimental) {
-                param("env.GRADLE_OPTS", "-Dorg.gradle.unsafe.isolated-projects=%enableIsolatedProjects%")
+                param("env.GRADLE_OPTS", "-Dorg.gradle.isolated-projects=%enableIsolatedProjects%")
             }
             param("credentialsStorageType", "credentialsJSON")
             // Disallow Web UI changes to TeamCity settings

--- a/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
+++ b/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
@@ -32,6 +32,6 @@ class GradleBuildToolRootProject(
 
         params {
             param("enableIsolatedProjects", "false") // TODO: remove as soon as CI is compatible with enabling IP
-            param("env.GRADLE_OPTS", "-Dorg.gradle.unsafe.isolated-projects=false")
+            param("env.GRADLE_OPTS", "-Dorg.gradle.isolated-projects=false")
         }
     })

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -195,7 +195,10 @@ abstract class BuildCommitDistribution @Inject internal constructor(
             "--no-daemon",
             if (gradleModeCompatibility == null) "--no-configuration-cache" else null,
             // TODO:isolated https://github.com/gradle/gradle/issues/36771
+            // Both names are needed: wrappers before Gradle 9.7 only understand the deprecated name,
+            // while 9.7+ wrappers prefer the current name when the checked-out commit enables IP with it.
             if (gradleModeCompatibility == "IP") null else "-Dorg.gradle.unsafe.isolated-projects=false",
+            if (gradleModeCompatibility == "IP") null else "-Dorg.gradle.isolated-projects=false",
             "--init-script",
             mirrorInitScript.absolutePath,
             PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY.let { name -> System.getProperty(name)?.let { "-D$name=$it" } },

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.entries-per-key=2
-org.gradle.unsafe.isolated-projects=true
+org.gradle.isolated-projects=true
 systemProp.org.gradle.classloaderscope.strict=true
 systemProp.gradle.publish.skip.namespace.check=true
 # Kotlin DSL settings

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -35,6 +35,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
     static final String BROKEN_SETTINGS_CONTENT = "broken settings file content!!!"
     static final String BROKEN_BUILD_CONTENT = "broken build file content!!!"
     static final String ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.internal.isolated-projects.tooling=true"
+    // Only passed to <9.7 targets, which understand only the deprecated property name
     static final String UNSAFE_ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.unsafe.isolated-projects=true"
 
     def setup() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/CustomResilientModelCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r16.CustomModel
 import org.gradle.integtests.tooling.r930.KotlinDslPluginRelatedToolingApiSpecification
+import org.gradle.util.GradleVersion
 
 import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.EDITABLE_BUILDS_FIRST
 import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryStrategy.ROOT_BUILD_FIRST
@@ -29,9 +30,20 @@ import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryS
 class CustomResilientModelCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
 
     private static final List<String> IP_CONFIGURE_ON_DEMAND_FLAGS = [
-        "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
-        "-Dorg.gradle.unsafe.isolated-projects=true"
+        "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true"
     ]
+
+    // Appends the flag enabling Isolated Projects to any non-empty flag list, under the name the
+    // target version understands: the isolated-projects property was renamed in Gradle 9.7.
+    private List<String> flagsForTargetVersion(List<String> flags) {
+        if (flags.isEmpty()) {
+            return flags
+        }
+        def name = targetVersion.baseVersion >= GradleVersion.version("9.7")
+            ? "org.gradle.isolated-projects"
+            : "org.gradle.unsafe.isolated-projects"
+        return flags + ["-D${name}=true".toString()]
+    }
 
     def setup() {
         settingsFile.delete()
@@ -124,7 +136,7 @@ class CustomPlugin implements Plugin<Project> {
             action(new TestResilientModelAction(CustomModel, queryStrategy))
                 .withArguments(
                     "--init-script=${file('init.gradle').absolutePath}",
-                    *extraGradleProperties
+                    *flagsForTargetVersion(extraGradleProperties)
                 )
                 .run()
         }
@@ -185,7 +197,7 @@ class CustomPlugin implements Plugin<Project> {
             action(new TestResilientModelAction(CustomModel, queryStrategy))
                 .withArguments(
                     "--init-script=${file('init.gradle').absolutePath}",
-                    *extraGradleProperties
+                    *flagsForTargetVersion(extraGradleProperties)
                 )
                 .run()
         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -44,8 +44,9 @@ import static org.gradle.integtests.tooling.r940.KotlinModelAction.QueryStrategy
 class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
 
     private static final List<String> NO_EXTRA_PROPERTIES = []
+    // skipIfIpNotSupported() guarantees these flags only reach 9.7+ targets, which understand the current name
     private static final List<String> IP_FLAGS = [
-        "-Dorg.gradle.unsafe.isolated-projects=true",
+        "-Dorg.gradle.isolated-projects=true",
     ]
 
     private static final List<String> BUILD_SCRIPT_COMPILE_ERROR = ["Build file", "build.gradle.kts", "Script compilation error"]

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/CustomResilientModelCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ class CustomResilientModelCrossVersionSpec extends KotlinDslPluginRelatedTooling
 
     private static final List<String> IP_CONFIGURE_ON_DEMAND_FLAGS = [
         "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
-        "-Dorg.gradle.unsafe.isolated-projects=true"
+        "-Dorg.gradle.isolated-projects=true"
     ]
 
     def setup() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -29,7 +29,7 @@ class ResilientFetchFailureCrossVersionSpec extends KotlinDslPluginRelatedToolin
 
     private static final List<String> CONFIGURE_ON_DEMAND_ON = [
         "-Dorg.gradle.internal.isolated-projects.configure-on-demand=true",
-        "-Dorg.gradle.unsafe.isolated-projects=true"
+        "-Dorg.gradle.isolated-projects=true"
     ]
 
     private static final List<String> ISOLATED_PROJECTS_ON = [

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -44,7 +44,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
     static final String BROKEN_SETTINGS_CONTENT = "broken settings file content!!!"
     static final String BROKEN_BUILD_CONTENT = "broken build file content!!!"
     static final String ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.internal.isolated-projects.tooling=true"
-    static final String UNSAFE_ISOLATED_PROJECTS_FLAG = "-Dorg.gradle.unsafe.isolated-projects=true"
+    static final String ISOLATED_PROJECTS_ENABLED_FLAG = "-Dorg.gradle.isolated-projects=true"
 
     private BuildException buildFailure
 
@@ -194,7 +194,7 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
         given:
         def intermediateCaching = [
             ISOLATED_PROJECTS_FLAG,
-            UNSAFE_ISOLATED_PROJECTS_FLAG
+            ISOLATED_PROJECTS_ENABLED_FLAG
         ]
         createRootProject()
         createFailingSettingsIncludedProject("included")

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientGradleProjectCrossVersionSpec.groovy
@@ -31,7 +31,7 @@ import static org.gradle.integtests.tooling.r940.TestResilientModelAction.QueryS
 class ResilientGradleProjectCrossVersionSpec extends KotlinDslPluginRelatedToolingApiSpecification {
 
     private static final List<String> IP_ENABLED = [
-        "-Dorg.gradle.unsafe.isolated-projects=true"
+        "-Dorg.gradle.isolated-projects=true"
     ]
 
     def setup() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -34,7 +34,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends KotlinDslPlu
 
     private static final List<String> NO_EXTRA_PROPERTIES = []
     private static final List<String> IP_FLAGS = [
-        "-Dorg.gradle.unsafe.isolated-projects=true",
+        "-Dorg.gradle.isolated-projects=true",
     ]
 
     def setup() {


### PR DESCRIPTION
## Summary

Cleans up leftover usages of the deprecated `org.gradle.unsafe.isolated-projects` property name, using the current `org.gradle.isolated-projects` where it is safe to do so.

Addresses #38400. Spun off from the review discussion on #37759, and **targets that feature branch** (`reinhold/ip/36461-beforeproject-convention-plugin`) rather than `master`.

## Changed (outer build config, runs on the current Gradle)

- Root `gradle.properties` — also removes a deprecation warning we were emitting when building Gradle itself.
- `.teamcity` `GRADLE_OPTS` in `CheckProject.kt` and `GradleBuildToolRootProject.kt`.

## Deliberately left as `unsafe` (still required or intentional)

- **tooling-api cross-version tests** (`r930`/`r940`/`r970`) — run against older Gradle versions (`@TargetGradleVersion('>=9.3.0'/'>=9.7.0')`) that only understand the `unsafe` name.
- **`BuildCommitDistribution`** — builds/runs potentially old baseline commits for performance tests (older distributions don't recognise the new name); pre-existing `// TODO:isolated` (#36771).
- **`IsolatedProjectsIntegrationTest`** — these tests verify the deprecated names still work (incl. "can enable via deprecated property").
- **`StartParameterBuildOptions`** — defines the deprecated aliases.
- **Docs** — release notes, upgrade guide, and `isolated_projects.adoc` document the old names on purpose.

## Not touched (judgement call for reviewers)

- `architecture/standards/0010-gradle-properties-naming.md` uses the old name as a naming-convention example. Left as-is; happy to update if preferred.

## Test plan

- [ ] CI on this branch (the change is string-literal only; `.teamcity` config compile + Gradle build are covered by `sanityCheck`).
