### PR TITLE
Deprecate starting processes at configuration time

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheValueSourceIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheValueSourceIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
-import org.gradle.process.ShellScript
 import spock.lang.Issue
 
 class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
@@ -513,36 +512,6 @@ class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfiguration
             withInput("Build file 'build.gradle': system property 'some.property'")
             withInput("Build file 'build.gradle': value from custom source 'MySource'")
         }
-    }
-
-    def "value source can use standard process API"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        ShellScript testScript = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
-
-        buildFile.text = """
-            import ${ByteArrayOutputStream.name}
-            import org.gradle.api.provider.*
-
-            abstract class ProcessSource implements ValueSource<String, ValueSourceParameters.None> {
-                @Override String obtain() {
-                    def baos = new ByteArrayOutputStream()
-                    def process = ${ShellScript.cmdToStringLiteral(testScript.getRelativeCommandLine(testDirectory))}.execute()
-                    process.waitForProcessOutput(baos, System.err)
-                    return baos.toString().trim()
-                }
-            }
-
-            def vsResult = providers.of(ProcessSource) {}
-            println("ValueSource result = \${vsResult.get()}")
-        """
-
-        when:
-        configurationCacheRun()
-
-        then:
-        configurationCache.assertStateStored()
-        outputContains("ValueSource result = Hello, world")
     }
 
     def "value source can read mutated system property inputs at configuration time"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ExternalProcessAtConfigurationTimeDeprecations.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ExternalProcessAtConfigurationTimeDeprecations.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.fixtures
