### PR TITLE
Upgradle 9.7.0-milestone-3

### DIFF
--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -33,12 +33,7 @@ dependencies {
 }
 
 configurations.testRuntimeClasspath {
-    // The kotlin-gradle-plugin jar bundles a partial, gradle-patched subset of the shaded
-    // `org.jetbrains.kotlin.com.intellij.*` classes. Its MockProject implements
-    // ComponentManagerEx, an interface that jar does NOT bundle, so when it shadows the complete
-    // classes from kotlin-compiler-embeddable, constructing KotlinCoreProjectEnvironment fails
-    // with NoClassDefFoundError. The test only needs the compiler-embeddable, so keep kgp off the
-    // test runtime classpath to let the complete embeddable classes win.
+    // https://youtrack.jetbrains.com/issue/KT-87492/KGP-jar-bundles-a-partial-and-unshaded-copy-of-org.jetbrains.kotlin.com.intellij.-classes-that-collide-with-kotlin-compiler
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")
 }
 

--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -32,6 +32,16 @@ dependencies {
     }
 }
 
+configurations.testRuntimeClasspath {
+    // The kotlin-gradle-plugin jar bundles a partial, gradle-patched subset of the shaded
+    // `org.jetbrains.kotlin.com.intellij.*` classes. Its MockProject implements
+    // ComponentManagerEx, an interface that jar does NOT bundle, so when it shadows the complete
+    // classes from kotlin-compiler-embeddable, constructing KotlinCoreProjectEnvironment fails
+    // with NoClassDefFoundError. The test only needs the compiler-embeddable, so keep kgp off the
+    // test runtime classpath to let the complete embeddable classes win.
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")
+}
+
 @Suppress("UnstableApiUsage")
 testing {
     suites {

--- a/build-logic/buildquality/build.gradle.kts
+++ b/build-logic/buildquality/build.gradle.kts
@@ -36,3 +36,13 @@ dependencies {
         because("RemovalReportWorkActionTest parses Kotlin sources via KotlinSourceParser")
     }
 }
+
+configurations.testRuntimeClasspath {
+    // The kotlin-gradle-plugin jar bundles a partial, gradle-patched subset of the shaded
+    // `org.jetbrains.kotlin.com.intellij.*` classes. Its MockProject implements
+    // ComponentManagerEx, an interface that jar does NOT bundle, so when it shadows the complete
+    // classes from kotlin-compiler-embeddable, constructing KotlinCoreProjectEnvironment fails
+    // with NoClassDefFoundError. The test only needs the compiler-embeddable, so keep kgp off the
+    // test runtime classpath to let the complete embeddable classes win.
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")
+}

--- a/build-logic/buildquality/build.gradle.kts
+++ b/build-logic/buildquality/build.gradle.kts
@@ -38,11 +38,6 @@ dependencies {
 }
 
 configurations.testRuntimeClasspath {
-    // The kotlin-gradle-plugin jar bundles a partial, gradle-patched subset of the shaded
-    // `org.jetbrains.kotlin.com.intellij.*` classes. Its MockProject implements
-    // ComponentManagerEx, an interface that jar does NOT bundle, so when it shadows the complete
-    // classes from kotlin-compiler-embeddable, constructing KotlinCoreProjectEnvironment fails
-    // with NoClassDefFoundError. The test only needs the compiler-embeddable, so keep kgp off the
-    // test runtime classpath to let the complete embeddable classes win.
+    // https://youtrack.jetbrains.com/issue/KT-87492/KGP-jar-bundles-a-partial-and-unshaded-copy-of-org.jetbrains.kotlin.com.intellij.-classes-that-collide-with-kotlin-compiler
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-milestone-2-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-milestone-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-milestone-3-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
### Context

Bump the Gradle wrapper distribution from `9.7.0-milestone-1` to `9.7.0-milestone-2` to dogfood the latest milestone.

Validated locally:
- `./gradlew help --dry-run` ✅
- `./gradlew sanityCheck` ✅

### Contributor Checklist
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
