### PR TITLE
Deprecate `org.gradle.kotlin.dsl.support.zipTo` and `unzipTo`

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslSupportZipFunctionsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslSupportZipFunctionsIntegrationTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import spock.lang.Issue
+
+
+class KotlinDslSupportZipFunctionsIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/38392")
+    fun `zipTo and unzipTo from the support package are available to build scripts but deprecated`() {
+        withBuildScript("""
+            import org.gradle.kotlin.dsl.support.zipTo
+            import org.gradle.kotlin.dsl.support.unzipTo
+            import java.io.File
+
+            tasks.register("roundTrip") {
+                val projectDir = layout.projectDirectory.asFile
+                val buildDir = layout.buildDirectory.get().asFile
+                doLast {
+                    val source = File(projectDir, "source").apply { mkdirs() }
+                    File(source, "hello.txt").writeText("Hello, Gradle!")
+
+                    val archive = File(buildDir, "archive.zip").apply { parentFile.mkdirs() }
+                    zipTo(archive, source)
+
+                    unzipTo(File(buildDir, "unpacked"), archive)
+                }
+            }
+        """)
+
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.kotlin.dsl.support.zipTo(File, File) function has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. Use the Zip task type instead. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/${org.gradle.util.GradleVersion.current().version}/userguide/upgrading_version_9.html#kotlin_dsl_zip_functions"
+        )
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.kotlin.dsl.support.unzipTo(File, File) function has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. Use ArchiveOperations.zipTree with a Copy task instead. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/${org.gradle.util.GradleVersion.current().version}/userguide/upgrading_version_9.html#kotlin_dsl_zip_functions"
+        )
+
+        build("roundTrip")
+
+        assertThat(
+            existing("build/unpacked/hello.txt").readText(),
+            equalTo("Hello, Gradle!")
+        )
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
 
+import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.file.PathTraversalChecker.safePathName
 import org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
@@ -30,7 +31,13 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
 
+@Deprecated("Use the Zip task type instead. See the Gradle 9.7 upgrading guide.")
 fun zipTo(zipFile: File, baseDir: File) {
+    DeprecationLogger.deprecate("The org.gradle.kotlin.dsl.support.zipTo(File, File) function")
+        .withAdvice("Use the Zip task type instead.")
+        .willBeRemovedInGradle10()
+        .withUpgradeGuideSection(9, "kotlin_dsl_zip_functions")
+        .nagUser()
     zipTo(zipFile, baseDir, baseDir.walkReproducibly())
 }
 
@@ -61,7 +68,7 @@ fun File.walkReproducibly(): Sequence<File> = sequence {
 
 private
 fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
-    zipTo(zipFile, fileEntriesRelativeTo(baseDir, files))
+    zipTo(zipFile.outputStream(), fileEntriesRelativeTo(baseDir, files))
 }
 
 
@@ -79,7 +86,13 @@ fun File.normalisedPathRelativeTo(baseDir: File) =
     normaliseFileSeparators(relativeTo(baseDir).path)
 
 
+@Deprecated("Use the Zip task type instead. See the Gradle 9.7 upgrading guide.")
 fun zipTo(zipFile: File, entries: Sequence<Pair<String, ByteArray>>) {
+    DeprecationLogger.deprecate("The org.gradle.kotlin.dsl.support.zipTo(File, Sequence) function")
+        .withAdvice("Use the Zip task type instead.")
+        .willBeRemovedInGradle10()
+        .withUpgradeGuideSection(9, "kotlin_dsl_zip_functions")
+        .nagUser()
     zipTo(zipFile.outputStream(), entries)
 }
 
@@ -102,7 +115,13 @@ fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>
 }
 
 
