### PR TITLE
Trigger ReadyForRelease weekly on release8x even without pending changes

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
@@ -120,6 +120,27 @@ class StageTrigger(
                     enabled = enableTriggers
                 }
             }
+
+            // Ensure stale legacy release branches are still verified weekly,
+            // even when there are no pending changes.
+            if (stage.stageName == StageName.READY_FOR_RELEASE && model.branch.isLegacyRelease) {
+                triggers.schedule {
+                    schedulingPolicy =
+                        weekly {
+                            dayOfWeek = ScheduleTrigger.DAY.Sunday
+                            // releaseNx runs at (N-4):00 to avoid different branches running at the same time,
+                            // see promotion.determineNightlyPromotionTriggerHour
+                            hour = 4
+                        }
+                    triggerBuild = always()
+                    withPendingChangesOnly = false
+                    branchFilter = determineBranchFilter(listOf(model.branch.branchName))
+                    // https://github.com/gradle/gradle-private/issues/4105
+                    // force not reuse the previous builds
+                    enforceCleanCheckout = true
+                    enabled = enableTriggers
+                }
+            }
         }
 
         dependencies {


### PR DESCRIPTION
### Problem

Closes https://github.com/gradle/gradle-private/issues/5286

Stale release branches should still run `ReadyforRelease` every weekend so we know they remain releasable:

1. `Gradle_Release7x_Check_Stage_ReadyforRelease_Trigger` — works
2. `Gradle_Release8x_Check_Stage_ReadyforRelease_Trigger` — never fires when the branch is stale

On release7x, the old DSL (`StagePasses.kt`) has a dedicated schedule trigger for the `READY_FOR_RELEASE` stage on legacy release branches: weekly on Sunday with `withPendingChangesOnly = false`, so it fires even with no new commits.

When the DSL was rewritten into `StageTriggers.kt` (as on release8x), that trigger was lost. The only remaining schedule trigger has `withPendingChangesOnly = true`, so a branch with no changes never triggers.

### Fix

Port the legacy-release weekly trigger to `StageTriggers.kt`: for `READY_FOR_RELEASE` on `releaseNx` branches, add a schedule trigger for Sunday at 4:00 (`releaseNx` runs at `(N-4):00` per the stagger convention in `promotion.determineNightlyPromotionTriggerHour`) with `withPendingChangesOnly = false` and `enforceCleanCheckout = true` (see https://github.com/gradle/gradle-private/issues/4105), matching the release7x behavior.

The `.teamcity` DSL compiles cleanly with `./mvnw compile`.