+
+import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.HasGradleExecutor
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
+/**
+ * Apply this trait to tests that start an external process at configuration time and therefore
+ * expect the "external process at configuration time" deprecation.
+ *
+ * The deprecation is only emitted when the configuration cache is off, so the expectation is
+ * declared only under the non-configuration-cache executer, mirroring
+ * {@link org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations}.
+ */
+@SelfType(HasGradleExecutor)
+trait ExternalProcessAtConfigurationTimeDeprecations {
+    void expectExternalProcessAtConfigurationTimeDeprecation(int count = 1) {
+        if (GradleContextualExecuter.notConfigCache) {
+            count.times {
+                executer.expectDocumentedDeprecationWarning("Starting an external process at configuration time has been deprecated. " +
+                    "This will fail with an error in Gradle 11. " +
+                    "Use ProviderFactory.exec/javaexec or a ValueSource to obtain the process output, or move the process execution into a task. " +
+                    "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#config_time_external_processes")
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/ProcessAtConfigurationTimeDeprecationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/ProcessAtConfigurationTimeDeprecationIntegrationTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.inputs.process
+
+import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
+import org.gradle.internal.cc.impl.fixtures.ExternalProcessAtConfigurationTimeDeprecations
+import org.gradle.process.ShellScript
+import org.gradle.process.TestJavaMain
+import org.gradle.util.internal.TextUtil
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/38399")
+class ProcessAtConfigurationTimeDeprecationIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ExternalProcessAtConfigurationTimeDeprecations {
+
+    def "starting an external process at configuration time via #trigger is deprecated when the configuration cache is off"() {
+        given:
+        def script = ShellScript.builder().printText("Hello from script").writeTo(testDirectory, "script")
+        def commandLine = ShellScript.cmdToVarargLiterals(script.commandLine)
+
+        buildFile """
+            abstract class Ops {
+                @Inject abstract ExecOperations getExecOps()
+
+                String[] command = [$commandLine]
+
+                void execOperationsExec() {
+                    execOps.exec { commandLine(command) }
+                }
+                void execOperationsJavaexec() {
+                    execOps.javaexec {
+                        mainClass.set("${TestJavaMain.class.name}")
+                        classpath("${TextUtil.escapeString(TestJavaMain.classLocation)}")
+                        args("Hello", "from", "Java")
+                    }
+                }
+                void processBuilderStart() {
+                    new ProcessBuilder(command).start().waitFor()
+                }
+                void processBuilderStartPipeline() {
+                    ProcessBuilder.startPipeline([new ProcessBuilder(command)]).each { it.waitFor() }
+                }
+                void runtimeExec() {
+                    Runtime.runtime.exec(command).waitFor()
+                }
+                void runtimeExecEnvpOverload() {
+                    Runtime.runtime.exec(command, null).waitFor()
+                }
+                void stringArrayExecute() {
+                    command.execute().waitFor()
+                }
+                void listExecute() {
+                    command.toList().execute().waitFor()
+                }
+            }
+
+            objects.newInstance(Ops).${trigger}()
+
+            tasks.register("noop") {}
+        """
+
+        and:
+        expectExternalProcessAtConfigurationTimeDeprecation()
+
+        expect:
+        run("noop")
+
+        where:
+        trigger << [
+            "execOperationsExec",
+            "execOperationsJavaexec",
+            "processBuilderStart",
+            "processBuilderStartPipeline",
+            "runtimeExec",
+            "runtimeExecEnvpOverload",
+            "stringArrayExecute",
+            "listExecute",
+        ]
+    }
+
+    def "starting an external process at configuration time is deprecated when the configuration cache is explicitly disabled"() {
+        given:
+        def script = ShellScript.builder().printText("Hello from script").writeTo(testDirectory, "script")
+        def commandLine = ShellScript.cmdToVarargLiterals(script.commandLine)
+
+        buildFile """
+            String[] command = [$commandLine]
+            new ProcessBuilder(command).start().waitFor()
+
+            tasks.register("noop") {}
+        """
+
+        and:
+        expectExternalProcessAtConfigurationTimeDeprecation()
+
+        expect:
+        run("noop", DISABLE_SYS_PROP)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -20,11 +20,12 @@ import org.gradle.api.internal.ConfigurationCacheDegradationController
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption
 import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
+import org.gradle.internal.cc.impl.fixtures.ExternalProcessAtConfigurationTimeDeprecations
 import org.gradle.process.ShellScript
 
 import static org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer.PROMO_PREFIX
 
-class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ExternalProcessAtConfigurationTimeDeprecations {
     def "shows promo message when build succeeds without giving explicit CC state"() {
         given:
         buildFile """
@@ -201,6 +202,10 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
 
             tasks.register("greet") {}
         """
+
+        and:
+        expectExternalProcessAtConfigurationTimeDeprecation()
+
         when:
         run("greet")
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintEventHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintEventHandler.kt
@@ -35,6 +35,7 @@ import org.gradle.groovy.scripts.internal.ScriptSourceListener
 import org.gradle.internal.buildoption.FeatureFlag
 import org.gradle.internal.buildoption.FeatureFlagListener
 import org.gradle.internal.cc.impl.CoupledProjectsListener
+import org.gradle.internal.cc.impl.InputTrackingState
 import org.gradle.internal.cc.impl.UndeclaredBuildInputListener
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.WorkInputListener
@@ -61,7 +62,8 @@ import java.util.EnumSet
 @ServiceScope(Scope.BuildTree::class)
 internal class ConfigurationCacheFingerprintEventHandler(
     private val workInputListeners: WorkInputListeners,
-    private val scriptFileResolverListeners: ScriptFileResolverListeners
+    private val scriptFileResolverListeners: ScriptFileResolverListeners,
+    private val inputTrackingState: InputTrackingState
 ) :
 // For these listeners this class is the only "real" implementation.
 // Event sources get our instance through ServiceRegistry.
@@ -125,11 +127,15 @@ internal class ConfigurationCacheFingerprintEventHandler(
     }
 
     override fun beforeValueObtained() {
-        delegate?.beforeValueObtained()
+        // A value source computes its own value, so reads made while it runs are not build
+        // configuration inputs. Input tracking is disabled here in all modes for consistency.
+        // Some infrastructure relies on the input tracking state even in Vintage builds to emit/suppress
+        // deprecations.
+        inputTrackingState.disableForCurrentThread()
     }
 
     override fun afterValueObtained() {
-        delegate?.afterValueObtained()
+        inputTrackingState.restoreForCurrentThread()
     }
 
     override fun onExecute(work: UnitOfWork, relevantBehaviors: EnumSet<InputBehavior>) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -444,15 +444,6 @@ class ConfigurationCacheFingerprintWriter(
         buildScopedSink.write(ConfigurationCacheFingerprint.EnvironmentVariablesPrefixedBy(prefix, snapshot))
     }
 
-    fun beforeValueObtained() {
-        // Do not track additional inputs while computing a value of the value source.
-        inputTrackingState.disableForCurrentThread()
-    }
-
-    fun afterValueObtained() {
-        inputTrackingState.restoreForCurrentThread()
-    }
-
     fun <T : Any, P : ValueSourceParameters> valueObtained(
         obtainedValue: ValueSourceProviderFactory.ValueListener.ObtainedValue<T, P>,
         source: org.gradle.api.provider.ValueSource<T, P>

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -26,6 +26,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.execution.ExecutionAccessListener
+import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.impl.InputTrackingState
 import org.gradle.internal.cc.impl.Workarounds.canAccessTaskExtensions
 import org.gradle.internal.cc.impl.isSupportedListener
@@ -37,6 +38,7 @@ import org.gradle.internal.configuration.problems.ProblemFactory
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage
+import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.execution.WorkExecutionTracker
 import org.gradle.internal.service.scopes.ListenerService
 import org.gradle.internal.service.scopes.Scope
@@ -53,7 +55,8 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     private val problemFactory: ProblemFactory,
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
     private val workExecutionTracker: WorkExecutionTracker,
-    private val inputTrackingState: InputTrackingState
+    private val inputTrackingState: InputTrackingState,
+    private val buildModelParameters: BuildModelParameters
 ) : ConfigurationCacheProblemsListener {
 
     override fun disallowedAtExecutionInjectedServiceAccessed(injectedServiceType: Class<*>, getterName: String, consumer: String) {
@@ -96,6 +99,16 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
             .documentationSection(RequirementsExternalProcess)
             .build()
         problems.onProblem(problem)
+
+        // The configuration cache (implied by Isolated Projects) already reports the problem above as an
+        // error. When it is off the process runs silently, so deprecate it here to warn ahead of time.
+        if (!buildModelParameters.isConfigurationCache) {
+            DeprecationLogger.deprecateAction("Starting an external process at configuration time")
+                .withAdvice("Use ProviderFactory.exec/javaexec or a ValueSource to obtain the process output, or move the process execution into a task.")
+                .willBecomeAnErrorInGradle11()
+                .withUpgradeGuideSection(9, "config_time_external_processes")
+                .nagUser()
+        }
     }
 
     private

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
@@ -43,7 +43,7 @@ class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        run("-q", ":empty")
+        run(":empty")
 
         then:
         outputContains("--some-arg")
@@ -71,7 +71,7 @@ class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        run("-q", ":empty")
+        run(":empty")
 
         then:
         outputContains("--some-arg")

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ValueSourceIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ValueSourceIntegrationTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.process.ShellScript
+import spock.lang.Issue
+
+class ValueSourceIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/38399")
+    def "value source can start an external process at configuration time with the process API"() {
+        given:
+        ShellScript testScript = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
+
+        buildFile """
+            import ${ByteArrayOutputStream.name}
+            import org.gradle.api.provider.*
+
+            abstract class ProcessSource implements ValueSource<String, ValueSourceParameters.None> {
+                @Override String obtain() {
+                    def baos = new ByteArrayOutputStream()
+                    def process = ${ShellScript.cmdToStringLiteral(testScript.getRelativeCommandLine(testDirectory))}.execute()
+                    process.waitForProcessOutput(baos, System.err)
+                    return baos.toString().trim()
+                }
+            }
+
+            def vsResult = providers.of(ProcessSource) {}
+            println("ValueSource result = \${vsResult.get()}")
+
+            task empty() {}
+        """
+
+        when:
+        run(":empty")
+
+        then:
+        outputContains("ValueSource result = Hello, world")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38399")
+    def "value source can start an external process at configuration time with injected ExecOperations"() {
+        given:
+        ShellScript testScript = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
+
+        buildFile """
+            import ${ByteArrayOutputStream.name}
+            import org.gradle.api.provider.*
+            import org.gradle.process.ExecOperations
+            import javax.inject.Inject
+
+            abstract class ProcessSource implements ValueSource<String, ValueSourceParameters.None> {
+                @Inject abstract ExecOperations getExecOperations()
+
+                @Override String obtain() {
+                    def baos = new ByteArrayOutputStream()
+                    getExecOperations().exec { spec ->
+                        spec.commandLine(${ShellScript.cmdToVarargLiterals(testScript.commandLine)})
+                        spec.standardOutput = baos
+                    }
+                    return baos.toString().trim()
+                }
+            }
+
+            def vsResult = providers.of(ProcessSource) {}
+            println("ValueSource result = \${vsResult.get()}")
+
+            task empty() {}
+        """
+
+        when:
+        run(":empty")
+
+        then:
+        outputContains("ValueSource result = Hello, world")
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -587,6 +587,10 @@ Because `obtain()` runs on every build, it is recommended to keep the implementa
 
 TIP: Plugin and build scripts should avoid running external processes at configuration time.
 
+Starting an external process at configuration time via `ExecOperations.exec` / `ExecOperations.javaexec`, `java.lang.ProcessBuilder`, `java.lang.Runtime.exec`, or the Groovy `String` / `String[]` / `List` `execute()` helpers is *deprecated* as of Gradle 9.7 and will become an error in Gradle 11.
+This deprecation only fires when the Configuration Cache is disabled; when it is enabled, the same behavior is already reported as a Configuration Cache problem.
+`providers.exec`, `providers.javaexec`, and `ValueSource` implementations are unaffected; those remain the supported way to run a process at configuration time.
+
 You should avoid using these APIs for running processes during configuration:
 
 - *Java/Kotlin*: `ProcessBuilder`, `Runtime.exec(...)`, etc...

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -587,19 +587,17 @@ Because `obtain()` runs on every build, it is recommended to keep the implementa
 
 TIP: Plugin and build scripts should avoid running external processes at configuration time.
 
-Starting an external process at configuration time via `ExecOperations.exec` / `ExecOperations.javaexec`, `java.lang.ProcessBuilder`, `java.lang.Runtime.exec`, or the Groovy `String` / `String[]` / `List` `execute()` helpers is *deprecated* as of Gradle 9.7 and will become an error in Gradle 11.
-This deprecation only fires when the Configuration Cache is disabled; when it is enabled, the same behavior is already reported as a Configuration Cache problem.
-`providers.exec`, `providers.javaexec`, and `ValueSource` implementations are unaffected; those remain the supported way to run a process at configuration time.
-
-You should avoid using these APIs for running processes during configuration:
+You must not use these APIs directly for running processes during configuration:
 
 - *Java/Kotlin*: `ProcessBuilder`, `Runtime.exec(...)`, etc...
 - *Groovy*: `*.execute()`, etc...
 - *Gradle*: `ExecOperations.exec`, `ExecOperations.javaexec`, etc...
 
-The flexibility of these methods prevent Gradle from determining how the calls impact the build configuration, making it difficult to ensure that the Configuration Cache entry can be safely reused.
+The flexibility of these methods prevents Gradle from determining how the calls impact the build configuration, making it difficult to ensure that the Configuration Cache entry can be safely reused.
+Therefore, Gradle reports a Configuration Cache problem when it detects such an invocation.
+Even when the Configuration Cache is disabled, calling these methods at configuration time still emits a deprecation warning and will become an error in a future Gradle version.
 
-However, if running processes is required at configuration time, you can use the configuration-cache-compatible APIs detailed below.
+If running processes is required at configuration time, you can use the configuration-cache-compatible APIs detailed below.
 
 For simpler cases, when grabbing the output of the process is enough,
 link:{groovyDslPath}/org.gradle.api.provider.ProviderFactory.html#org.gradle.api.provider.ProviderFactory:exec(org.gradle.api.Action)[`providers.exec()`] and

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -101,14 +101,15 @@ No action is required in Gradle 9.x; if you set it explicitly, you can remove it
 [[config_time_external_processes]]
 ==== Starting external processes at configuration time with `ExecOperations` and Java/Groovy standard APIs
 
-Starting an external process at configuration time with `ExecOperations` or the Java and Groovy standard APIs directly is now deprecated. This includes:
+Starting an external process at configuration time with link:{javadocPath}/org/gradle/process/ExecOperations.html[`ExecOperations`] or the Java and Groovy standard APIs directly is now deprecated.
+This includes:
 
 - `ExecOperations.exec` and `ExecOperations.javaexec`.
 - `java.lang.ProcessBuilder.start()` and `ProcessBuilder.startPipeline(...)`.
 - `java.lang.Runtime.exec(...)` (all overloads).
 - The Groovy process helpers `String.execute(...)`, `String[].execute(...)`, and `List.execute(...)`.
 
-This does *not* affect uses of the `ProviderFactory.exec` / `ProviderFactory.javaexec` providers (`providers.exec` / `providers.javaexec`) or a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that runs a process inside — those remain the supported way to run a process at configuration time.
+This does *not* affect uses of the link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec(org.gradle.api.Action)[`ProviderFactory.exec`] / link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec(org.gradle.api.Action)[`ProviderFactory.javaexec`] providers (`providers.exec` / `providers.javaexec`) or a <<configuration_cache_requirements.adoc#config_cache:requirements:external_processes, `ValueSource`>> that runs a process inside — those remain the supported way to run a process at configuration time.
 
 Starting an external process at configuration time in any of the deprecated ways is already an error when the Configuration Cache is enabled.
 To simplify preparation for the Configuration Cache being enabled by default in Gradle 10, and to open the way to it becoming the only mode of execution, Gradle now unconditionally deprecates behaviors that are unsupported with the Configuration Cache.
@@ -119,7 +120,7 @@ Migrate to one of the following, in order of preference:
 Use an link:{javadocPath}/org/gradle/api/tasks/Exec.html[`Exec`] or link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[`JavaExec`] task, or a custom task that injects link:{javadocPath}/org/gradle/process/ExecOperations.html[`ExecOperations`] and runs the process in its task action.
 2. For simple cases, use link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec(org.gradle.api.Action)[`providers.exec`] / link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec(org.gradle.api.Action)[`providers.javaexec`].
 Prefer wiring the returned provider lazily to task inputs, and call `get()` only as a last resort.
-3. For more complex output processing, use a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that injects `ExecOperations` (or uses `java.lang.ProcessBuilder` directly).
+3. For more complex output processing, use a <<configuration_cache_requirements.adoc#config_cache:requirements:external_processes, `ValueSource`>> that injects link:{javadocPath}/org/gradle/process/ExecOperations.html[`ExecOperations`] (or uses `java.lang.ProcessBuilder` directly).
 The same guidance about wiring the provider lazily to task inputs applies.
 
 This behavior will become an error in Gradle 11.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -99,26 +99,26 @@ Once `org.gradle.parallel` and `org.gradle.tooling.parallel` are independent, th
 No action is required in Gradle 9.x; if you set it explicitly, you can remove it when upgrading to Gradle 10.
 
 [[config_time_external_processes]]
-==== Starting external processes at configuration time with `ExecOperations` and Java standard APIs
+==== Starting external processes at configuration time with `ExecOperations` and Java/Groovy standard APIs
 
-Starting an external process at configuration time with `ExecOperations` or the Java standard APIs is now deprecated. This includes:
+Starting an external process at configuration time with `ExecOperations` or the Java and Groovy standard APIs directly is now deprecated. This includes:
 
-- `ExecOperations.exec` and `ExecOperations.javaexec` invoked directly at configuration time.
+- `ExecOperations.exec` and `ExecOperations.javaexec`.
 - `java.lang.ProcessBuilder.start()` and `ProcessBuilder.startPipeline(...)`.
 - `java.lang.Runtime.exec(...)` (all overloads).
 - The Groovy process helpers `String.execute(...)`, `String[].execute(...)`, and `List.execute(...)`.
 
 This does *not* affect uses of the `ProviderFactory.exec` / `ProviderFactory.javaexec` providers (`providers.exec` / `providers.javaexec`) or a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that runs a process inside — those remain the supported way to run a process at configuration time.
 
-Starting an external process at configuration time in any of the deprecated ways is already an error when the configuration cache is enabled.
-To simplify preparation for the configuration cache being enabled by default in Gradle 10, and to open the way to the configuration cache becoming the only mode of execution, Gradle now unconditionally deprecates behaviors that are unsupported with the configuration cache.
+Starting an external process at configuration time in any of the deprecated ways is already an error when the Configuration Cache is enabled.
+To simplify preparation for the Configuration Cache being enabled by default in Gradle 10, and to open the way to it becoming the only mode of execution, Gradle now unconditionally deprecates behaviors that are unsupported with the Configuration Cache.
 
 Migrate to one of the following, in order of preference:
 
 1. *Move the process execution into a task*, so it runs at execution time and benefits from build caching, up-to-date checks, and work avoidance.
 Use an link:{javadocPath}/org/gradle/api/tasks/Exec.html[`Exec`] or link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[`JavaExec`] task, or a custom task that injects link:{javadocPath}/org/gradle/process/ExecOperations.html[`ExecOperations`] and runs the process in its task action.
-2. For simple cases, use link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec-org.gradle.api.Action-[`providers.exec`] / link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec-org.gradle.api.Action-[`providers.javaexec`].
-Prefer wiring the returned provider lazily into task inputs, and call `get()` only as a last resort.
+2. For simple cases, use link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec(org.gradle.api.Action)[`providers.exec`] / link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec(org.gradle.api.Action)[`providers.javaexec`].
+Prefer wiring the returned provider lazily to task inputs, and call `get()` only as a last resort.
 3. For more complex output processing, use a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that injects `ExecOperations` (or uses `java.lang.ProcessBuilder` directly).
 The same guidance about wiring the provider lazily to task inputs applies.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -98,6 +98,32 @@ Additionally, the transitional system property `org.gradle.tooling.parallel.igno
 Once `org.gradle.parallel` and `org.gradle.tooling.parallel` are independent, the flag is redundant, so Gradle 10 simply ignores it.
 No action is required in Gradle 9.x; if you set it explicitly, you can remove it when upgrading to Gradle 10.
 
+[[config_time_external_processes]]
+==== Starting external processes at configuration time with `ExecOperations` and Java standard APIs
+
+Starting an external process at configuration time with `ExecOperations` or the Java standard APIs is now deprecated. This includes:
+
+- `ExecOperations.exec` and `ExecOperations.javaexec` invoked directly at configuration time.
+- `java.lang.ProcessBuilder.start()` and `ProcessBuilder.startPipeline(...)`.
+- `java.lang.Runtime.exec(...)` (all overloads).
+- The Groovy process helpers `String.execute(...)`, `String[].execute(...)`, and `List.execute(...)`.
+
+This does *not* affect uses of the `ProviderFactory.exec` / `ProviderFactory.javaexec` providers (`providers.exec` / `providers.javaexec`) or a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that runs a process inside — those remain the supported way to run a process at configuration time.
+
+Starting an external process at configuration time in any of the deprecated ways is already an error when the configuration cache is enabled.
+To simplify preparation for the configuration cache being enabled by default in Gradle 10, and to open the way to the configuration cache becoming the only mode of execution, Gradle now unconditionally deprecates behaviors that are unsupported with the configuration cache.
+
+Migrate to one of the following, in order of preference:
+
+1. *Move the process execution into a task*, so it runs at execution time and benefits from build caching, up-to-date checks, and work avoidance.
+Use an link:{javadocPath}/org/gradle/api/tasks/Exec.html[`Exec`] or link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[`JavaExec`] task, or a custom task that injects link:{javadocPath}/org/gradle/process/ExecOperations.html[`ExecOperations`] and runs the process in its task action.
+2. For simple cases, use link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec-org.gradle.api.Action-[`providers.exec`] / link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec-org.gradle.api.Action-[`providers.javaexec`].
+Prefer wiring the returned provider lazily into task inputs, and call `get()` only as a last resort.
+3. For more complex output processing, use a link:{userManualPath}/configuration_cache_requirements.html#config_cache:requirements:external_processes[`ValueSource`] that injects `ExecOperations` (or uses `java.lang.ProcessBuilder` directly).
+The same guidance about wiring the provider lazily to task inputs applies.
+
+This behavior will become an error in Gradle 11.
+
 [[changes_9.7.0]]
 == Upgrading from 9.6.0 and earlier
 

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/AntWorkerMemoryLeakIntegrationTest.groovy
@@ -22,9 +22,7 @@ import org.gradle.integtests.fixtures.GitUtility
 import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
-
 import org.gradle.testing.fixture.GroovyCoverage
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
@@ -164,11 +162,13 @@ class AntWorkerMemoryLeakIntegrationTest extends AbstractIntegrationSpec {
         return VersionNumber.parse(GroovyCoverage.SUPPORTED_BY_JDK.min()) <= VersionNumber.parse("2.4.7") ? [ "2.4.7" ] : []
     }
 
-    @Requires([JdkVersionTestPreconditions.Jdk11OrLater, TestExecutionPreconditions.NotConfigCached]) // grgit 5 requires JDK 11, see https://github.com/ajoberstar/grgit/issues/355
+    @Requires(JdkVersionTestPreconditions.Jdk11OrLater) // grgit 5 requires JDK 11, see https://github.com/ajoberstar/grgit/issues/355
     void "does not fail with a PermGen space error or a missing method exception"() {
         given:
         GitUtility.initGitDir(testDirectory)
-        buildFile << """
+        buildFile """
+            import org.ajoberstar.grgit.*
+
             buildscript {
               repositories {
                 ${mavenCentralRepository()}
@@ -179,14 +179,28 @@ class AntWorkerMemoryLeakIntegrationTest extends AbstractIntegrationSpec {
               }
             }
 
-            import org.ajoberstar.grgit.*
-            Grgit.open(currentDir: project.rootProject.rootDir)
+            def openGit = tasks.register("openGit") {
+                def repoDir = project.rootProject.rootDir
+                doLast {
+                    Grgit.open(currentDir: repoDir)
+                    println("GrGit run")
+                }
+            }
+
+            allprojects {
+                tasks.withType(AbstractCodeQualityTask).configureEach {
+                    dependsOn(":openGit")
+                }
+            }
         """
         withCheckstyle()
         goodCode(LOCAL_GROOVY)
 
-        expect:
+        when:
         succeeds 'check'
+
+        then:
+        outputContains("GrGit run")
 
         where:
         iteration << (0..10)


### PR DESCRIPTION
Starting an external process at configuration time is unsupported with the configuration cache and is already reported as an error when it is enabled. With the configuration cache off the process runs silently. As the configuration cache moves toward being enabled by default, emit a deprecation for this case so build and plugin authors get an actionable warning ahead of time. The behavior will become an error in Gradle 11.

The deprecation is emitted at the point where all external-process APIs converge, gated to the configuration-cache-off path so the existing error path is unchanged. It covers ExecOperations.exec/javaexec, ProcessBuilder.start/startPipeline, Runtime.exec, and the Groovy String/String[]/List.execute helpers. Processes started through ProviderFactory.exec/javaexec or a ValueSource remain supported and are unaffected.

Fixes #38399. 