+@Deprecated("Use ArchiveOperations.zipTree with a Copy task instead. See the Gradle 9.7 upgrading guide.")
 fun unzipTo(outputDirectory: File, zipFile: File) {
+    DeprecationLogger.deprecate("The org.gradle.kotlin.dsl.support.unzipTo(File, File) function")
+        .withAdvice("Use ArchiveOperations.zipTree with a Copy task instead.")
+        .willBeRemovedInGradle10()
+        .withUpgradeGuideSection(9, "kotlin_dsl_zip_functions")
+        .nagUser()
     ZipFile(zipFile).use { zip ->
         for (entry in zip.entries()) {
             unzipEntryTo(outputDirectory, zip, entry)

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -57,7 +57,6 @@ In Gradle 10, the property will be ignored, and the model will always be built f
 ==== Deprecation of the Kotlin DSL `zipTo` and `unzipTo` functions
 
 The `zipTo` and `unzipTo` functions in the `org.gradle.kotlin.dsl.support` package have been deprecated and will be removed in Gradle 10.
-They were never intended as public API.
 
 To create an archive, use the link:{javadocPath}/org/gradle/api/tasks/bundling/Zip.html[`Zip`] task type:
 
@@ -72,7 +71,7 @@ tasks.register<Zip>("packageDistribution") {
 }
 ----
 
-To unpack an archive, use link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:zipTree(java.lang.Object)[`Project.zipTree`] with a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[`Copy`] task:
+To unpack an archive in a build script, call `zipTree` inside a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[`Copy`] task:
 
 [source,kotlin]
 .build.gradle.kts

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -127,6 +127,60 @@ Update your `gradle.properties` and command-line invocations to the new names.
 
 See the <<isolated_projects.adoc#sec:enable, Enabling Isolated Projects>> section in the Gradle User Manual for the recommended setup.
 
+[[kotlin_dsl_zip_functions]]
+==== Deprecation of the Kotlin DSL `zipTo` and `unzipTo` functions
+
+The `zipTo` and `unzipTo` functions in the `org.gradle.kotlin.dsl.support` package have been deprecated and will be removed in Gradle 10.
+They were never intended as public API.
+
+To create an archive, use the link:{javadocPath}/org/gradle/api/tasks/bundling/Zip.html[`Zip`] task type:
+
+[source,kotlin]
+.build.gradle.kts
+----
+tasks.register<Zip>("packageDistribution") {
+    archiveFileName = "my-distribution.zip"
+    destinationDirectory = layout.buildDirectory.dir("dist")
+
+    from(layout.buildDirectory.dir("toArchive"))
+}
+----
+
+To unpack an archive, use link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:zipTree(java.lang.Object)[`Project.zipTree`] with a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[`Copy`] task:
+
+[source,kotlin]
+.build.gradle.kts
+----
+tasks.register<Copy>("unpackFiles") {
+    from(zipTree("src/resources/thirdPartyResources.zip"))
+    into(layout.buildDirectory.dir("resources"))
+}
+----
+
+If you need to unpack imperatively from within a task action, inject link:{javadocPath}/org/gradle/api/file/ArchiveOperations.html[`ArchiveOperations`] and link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html[`FileSystemOperations`]:
+
+[source,kotlin]
+.build.gradle.kts
+----
+abstract class UnpackTask @Inject constructor(
+    private val archives: ArchiveOperations,
+    private val fs: FileSystemOperations
+) : DefaultTask() {
+    @get:InputFile abstract val zipFile: RegularFileProperty
+    @get:OutputDirectory abstract val destinationDir: DirectoryProperty
+
+    @TaskAction
+    fun unpack() {
+        fs.copy {
+            from(archives.zipTree(zipFile))
+            into(destinationDir)
+        }
+    }
+}
+----
+
+See <<working_with_files.adoc#sec:unpacking_archives_example, Unpacking archives>> in the Gradle User Manual for more details.
+
 [[changes_9.6.0]]
 == Upgrading from 9.5.0 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -53,6 +53,60 @@ With <<isolated_projects.adoc#isolated_projects,Isolated Projects>> enabled, set
 
 In Gradle 10, the property will be ignored, and the model will always be built for all the Kotlin DSL scripts of the build.
 
+[[kotlin_dsl_zip_functions]]
+==== Deprecation of the Kotlin DSL `zipTo` and `unzipTo` functions
+
+The `zipTo` and `unzipTo` functions in the `org.gradle.kotlin.dsl.support` package have been deprecated and will be removed in Gradle 10.
+They were never intended as public API.
+
+To create an archive, use the link:{javadocPath}/org/gradle/api/tasks/bundling/Zip.html[`Zip`] task type:
+
+[source,kotlin]
+.build.gradle.kts
+----
+tasks.register<Zip>("packageDistribution") {
+    archiveFileName = "my-distribution.zip"
+    destinationDirectory = layout.buildDirectory.dir("dist")
+
+    from(layout.buildDirectory.dir("toArchive"))
+}
+----
+
+To unpack an archive, use link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:zipTree(java.lang.Object)[`Project.zipTree`] with a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[`Copy`] task:
+
+[source,kotlin]
+.build.gradle.kts
+----
+tasks.register<Copy>("unpackFiles") {
+    from(zipTree("src/resources/thirdPartyResources.zip"))
+    into(layout.buildDirectory.dir("resources"))
+}
+----
+
+If you need to unpack imperatively from within a task action, inject link:{javadocPath}/org/gradle/api/file/ArchiveOperations.html[`ArchiveOperations`] and link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html[`FileSystemOperations`]:
+
+[source,kotlin]
+.build.gradle.kts
+----
+abstract class UnpackTask @Inject constructor(
+    private val archives: ArchiveOperations,
+    private val fs: FileSystemOperations
+) : DefaultTask() {
+    @get:InputFile abstract val zipFile: RegularFileProperty
+    @get:OutputDirectory abstract val destinationDir: DirectoryProperty
+
+    @TaskAction
+    fun unpack() {
+        fs.copy {
+            from(archives.zipTree(zipFile))
+            into(destinationDir)
+        }
+    }
+}
+----
+
+See <<working_with_files.adoc#sec:unpacking_archives_example, Unpacking archives>> in the Gradle User Manual for more details.
+
 [[changes_9.8.0]]
 == Upgrading from 9.7.0 and earlier
 


### PR DESCRIPTION
Might follow up https://github.com/gradle/gradle/pull/38416

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
