### PR TITLE
Clarify how variant reselection handles dependencies

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
@@ -86,8 +86,8 @@ The graph resolution attributes specified on the configuration are completely ig
 ====
 Variant reselection operates on the components already present in the resolved graph: it re-picks a variant of each component in place.
 It does not re-run graph resolution.
-As a result, variants that delegate to a different component via an `available-at` pointer in Gradle Module Metadata are not followed, and the artifacts of the pointed-at component do not appear in the view.
-To resolve such variants, declare a separate `Configuration` whose request attributes already select them.
+As a result, any dependencies declared on the reselected variant -- whether ordinary dependencies on other modules or `available-at` pointers to a different component -- are not followed, and the artifacts of those additional components do not appear in the view.
+To include such artifacts, declare a separate `Configuration` whose request attributes already select the target variant; graph resolution will then traverse the variant's dependencies as usual.
 ====
 
 [[sec:performing_lenient_artifact_selection]]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
@@ -253,6 +253,90 @@ class ArtifactVariantReselectionIntegrationTest extends AbstractIntegrationSpec 
         succeeds(":resolve")
     }
 
+    def "withVariantReselection does not traverse dependencies declared on the reselected variant, but a separate configuration does"() {
+        // 'foo:main:1.0' has a "main" variant with its own file and a "docs" variant that has its
+        // own file AND declares a dependency on 'foo:extra-docs:1.0'.
+        // 'foo:extra-docs:1.0' has a "docs" variant with its own file.
+        //
+        // A separate configuration whose request attributes already select the "docs" variant
+        // triggers full graph resolution. Graph resolution traverses the docs variant's
+        // dependency, adding foo:extra-docs:1.0 to the graph; both docs artifacts appear.
+        //
+        // An ArtifactView built on a configuration that requested the "main" variant and
+        // re-selects via withVariantReselection() does NOT re-run graph resolution. It re-picks a
+        // different variant of each component already in the graph. The "docs" variant of
+        // foo:main:1.0 is selected and its own artifact appears, but the docs variant's
+        // dependency on foo:extra-docs:1.0 is never traversed, so that component's artifact is
+        // absent from the view.
+        given:
+        mavenRepo.module("foo", "main", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("mainElements", [attr: "main"]) {
+                artifact("main-1.0.jar")
+            }
+            .variant("docsElements", [attr: "docs"]) {
+                artifact("main-1.0-docs.jar")
+                dependsOn("foo:extra-docs:1.0")
+            }
+            .publish()
+
+        mavenRepo.module("foo", "extra-docs", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("docsElements", [attr: "docs"]) {
+                artifact("extra-docs-1.0.jar")
+            }
+            .publish()
+
+        buildFile << """
+            def attr = Attribute.of("attr", String)
+
+            repositories { maven { url = "${mavenRepo.uri}" } }
+
+            configurations {
+                mainConf {
+                    canBeConsumed = false
+                    attributes { attribute(attr, "main") }
+                }
+                docsConf {
+                    canBeConsumed = false
+                    attributes { attribute(attr, "docs") }
+                }
+            }
+
+            dependencies {
+                mainConf "foo:main:1.0"
+                docsConf "foo:main:1.0"
+            }
+
+            task resolve {
+                def mainFiles = configurations.mainConf.incoming.files
+                def reselectedViewFiles = configurations.mainConf.incoming.artifactView {
+                    withVariantReselection()
+                    attributes { attribute(attr, "docs") }
+                }.files
+                def docsConfFiles = configurations.docsConf.incoming.files
+
+                doLast {
+                    // Baseline: the main variant's artifact.
+                    assert mainFiles*.name.toSet() == ["main-1.0.jar"].toSet()
+
+                    // Variant reselection picks the docs variant on foo:main:1.0 but does not
+                    // traverse the docs variant's dependency on foo:extra-docs:1.0.
+                    assert reselectedViewFiles*.name.toSet() == ["main-1.0-docs.jar"].toSet()
+
+                    // A separate configuration whose attributes already select the docs variant
+                    // runs full graph resolution and traverses the docs variant's dependency.
+                    assert docsConfFiles*.name.toSet() == ["main-1.0-docs.jar", "extra-docs-1.0.jar"].toSet()
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
     private static String multiFeatureProducer() {
         """
             plugins {


### PR DESCRIPTION
Variant reselection, performed via `withVariantReselection()`, operates on components already present in the resolved graph. It does not re-run full graph resolution. Therefore, any dependencies (including `available-at` pointers or ordinary dependencies) declared on the reselected variant are not traversed or added to the view.

This change updates the documentation to explicitly state this behavior and adds an integration test to confirm it.

Continues clarifying behavior from:
- https://github.com/gradle/gradle/pull/38339