### PR TITLE
Deprecate invalid Attribute value types

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest.kt
@@ -162,20 +162,22 @@ class KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest(
             .withStackTraceChecksDisabled() // The Kotlin compiler daemon intermittently crashes and logs a stack trace before falling back; that's not what we test here.
             .run()
 
-        // KGP 2.0.20 and 2.0.21 register an attribute whose type is a plain enum
-        // (KotlinNativeBundleArtifactFormat.KotlinNativeBundleArtifactsTypes). Gradle allows
-        // this via a targeted compatibility exception in Attribute.of and emits a deprecation
-        // warning. Verify the warning is present for those specific KGP versions and absent
-        // for the neighboring 2.1.0 and 2.1.21 versions (which no longer use the plain enum).
+        // The KGP 2.0.x line registers an attribute whose type is a plain enum
+        // (KotlinNativeBundleArtifactFormat.KotlinNativeBundleArtifactsTypes). That plain
+        // enum type would normally trigger the generic unsupported-attribute-value-type
+        // deprecation, but Attribute.of recognizes its fully-qualified name and instead
+        // emits a KGP-specific deprecation identifying the plugin as the source. Verify
+        // that KGP-specific message is present for the 2.0.x rows in this matrix and
+        // absent from KGP 2.1.0+ (which no longer uses the plain enum for this attribute).
         val kgpEnumDeprecationSummary =
             "Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type has been deprecated."
-        if (kgpVersion == "2.0.20" || kgpVersion == "2.0.21") {
+        if (kgpVersion.startsWith("2.0.")) {
             result.assertOutputContains(kgpEnumDeprecationSummary)
         } else {
             check(!result.output.contains(kgpEnumDeprecationSummary)) {
                 "KGP $kgpVersion unexpectedly emitted the KotlinNativeBundleArtifactsTypes deprecation. " +
-                    "If KGP started re-using the plain enum, the special case in Attribute.of and the " +
-                    "'upgrade to 2.1.0 or later' guidance in the upgrade guide need to be revisited."
+                    "If a post-2.0.x KGP started re-using the plain enum, the special case in Attribute.of " +
+                    "and the 'upgrade to KGP 2.1.0 or later' guidance in the upgrade guide need to be revisited."
             }
         }
     }

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest.kt
@@ -49,8 +49,9 @@ class KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest(
             arrayOf("8.9", "1.9.23", "1.8"),
             arrayOf("8.10", "1.9.24", "1.8"),
             arrayOf("8.11", "2.0.20", "1.8"),
-            arrayOf("8.12", "2.0.21", "1.8")
-            ,
+            arrayOf("8.12", "2.0.21", "1.8"),
+            arrayOf("8.13", "2.1.0", "2.1"),
+            arrayOf("8.14", "2.1.21", "2.1"),
             arrayOf("9.0.0", "2.2.0", "2.2"),
             arrayOf("9.2.0", "2.2.20", "2.2"),
             arrayOf("9.3.0", "2.2.21", "2.2"),
@@ -154,12 +155,29 @@ class KotlinPluginAppliedWithOlderGradleVersionsIntegrationTest(
             """
         )
 
-        inDirectory(file("plugin"))
+        val result = inDirectory(file("plugin"))
             .withTasks("publish")
             .withJavaHome(jdk.javaHome.absolutePath)
             .noDeprecationChecks() // KGP emits deprecation warnings that vary by version and are not what we test here.
             .withStackTraceChecksDisabled() // The Kotlin compiler daemon intermittently crashes and logs a stack trace before falling back; that's not what we test here.
             .run()
+
+        // KGP 2.0.20 and 2.0.21 register an attribute whose type is a plain enum
+        // (KotlinNativeBundleArtifactFormat.KotlinNativeBundleArtifactsTypes). Gradle allows
+        // this via a targeted compatibility exception in Attribute.of and emits a deprecation
+        // warning. Verify the warning is present for those specific KGP versions and absent
+        // for the neighboring 2.1.0 and 2.1.21 versions (which no longer use the plain enum).
+        val kgpEnumDeprecationSummary =
+            "Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type has been deprecated."
+        if (kgpVersion == "2.0.20" || kgpVersion == "2.0.21") {
+            result.assertOutputContains(kgpEnumDeprecationSummary)
+        } else {
+            check(!result.output.contains(kgpEnumDeprecationSummary)) {
+                "KGP $kgpVersion unexpectedly emitted the KotlinNativeBundleArtifactsTypes deprecation. " +
+                    "If KGP started re-using the plain enum, the special case in Attribute.of and the " +
+                    "'upgrade to 2.1.0 or later' guidance in the upgrade guide need to be revisited."
+            }
+        }
     }
 
     private fun applyPlugin(jdk: Jvm): ExecutionResult {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatableSerializerRegistryTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatableSerializerRegistryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot.impl
 
+import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.TestHashCodes
@@ -354,7 +355,12 @@ class IsolatableSerializerRegistryTest extends Specification {
         return isolatables as Isolatable<?>[]
     }
 
-    static class SomeType { }
+    static class SomeType implements Named {
+        @Override
+        String getName() {
+            return "name"
+        }
+    }
 
     static class SerializableType implements Serializable {
         final String foo

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
@@ -281,8 +281,9 @@ include::sample[dir="snippets/reference/dependency-management/controlling-depend
 include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/attributeMatching/groovy",files="build.gradle[tags=define_attribute]"]
 ====
 
-Attribute types support most Java primitive classes; such as `String` and `Integer`.
+Attribute types support most Java primitive classes; such as `String`, `Boolean`, and any subtype of `Number` (including `Integer`).
 Or anything extending `org.gradle.api.Named`.
+Plain Java `Enum` types (that do not implement `Named`) are **not** supported as attribute value types — resolution and publishing paths that desugar attributes require the value type to implement `Named`.
 
 Attributes should always be declared in the _attribute schema_ found on the `dependencies` handler:
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -308,6 +308,35 @@ The following have been deprecated for removal:
 
 The existing `StartParameter` instance for a build may be obtained via link:{javadocPath}/org/gradle/api/invocation/Gradle.html#getStartParameter()[`Gradle.getStartParameter()`] instead of constructing or copying one.
 
+[[unsupported_attribute_value_type]]
+==== Deprecation of unsupported attribute value types
+
+Attribute value types are limited to: `String`, `Boolean`, any subtype of `Number`, and any type that implements `org.gradle.api.Named`.
+
+Passing any other type to link:{javadocPath}/org/gradle/api/attributes/Attribute.html#of(java.lang.String,java.lang.Class)[`Attribute.of(String, Class)`] — or declaring an unsupported type as the type parameter of an `AttributeCompatibilityRule` or `AttributeDisambiguationRule` — now emits a deprecation warning and will become an error in Gradle 10.
+
+The most common case is a plain Java `Enum` that does not implement `Named`.
+Such types often work at first but fail later during dependency resolution, publishing, or configuration cache serialization — where the machinery assumes an attribute value can be reconstructed by name.
+
+To fix a build affected by this deprecation, change the attribute value type to one of the supported types.
+For enums, the simplest fix is to make the enum implement `Named` and return the constant's name from `getName()`.
+
+See the <<variant_attributes.adoc#sec:creating-attributes, variant attributes documentation>> for the full set of supported attribute value types.
+
+[[kgp_native_bundle_attribute_enum]]
+==== Deprecation of using `KotlinNativeBundleArtifactsTypes` as an attribute value type
+
+The Kotlin Gradle Plugin (KGP) 2.0.x line registers an attribute of type `org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeBundleArtifactFormat.KotlinNativeBundleArtifactsTypes` — a plain Java `Enum` that does not implement `org.gradle.api.Named`.
+
+This deprecation is a specialized variant of the general <<#unsupported_attribute_value_type, unsupported attribute value type>> deprecation, called out separately so users can identify KGP as the source and remediate by upgrading the plugin.
+
+To fix builds affected by this deprecation, upgrade the Kotlin Gradle Plugin to 2.1.0 or later.
+KGP 2.1.0 and newer do not use a plain enum for this attribute and are unaffected.
+
+Like the general case, this deprecation will become an error in Gradle 10.
+
+See the <<variant_attributes.adoc#sec:creating-attributes, variant attributes documentation>> for the full set of supported attribute value types.
+
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier
 

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/attributeMatching/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/attributeMatching/groovy/build.gradle
@@ -87,6 +87,14 @@ configurations {
 def myAttribute = Attribute.of("my.attribute.name", String)
 // An attribute of type `Usage`
 def myUsage = Attribute.of("my.usage.attribute", Usage)
+// An attribute of an `Enum` type that implements `Named` (plain enums are not supported)
+enum MyEnum implements Named {
+    FOO, BAR
+
+    @Override
+    String getName() { return name() }
+}
+def myEnumAttribute = Attribute.of("my.enum.attribute", MyEnum)
 // end::define_attribute[]
 
 // tag::register-attributes[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/attributeMatching/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/attributeMatching/kotlin/build.gradle.kts
@@ -84,6 +84,13 @@ configurations {
 val myAttribute = Attribute.of("my.attribute.name", String::class.java)
 // An attribute of type `Usage`
 val myUsage = Attribute.of("my.usage.attribute", Usage::class.java)
+// An attribute of an `Enum` type that implements `Named` (plain enums are not supported)
+enum class MyEnum : Named {
+    FOO, BAR;
+
+    override fun getName(): String = name
+}
+val myEnumAttribute = Attribute.of("my.enum.attribute", MyEnum::class.java)
 // end::define_attribute[]
 
 // tag::register-attributes[]

--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     testImplementation(testFixtures(projects.core))
     testImplementation(testFixtures(projects.coreApi))
     testImplementation(testFixtures(projects.execution))
+    testImplementation(testFixtures(projects.logging))
     testImplementation(testFixtures(projects.messaging))
     testImplementation(testFixtures(projects.resourcesHttp))
     testImplementation(testFixtures(projects.snapshots))

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
@@ -47,8 +47,6 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
         where:
         type      | value
         "Thing"   | "new Thing(name: 'broken')"
-        "Project" | "project"
-        "List"    | "[{}]"
     }
 
     def "can use attribute value that can be made isolated - #type"() {
@@ -71,38 +69,8 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
         type       | value
         "Integer"  | "123"
         "Number"   | "123"
-        "Object"   | "123"
-        "List"     | "['string']"
         "Flavor"   | "objects.named(Flavor, 'abc')"
         "Named"    | "objects.named(Named, 'abc')"
-        "Number[]" | "[1, 1.2] as Number[]"
-    }
-
-    def "attribute value is isolated from original value"() {
-        given:
-        buildFile << """
-    class Thing implements Named, Serializable {
-        String name
-    }
-    def attr = Attribute.of(List)
-
-    configurations {
-        ok
-    }
-    def value = [new Thing(name: 'a'), new Thing(name: 'b')]
-    configurations.ok.attributes.attribute(attr, value)
-
-    value[0].name = 'other'
-    value.add(new Thing(name: 'c'))
-
-    def isolated = configurations.ok.attributes.getAttribute(attr)
-    assert isolated.size() == 2
-    assert isolated[0].name == 'a'
-    assert isolated[1].name == 'b'
-"""
-
-        expect:
-        succeeds()
     }
 
     def "can use addAllLater in Kotlin"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeContainerIntegrationTest.groovy
@@ -23,6 +23,20 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 
 class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
+
+    /**
+     * Builds the exact deprecation warning that {@code Attribute.of} emits when an unsupported
+     * type is used as an attribute value type.
+     */
+    private static String unsupportedTypeDeprecation(String typeName, String attributeName) {
+        return "Using type '${typeName}' as a value type for attribute '${attributeName}' has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Attribute values must be of type String, Boolean, a subtype of Number, or implement org.gradle.api.Named. " +
+            "Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization. " +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#unsupported_attribute_value_type"
+    }
+
     def "cannot use an attribute value that cannot be made isolated - #type"() {
         given:
         buildFile << """
@@ -38,6 +52,9 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
 """
 
         when:
+        if (expectedDeprecation) {
+            executer.expectDocumentedDeprecationWarning(expectedDeprecation)
+        }
         fails()
 
         then:
@@ -45,8 +62,14 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not serialize value of type ")
 
         where:
-        type      | value
-        "Thing"   | "new Thing(name: 'broken')"
+        // Attribute.of(Class) uses the type's canonical name — with WordUtils.uncapitalize applied,
+        // which only lowercases the first character of the whole string. For 'Project' and 'List'
+        // that first character is already lowercase, so the attribute name ends up equal to the
+        // full canonical name. Thing implements Named, so no deprecation fires for that row.
+        type      | value                       | expectedDeprecation
+        "Thing"   | "new Thing(name: 'broken')" | null
+        "Project" | "project"                   | unsupportedTypeDeprecation("org.gradle.api.Project", "org.gradle.api.Project")
+        "List"    | "[{}]"                      | unsupportedTypeDeprecation("java.util.List", "java.util.List")
     }
 
     def "can use attribute value that can be made isolated - #type"() {
@@ -62,15 +85,57 @@ class AttributeContainerIntegrationTest extends AbstractIntegrationSpec {
     configurations.ok.files.each { println it }
 """
 
-        expect:
+        when:
+        if (expectedDeprecation) {
+            executer.expectDocumentedDeprecationWarning(expectedDeprecation)
+        }
+
+        then:
         succeeds()
 
         where:
-        type       | value
-        "Integer"  | "123"
-        "Number"   | "123"
-        "Flavor"   | "objects.named(Flavor, 'abc')"
-        "Named"    | "objects.named(Named, 'abc')"
+        // Integer/Number are subtypes of Number, and Flavor/Named implement Named — all allowlisted.
+        // Object, List, Number[] are not allowlisted and trigger the deprecation.
+        // Note: for Number[] the deprecation message uses Class.getName() (JVM binary form) for the
+        // type portion but the canonical name for the attribute-name portion.
+        type       | value                              | expectedDeprecation
+        "Integer"  | "123"                              | null
+        "Number"   | "123"                              | null
+        "Object"   | "123"                              | unsupportedTypeDeprecation("java.lang.Object", "java.lang.Object")
+        "List"     | "['string']"                       | unsupportedTypeDeprecation("java.util.List", "java.util.List")
+        "Flavor"   | "objects.named(Flavor, 'abc')"     | null
+        "Named"    | "objects.named(Named, 'abc')"      | null
+        "Number[]" | "[1, 1.2] as Number[]"             | unsupportedTypeDeprecation("[Ljava.lang.Number;", "java.lang.Number[]")
+    }
+
+    def "attribute value is isolated from original value"() {
+        given:
+        buildFile << """
+    class Thing implements Named, Serializable {
+        String name
+    }
+    def attr = Attribute.of(List)
+
+    configurations {
+        ok
+    }
+    def value = [new Thing(name: 'a'), new Thing(name: 'b')]
+    configurations.ok.attributes.attribute(attr, value)
+
+    value[0].name = 'other'
+    value.add(new Thing(name: 'c'))
+
+    def isolated = configurations.ok.attributes.getAttribute(attr)
+    assert isolated.size() == 2
+    assert isolated[0].name == 'a'
+    assert isolated[1].name == 'b'
+"""
+
+        expect:
+        // Attribute.of(List) trips the unsupported-type deprecation; the isolation logic itself
+        // still works (List of Serializable Named is isolatable) so the build succeeds.
+        executer.expectDocumentedDeprecationWarning(unsupportedTypeDeprecation("java.util.List", "java.util.List"))
+        succeeds()
     }
 
     def "can use addAllLater in Kotlin"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -28,9 +28,12 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             interface Flavor extends Named {
             }
 
-            enum BuildType {
+            enum BuildType implements Named {
                 debug,
                 release
+
+                @Override
+                String getName() { return name() }
             }
 
             def flavor = Attribute.of(Flavor)
@@ -925,9 +928,12 @@ All of them match the consumer attributes:
         settingsFile << "include 'a', 'b', 'c'"
 
         def common = """
-            enum Arch {
+            enum Arch implements Named {
                x86,
                arm64
+
+               @Override
+               String getName() { return name() }
             }
             def arch = Attribute.of(Arch)
             def dummy = Attribute.of('dummy', String)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -644,8 +644,9 @@ repositories {
     }
 }
 
-enum BuildTypeEnum {
+enum BuildTypeEnum implements Named {
     debug, release
+    @Override String getName() { return name() }
 }
 interface BuildType extends Named {
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -75,7 +75,48 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
         ConfigurableRule<CompatibilityCheckDetails<T>> rule,
         Instantiator instantiator
     ) {
-        return new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(rule.getRuleClass()));
+        Class<?> ruleClass = rule.getRuleClass();
+        Action<CompatibilityCheckDetails<T>> delegate =
+            new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(ruleClass));
+        return new ValidatingAction<>(ruleClass, delegate);
+    }
+
+    /**
+     * Wraps an {@link InstantiatingAction} with a per-class fail-fast check that the rule's
+     * declared type parameter is a supported attribute value type. Implemented as a named
+     * inner class rather than a lambda so it can be serialized by the configuration cache
+     * (lambda-synthesized classes aren't visible to the CC classloader hierarchy).
+     */
+    private static class ValidatingAction<T> implements Action<CompatibilityCheckDetails<T>> {
+        private final Class<?> ruleClass;
+        private final Action<CompatibilityCheckDetails<T>> delegate;
+
+        ValidatingAction(Class<?> ruleClass, Action<CompatibilityCheckDetails<T>> delegate) {
+            this.ruleClass = ruleClass;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void execute(CompatibilityCheckDetails<T> details) {
+            AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeCompatibilityRule.class);
+            delegate.execute(details);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return delegate.equals(((ValidatingAction<?>) o).delegate);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
     }
 
     private static class ExceptionHandler<T> implements InstantiatingAction.ExceptionHandler<CompatibilityCheckDetails<T>> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -82,14 +82,23 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
     }
 
     /**
-     * Wraps an {@link InstantiatingAction} with a per-class fail-fast check that the rule's
-     * declared type parameter is a supported attribute value type. Implemented as a named
-     * inner class rather than a lambda so it can be serialized by the configuration cache
-     * (lambda-synthesized classes aren't visible to the CC classloader hierarchy).
+     * Wraps an {@link InstantiatingAction} with a check that the rule's declared type parameter is
+     * a supported attribute value type. Implemented as a named inner class rather than a lambda so
+     * it can be serialized by the configuration cache (lambda-synthesized classes aren't visible to
+     * the CC classloader hierarchy).
      */
     private static class ValidatingAction<T> implements Action<CompatibilityCheckDetails<T>> {
         private final Class<?> ruleClass;
         private final Action<CompatibilityCheckDetails<T>> delegate;
+
+        /**
+         * Throttles the reflective type-parameter validation, which would otherwise run on every
+         * attribute match. Kept as per-instance state (rather than a static across all rules) so it
+         * neither leaks the rule's plugin classloader for the life of the daemon nor suppresses the
+         * deprecation on builds after the first. Transient so a config-cache restore re-validates
+         * rather than inheriting a stale "already validated" flag.
+         */
+        private transient volatile boolean validated;
 
         ValidatingAction(Class<?> ruleClass, Action<CompatibilityCheckDetails<T>> delegate) {
             this.ruleClass = ruleClass;
@@ -98,7 +107,10 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
 
         @Override
         public void execute(CompatibilityCheckDetails<T> details) {
-            AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeCompatibilityRule.class);
+            if (!validated) {
+                validated = true;
+                AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeCompatibilityRule.class);
+            }
             delegate.execute(details);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -76,8 +76,7 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
         Instantiator instantiator
     ) {
         Class<?> ruleClass = rule.getRuleClass();
-        Action<CompatibilityCheckDetails<T>> delegate =
-            new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(ruleClass));
+        Action<CompatibilityCheckDetails<T>> delegate = new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(ruleClass));
         return new ValidatingAction<>(ruleClass, delegate);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -79,7 +79,48 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
         ConfigurableRule<MultipleCandidatesDetails<T>> rule,
         Instantiator instantiator
     ) {
-        return new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(rule.getRuleClass()));
+        Class<?> ruleClass = rule.getRuleClass();
+        Action<MultipleCandidatesDetails<T>> delegate =
+            new InstantiatingAction<>(DefaultConfigurableRules.of(rule), instantiator, new ExceptionHandler<>(ruleClass));
+        return new ValidatingAction<>(ruleClass, delegate);
+    }
+
+    /**
+     * Wraps an {@link InstantiatingAction} with a per-class fail-fast check that the rule's
+     * declared type parameter is a supported attribute value type. Implemented as a named
+     * inner class rather than a lambda so it can be serialized by the configuration cache
+     * (lambda-synthesized classes aren't visible to the CC classloader hierarchy).
+     */
+    private static class ValidatingAction<T> implements Action<MultipleCandidatesDetails<T>> {
+        private final Class<?> ruleClass;
+        private final Action<MultipleCandidatesDetails<T>> delegate;
+
+        ValidatingAction(Class<?> ruleClass, Action<MultipleCandidatesDetails<T>> delegate) {
+            this.ruleClass = ruleClass;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void execute(MultipleCandidatesDetails<T> details) {
+            AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeDisambiguationRule.class);
+            delegate.execute(details);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return delegate.equals(((ValidatingAction<?>) o).delegate);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
     }
 
     private static class ExceptionHandler<T> implements InstantiatingAction.ExceptionHandler<MultipleCandidatesDetails<T>> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -95,6 +95,15 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
         private final Class<?> ruleClass;
         private final Action<MultipleCandidatesDetails<T>> delegate;
 
+        /**
+         * Throttles the reflective type-parameter validation, which would otherwise run on every
+         * attribute match. Kept as per-instance state (rather than a static across all rules) so it
+         * neither leaks the rule's plugin classloader for the life of the daemon nor suppresses the
+         * deprecation on builds after the first. Transient so a config-cache restore re-validates
+         * rather than inheriting a stale "already validated" flag.
+         */
+        private transient volatile boolean validated;
+
         ValidatingAction(Class<?> ruleClass, Action<MultipleCandidatesDetails<T>> delegate) {
             this.ruleClass = ruleClass;
             this.delegate = delegate;
@@ -102,7 +111,10 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
 
         @Override
         public void execute(MultipleCandidatesDetails<T> details) {
-            AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeDisambiguationRule.class);
+            if (!validated) {
+                validated = true;
+                AttributeTypeValidator.validateRuleTypeParameter(ruleClass, AttributeDisambiguationRule.class);
+            }
             delegate.execute(details);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
@@ -25,8 +25,14 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
+import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Optional;
 
 /**
  * A thread-safe and reusable attribute container serializer that will desugar typed attributes.
@@ -42,6 +48,7 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
     private static final byte BOOLEAN_ATTRIBUTE = 2;
     private static final byte DESUGARED_ATTRIBUTE = 3;
     private static final byte INTEGER_ATTRIBUTE = 4;
+    private static final byte NUMBER_ATTRIBUTE = 5;
 
     public DesugaringAttributeContainerSerializer(AttributesFactory attributesFactory, NamedObjectInstantiator namedObjectInstantiator) {
         this.attributesFactory = attributesFactory;
@@ -49,6 +56,7 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
     }
 
     @Override
+    @NonNull
     public ImmutableAttributes read(Decoder decoder) throws IOException {
         ImmutableAttributes attributes = ImmutableAttributes.EMPTY;
         int count = decoder.readSmallInt();
@@ -63,6 +71,11 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
             } else if (type == INTEGER_ATTRIBUTE){
                 int value = decoder.readInt();
                 attributes = attributesFactory.concat(attributes, Attribute.of(name, Integer.class), value);
+            } else if (type == NUMBER_ATTRIBUTE) {
+                String className = decoder.readString();
+                String value = decoder.readString();
+                Class<Number> numberType = resolveNumberType(className);
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, numberType), parseNumber(numberType, value));
             } else if (type == DESUGARED_ATTRIBUTE) {
                 String value = decoder.readString();
                 attributes = attributesFactory.concat(attributes, Attribute.of(name, String.class), new CoercingStringValueSnapshot(value, namedObjectInstantiator));
@@ -71,6 +84,7 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
         return attributes;
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
     public void write(Encoder encoder, AttributeContainer container) throws IOException {
         encoder.writeSmallInt(container.keySet().size());
@@ -85,13 +99,61 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
             } else if (attribute.getType().equals(Integer.class)){
                 encoder.writeByte(INTEGER_ATTRIBUTE);
                 encoder.writeInt((Integer) container.getAttribute(attribute));
+            } else if (Number.class.isAssignableFrom(attribute.getType())) {
+                // Any other Number subtype (Long, Double, BigDecimal, ...). Preserve the concrete
+                // type and value as strings so the exact type can be reconstructed on read.
+                Number attributeValue = (Number) container.getAttribute(attribute);
+                encoder.writeByte(NUMBER_ATTRIBUTE);
+                encoder.writeString(attribute.getType().getName());
+                encoder.writeString(attributeValue.toString());
             } else {
-                // Attribute.of rejects any type that is not String/Boolean/Integer/Named at
-                // creation time, so this branch is reached only via Named subtypes.
+                // Attribute.of only accepts String, Boolean, a Number subtype, or a Named subtype;
+                // the first three are handled above, so this branch is reached only via Named subtypes.
                 Named attributeValue = (Named) container.getAttribute(attribute);
                 encoder.writeByte(DESUGARED_ATTRIBUTE);
                 encoder.writeString(attributeValue.getName());
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Number> Class<T> resolveNumberType(String className) {
+        try {
+            return (Class<T>) Class.forName(className, false, DesugaringAttributeContainerSerializer.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Cannot deserialize attribute value: number type '" + className + "' was not found", e);
+        }
+    }
+
+    /**
+     * Reconstructs a {@link Number} of the given concrete type from its {@link Number#toString()} form,
+     * mirroring {@link #write}. Uses the type's {@code valueOf(String)} factory when present (covers
+     * {@code Byte}, {@code Short}, {@code Integer}, {@code Long}, {@code Float}, {@code Double}) and
+     * falls back to a {@code (String)} constructor (covers {@code BigInteger}, {@code BigDecimal}).
+     */
+    private static <T extends Number> T parseNumber(Class<T> numberType, String value) {
+        Optional<Method> valueOfMethod = findValueOfMethodForType(numberType);
+        try {
+            if (valueOfMethod.isPresent()) {
+                return numberType.cast(valueOfMethod.get().invoke(null, value));
+            } else {
+                Constructor<T> constructor = numberType.getConstructor(String.class);
+                return constructor.newInstance(value);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InstantiationException e) {
+            throw new IllegalStateException("Cannot reconstruct attribute value '" + value + "' as " + numberType.getName() + ": no usable static 'valueOf(String)' factory or '" + numberType.getName() + "(String)' constructor", e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException("Cannot reconstruct attribute value '" + value + "' as " + numberType.getName() + ": error invoking 'valueOf(String)'", e);
+        }
+    }
+
+    private static Optional<Method> findValueOfMethodForType(Class<?> numberType) {
+        try {
+            Method valueOf = numberType.getMethod("valueOf", String.class);
+            boolean usable = Modifier.isStatic(valueOf.getModifiers()) && numberType.isAssignableFrom(valueOf.getReturnType());
+            return usable ? Optional.of(valueOf) : Optional.empty();
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
@@ -86,7 +86,8 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
                 encoder.writeByte(INTEGER_ATTRIBUTE);
                 encoder.writeInt((Integer) container.getAttribute(attribute));
             } else {
-                assert Named.class.isAssignableFrom(attribute.getType());
+                // Attribute.of rejects any type that is not String/Boolean/Integer/Named at
+                // creation time, so this branch is reached only via Named subtypes.
                 Named attributeValue = (Named) container.getAttribute(attribute);
                 encoder.writeByte(DESUGARED_ATTRIBUTE);
                 encoder.writeString(attributeValue.getName());

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1959,8 +1959,13 @@ This method is only meant to be called on configurations which allow the (non-de
         String name
     }
 
-    enum Platform {
+    enum Platform implements Named {
         JAVA6,
         JAVA7
+
+        @Override
+        String getName() {
+            return this
+        }
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -43,25 +43,12 @@ class DefaultAttributesSchemaTest extends Specification {
         ]
     }
 
-    def "can create an attribute of array type #type"() {
-        when:
-        Attribute.of('foo', type)
-
-        then:
-        noExceptionThrown()
-
-        where:
-        type << [
-            String[].class,
-            Number[].class,
-            MyEnum[].class,
-            Flavor[].class
-        ]
-    }
-
-    enum MyEnum {
+    enum MyEnum implements Named {
         FOO,
         BAR
+
+        @Override
+        String getName() { return name() }
     }
 
     def "fails if no strategy is declared for custom type"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -18,7 +18,17 @@ package org.gradle.api.internal.attributes
 
 import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter
+import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.GradleVersion
+import org.gradle.util.TestUtil
+import org.junit.Rule
 import spock.lang.Specification
 
 /**
@@ -26,6 +36,18 @@ import spock.lang.Specification
  */
 class DefaultAttributesSchemaTest extends Specification {
     def schema = AttributeTestUtil.mutableSchema()
+
+    // Capture WARN-level events so we can assert on the deprecation warnings emitted by
+    // Attribute.of when an unsupported attribute value type is declared.
+    final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+    @Rule
+    final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    def setup() {
+        def diagnosticsFactory = new NoOpProblemDiagnosticsFactory()
+        DeprecationLogger.reset()
+        DeprecationLogger.init(WarningMode.All, Mock(BuildOperationProgressEventEmitter), TestUtil.problemsService(), diagnosticsFactory.newUnlimitedStream())
+    }
 
     def "can create an attribute of scalar type #type"() {
         when:
@@ -40,6 +62,27 @@ class DefaultAttributesSchemaTest extends Specification {
             Number,
             MyEnum,
             Flavor
+        ]
+    }
+
+    def "creating an attribute of array type #type emits the unsupported-type deprecation"() {
+        when:
+        Attribute.of('foo', type)
+
+        then:
+        // Array types are not in the allowlist (only String, Boolean, Number-subtypes, and
+        // Named-subtypes are). Attribute.of now emits a deprecation warning rather than
+        // throwing — this will fail with an error in Gradle 10.
+        def warns = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
+        warns.size() == 1
+        warns[0].message == "Using type '${type.name}' as a value type for attribute 'foo' has been deprecated. This will fail with an error in Gradle 10. Attribute values must be of type String, Boolean, a subtype of Number, or implement org.gradle.api.Named. Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#unsupported_attribute_value_type"
+
+        where:
+        type << [
+            String[].class,
+            Number[].class,
+            MyEnum[].class,
+            Flavor[].class
         ]
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcherTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcherTest.groovy
@@ -391,48 +391,6 @@ class DefaultAttributeMatcherTest extends Specification {
         matcher.matchMultipleCandidates([candidate1, candidate2], requested) == [candidate1]
     }
 
-    def "cannot match when producer uses desugared attribute of unsupported type"() {
-        given:
-        def consumer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
-        def producer = Attribute.of("a", String)
-
-        def matcher = newMatcher {
-            attribute(consumer)
-        }
-
-        def candidate1 = candidateTyped((producer): "name1")
-        def candidate2 = candidateTyped((producer): "name2")
-        def requested = attributesTyped((consumer): new NotSerializableInGradleMetadataAttribute("name1"))
-
-        when:
-        matcher.matchMultipleCandidates([candidate1, candidate2], requested)
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type org.gradle.api.internal.attributes.matching.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute but found a value of type java.lang.String."
-    }
-
-    def "cannot match when consumer uses desugared attribute of unsupported type"() {
-        given:
-        def consumer = Attribute.of("a", String)
-        def producer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
-
-        def matcher = newMatcher {
-            attribute(consumer)
-        }
-
-        def candidate1 = candidateTyped((producer): new NotSerializableInGradleMetadataAttribute("name1"))
-        def candidate2 = candidateTyped((producer): new NotSerializableInGradleMetadataAttribute("name2"))
-        def requested = attributesTyped((consumer): "name1")
-
-        when:
-        matcher.matchMultipleCandidates([candidate1, candidate2], requested)
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type java.lang.String but found a value of type org.gradle.api.internal.attributes.matching.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute."
-    }
-
     def "matching fails when attribute has incompatible types in consumer and producer"() {
         given:
         def consumer = Attribute.of("a", String)
@@ -538,13 +496,11 @@ class DefaultAttributeMatcherTest extends Specification {
     }
 
     interface NamedTestAttribute extends Named { }
-    enum EnumTestAttribute { NAME1, NAME2 }
-    static class NotSerializableInGradleMetadataAttribute implements Serializable {
-        String name
+    enum EnumTestAttribute implements Named {
+        NAME1, NAME2
 
-        NotSerializableInGradleMetadataAttribute(String name) {
-            this.name = name
-        }
+        @Override
+        String getName() { return name() }
     }
 
     private AttributeMatcher newMatcher(@DelegatesTo(TestSchema) Closure<?> action = {}) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcherTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcherTest.groovy
@@ -25,9 +25,18 @@ import org.gradle.api.attributes.MultipleCandidatesDetails
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter
+import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.GradleVersion
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
+import org.junit.Rule
 import spock.lang.Specification
 
 import javax.inject.Inject
@@ -37,6 +46,18 @@ import static org.gradle.util.AttributeTestUtil.attributesTyped
 import static org.gradle.util.TestUtil.objectFactory
 
 class DefaultAttributeMatcherTest extends Specification {
+
+    // Capture WARN-level events so we can assert on the deprecation warnings emitted by
+    // Attribute.of when an unsupported attribute value type is declared.
+    final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+    @Rule
+    final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    def setup() {
+        def diagnosticsFactory = new NoOpProblemDiagnosticsFactory()
+        DeprecationLogger.reset()
+        DeprecationLogger.init(WarningMode.All, Mock(BuildOperationProgressEventEmitter), TestUtil.problemsService(), diagnosticsFactory.newUnlimitedStream())
+    }
 
     def "selects candidate with same set of attributes and whose values match"() {
         given:
@@ -391,6 +412,69 @@ class DefaultAttributeMatcherTest extends Specification {
         matcher.matchMultipleCandidates([candidate1, candidate2], requested) == [candidate1]
     }
 
+    def "cannot match when producer uses desugared attribute of unsupported type"() {
+        given:
+        def consumer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
+        def producer = Attribute.of("a", String)
+
+        def matcher = newMatcher {
+            attribute(consumer)
+        }
+
+        def candidate1 = candidateTyped((producer): "name1")
+        def candidate2 = candidateTyped((producer): "name2")
+        def requested = attributesTyped((consumer): new NotSerializableInGradleMetadataAttribute("name1"))
+
+        when:
+        matcher.matchMultipleCandidates([candidate1, candidate2], requested)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type org.gradle.api.internal.attributes.matching.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute but found a value of type java.lang.String."
+
+        and:
+        // Attribute.of on the consumer's unsupported type emits the deprecation warning too.
+        def warns = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
+        warns.size() == 1
+        warns[0].message == unsupportedTypeDeprecation(NotSerializableInGradleMetadataAttribute.name, 'a')
+    }
+
+    def "cannot match when consumer uses desugared attribute of unsupported type"() {
+        given:
+        def consumer = Attribute.of("a", String)
+        def producer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
+
+        def matcher = newMatcher {
+            attribute(consumer)
+        }
+
+        def candidate1 = candidateTyped((producer): new NotSerializableInGradleMetadataAttribute("name1"))
+        def candidate2 = candidateTyped((producer): new NotSerializableInGradleMetadataAttribute("name2"))
+        def requested = attributesTyped((consumer): "name1")
+
+        when:
+        matcher.matchMultipleCandidates([candidate1, candidate2], requested)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type java.lang.String but found a value of type org.gradle.api.internal.attributes.matching.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute."
+
+        and:
+        // Attribute.of on the producer's unsupported type emits the deprecation warning too.
+        def warns = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
+        warns.size() == 1
+        warns[0].message == unsupportedTypeDeprecation(NotSerializableInGradleMetadataAttribute.name, 'a')
+    }
+
+    private static String unsupportedTypeDeprecation(String typeName, String attributeName) {
+        return "Using type '${typeName}' as a value type for attribute '${attributeName}' has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "Attribute values must be of type String, Boolean, a subtype of Number, or implement org.gradle.api.Named. " +
+            "Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization. " +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#unsupported_attribute_value_type"
+    }
+
     def "matching fails when attribute has incompatible types in consumer and producer"() {
         given:
         def consumer = Attribute.of("a", String)
@@ -495,12 +579,21 @@ class DefaultAttributeMatcherTest extends Specification {
         new ImmutableAttributesBackedMatchingCandidate(attributesTyped(attributes))
     }
 
-    interface NamedTestAttribute extends Named { }
-    enum EnumTestAttribute implements Named {
+    private static interface NamedTestAttribute extends Named { }
+
+    private enum EnumTestAttribute implements Named {
         NAME1, NAME2
 
         @Override
         String getName() { return name() }
+    }
+
+    private static class NotSerializableInGradleMetadataAttribute implements Serializable {
+        String name
+
+        NotSerializableInGradleMetadataAttribute(String name) {
+            this.name = name
+        }
     }
 
     private AttributeMatcher newMatcher(@DelegatesTo(TestSchema) Closure<?> action = {}) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model
 
+import org.gradle.api.Named
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.attributes.Attribute
@@ -338,12 +339,15 @@ Configuration 'bar':
         return variant
     }
 
-    enum JavaVersion {
+    enum JavaVersion implements Named {
         JAVA5,
         JAVA6,
         JAVA7,
         JAVA8,
         JAVA9
+
+        @Override
+        String getName() { return name() }
     }
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/CustomNumberDesugaringSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/CustomNumberDesugaringSerializerTest.groovy
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.resolve.caching
+
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.attributes.AttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * PROOF test for {@link DesugaringAttributeContainerSerializer} with user-defined {@code Number}
+ * subtypes, forcing the {@code NUMBER_ATTRIBUTE} read branch (resolveNumberType -> parseNumber
+ * -> Class.forName). Characterizes:
+ * <ul>
+ *   <li>reconstruction via a static {@code valueOf(String)} factory,</li>
+ *   <li>reconstruction via a {@code (String)} constructor,</li>
+ *   <li>a type with neither (expected to fail in parseNumber), and</li>
+ *   <li>a type loaded by a classloader the serializer's classloader cannot see — the case
+ *       that decides whether finding #2's Class.forName concern is real.</li>
+ * </ul>
+ */
+class CustomNumberDesugaringSerializerTest extends SerializerSpec {
+    private AttributesFactory attributesFactory = AttributeTestUtil.attributesFactory()
+    private DesugaringAttributeContainerSerializer serializer = new DesugaringAttributeContainerSerializer(attributesFactory, TestUtil.objectInstantiator())
+
+    def "round-trips a custom Number reconstructed via a static valueOf(String) factory"() {
+        given:
+        def attribute = Attribute.of("test", WithValueOf)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new WithValueOf(7))
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.type == WithValueOf
+        def value = result.getAttribute(resultAttribute)
+        value.class == WithValueOf
+        value == new WithValueOf(7)
+    }
+
+    def "round-trips a custom Number reconstructed via a (String) constructor"() {
+        given:
+        def attribute = Attribute.of("test", WithStringCtor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new WithStringCtor("7"))
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.type == WithStringCtor
+        def value = result.getAttribute(resultAttribute)
+        value.class == WithStringCtor
+        value == new WithStringCtor("7")
+    }
+
+    def "fails to reconstruct a custom Number that has neither valueOf(String) nor a (String) constructor"() {
+        given:
+        def attribute = Attribute.of("test", WithNeither)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new WithNeither(7))
+
+        when:
+        serialize(container, serializer)
+
+        then:
+        // parseNumber finds no valueOf(String) factory and no (String) constructor.
+        def e = thrown(IllegalStateException)
+        e.message.contains("Cannot reconstruct attribute value '7' as")
+        e.message.contains(WithNeither.name)
+        e.cause instanceof NoSuchMethodException
+    }
+
+    def "custom Number type not visible to the serializer's classloader fails to reconstruct on read"() {
+        given: "a Number subtype defined in a child classloader the serializer's classloader cannot see"
+        def childLoader = new GroovyClassLoader(DesugaringAttributeContainerSerializer.classLoader)
+        Class<?> hidden = childLoader.parseClass('''
+            class HiddenNumber extends Number {
+                final int v
+                HiddenNumber(int v) { this.v = v }
+                static HiddenNumber valueOf(String s) { new HiddenNumber(Integer.parseInt(s)) }
+                int intValue() { v }
+                long longValue() { (long) v }
+                float floatValue() { (float) v }
+                double doubleValue() { (double) v }
+                String toString() { String.valueOf(v) }
+                boolean equals(Object o) { o.getClass() == getClass() && o.v == v }
+                int hashCode() { v }
+            }
+        ''')
+        def value = hidden.getConstructor(int.class).newInstance(7)
+        def attribute = Attribute.of("test", hidden)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, value)
+
+        when:
+        serialize(container, serializer)
+
+        then:
+        // Write succeeds (only needs the type name + toString). Read fails: resolveNumberType does
+        // Class.forName on the serializer's own (parent) classloader, which cannot see a type defined
+        // in the child loader. This is finding #2: presence on producer/consumer build classpaths is
+        // NOT sufficient, because those live in child classloaders of Gradle's core.
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot deserialize attribute value: number type 'HiddenNumber' was not found"
+        e.cause instanceof ClassNotFoundException
+    }
+
+    def "round-trips a negative custom Number value"() {
+        given:
+        def attribute = Attribute.of("test", WithValueOf)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new WithValueOf(-42))
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        result.getAttribute(result.keySet().first()) == new WithValueOf(-42)
+    }
+
+    def "ignores a valueOf(String) whose return type is not the number type and falls back to the (String) constructor"() {
+        given:
+        def attribute = Attribute.of("test", ValueOfWrongReturnType)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new ValueOfWrongReturnType("7"))
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then: "the wrong-typed valueOf is rejected by the isAssignableFrom guard, so the (String) constructor is used"
+        def value = result.getAttribute(result.keySet().first())
+        value.class == ValueOfWrongReturnType
+        value == new ValueOfWrongReturnType("7")
+    }
+
+    def "wraps an exception thrown by valueOf(String) during reconstruction"() {
+        given:
+        def attribute = Attribute.of("test", ThrowingValueOf)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new ThrowingValueOf(7))
+
+        when:
+        serialize(container, serializer)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("error invoking 'valueOf(String)'")
+        e.cause instanceof InvocationTargetException
+    }
+
+    def "fails to reconstruct a JDK Number subtype (AtomicInteger) that lacks valueOf(String) and a (String) constructor"() {
+        given: "AtomicInteger is a Number subtype visible to the core classloader, but has no valueOf(String) and no (String) constructor"
+        def attribute = Attribute.of("test", AtomicInteger)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new AtomicInteger(7))
+
+        when:
+        serialize(container, serializer)
+
+        then: "resolveNumberType succeeds (visible), but parseNumber cannot rebuild it — 'any Number subtype' is narrower than the docs imply"
+        def e = thrown(IllegalStateException)
+        e.message.contains("Cannot reconstruct attribute value '7' as")
+        e.cause instanceof NoSuchMethodException
+    }
+
+    // --- Custom Number subtypes visible to this test's (and the serializer's) classloader ---
+
+    static class WithValueOf extends Number implements Serializable {
+        final int v
+        WithValueOf(int v) { this.v = v }
+        static WithValueOf valueOf(String s) { new WithValueOf(Integer.parseInt(s)) }
+        int intValue() { v }
+        long longValue() { (long) v }
+        float floatValue() { (float) v }
+        double doubleValue() { (double) v }
+        String toString() { String.valueOf(v) }
+        boolean equals(Object o) { o instanceof WithValueOf && ((WithValueOf) o).v == v }
+        int hashCode() { v }
+    }
+
+    static class WithStringCtor extends Number implements Serializable {
+        final int v
+        WithStringCtor(String s) { this.v = Integer.parseInt(s) }
+        int intValue() { v }
+        long longValue() { (long) v }
+        float floatValue() { (float) v }
+        double doubleValue() { (double) v }
+        String toString() { String.valueOf(v) }
+        boolean equals(Object o) { o instanceof WithStringCtor && ((WithStringCtor) o).v == v }
+        int hashCode() { v }
+    }
+
+    static class WithNeither extends Number implements Serializable {
+        final int v
+        WithNeither(int v) { this.v = v }
+        int intValue() { v }
+        long longValue() { (long) v }
+        float floatValue() { (float) v }
+        double doubleValue() { (double) v }
+        String toString() { String.valueOf(v) }
+        boolean equals(Object o) { o instanceof WithNeither && ((WithNeither) o).v == v }
+        int hashCode() { v }
+    }
+
+    static class ValueOfWrongReturnType extends Number implements Serializable {
+        final int v
+        ValueOfWrongReturnType(String s) { this.v = Integer.parseInt(s) }
+        // Wrong return type (not assignable to ValueOfWrongReturnType): must be rejected by parseNumber.
+        static String valueOf(String s) { "ignored" }
+        int intValue() { v }
+        long longValue() { (long) v }
+        float floatValue() { (float) v }
+        double doubleValue() { (double) v }
+        String toString() { String.valueOf(v) }
+        boolean equals(Object o) { o instanceof ValueOfWrongReturnType && ((ValueOfWrongReturnType) o).v == v }
+        int hashCode() { v }
+    }
+
+    static class ThrowingValueOf extends Number implements Serializable {
+        final int v
+        ThrowingValueOf(int v) { this.v = v }
+        static ThrowingValueOf valueOf(String s) { throw new IllegalArgumentException("boom: " + s) }
+        int intValue() { v }
+        long longValue() { (long) v }
+        float floatValue() { (float) v }
+        double doubleValue() { (double) v }
+        String toString() { String.valueOf(v) }
+        boolean equals(Object o) { o instanceof ThrowingValueOf && ((ThrowingValueOf) o).v == v }
+        int hashCode() { v }
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.resolve.caching
+
+import org.gradle.api.Named
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.attributes.AttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+
+/**
+ * Unit tests for {@link DesugaringAttributeContainerSerializer}.
+ */
+class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
+    private AttributesFactory attributesFactory = AttributeTestUtil.attributesFactory()
+    private DesugaringAttributeContainerSerializer serializer = new DesugaringAttributeContainerSerializer(attributesFactory, TestUtil.objectInstantiator())
+
+    def "round-trips a #type.simpleName attribute value (#value)"() {
+        given:
+        def attribute = Attribute.of("test", type)
+        //noinspection GroovyAssignabilityCheck
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, value)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        result.keySet().size() == 1
+        def resultAttribute = result.keySet().first()
+        resultAttribute.name == "test"
+        resultAttribute.type == type
+        def resultValue = result.getAttribute(resultAttribute)
+        resultValue.class == type
+
+        and:
+        // Use .equals() rather than Groovy '==' so NaN round-trips compare equal and BigDecimal
+        // comparison stays scale-sensitive, verifying an exact reconstruction.
+        //noinspection ChangeToOperator
+        resultValue.equals(value)
+
+        where:
+        type       | value
+        Byte       | (Byte) 42
+        Byte       | Byte.MIN_VALUE
+        Byte       | Byte.MAX_VALUE
+        Short      | (Short) 4242
+        Short      | Short.MIN_VALUE
+        Short      | Short.MAX_VALUE
+        Integer    | 7
+        Integer    | Integer.MIN_VALUE
+        Integer    | Integer.MAX_VALUE
+        Long       | 9000000000L
+        Long       | Long.MIN_VALUE
+        Long       | Long.MAX_VALUE
+        Float      | 1.5f
+        Float      | Float.MIN_VALUE
+        Float      | Float.MAX_VALUE
+        Float      | Float.NaN
+        Float      | Float.POSITIVE_INFINITY
+        Double     | 3.14159d
+        Double     | Double.MIN_VALUE
+        Double     | Double.MAX_VALUE
+        Double     | Double.NaN
+        Double     | Double.NEGATIVE_INFINITY
+        BigInteger | BigInteger.valueOf(123456789012345678L).multiply(BigInteger.TEN)
+        BigDecimal | new BigDecimal("12345678901234567890.0987654321")
+    }
+
+    def "round-trips a String attribute value"() {
+        given:
+        def attribute = Attribute.of("test", String)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, "hello")
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.type == String
+        result.getAttribute(resultAttribute) == "hello"
+    }
+
+    def "round-trips a Boolean attribute value"() {
+        given:
+        def attribute = Attribute.of("test", Boolean)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, true)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.type == Boolean
+        result.getAttribute(resultAttribute) == true
+    }
+
+    def "desugars a Named attribute value"() {
+        given:
+        def named = TestUtil.objectInstantiator().named(Flavor, "vanilla")
+        def attribute = Attribute.of("flavor", Flavor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, named)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.name == "flavor"
+        result.getAttribute(Attribute.of("flavor", String)) == "vanilla"
+    }
+
+    def "round-trips a container holding a mix of value types"() {
+        given:
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, Attribute.of("s", String), "text")
+        container = attributesFactory.concat(container, Attribute.of("i", Integer), 1)
+        container = attributesFactory.concat(container, Attribute.of("l", Long), 2L)
+        container = attributesFactory.concat(container, Attribute.of("d", Double), 3.0d)
+        container = attributesFactory.concat(container, Attribute.of("b", Boolean), false)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        result.keySet().size() == 5
+        result.getAttribute(Attribute.of("s", String)) == "text"
+        result.getAttribute(Attribute.of("i", Integer)) == 1
+        result.getAttribute(Attribute.of("l", Long)) == 2L
+        result.getAttribute(Attribute.of("d", Double)) == 3.0d
+        result.getAttribute(Attribute.of("b", Boolean)) == false
+    }
+
+    interface Flavor extends Named {}
+}

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -582,8 +582,13 @@ class GradleModuleMetadataWriterTest extends Specification {
 """
     }
 
-    enum SomeEnum {
+    enum SomeEnum implements Named {
         VALUE_1, VALUE_2
+
+        @Override
+        String getName() {
+            return name()
+        }
     }
 
     def "writes file for component with variants with attributes"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -370,7 +370,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
             ${resolve.configureSettings("_compileFree", "_compilePaid")}
         """
         buildFile << """
-            enum SomeEnum { free, paid }
+            enum SomeEnum implements Named {
+                free, paid
+                @Override String getName() { return name() }
+            }
             interface Thing extends Named { }
             @groovy.transform.EqualsAndHashCode
             class OtherThing implements Thing, Serializable { String name }
@@ -405,7 +408,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         """
 
         file('includedBuild/build.gradle') << """
-            enum SomeEnum { free, paid }
+            enum SomeEnum implements Named {
+                free, paid
+                @Override String getName() { return name() }
+            }
             interface Thing extends Named { }
             @groovy.transform.EqualsAndHashCode
             class OtherThing implements Thing, Serializable { String name }
@@ -1012,8 +1018,20 @@ All of them match the consumer attributes:
                     groovy {
                         com {
                             acme {
-                                'Flavor.groovy'('package com.acme; enum Flavor { free, paid }')
-                                'BuildType.groovy'('package com.acme; enum BuildType { debug {}, release {} }')
+                                'Flavor.groovy'('''package com.acme
+                                    import org.gradle.api.Named
+                                    enum Flavor implements Named {
+                                        free, paid
+                                        @Override String getName() { return name() }
+                                    }
+                                ''')
+                                'BuildType.groovy'('''package com.acme
+                                    import org.gradle.api.Named
+                                    enum BuildType implements Named {
+                                        debug {}, release {}
+                                        @Override String getName() { return name() }
+                                    }
+                                ''')
                                 'TypedAttributesPlugin.groovy'('''package com.acme
 
                                     import org.gradle.api.Plugin

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
@@ -69,22 +69,21 @@ public class Attribute<T> implements Named {
         "org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeBundleArtifactFormat$KotlinNativeBundleArtifactsTypes";
 
     private static void validateSupportedType(String name, Class<?> type) {
-        if (AttributeTypeValidator.isSupportedAttributeType(type)) {
-            return;
+        if (!AttributeTypeValidator.isSupportedAttributeType(type)) {
+            if (KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName())) {
+                DeprecationLogger.deprecate("Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type")
+                    .withContext("This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute.")
+                    .willBecomeAnErrorInGradle10()
+                    .withUpgradeGuideSection(9, "kgp_native_bundle_attribute_enum")
+                    .nagUser();
+            } else {
+                DeprecationLogger.deprecate("Using type '" + type.getName() + "' as a value type for attribute '" + name + "'")
+                    .withContext("Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ". Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization.")
+                    .willBecomeAnErrorInGradle10()
+                    .withUpgradeGuideSection(9, "unsupported_attribute_value_type")
+                    .nagUser();
+            }
         }
-        if (KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName())) {
-            DeprecationLogger.deprecate("Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type")
-                .withContext("This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute.")
-                .willBecomeAnErrorInGradle10()
-                .withUpgradeGuideSection(9, "kgp_native_bundle_attribute_enum")
-                .nagUser();
-            return;
-        }
-        DeprecationLogger.deprecate("Using type '" + type.getName() + "' as a value type for attribute '" + name + "'")
-            .withContext("Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ". Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization.")
-            .willBecomeAnErrorInGradle10()
-            .withUpgradeGuideSection(9, "unsupported_attribute_value_type")
-            .nagUser();
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
@@ -56,26 +56,21 @@ public class Attribute<T> implements Named {
         return new Attribute<T>(name, type);
     }
 
-    /**
-     * Fully-qualified name of a plain enum used as an attribute value type by the Kotlin Gradle
-     * Plugin 2.0.x line (empirically observed in 2.0.0 through 2.0.21). KGP 2.1.0+ no longer uses
-     * this enum. To preserve compatibility with the affected KGP versions, this exact class name
-     * is allowed to pass {@link #validateSupportedType(String, Class)} with a targeted deprecation
-     * warning identifying KGP as the source, instead of the generic unsupported-type deprecation.
-     * <p>
-     * This special case should be removed when compatibility with KGP 2.0.x is no longer required.
-     */
-    private static final String KGP_NATIVE_BUNDLE_ENUM_FQN =
-        "org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeBundleArtifactFormat$KotlinNativeBundleArtifactsTypes";
-
     private static void validateSupportedType(String name, Class<?> type) {
         if (!AttributeTypeValidator.isSupportedAttributeType(type)) {
-            if (KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName())) {
-                DeprecationLogger.deprecate("Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type")
+            if (AttributeTypeValidator.isKGPSpecialCase(type)) {
+                DeprecationLogger.deprecate("Using the enum type " + type.getSimpleName() + " as an attribute value type")
                     .withContext("This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute.")
                     .willBecomeAnErrorInGradle10()
                     .withUpgradeGuideSection(9, "kgp_native_bundle_attribute_enum")
                     .nagUser();
+            } else if (AttributeTypeValidator.isAlienNamedSpecialCase(type)) {
+                throw new IllegalArgumentException(String.format(
+                    "Using an attribute value type that implements org.gradle.api.Named loaded from a different classloader is not supported. " +
+                        "The type '%s' declared for attribute '%s' was loaded from %s, but Gradle's own Named class is in %s. " +
+                        "This may indicate a shaded or duplicated Gradle API on the classpath.",
+                    type.getName(), name, type.getClassLoader(), Named.class.getClassLoader()
+                ));
             } else {
                 DeprecationLogger.deprecate("Using type '" + type.getName() + "' as a value type for attribute '" + name + "'")
                     .withContext("Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ". Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization.")

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
@@ -17,12 +17,19 @@
 package org.gradle.api.attributes;
 
 import org.gradle.api.Named;
+import org.gradle.api.internal.attributes.AttributeTypeValidator;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 /**
  * An attribute is a named entity with a type. It is used in conjunction with a {@link AttributeContainer}
  * to provide a type safe container for attributes. This class isn't intended to store the value of an
  * attribute, but only represent the identity of the attribute. It means that an attribute must be immutable
  * and can potentially be pooled. Attributes can be created using the {@link #of(String, Class) factory method}.
+ * <p>
+ * Supported attribute value types are: {@code String}, {@code Boolean}, any subtype of {@link Number},
+ * and any type implementing {@link Named}. {@link #of(String, Class)} emits a deprecation warning for
+ * any other type — including plain Java {@link Enum} types that do not implement {@link Named} — and
+ * this will become an error in Gradle 10.
  *
  * @param <T> the type of the named attribute
  *
@@ -39,12 +46,45 @@ public class Attribute<T> implements Named {
      * of {@link Attribute}, so consumers are required to compare the attributes with the {@link #equals(Object)}
      * method.
      * @param name the name of the attribute
-     * @param type the class of the attribute
+     * @param type the class of the attribute; must be {@code String}, {@code Boolean}, a subtype of
+     *             {@link Number}, or a subtype of {@link Named}
      * @param <T> the type of the attribute
      * @return an attribute with the given name and type
      */
     public static <T> Attribute<T> of(String name, Class<T> type) {
+        validateSupportedType(name, type);
         return new Attribute<T>(name, type);
+    }
+
+    /**
+     * Fully-qualified name of a plain enum used as an attribute value type by the Kotlin Gradle
+     * Plugin 2.0.x line (empirically observed in 2.0.0 through 2.0.21). KGP 2.1.0+ no longer uses
+     * this enum. To preserve compatibility with the affected KGP versions, this exact class name
+     * is allowed to pass {@link #validateSupportedType(String, Class)} with a targeted deprecation
+     * warning identifying KGP as the source, instead of the generic unsupported-type deprecation.
+     * <p>
+     * This special case should be removed when compatibility with KGP 2.0.x is no longer required.
+     */
+    private static final String KGP_NATIVE_BUNDLE_ENUM_FQN =
+        "org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeBundleArtifactFormat$KotlinNativeBundleArtifactsTypes";
+
+    private static void validateSupportedType(String name, Class<?> type) {
+        if (AttributeTypeValidator.isSupportedAttributeType(type)) {
+            return;
+        }
+        if (KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName())) {
+            DeprecationLogger.deprecate("Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type")
+                .withContext("This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute.")
+                .willBecomeAnErrorInGradle10()
+                .withUpgradeGuideSection(9, "kgp_native_bundle_attribute_enum")
+                .nagUser();
+            return;
+        }
+        DeprecationLogger.deprecate("Using type '" + type.getName() + "' as a value type for attribute '" + name + "'")
+            .withContext("Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ". Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization.")
+            .willBecomeAnErrorInGradle10()
+            .withUpgradeGuideSection(9, "unsupported_attribute_value_type")
+            .nagUser();
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -27,16 +27,24 @@ import java.util.Set;
 
 /**
  * An attribute container is a container of {@link Attribute attributes}, which are
- * strongly typed named entities. Such a container is responsible for storing and
+ * strongly typed named entities.
+ * <p>
+ * Such a container is responsible for storing and
  * getting attributes in a type safe way. In particular, attributes are strongly typed,
  * meaning that when we get a value from the container, the returned value type is
  * inferred from the type of the attribute. In a way, an attribute container is
  * similar to a {@link java.util.Map} where the entry is a "typed String" and the value
  * is of the string type. However, the set of methods available to the container is
  * much more limited.
- *
+ * <p>
  * It is not allowed to have two attributes with the same name but different types in
  * the container.
+ * <p>
+ * Supported attribute value types are: {@code String}, {@code Boolean}, any subtype of {@link Number},
+ * and any type implementing {@link Named}.
+ * <p>
+ * Plain Java {@link Enum} types (that do <strong>NOT</strong> implement {@link Named}) are
+ * <strong>NOT</strong> supported.
  *
  * @since 3.3
  */
@@ -53,6 +61,7 @@ public interface AttributeContainer extends HasAttributes {
     /**
      * Sets an attribute value. It is not allowed to use <code>null</code> as
      * an attribute value.
+     *
      * @param <T> the type of the attribute
      * @param key the attribute key
      * @param value the attribute value

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
@@ -39,6 +39,15 @@ import java.lang.reflect.Type;
  */
 public final class AttributeTypeValidator {
     /**
+     * Fully-qualified name of a plain enum used as an attribute value type by the Kotlin Gradle
+     * Plugin 2.0.x line (empirically observed in 2.0.0 through 2.0.21). KGP 2.1.0+ no longer
+     * uses this enum. Not referenced by class literal because the enum lives in the KGP
+     * distribution and is not on Gradle's compile classpath.
+     */
+    private static final String KGP_NATIVE_BUNDLE_ENUM_FQN =
+        "org.jetbrains.kotlin.gradle.targets.native.toolchain.KotlinNativeBundleArtifactFormat$KotlinNativeBundleArtifactsTypes";
+
+    /**
      * Returns whether the given class is one of the supported attribute value types:
      * {@code String}, {@code Boolean}, any subtype of {@code Number}, or a type implementing
      * {@link Named}.
@@ -48,6 +57,45 @@ public final class AttributeTypeValidator {
             || type == Boolean.class
             || Number.class.isAssignableFrom(type)
             || Named.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Returns whether the given type is the specific plain-enum class
+     * {@code KotlinNativeBundleArtifactsTypes} used as an attribute value type by the Kotlin
+     * Gradle Plugin 2.0.x line (empirically observed in 2.0.0 through 2.0.21). KGP 2.1.0+ no
+     * longer uses this enum. Callers may accept this type with a targeted deprecation warning
+     * identifying KGP as the source, instead of the generic unsupported-type deprecation.
+     * <p>
+     * This special case should be removed when compatibility with KGP 2.0.x is no longer required.
+     */
+    public static boolean isKGPSpecialCase(Class<?> type) {
+        return KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName());
+    }
+
+    /**
+     * Returns whether the given type has, anywhere in its supertype chain (interfaces or
+     * superclasses, recursively), an interface whose fully-qualified name is
+     * {@code "org.gradle.api.Named"} but whose {@link Class} identity differs from {@link Named}.
+     * This "alien Named" situation almost always indicates a shaded or duplicated {@code gradle-api}
+     * on the classpath — the same interface loaded twice by different classloaders is treated by
+     * the JVM as two unrelated types, so {@code Named.class.isAssignableFrom(type)} returns
+     * {@code false} even though the type does implement (a copy of) {@code Named}.
+     * <p>
+     * This detection is intended to run only after {@link #isSupportedAttributeType(Class)} has
+     * already returned {@code false}, so a type that implements our real {@code Named} alongside
+     * an alien {@code Named} still short-circuits via that check and never reaches here.
+     */
+    public static boolean isAlienNamedSpecialCase(Class<?> type) {
+        if ("org.gradle.api.Named".equals(type.getName()) && type != Named.class) {
+            return true;
+        }
+        for (Class<?> iface : type.getInterfaces()) {
+            if (isAlienNamedSpecialCase(iface)) {
+                return true;
+            }
+        }
+        Class<?> sup = type.getSuperclass();
+        return sup != null && isAlienNamedSpecialCase(sup);
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
@@ -22,26 +22,22 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Runtime validation helpers for attribute value types.
  * <p>
  * The public {@link org.gradle.api.attributes.Attribute#of(String, Class)} factory validates
  * attribute value types up front at declaration. This helper provides the same allowlist check
- * so it can be reused by rule-registration code that needs to fail-fast when a rule is written
- * against an unsupported attribute value type — a case that Java generics don't catch when
- * rules are registered through raw types, wildcards, or reflection.
+ * so it can be reused by attribute rule chains, which warn when a rule is written against an
+ * unsupported attribute value type — a case that Java generics don't catch when rules are
+ * registered through raw types, wildcards, or reflection.
+ * <p>
+ * Unlike the factory, this check runs lazily: it fires the first time a rule is exercised during
+ * attribute matching (not at rule registration), so a rule whose attribute is never matched emits
+ * no warning. When an unsupported type is detected it emits a deprecation warning rather than
+ * failing — see {@link #validateRuleTypeParameter}.
  */
 public final class AttributeTypeValidator {
-    /**
-     * Rule classes that have already been validated. Prevents the reflective type-parameter
-     * extraction below from running on every attribute match — the check runs at most once per
-     * concrete rule class per JVM.
-     */
-    private static final Set<Class<?>> ALREADY_VALIDATED_RULES = ConcurrentHashMap.newKeySet();
-
     /**
      * Returns whether the given class is one of the supported attribute value types:
      * {@code String}, {@code Boolean}, any subtype of {@code Number}, or a type implementing
@@ -59,7 +55,14 @@ public final class AttributeTypeValidator {
      * (typically {@code AttributeCompatibilityRule} or {@code AttributeDisambiguationRule}) is
      * a supported attribute value type.
      * <p>
-     * Runs at most once per {@code ruleClass}. Silently accepts if:
+     * This performs reflective type-argument extraction on every call, so callers that invoke it
+     * on a hot path (e.g. per attribute match) are responsible for throttling it — see the
+     * per-instance guard in the rule-chain {@code ValidatingAction}s. It deliberately keeps no
+     * static state of its own: caching validated rule classes in a JVM-lifetime static would
+     * both leak plugin classloaders across builds and suppress the deprecation on every build
+     * after the first in a reused daemon.
+     * <p>
+     * Silently accepts if:
      * <ul>
      *   <li>the type argument cannot be resolved to a concrete class (rule is itself generic,
      *       uses a wildcard, or hides its type argument behind an abstract intermediate whose
@@ -73,9 +76,6 @@ public final class AttributeTypeValidator {
      * one of the supported attribute value types. This will become an error in Gradle 10.
      */
     public static void validateRuleTypeParameter(Class<?> ruleClass, Class<?> ruleInterface) {
-        if (!ALREADY_VALIDATED_RULES.add(ruleClass)) {
-            return;
-        }
         Class<?> typeArg = extractInterfaceTypeArgument(ruleClass, ruleInterface);
         if (typeArg == null || typeArg == Object.class) {
             return;

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.Named;
+import org.gradle.internal.deprecation.DeprecationLogger;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Runtime validation helpers for attribute value types.
+ * <p>
+ * The public {@link org.gradle.api.attributes.Attribute#of(String, Class)} factory validates
+ * attribute value types up front at declaration. This helper provides the same allowlist check
+ * so it can be reused by rule-registration code that needs to fail-fast when a rule is written
+ * against an unsupported attribute value type — a case that Java generics don't catch when
+ * rules are registered through raw types, wildcards, or reflection.
+ */
+public final class AttributeTypeValidator {
+    /**
+     * Rule classes that have already been validated. Prevents the reflective type-parameter
+     * extraction below from running on every attribute match — the check runs at most once per
+     * concrete rule class per JVM.
+     */
+    private static final Set<Class<?>> ALREADY_VALIDATED_RULES = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Returns whether the given class is one of the supported attribute value types:
+     * {@code String}, {@code Boolean}, any subtype of {@code Number}, or a type implementing
+     * {@link Named}.
+     */
+    public static boolean isSupportedAttributeType(Class<?> type) {
+        return type == String.class
+            || type == Boolean.class
+            || Number.class.isAssignableFrom(type)
+            || Named.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Validates that the type argument the given rule class supplies to the given rule interface
+     * (typically {@code AttributeCompatibilityRule} or {@code AttributeDisambiguationRule}) is
+     * a supported attribute value type.
+     * <p>
+     * Runs at most once per {@code ruleClass}. Silently accepts if:
+     * <ul>
+     *   <li>the type argument cannot be resolved to a concrete class (rule is itself generic,
+     *       uses a wildcard, or hides its type argument behind an abstract intermediate whose
+     *       interface uses an unbound variable), or</li>
+     *   <li>the type argument is {@link Object} — this is the erasure default for raw-typed rule
+     *       declarations, and rejecting it would break test-only "accept-anything" rules that
+     *       intentionally don't care about the value type.</li>
+     * </ul>
+     * <p>
+     * Emits a deprecation warning if the type argument is resolved to a class that is not
+     * one of the supported attribute value types. This will become an error in Gradle 10.
+     */
+    public static void validateRuleTypeParameter(Class<?> ruleClass, Class<?> ruleInterface) {
+        if (!ALREADY_VALIDATED_RULES.add(ruleClass)) {
+            return;
+        }
+        Class<?> typeArg = extractInterfaceTypeArgument(ruleClass, ruleInterface);
+        if (typeArg == null || typeArg == Object.class) {
+            return;
+        }
+        if (!isSupportedAttributeType(typeArg)) {
+            DeprecationLogger.deprecate("Using type '" + typeArg.getName() + "' as the type parameter of attribute rule '" + ruleClass.getName() + "'")
+                .withContext("Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ". Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization.")
+                .willBecomeAnErrorInGradle10()
+                .withUpgradeGuideSection(9, "unsupported_attribute_value_type")
+                .nagUser();
+        }
+    }
+
+    /**
+     * Walks the given concrete class's superclass/superinterface chain looking for the first
+     * declaration of {@code targetInterface} whose type argument resolves to a concrete class.
+     * Returns {@code null} if no such declaration is found or the type argument is a wildcard
+     * or unbound type variable.
+     */
+    @Nullable
+    private static Class<?> extractInterfaceTypeArgument(Class<?> concrete, Class<?> targetInterface) {
+        Class<?> current = concrete;
+        while (current != null && current != Object.class) {
+            for (Type iface : current.getGenericInterfaces()) {
+                if (iface instanceof ParameterizedType) {
+                    ParameterizedType pt = (ParameterizedType) iface;
+                    if (pt.getRawType() == targetInterface) {
+                        Type[] args = pt.getActualTypeArguments();
+                        if (args.length == 1 && args[0] instanceof Class) {
+                            return (Class<?>) args[0];
+                        }
+                        return null;
+                    }
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/CustomNumberAttributeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/CustomNumberAttributeIntegrationTest.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+/**
+ * Integration tests for {@code Number}-typed attribute values flowing through the
+ * resolution-result streaming path ({@code DesugaringAttributeContainerSerializer}).
+ * <p>
+ * Only the request attributes of an <em>ad-hoc root</em> node (a detached configuration, or the
+ * synthetic root of a resolvable configuration that has a real dependency, avoiding the
+ * short-circuit executor) are serialized <em>raw</em> through this serializer. Module/project
+ * node attributes are desugared to {@code String} and never hit the NUMBER branch. The
+ * {@code write} branch is engaged at task-graph-time resolution and is exercised here. The
+ * {@code read}/reconstruction branch ({@code resolveNumberType} + {@code parseNumber}), by
+ * contrast, was empirically found <em>not</em> to be reachable from integration-test build shapes:
+ * task-input snapshotting is write-only ({@code ResolutionResultSerializer.read} is unsupported),
+ * execution-time {@code resolutionResult} queries use the in-memory graph, and build-operation
+ * capture desugars values to their {@code toString} rather than re-streaming raw values. The read
+ * path (including the cross-classloader failure for build-defined custom {@code Number} types) is
+ * therefore covered by the unit test {@code CustomNumberDesugaringSerializerTest} instead.
+ */
+final class CustomNumberAttributeIntegrationTest extends AbstractIntegrationSpec {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    private static final String CUSTOM_NUMBER = """
+        class SemVer extends Number {
+            final int v
+            SemVer(int v) { this.v = v }
+            static SemVer valueOf(String s) { new SemVer(Integer.parseInt(s)) }
+            int intValue() { v }
+            long longValue() { (long) v }
+            float floatValue() { (float) v }
+            double doubleValue() { (double) v }
+            String toString() { String.valueOf(v) }
+            boolean equals(Object o) { o instanceof SemVer && ((SemVer) o).v == v }
+            int hashCode() { v }
+        }
+    """
+
+    def "a JDK Number request attribute on a detached configuration used as a task input streams through the NUMBER write branch without regression"() {
+        // Mirrors the ES 9.5.1 regression shape (EnumAttributeIntegrationTest), but with a Number
+        // instead of a plain enum. The enum hit a CCE on write; a Number takes the NUMBER write
+        // branch instead and proceeds cleanly.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0").publish()
+
+        buildFile("""
+            def NUM = Attribute.of("myNumberAttribute", Long.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            def detached = configurations.detachedConfiguration(
+                dependencies.create("org.example:producer:1.0")
+            )
+            detached.attributes { attribute(NUM, 9000000000L) }
+
+            tasks.register("t") {
+                inputs.files(detached)
+                doLast { }
+            }
+        """)
+
+        expect:
+        succeeds("t")
+    }
+
+    def "a JDK Long request attribute on a resolvable ad-hoc root is captured in the resolve build operation"() {
+        given:
+        mavenRepo.module("org.example", "producer", "1.0").publish()
+
+        buildFile("""
+            def NUM = Attribute.of("myNumberAttribute", Long.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(configurations.deps)
+                    attributes { attribute(NUM, 9000000000L) }
+                }
+            }
+
+            dependencies { deps("org.example:producer:1.0") }
+
+            tasks.register("resolve") {
+                def files = configurations.res.incoming.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        when:
+        succeeds("resolve")
+
+        then: "the request attribute reaches the build-op via desugaring to its toString (not the streaming read path)"
+        def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
+        op.result.requestedAttributes.find { it.name == "myNumberAttribute" }.value.toString() == "9000000000"
+    }
+
+    def "an inline custom Number request attribute resolves end-to-end and is captured in the resolve build operation"() {
+        // A build-script-defined custom Number is invisible to the serializer's core classloader,
+        // so the streaming read()/reconstruction path CANNOT rebuild it (see finding #2, covered by
+        // CustomNumberDesugaringSerializerTest). But resolution never engages that read path: the
+        // value is desugared to its toString for the build-op/execution-time views. So resolution
+        // succeeds cleanly here — documenting that the defect is latent, not hit by normal builds.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0").publish()
+
+        buildFile("""
+            ${CUSTOM_NUMBER}
+            def NUM = Attribute.of("myNumberAttribute", SemVer.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(configurations.deps)
+                    attributes { attribute(NUM, SemVer.valueOf("7")) }
+                }
+            }
+
+            dependencies { deps("org.example:producer:1.0") }
+
+            tasks.register("resolve") {
+                def files = configurations.res.incoming.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        when:
+        succeeds("resolve")
+
+        then:
+        def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
+        op.result.requestedAttributes.find { it.name == "myNumberAttribute" }.value.toString() == "7"
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/EnumAttributeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/EnumAttributeIntegrationTest.groovy
@@ -1,0 +1,1564 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import groovy.test.NotYetImplemented
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * Integration tests demonstrating that plain Java {@code Enum} types (those that do not
+ * implement {@link org.gradle.api.Named}) are <strong>NOT</strong> supported as attribute values in Gradle's
+ * dependency-resolution and publishing pipelines.
+ * <p>
+ * {@link org.gradle.api.attributes.Attribute#of(String, Class)} validates the requested attribute
+ * type up front: it accepts {@code String}, {@code Boolean}, any subtype of {@link Number}, and
+ * any type implementing {@link org.gradle.api.Named}. Any other type — including plain Java
+ * {@code Enum} types — currently emits a deprecation warning and will become a hard error in
+ * Gradle 10 (see {@code Attribute.of} javadoc). The tests here document both the current
+ * deprecation-warning behavior and the underlying failure modes that motivated the deprecation.
+ * <p>
+ * A Named-implementing enum ({@code enum X implements Named}) delegating {@code getName()} to the
+ * built-in {@code name()} is the supported way to use an enum as an attribute value.
+ * <p>
+ * Each test in the "enums succeed" region is parameterized with two enum flavors:
+ * <ul>
+ *   <li>{@code PLAIN} — a bare {@code enum MyEnum { FOO, BAR }} that does NOT implement
+ *       {@link org.gradle.api.Named}. Emits a deprecation warning at declaration time but
+ *       continues to work end-to-end for the pipelines exercised here.</li>
+ *   <li>{@code NAMED} — an {@code enum MyEnum implements Named} that delegates
+ *       {@code getName()} to the built-in {@code name()}. Accepted; works end-to-end.</li>
+ * </ul>
+ * <p>
+ * Tests are organized into two regions:
+ * <ul>
+ *   <li><b>enums succeed</b> — valid usage patterns whose underlying Gradle pipelines handle
+ *       plain enums correctly today; both flavors succeed. The plain flavor additionally emits
+ *       the deprecation warning from {@code Attribute.of}.</li>
+ *   <li><b>un-named enums fail</b> — plain-enum-only tests documenting the underlying failure
+ *       modes that motivated the deprecation: the ES 9.5.1 regression (CCE at
+ *       {@code DesugaringAttributeContainerSerializer:91}) and two JDK-contract failures at
+ *       {@code Enum.valueOf} callsites ({@code IsolatedEnumValueSnapshot:56} and
+ *       {@code CoercingStringValueSnapshot:39}). These tests are marked
+ *       {@link groovy.test.NotYetImplemented} because the current deprecation-only enforcement
+ *       lets these scenarios proceed further than the ideal Gradle-10 behavior, which is to
+ *       fail up front at {@code Attribute.of}. See {@code problems-with-unnamed-enums.md} in
+ *       this directory for details on each root cause.</li>
+ * </ul>
+ */
+@Issue("https://github.com/gradle/gradle/issues/38242")
+final class EnumAttributeIntegrationTest extends AbstractIntegrationSpec {
+    // region setup
+    // Enum declaration templates injected into build scripts. Each declares a top-level
+    // `MyEnum` type with constants FOO and BAR. The PLAIN flavor is a bare enum. The NAMED
+    // flavor implements `org.gradle.api.Named` (default-imported in build scripts) by
+    // delegating `getName()` to the built-in `name()`.
+    private static final String PLAIN_ENUM = """
+        enum MyEnum { FOO, BAR }
+    """
+
+    private static final String NAMED_ENUM = """
+        enum MyEnum implements Named {
+            FOO, BAR
+
+            @Override
+            String getName() { return name() }
+        }
+    """
+
+    private static final String PLAIN_DESC = "plain Enum"
+    private static final String NAMED_DESC = "Named-implementing Enum"
+
+    // Distinctive summary line emitted by Attribute.of when a plain (non-Named) enum type is
+    // declared as an attribute value type. Same script text emits the deprecation once per
+    // distinct declaration site, so the count depends on the test structure — we assert on
+    // presence via outputContains rather than registering per-emission expectations.
+    private static final String PLAIN_ENUM_DEPRECATION_SUMMARY =
+        "Using type 'MyEnum' as a value type for attribute 'myEnumAttribute' has been deprecated."
+
+    /**
+     * Runs the given task and asserts success. Named-implementing enums pass through untouched.
+     * Plain enums additionally trigger the {@code Attribute.of} deprecation warning, which is
+     * asserted via {@code outputContains}. The deprecation will become an error in Gradle 10.
+     */
+    private void expectResolve(String taskName, boolean implementsNamed, List<String> expectedOutputs = []) {
+        if (!implementsNamed) {
+            executer.noDeprecationChecks()
+        }
+        succeeds(taskName)
+        if (!implementsNamed) {
+            outputContains(PLAIN_ENUM_DEPRECATION_SUMMARY)
+        }
+        expectedOutputs.each { outputContains(it) }
+    }
+    // endregion setup
+
+    // region enums succeed
+    // -------------------------------------------------------------------------
+    // Every test in this region exercises a valid Gradle attribute-usage pattern.
+    // Named-implementing enums pass end-to-end. Plain enums additionally emit the
+    // PLAIN_ENUM_DEPRECATION_SUMMARY deprecation warning from Attribute.of but continue
+    // through the pipeline successfully. That deprecation will become an error in
+    // Gradle 10 — at which point these plain-enum iterations will need to be
+    // updated (and the un-named enums fail region tests may become passable).
+    // -------------------------------------------------------------------------
+    def "in-memory attribute matching accepts a #enumDesc as an attribute value"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "AttributeCompatibilityRule typed on a #enumDesc makes candidate values compatible"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.BAR) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            abstract class MyEnumCompatibilityRule implements AttributeCompatibilityRule<MyEnum> {
+                void execute(CompatibilityCheckDetails<MyEnum> details) { details.compatible() }
+            }
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE) {
+                        compatibilityRules.add(MyEnumCompatibilityRule)
+                    }
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "AttributeDisambiguationRule typed on a #enumDesc picks a candidate"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/foo.txt") << "foo output"
+        file("producer/bar.txt") << "bar output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("fooVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("foo.txt"))
+                }
+                consumable("barVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.BAR) }
+                    outgoing.artifact(file("bar.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            abstract class MyEnumCompatibilityRule implements AttributeCompatibilityRule<MyEnum> {
+                void execute(CompatibilityCheckDetails<MyEnum> details) { details.compatible() }
+            }
+            abstract class MyEnumDisambiguationRule implements AttributeDisambiguationRule<MyEnum> {
+                void execute(MultipleCandidatesDetails<MyEnum> details) {
+                    if (details.candidateValues.contains(MyEnum.BAR)) {
+                        details.closestMatch(MyEnum.BAR)
+                    }
+                }
+            }
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE) {
+                        compatibilityRules.add(MyEnumCompatibilityRule)
+                        disambiguationRules.add(MyEnumDisambiguationRule)
+                    }
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: bar.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "supplying a #enumDesc attribute value via a lazy Provider works end-to-end"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes {
+                        attributeProvider(ATTRIBUTE_TYPE, project.provider { MyEnum.FOO })
+                    }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes {
+                        attributeProvider(ATTRIBUTE_TYPE, project.provider { MyEnum.FOO })
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "materializing resolutionResult with a #enumDesc on a local project dependency"() {
+        // Local project dependencies do not stream the resolution result through
+        // DesugaringAttributeContainerSerializer. Empirically, even without the up-front
+        // Attribute.of check, both flavors resolve cleanly here.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def rootProvider = configurations.myResolver.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootProvider.get()
+                    println("Root: " + root.moduleVersion)
+                    root.dependencies.each { d -> println("Dep: " + d) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Dep: project ':producer'"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "consuming a Maven-published variant with a #enumDesc-typed request attribute"() {
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("myVariant", [myEnumAttribute: "FOO"]) {
+                artifact("producer-1.0.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories {
+                maven { url = uri("${mavenRepo.uri}") }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps("org.example:producer:1.0")
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Resolved: producer-1.0.jar"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "consuming an Ivy-published variant with a #enumDesc-typed request attribute"() {
+        given:
+        ivyRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("myVariant", [myEnumAttribute: "FOO"])
+            .withVariant("myVariant") {
+                artifact("producer-1.0.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories {
+                ivy { url = uri("${ivyRepo.uri}") }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps("org.example:producer:1.0")
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Resolved: "])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "withVariantReselection using a #enumDesc as the reselection attribute"() {
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("fooVariant", [myEnumAttribute: "FOO"]) {
+                artifact("producer-1.0-foo.jar")
+            }
+            .variant("barVariant", [myEnumAttribute: "BAR"]) {
+                artifact("producer-1.0-bar.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories {
+                maven { url = uri("${mavenRepo.uri}") }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps("org.example:producer:1.0")
+            }
+
+            tasks.register("resolve") {
+                def reselected = configurations.myResolver.incoming.artifactView {
+                    withVariantReselection()
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.BAR) }
+                }.files
+                doLast {
+                    reselected.each { println("Reselected: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Reselected: producer-1.0-bar.jar"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "config-cache round-trip on a task holding a resolvable configuration with a #enumDesc"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            abstract class HoldEnum extends DefaultTask {
+                @Input
+                abstract Property<MyEnum> getEnumInput()
+                @InputFiles
+                abstract ConfigurableFileCollection getFiles()
+                @TaskAction
+                void run() {
+                    println("Enum: " + enumInput.get())
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+
+            tasks.register("resolve", HoldEnum) {
+                enumInput.set(MyEnum.FOO)
+                files.from(configurations.myResolver)
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Enum: FOO", "Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    // region additional coverage
+    // -------------------------------------------------------------------------
+    // These tests exercise additional code paths (publishing, build ops,
+    // component metadata rules, external-Maven resolutionResult, dedup
+    // serialization, extendsFrom inheritance, schema registration). Empirically,
+    // plain enums work cleanly through all of these paths when validateSupportedType
+    // is disabled; the tests belong in "enums succeed" because their assertions
+    // are structurally identical to the other tests in this region.
+    // -------------------------------------------------------------------------
+
+    def "publishing a variant with a #enumDesc-typed attribute to a Maven repository"() {
+        // Exercises the producer-side publishing pipeline via maven-publish.
+        // ModuleMetadataSpecBuilder.attributeValueFor already handles Enum values by name
+        // via .name(), so the underlying pipeline is enum-safe. Under the current policy,
+        // Attribute.of rejects plain enums upstream, so the plain row fails at script eval
+        // on the producer side rather than reaching the GMM writer.
+        given:
+        file("output.txt") << "sample output"
+        buildFile("""
+            plugins { id 'maven-publish' }
+
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            group = 'org.example'
+            version = '1.0'
+
+            def myVariant = configurations.consumable("myVariant") {
+                attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                outgoing.artifact(file("output.txt"))
+            }
+
+            def component = publishing.softwareComponentFactory.adhoc("myComponent")
+            component.addVariantsFromConfiguration(myVariant.get()) {
+                mapToMavenScope("runtime")
+            }
+            components.add(component)
+
+            publishing {
+                repositories { maven { url = uri("${mavenRepo.uri}") } }
+                publications {
+                    maven(MavenPublication) { from components.myComponent }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("publish", implementsNamed)
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "resolution emits build operations with a #enumDesc attribute value"() {
+        // Probes AttributesToMapConverter.getAttributeValueAsString: the build-op path
+        // uses value.toString() as a fallback, which for an enum yields the constant name.
+        // Any successful resolution emits build operations that carry the attribute
+        // container through this code path — enum-safe.
+        given:
+        settingsFile("include 'consumer', 'producer'")
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "resolution build-op result desugars a #enumDesc attribute via toString"() {
+        // Probes ResolveConfigurationResolutionBuildOperationResult.desugarAttributes,
+        // which has its own desugaring: primitives, then Named, then a .toString() fallback.
+        // Enums fall into the fallback branch — the constant name is emitted verbatim.
+        given:
+        settingsFile("include 'consumer', 'producer'")
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def rootProvider = configurations.myResolver.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootProvider.get()
+                    println("Root: " + root.moduleVersion)
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Root: "])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "component metadata rule adds a #enumDesc attribute to a resolved module"() {
+        // A component metadata rule mutates the resolved graph's attributes at rule
+        // execution time. The rule references MyEnum inside its execute() body — but the
+        // consumer script's own Attribute.of call fires first at script eval for plain
+        // enums.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("myVariant", [:]) {
+                artifact("producer-1.0.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            abstract class AddEnumAttributeRule implements ComponentMetadataRule {
+                @Override
+                void execute(ComponentMetadataContext ctx) {
+                    def attr = Attribute.of("myEnumAttribute", MyEnum.class)
+                    ctx.details.allVariants {
+                        attributes { attribute(attr, MyEnum.FOO) }
+                    }
+                }
+            }
+
+            dependencies {
+                components {
+                    withModule("org.example:producer", AddEnumAttributeRule)
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies { myDeps("org.example:producer:1.0") }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Resolved: producer-1.0.jar"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "materializing resolutionResult with a #enumDesc on an external Maven dependency"() {
+        // Static code-reading suggests `.resolutionResult.rootComponent.get()` on an external
+        // Maven dep should stream through StreamingResolutionResultBuilder →
+        // DesugaringAttributeContainerSerializer and reproduce the ES/9.5.1 regression.
+        // Empirically it does not — execution-time result queries operate against the
+        // in-memory graph and don't re-stream. Only the ES-shape (test in un-named enums fail
+        // region: detached configuration + task inputs at task-graph-time) hits the streaming
+        // path. This test therefore succeeds cleanly for both flavors when the up-front check
+        // is disabled.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("myVariant", [myEnumAttribute: "FOO"]) {
+                artifact("producer-1.0.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies { myDeps("org.example:producer:1.0") }
+
+            tasks.register("resolve") {
+                def rootProvider = configurations.myResolver.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootProvider.get()
+                    println("Root: " + root.moduleVersion)
+                    root.dependencies.each { d -> println("Dep: " + d) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Dep: org.example:producer:1.0"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "deduplicated serialization when multiple variants share a #enumDesc attribute container"() {
+        // DeduplicatingAttributeContainerSerializer wraps DesugaringAttributeContainerSerializer
+        // and interns identical attribute containers on write. Static code-reading suggests
+        // materializing the resolution result on a module with overlapping variant attributes
+        // should hit the dedup wrapper — but empirically it does not, for the same reason as
+        // the external-Maven resolutionResult test above: execution-time result queries use
+        // the in-memory graph. This test succeeds cleanly for both flavors when the up-front
+        // check is disabled.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("variant1", [myEnumAttribute: "FOO", tag: "one"]) {
+                artifact("producer-1.0-a.jar")
+            }
+            .variant("variant2", [myEnumAttribute: "FOO", tag: "two"]) {
+                artifact("producer-1.0-b.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+            def TAG_ATTR = Attribute.of("tag", String.class)
+
+            repositories { maven { url = uri("${mavenRepo.uri}") } }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes {
+                        attribute(ATTRIBUTE_TYPE, MyEnum.FOO)
+                        attribute(TAG_ATTR, "one")
+                    }
+                }
+            }
+
+            dependencies { myDeps("org.example:producer:1.0") }
+
+            tasks.register("resolve") {
+                def rootProvider = configurations.myResolver.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootProvider.get()
+                    println("Root: " + root.moduleVersion)
+                }
+            }
+        """)
+
+        expect:
+        expectResolve("resolve", implementsNamed, ["Root: "])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "resolvable configuration inheriting a #enumDesc attribute via extendsFrom"() {
+        // Attribute inheritance goes through the container's addAllLater / concat chain,
+        // which doesn't touch the desugaring serializer. Any failure comes from Attribute.of
+        // during script eval, not from any downstream serialization.
+        given:
+        settingsFile("include 'consumer', 'producer'")
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myBase") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myBase"))
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "registering a #enumDesc-typed attribute in the attributes schema"() {
+        // Registering an attribute in the schema (dependencies.attributesSchema { attribute(...) })
+        // walks through DefaultAttributesSchema.attribute(...). The consumer script's own
+        // Attribute.of call fires the validation first, so plain row fails identically to
+        // other consumer-side plain rows.
+        given:
+        settingsFile("include 'consumer', 'producer'")
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE)
+                }
+            }
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE)
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+    // endregion additional coverage
+
+    // region enum-as-JVM-singleton
+    // -------------------------------------------------------------------------
+    // Tests that probe the JVM-level enum-singleton semantics: cross-classloader
+    // coercion producing consumer-side singletons, anonymous per-constant subclasses
+    // being unwrapped via getDeclaringClass, and config-cache save+load preserving
+    // the singleton identity. These sit inside "enums succeed" because the underlying
+    // machinery handles them correctly for both flavors — the Named row succeeds
+    // end-to-end and the plain row is rejected up front by Attribute.of, exactly
+    // like every other test in the "enums succeed" region.
+    // -------------------------------------------------------------------------
+    def "consequence (#enumDesc): cross-classloader coercion silently creates a different singleton"() {
+        // Producer and consumer scripts each declare their own MyEnum in independent
+        // classloaders. Consumer-side coercion returns the CONSUMER's FOO singleton,
+        // not the producer's. This test verifies the retrieved attribute value belongs
+        // to the consumer's classloader — the "trap" being that a plugin author
+        // holding a reference to a DIFFERENT classloader's FOO would see reference
+        // inequality even though names match.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def artifacts = configurations.myResolver.incoming.artifactView {}.artifacts.resolvedArtifacts
+                doLast {
+                    artifacts.get().each { r ->
+                        def retrieved = r.variant.attributes.getAttribute(ATTRIBUTE_TYPE)
+                        assert retrieved.is(MyEnum.FOO): "retrieved \$retrieved is not identical to consumer's MyEnum.FOO"
+                        assert retrieved.declaringClass.classLoader.is(MyEnum.class.classLoader)
+                        println("Consumer-classloader singleton: OK")
+                    }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Consumer-classloader singleton: OK"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+
+    def "consequence (#enumDesc): enum with anonymous per-constant inner-class bodies works via getDeclaringClass"() {
+        // Enum constants declared with per-constant bodies produce anonymous subclasses
+        // (MyEnum$1, MyEnum$2). Gradle uses Enum#getDeclaringClass, not Object#getClass,
+        // so no code path treats MyEnum$1 as the attribute value type.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc                | enumDecl                                                         | implementsNamed
+        "plain Enum with body"  | """enum MyEnum {
+                                       FOO { @Override String describe() { return "the-foo" } },
+                                       BAR { @Override String describe() { return "the-bar" } };
+                                       abstract String describe()
+                                   }"""                                                            | false
+        "Named Enum with body"  | """enum MyEnum implements Named {
+                                       FOO { @Override String describe() { return "the-foo" } },
+                                       BAR { @Override String describe() { return "the-bar" } };
+                                       abstract String describe()
+                                       @Override String getName() { return name() }
+                                   }"""                                                            | true
+    }
+
+    def "consequence (#enumDesc): config-cache save-and-reuse preserves the attribute value across script re-parse"() {
+        // A build script declaring its own enum gets a fresh classloader on every
+        // configuration. Config-cache save serializes attribute values by class name +
+        // constant name; restore re-runs the script and re-resolves the constant via
+        // Enum.valueOf. This verifies a save→reuse cycle produces the same result.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            ${enumDecl}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect: "the configCacheIntegTest task variant already replays every test through configuration-cache save+load; a single successful run here proves the enum attribute survives that round-trip"
+        expectResolve(":consumer:resolve", implementsNamed, ["Resolved: output.txt"])
+
+        where:
+        enumDesc   | enumDecl    | implementsNamed
+        PLAIN_DESC | PLAIN_ENUM  | false
+        NAMED_DESC | NAMED_ENUM  | true
+    }
+    // endregion enum-as-JVM-singleton
+    // endregion enums succeed
+
+    // region un-named enums fail
+    // -------------------------------------------------------------------------
+    // The three scenarios below document underlying failures that surface when a
+    // plain (non-Named) enum is used as an attribute value type. In the current
+    // deprecation-only regime, Attribute.of does NOT halt execution up front —
+    // it emits a deprecation warning and lets the build proceed. Depending on the
+    // pipeline exercised, the build may then either fail deeper in (test 13's ES
+    // regression, test 14's cross-classloader coercion, test 15's GMM coercion),
+    // or complete without any hard error visible in the assertions here.
+    //
+    // Each test is marked @NotYetImplemented and asserts the IDEAL future
+    // behavior: Attribute.of should reject a plain enum up front. When the
+    // deprecation is promoted to an error in Gradle 10, these tests are expected
+    // to pass and the @NotYetImplemented annotations should be removed.
+    // See problems-with-unnamed-enums.md in this directory for full analysis.
+    // -------------------------------------------------------------------------
+    @NotYetImplemented
+    def "task-input on a detached configuration with a plain Enum attribute value (regression from Gradle 9.5.1)"() {
+        // Reproducer for the ClassCastException reported by the Elasticsearch team.
+        // Task-graph-time resolution of a detached configuration with an external Maven dep
+        // streams through StreamingResolutionResultBuilder → DesugaringAttributeContainerSerializer,
+        // whose else-branch performs an unchecked (Named) cast at line 91. On a plain enum
+        // this raises ClassCastException, which DefaultBinaryStore.write wraps as
+        // "Problems writing to Binary store". Ideal behavior: Attribute.of rejects the plain
+        // enum up front. Current (deprecation-only) behavior: Attribute.of emits a deprecation
+        // and the task proceeds far enough to eventually hit the CCE (or, in some environments,
+        // completes without surfacing the failure the assertions below check for).
+        given:
+        mavenRepo.module("org.example", "producer", "1.0").publish()
+
+        buildFile("""
+            ${PLAIN_ENUM}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories {
+                maven { url = uri("${mavenRepo.uri}") }
+            }
+
+            def detachedConf = configurations.detachedConfiguration(
+                dependencies.create("org.example:producer:1.0")
+            )
+            detachedConf.attributes {
+                attribute(ATTRIBUTE_TYPE, MyEnum.FOO)
+            }
+
+            tasks.register("myTask") {
+                inputs.files(detachedConf)
+                doLast { }
+            }
+        """)
+
+        expect:
+        fails("myTask")
+        failure.assertHasCause(PLAIN_ENUM_DEPRECATION_SUMMARY)
+    }
+
+    @NotYetImplemented
+    def "enum constants are compile-time closed — producer offers a constant absent from the consumer's enum (plain Enum)"() {
+        // The producer publishes a variant using MyEnum.BAR. The consumer's MyEnum has only
+        // FOO. Ideal behavior: Attribute.of rejects the plain enum type up front. Current
+        // (deprecation-only) behavior: Attribute.of emits a deprecation and the build proceeds
+        // into the resolution machinery, where the outcome depends on which coercion path is
+        // exercised for plain enums.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            enum MyEnum { FOO, BAR }
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.BAR) }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            enum MyEnum { FOO }
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        fails(":consumer:resolve")
+        failure.assertHasCause(PLAIN_ENUM_DEPRECATION_SUMMARY)
+    }
+
+    @NotYetImplemented
+    def "GMM value that is not a valid enum constant fails coercion (plain Enum)"() {
+        // The GMM wire attribute value must be exactly a constant name of the consumer's enum
+        // type. Any drift (typo, renamed constant, spurious value from a component-metadata rule)
+        // surfaces as the raw JDK IAE. Ideal behavior: Attribute.of rejects the plain enum type
+        // up front. Current (deprecation-only) behavior: Attribute.of emits a deprecation and
+        // the build proceeds until it eventually hits the coercion failure.
+        given:
+        mavenRepo.module("org.example", "producer", "1.0")
+            .withModuleMetadata()
+            .withoutDefaultVariants()
+            .variant("myVariant", [myEnumAttribute: "NOT_A_CONSTANT"]) {
+                artifact("producer-1.0.jar")
+            }
+            .publish()
+
+        buildFile("""
+            ${PLAIN_ENUM}
+            def ATTRIBUTE_TYPE = Attribute.of("myEnumAttribute", MyEnum.class)
+
+            repositories {
+                maven { url = uri("${mavenRepo.uri}") }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, MyEnum.FOO) }
+                }
+            }
+
+            dependencies {
+                myDeps("org.example:producer:1.0")
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.files
+                doLast {
+                    files.each { println("Resolved: " + it.name) }
+                }
+            }
+        """)
+
+        expect:
+        fails("resolve")
+        failure.assertHasCause(PLAIN_ENUM_DEPRECATION_SUMMARY)
+    }
+    def "registering an AttributeCompatibilityRule typed on a plain Enum emits a deprecation when the rule fires"() {
+        // The attribute itself is a String (which passes Attribute.of), but the rule is typed
+        // on a plain enum, which Groovy allows to register via loose generics.
+        // AttributeTypeValidator.validateRuleTypeParameter walks the rule class's superinterfaces
+        // at first fire, extracts the plain-enum type argument, and emits a deprecation warning.
+        // This will become a hard failure in Gradle 10.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/output.txt") << "sample output"
+        buildFile("producer/build.gradle", """
+            def ATTRIBUTE_TYPE = Attribute.of("myAttr", String.class)
+            configurations {
+                consumable("myVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, "PRODUCER") }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            enum MyPlainEnum { FOO, BAR }
+
+            def ATTRIBUTE_TYPE = Attribute.of("myAttr", String.class)
+
+            abstract class BadRule implements AttributeCompatibilityRule<MyPlainEnum> {
+                void execute(CompatibilityCheckDetails details) { details.compatible() }
+            }
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE) {
+                        compatibilityRules.add(BadRule)
+                    }
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, "CONSUMER") }
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        executer.noDeprecationChecks()
+        succeeds(":consumer:resolve")
+        outputContains("as the type parameter of attribute rule 'BadRule' has been deprecated.")
+        outputContains("Resolved: output.txt")
+    }
+
+    def "registering an AttributeDisambiguationRule typed on a plain Enum emits a deprecation when the rule fires"() {
+        // For the disambiguation rule to fire we need multiple *compatible* candidates.
+        // Producer offers two variants with distinct values on the target attribute — a
+        // compatibility rule (typed correctly on String) makes both compatible; then the
+        // badly-typed disambiguation rule is invoked to pick between them and trips our
+        // validator's deprecation warning.
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        file("producer/foo.txt") << "foo output"
+        file("producer/bar.txt") << "bar output"
+        buildFile("producer/build.gradle", """
+            def ATTRIBUTE_TYPE = Attribute.of("myAttr", String.class)
+            configurations {
+                consumable("fooVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, "foo") }
+                    outgoing.artifact(file("foo.txt"))
+                }
+                consumable("barVariant") {
+                    attributes { attribute(ATTRIBUTE_TYPE, "bar") }
+                    outgoing.artifact(file("bar.txt"))
+                }
+            }
+        """)
+
+        buildFile("consumer/build.gradle", """
+            enum MyPlainEnum { FOO, BAR }
+
+            def ATTRIBUTE_TYPE = Attribute.of("myAttr", String.class)
+
+            abstract class AlwaysCompatibleRule implements AttributeCompatibilityRule<String> {
+                void execute(CompatibilityCheckDetails<String> details) { details.compatible() }
+            }
+            abstract class BadDisambiguationRule implements AttributeDisambiguationRule<MyPlainEnum> {
+                void execute(MultipleCandidatesDetails details) { details.closestMatch(details.candidateValues.first()) }
+            }
+
+            dependencies {
+                attributesSchema {
+                    attribute(ATTRIBUTE_TYPE) {
+                        compatibilityRules.add(AlwaysCompatibleRule)
+                        disambiguationRules.add(BadDisambiguationRule)
+                    }
+                }
+            }
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes { attribute(ATTRIBUTE_TYPE, "foo") }
+                }
+            }
+
+            dependencies { myDeps(project(":producer")) }
+
+            tasks.register("resolve") {
+                def files = configurations.myResolver.incoming.artifactView {}.files
+                doLast { files.each { println("Resolved: " + it.name) } }
+            }
+        """)
+
+        expect:
+        executer.noDeprecationChecks()
+        succeeds(":consumer:resolve")
+        outputContains("as the type parameter of attribute rule 'BadDisambiguationRule' has been deprecated.")
+    }
+    // endregion un-named enums fail
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/BaseAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/BaseAttributeContainerTest.groovy
@@ -107,7 +107,7 @@ import spock.lang.Specification
         }
     }
 
-    def "can't contain 2 identically named attributes with the same type loaded from different classloaders"() {
+    def "can't load Named in a second classloader to make an attribute value"() {
         given: "a second classloader, that has no parent, and can load the Named class"
 
         URL[] urls = [Named.class, MyNamed.class].collect {
@@ -134,19 +134,12 @@ import spock.lang.Specification
 
         namedInstance.class != named2Instance.class
 
-        when:
-        def container = createContainer([(Attribute.of("test", Named)): namedInstance, (Attribute.of("test", named2)): named2Instance])
-        container.keySet() // Realize elements of the container
+        when: "an Attribute is declared with the Named class loaded from an alien classloader — Named.class.isAssignableFrom uses reference equality, so this fails the supported-type check"
+        Attribute.of("test", named2)
 
-        then:
-        def exception = thrown(Exception)
-        if (exception instanceof AttributeMergingException) {
-            assert exception.message == "An attribute named 'test' of type 'org.gradle.api.Named' already exists in this container"
-        } else if (container instanceof ImmutableAttributes) {
-            assert exception.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'test' of type 'org.gradle.api.Named' and you are trying to store another one of type 'org.gradle.api.Named'"
-        } else {
-            assert exception.message == "Cannot have two attributes with the same name but different types. This container has an attribute named 'test' of type 'org.gradle.api.Named' and another attribute of type 'org.gradle.api.Named'"
-        }
+        then: "Attribute.of emits the unsupported-type deprecation warning (will become an error in Gradle 10)"
+        def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
+        events.size() == 1
+        events[0].message == "Using type 'org.gradle.api.Named' as a value type for attribute 'test' has been deprecated. This will fail with an error in Gradle 10. Attribute values must be of type String, Boolean, a subtype of Number, or implement org.gradle.api.Named. Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#unsupported_attribute_value_type"
     }
-
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/BaseAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/BaseAttributeContainerTest.groovy
@@ -137,9 +137,37 @@ import spock.lang.Specification
         when: "an Attribute is declared with the Named class loaded from an alien classloader — Named.class.isAssignableFrom uses reference equality, so this fails the supported-type check"
         Attribute.of("test", named2)
 
-        then: "Attribute.of emits the unsupported-type deprecation warning (will become an error in Gradle 10)"
-        def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
-        events.size() == 1
-        events[0].message == "Using type 'org.gradle.api.Named' as a value type for attribute 'test' has been deprecated. This will fail with an error in Gradle 10. Attribute values must be of type String, Boolean, a subtype of Number, or implement org.gradle.api.Named. Using an unsupported type may cause failures during dependency resolution, publishing, or configuration cache serialization. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#unsupported_attribute_value_type"
+        then: "Attribute.of throws IllegalArgumentException identifying the classloader mismatch as the actual problem"
+        def e = thrown(IllegalArgumentException)
+        e.message.startsWith("Using an attribute value type that implements org.gradle.api.Named loaded from a different classloader is not supported.")
+        e.message.contains("The type 'org.gradle.api.Named' declared for attribute 'test' was loaded from ")
+        e.message.contains("This may indicate a shaded or duplicated Gradle API on the classpath.")
+
+        and: "no deprecation warning is emitted — the misconfiguration is reported via the thrown exception, not the deprecation channel"
+        outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }.empty
+    }
+
+    def "declaring an attribute with a type implementing proper Named succeeds even when an alien Named is also on the classpath"() {
+        given: "a second classloader with its own copy of Named, coexisting with Gradle's proper Named"
+        URL[] urls = [Named.class, MyNamed.class].collect {
+            ClasspathUtil.getClasspathForClass(it).toURI().toURL()
+        }.toArray(new URL[0])
+        ClassLoader loader2 = new URLClassLoader(urls, (ClassLoader) null)
+        Class<?> named2 = loader2.loadClass(Named.name)
+
+        expect: "the alien classloader really does define a distinct Named Class object"
+        named2 != Named
+        named2.classLoader != Named.classLoader
+
+        when: "an Attribute is declared with a type implementing the proper (Gradle-loaded) Named"
+        def attr = Attribute.of("test", MyNamed)
+
+        then: "Attribute.of accepts the type cleanly — Named.class.isAssignableFrom(MyNamed) is true, so the isSupportedAttributeType early-return short-circuits the alien-Named walker before it can inspect the hierarchy"
+        attr != null
+        attr.name == "test"
+        attr.type == MyNamed
+
+        and: "no deprecation warning is emitted — a type implementing proper Named is fully supported regardless of what other Nameds exist elsewhere on the classpath"
+        outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }.empty
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -23,7 +23,8 @@ import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAR
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAZ
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.BOOLEAN_BAR
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.FOO
-import static org.gradle.api.internal.attributes.immutable.TestAttributes.OBJECT_BAR
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.INTEGER_BAR
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.NUMBER_BAR
 
 /**
  * Unit tests for {@link DefaultAttributesFactory}.
@@ -221,7 +222,7 @@ class DefaultAttributesFactoryTest extends Specification {
 
     def "safeConcat can detect incompatible attributes with different types when merging; different value and different compatible types"() {
         given:
-        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OBJECT_BAR, "bar1")) // Object-typed bar
+        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(NUMBER_BAR, 1)) // Number-typed bar
         def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(BAR, "bar2")) // String-typed bar
 
         when:
@@ -229,22 +230,22 @@ class DefaultAttributesFactoryTest extends Specification {
 
         then:
         AttributeMergingException e = thrown()
-        e.attribute == OBJECT_BAR
-        e.leftValue == "bar1"
+        e.attribute == NUMBER_BAR
+        e.leftValue == 1
         e.rightValue == "bar2"
-        e.message == "An attribute named 'bar' of type 'java.lang.Object' already exists in this container"
+        e.message == "An attribute named 'bar' of type 'java.lang.Number' already exists in this container"
     }
 
     def "safeConcat can detect incompatible attributes with different types when merging; same value and different compatible types"() {
         given:
-        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OBJECT_BAR, "bar1")) // Object-typed bar
-        def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(BAR, "bar1")) // String-typed bar
+        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(NUMBER_BAR, 1)) // Number-typed bar
+        def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(INTEGER_BAR, 1)) // Integer-typed bar
 
         when:
         factory.safeConcat(set1, set2)
 
         then:
         Exception e = thrown()
-        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Object'"
+        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.Integer' and you are trying to store another one of type 'java.lang.Number'"
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestAttributes.groovy
@@ -26,6 +26,7 @@ final class TestAttributes {
     static final Attribute<String> FOO = Attribute.of("foo", String)
     static final Attribute<String> BAR = Attribute.of("bar", String)
     static final Attribute<Boolean> BOOLEAN_BAR = Attribute.of("bar", Boolean.class)
-    static final Attribute<Object> OBJECT_BAR = Attribute.of("bar", Object.class)
+    static final Attribute<Number> NUMBER_BAR = Attribute.of("bar", Number.class)
+    static final Attribute<Integer> INTEGER_BAR = Attribute.of("bar", Integer.class)
     static final Attribute<String> BAZ = Attribute.of("baz", String)
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
@@ -44,7 +44,9 @@ class SnapshotTestUtil {
         return new ClassLoaderHierarchyHasher() {
             @Override
             HashCode getClassLoaderHash(ClassLoader classLoader) {
-                return TestHashCodes.hashCodeFrom(classLoader.hashCode())
+                // classLoader is null for bootstrap-loaded types (e.g. java.lang.Byte, java.math.BigDecimal).
+                // The production hasher handles that case; this test double must too, or isolating such values NPEs.
+                return TestHashCodes.hashCodeFrom(classLoader == null ? 0 : classLoader.hashCode())
             }
         };
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -105,6 +105,7 @@ class KotlinGradlePluginVersions {
 
     static final VersionNumber KOTLIN_2_0_0 = VersionNumber.parse('2.0.0')
     static final VersionNumber KOTLIN_2_0_20 = VersionNumber.parse('2.0.20')
+    static final VersionNumber KOTLIN_2_1_0 = VersionNumber.parse('2.1.0')
     static final VersionNumber KOTLIN_2_1_20 = VersionNumber.parse('2.1.20')
     static final VersionNumber KOTLIN_2_1_21 = VersionNumber.parse('2.1.21')
     static final VersionNumber KOTLIN_2_2_0 = VersionNumber.parse('2.2.0')

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -225,6 +225,13 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_21) {
             deprecations << "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration".toString()
         }
+        // The KGP 2.0.x line declares an attribute of type KotlinNativeBundleArtifactsTypes,
+        // a plain enum that does not implement Named. Attribute.of allows this via a targeted
+        // compatibility exception and emits a KGP-specific deprecation warning. KGP 2.1.0+ no
+        // longer uses the plain enum, so the deprecation is expected only for the 2.0.x range.
+        if (kotlinVersionNumber.baseVersion >= KotlinGradlePluginVersions.KOTLIN_2_0_0 && kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_0) {
+            deprecations << "Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type has been deprecated. This will fail with an error in Gradle 10. This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#kgp_native_bundle_attribute_enum".toString()
+        }
         return deprecations
     }
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -255,6 +255,13 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-api-jars'. Declare a Usage attribute with value 'java-api' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()
             deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-runtime-jars'. Declare a Usage attribute with value 'java-runtime' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()
         }
+        // The KGP 2.0.x line declares an attribute of type KotlinNativeBundleArtifactsTypes,
+        // a plain enum that does not implement Named. Attribute.of allows this via a targeted
+        // compatibility exception and emits a KGP-specific deprecation warning. KGP 2.1.0+ no
+        // longer uses the plain enum, so the deprecation is expected only for the 2.0.x range.
+        if (kotlinVersionNumber.baseVersion >= KotlinGradlePluginVersions.KOTLIN_2_0_0 && kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_0) {
+            deprecations << "Using the enum type KotlinNativeBundleArtifactsTypes as an attribute value type has been deprecated. This will fail with an error in Gradle 10. This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#kgp_native_bundle_attribute_enum".toString()
+        }
         return deprecations
     }
 }


### PR DESCRIPTION
Plain `Enum` types, array types, and other types that are not `Boolean`, `String`, `Number` or `Named` are specifically **not** allowed as attribute values, even though they would work in some limited situations.  They can cause problems when published.

Any other types will now emit a deprecation warning.

Also adds tests to cover non-`Integer` numeric types, and properly implements serialization of them.  All allowed types are now tested.

This aligns the actual code with what is advertised as valid `Attribute` value types in the docs, and makes those docs exhaustively and precisely list all the allowed types.  

A custom deprecation warning is also added to cover older versions of KGP, which use raw `Enum` values (more recent KGP versions do not).