### PR TITLE
Document applying third-party plugins from lifecycle callbacks

### DIFF
--- a/platforms/core-configuration/isolated-action-services/src/main/kotlin/org/gradle/internal/isolate/actions/services/DefaultIsolatedProjectEvaluationListenerProvider.kt
+++ b/platforms/core-configuration/isolated-action-services/src/main/kotlin/org/gradle/internal/isolate/actions/services/DefaultIsolatedProjectEvaluationListenerProvider.kt
@@ -256,7 +256,7 @@ fun lifecyclePluginHint(pluginId: String, fromIncludedPluginBuild: Boolean, docu
                 "published from that build (recommended)."
         else ""
     val documentation =
-        documentationRegistry.getDocumentationRecommendationFor("information", "isolated_projects", "sec:lifecycle_callbacks_with_included_plugin_builds")
+        documentationRegistry.getDocumentationRecommendationFor("information", "isolated_projects", "sec:applying_plugins_from_a_lifecycle_callback")
     return "\n" + genericAdvice + includedBuildAdvice + "\n" + documentation
 }
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -711,17 +711,18 @@ Applying a convention plugin from a build registered via `pluginManagement.inclu
 ====
 
 [[sec:lifecycle_callbacks_with_included_plugin_builds]]
-===== Applying convention plugins from an included build
+===== Applying plugins from a lifecycle callback
 
-Plugins from a build registered via `pluginManagement.includeBuild(...)` are resolved lazily so they are built only when explicitly requested in a `plugins {}` block.
-When Gradle sees `plugins { id("my.convention") }`, it builds `my.convention` from the included build and exports the resulting classpath into the surrounding script's classloader scope.
+A `gradle.lifecycle.beforeProject` (or `afterProject`) callback can only apply a plugin that is already on the project's plugin classpath.
+The callback merely registers an action; it does not resolve plugins itself.
+So `apply(plugin = "...")` from a callback fails with `Plugin with id '...' not found` for any plugin that is resolved lazily — that is, only built or downloaded when a `plugins {}` block requests it — and that has not already been resolved onto a classloader scope the project inherits.
+This affects two common cases:
 
-There is a limitation however:
+- a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, and
+- a third-party plugin from a repository, such as the Gradle Plugin Portal or a Maven repository.
 
-- Using a `plugins {}` block in `settings.gradle(.kts)` or any project script *works*, because the block itself triggers the build of the plugin.
-- Using the plugin from inside a `gradle.lifecycle.beforeProject` (or `afterProject`) callback registered in the settings script *does not work*.
-The callback only registers an action; it doesn't request anything.
-By the time the callback runs at project configuration, nothing has asked Gradle to build the plugin, so `apply(plugin = "...")` fails with `Plugin with id '...' not found`.
+Using such a plugin from a `plugins {}` block in `settings.gradle(.kts)` or any project script *works*, because the block itself triggers resolution.
+Using it from a lifecycle callback *does not*, because nothing has triggered resolution by the time the callback runs at project configuration.
 
 This limitation does not apply to `buildSrc/`: it is built eagerly and its classpath is exported to every project, so a `gradle.lifecycle.beforeProject` callback can apply a `buildSrc` convention plugin directly, with none of the workarounds below.
 Moving build logic into `buildSrc` solely to sidestep this limitation is not recommended, however; Gradle best practice is to <<best_practices_structuring_builds.adoc#favor_composite_builds,favor `build-logic` composite builds over `buildSrc`>>.
@@ -753,17 +754,53 @@ Apply the settings convention plugin from `settings.gradle(.kts)`:
 include::sample[dir="snippets/isolatedProjects/lifecycleSettingsPlugin/kotlin",files="settings.gradle.kts[tags=settings-file]"]
 include::sample[dir="snippets/isolatedProjects/lifecycleSettingsPlugin/groovy",files="settings.gradle[tags=settings-file]"]
 
-*Alternative: pre-resolve via the settings `plugins {}` block*
+*Pre-resolve in the settings `plugins {}` block*
 
-For simple cases where adding a settings plugin to your included build is unwarranted, declare the project convention plugin in the settings `plugins {}` block with `apply false`.
-This forces resolution at settings evaluation time and exports the classpath into the settings classloader scope, the parent of every project's scope, so the `beforeProject` callback can find the plugin:
+Declare the plugin in the settings `plugins {}` block with `apply false`.
+This forces resolution at settings evaluation time and exports the classpath into the settings classloader scope — the parent of every project's scope — without applying the plugin there, so the `beforeProject` callback can find it.
+This works for both cases above.
+For a convention plugin from an included build:
 
 include::sample[dir="snippets/isolatedProjects/lifecycleApplyFalse/kotlin",files="settings.gradle.kts[tags=settings-file]"]
 include::sample[dir="snippets/isolatedProjects/lifecycleApplyFalse/groovy",files="settings.gradle[tags=settings-file]"]
 
+For a third-party plugin from a repository, include the plugin version so it can be resolved (or declare the version in `pluginManagement { plugins { ... } }` and request it without a version here):
+
+[source,kotlin]
+.settings.gradle.kts
+----
+plugins {
+    id("com.example.foo") version "1.2.3" apply false
+}
+
+gradle.lifecycle.beforeProject {
+    apply(plugin = "com.example.foo")
+}
+----
+
+*Migrating from `allprojects {}`*
+
+Under Isolated Projects, applying a plugin to other projects from an `allprojects {}` (or `subprojects {}`) block in the root build script is not allowed, because it configures projects other than the one owning the script.
+A third-party plugin applied this way is usually declared with `apply false` in the *root build script*:
+
+[source,kotlin]
+.build.gradle.kts
+----
+plugins {
+    id("com.example.foo") version "1.2.3" apply false
+}
+
+allprojects {
+    apply(plugin = "com.example.foo")
+}
+----
+
+Replacing `allprojects {}` with a `gradle.lifecycle.beforeProject` callback is not enough on its own: the callback is registered in the settings script and runs against a classloader scope that does not see the root build script's classpath.
+The plugin declaration must move into `settings.gradle(.kts)` too, exactly as in the settings `plugins {}` workaround shown above.
+
 [NOTE]
 ====
-Both patterns are workarounds for the current implementation limitation listed under <<sec:current_limitations>>.
+These patterns are workarounds for the current implementation limitation listed under <<sec:current_limitations>>.
 ====
 
 [[sec:isolated_project_api]]

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -249,7 +249,7 @@ The current implementation of Isolated Projects has a number of limitations that
 * Changes to included builds invalidate all cached results, even unrelated ones.
 * Tooling model caching is local only: no sharing across checkouts or remote caching.
 * A `gradle.lifecycle.beforeProject` callback registered in `settings.gradle(.kts)` cannot directly apply a lazily-resolved plugin, such as a convention plugin from a build registered via `pluginManagement.includeBuild(...)` or a third-party plugin from a repository, because the callback alone does not trigger resolution of that plugin and the export of its classpath.
-See <<sec:lifecycle_callbacks_with_included_plugin_builds>> for working patterns.
+See <<sec:applying_plugins_from_a_lifecycle_callback>> for working patterns.
 
 [[sec:constraints]]
 == Isolated Projects constraints
@@ -707,10 +707,10 @@ include::sample[dir="snippets/structuring-builds/isolatedProjects-lifecycleApi/g
 [NOTE]
 ====
 The example above applies the `base` plugin, which ships with Gradle and is therefore always on the project's plugin classpath.
-Applying a plugin that is resolved lazily, such as a convention plugin from a build registered via `pluginManagement.includeBuild(...)` or a third-party plugin from a repository, is subject to a current limitation; see <<sec:lifecycle_callbacks_with_included_plugin_builds>>.
+Applying a plugin that is resolved lazily, such as a convention plugin from a build registered via `pluginManagement.includeBuild(...)` or a third-party plugin from a repository, is subject to a current limitation; see <<sec:applying_plugins_from_a_lifecycle_callback>>.
 ====
 
-[[sec:lifecycle_callbacks_with_included_plugin_builds]]
+[[sec:applying_plugins_from_a_lifecycle_callback]]
 ===== Applying plugins from a lifecycle callback
 
 A `gradle.lifecycle.beforeProject` (or `afterProject`) callback can only apply a plugin that is already on the project's plugin classpath.
@@ -729,7 +729,8 @@ Moving build logic into `buildSrc` solely to sidestep this limitation is not rec
 
 Two workarounds are available.
 
-*Recommended: register `beforeProject` from a settings convention plugin*
+[[sec:settings_convention_plugin_workaround]]
+====== Recommended: register `beforeProject` from a settings convention plugin
 
 Publish two precompiled script plugins from your included build (named `build-logic` here): the project convention plugin you want to apply, and a <<implementing_gradle_plugins_precompiled.adoc#settings_pre_compiled_plugins,settings convention plugin>> that registers the `gradle.lifecycle.beforeProject` callback which applies it.
 Both live in the included build, for example under `build-logic/src/main/groovy`:
@@ -754,7 +755,8 @@ Apply the settings convention plugin from `settings.gradle(.kts)`:
 include::sample[dir="snippets/isolatedProjects/lifecycleSettingsPlugin/kotlin",files="settings.gradle.kts[tags=settings-file]"]
 include::sample[dir="snippets/isolatedProjects/lifecycleSettingsPlugin/groovy",files="settings.gradle[tags=settings-file]"]
 
-*Pre-resolve in the settings `plugins {}` block*
+[[sec:pre_resolve_in_settings_plugins_block]]
+====== Pre-resolve in the settings `plugins {}` block
 
 Declare the plugin in the settings `plugins {}` block with `apply false`.
 This forces resolution at settings evaluation time and exports the classpath into the settings classloader scope — the parent of every project's scope — without applying the plugin there, so the `beforeProject` callback can find it.
@@ -795,7 +797,8 @@ gradle.lifecycle.beforeProject {
 ----
 =====
 
-*Migrating from `allprojects {}`*
+[[sec:migrating_from_allprojects]]
+====== Migrating from `allprojects {}`
 
 Under Isolated Projects, applying a plugin to other projects from an `allprojects {}` (or `subprojects {}`) block in the root build script is not allowed, because it configures projects other than the one owning the script.
 A third-party plugin applied this way is usually declared with `apply false` in the *root build script*:
@@ -809,6 +812,7 @@ plugins {
     id("com.example.foo") version "1.2.3" apply false
 }
 
+// Not Isolated Projects-compatible — see below
 allprojects {
     apply(plugin = "com.example.foo")
 }
@@ -823,6 +827,7 @@ plugins {
     id 'com.example.foo' version '1.2.3' apply false
 }
 
+// Not Isolated Projects-compatible — see below
 allprojects {
     apply plugin: 'com.example.foo'
 }

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -715,7 +715,7 @@ Applying a plugin that is resolved lazily, such as a convention plugin from a bu
 
 A `gradle.lifecycle.beforeProject` (or `afterProject`) callback can only apply a plugin that is already on the project's plugin classpath.
 The callback merely registers an action; it does not resolve plugins itself.
-So `apply(plugin = "...")` from a callback fails with `Plugin with id '...' not found` for any plugin that is resolved lazily — that is, only built or downloaded when a `plugins {}` block requests it — and that has not already been resolved onto a classloader scope the project inherits.
+So `apply(plugin = "...")` from a callback fails with `Plugin with id '...' not found` for any plugin that is resolved lazily (only built or downloaded when a `plugins {}` block requests it), unless it has already been resolved onto a classloader scope the project inherits.
 This affects two common cases:
 
 - a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, and

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -766,8 +766,10 @@ include::sample[dir="snippets/isolatedProjects/lifecycleApplyFalse/groovy",files
 
 For a third-party plugin from a repository, include the plugin version so it can be resolved (or declare the version in `pluginManagement { plugins { ... } }` and request it without a version here):
 
-[source,kotlin]
+[.multi-language-sample]
+=====
 .settings.gradle.kts
+[source,kotlin]
 ----
 plugins {
     id("com.example.foo") version "1.2.3" apply false
@@ -777,14 +779,31 @@ gradle.lifecycle.beforeProject {
     apply(plugin = "com.example.foo")
 }
 ----
+=====
+[.multi-language-sample]
+=====
+.settings.gradle
+[source,groovy]
+----
+plugins {
+    id 'com.example.foo' version '1.2.3' apply false
+}
+
+gradle.lifecycle.beforeProject {
+    it.apply plugin: 'com.example.foo'
+}
+----
+=====
 
 *Migrating from `allprojects {}`*
 
 Under Isolated Projects, applying a plugin to other projects from an `allprojects {}` (or `subprojects {}`) block in the root build script is not allowed, because it configures projects other than the one owning the script.
 A third-party plugin applied this way is usually declared with `apply false` in the *root build script*:
 
-[source,kotlin]
+[.multi-language-sample]
+=====
 .build.gradle.kts
+[source,kotlin]
 ----
 plugins {
     id("com.example.foo") version "1.2.3" apply false
@@ -794,6 +813,21 @@ allprojects {
     apply(plugin = "com.example.foo")
 }
 ----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+plugins {
+    id 'com.example.foo' version '1.2.3' apply false
+}
+
+allprojects {
+    apply plugin: 'com.example.foo'
+}
+----
+=====
 
 Replacing `allprojects {}` with a `gradle.lifecycle.beforeProject` callback is not enough on its own: the callback is registered in the settings script and runs against a classloader scope that does not see the root build script's classpath.
 The plugin declaration must move into `settings.gradle(.kts)` too, exactly as in the settings `plugins {}` workaround shown above.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -248,7 +248,7 @@ The current implementation of Isolated Projects has a number of limitations that
 * The configuration phase might require more memory to process more work in parallel.
 * Changes to included builds invalidate all cached results, even unrelated ones.
 * Tooling model caching is local only: no sharing across checkouts or remote caching.
-* A `gradle.lifecycle.beforeProject` callback registered in `settings.gradle(.kts)` cannot directly apply a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, because the callback alone does not trigger resolution of that plugin and the export of its classpath.
+* A `gradle.lifecycle.beforeProject` callback registered in `settings.gradle(.kts)` cannot directly apply a lazily-resolved plugin, such as a convention plugin from a build registered via `pluginManagement.includeBuild(...)` or a third-party plugin from a repository, because the callback alone does not trigger resolution of that plugin and the export of its classpath.
 See <<sec:lifecycle_callbacks_with_included_plugin_builds>> for working patterns.
 
 [[sec:constraints]]
@@ -707,7 +707,7 @@ include::sample[dir="snippets/structuring-builds/isolatedProjects-lifecycleApi/g
 [NOTE]
 ====
 The example above applies the `base` plugin, which ships with Gradle and is therefore always on the project's plugin classpath.
-Applying a convention plugin from a build registered via `pluginManagement.includeBuild(...)` is subject to a current limitation; see <<sec:lifecycle_callbacks_with_included_plugin_builds>>.
+Applying a plugin that is resolved lazily, such as a convention plugin from a build registered via `pluginManagement.includeBuild(...)` or a third-party plugin from a repository, is subject to a current limitation; see <<sec:lifecycle_callbacks_with_included_plugin_builds>>.
 ====
 
 [[sec:lifecycle_callbacks_with_included_plugin_builds]]

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
@@ -362,7 +362,7 @@ include::sample[dir="snippets/reference/runtime-configuration/callbacks/groovy",
 ====
 
 TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled, applying a plugin that is resolved lazily — for example a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, or a third-party plugin from a repository — requires additional setup.
-See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying plugins from a lifecycle callback>>.
+See <<isolated_projects.adoc#sec:applying_plugins_from_a_lifecycle_callback,Applying plugins from a lifecycle callback>>.
 
 [[after_project]]
 ==== `afterProject`
@@ -376,7 +376,7 @@ include::sample[dir="snippets/reference/runtime-configuration/callbacks/groovy",
 ====
 
 TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled, applying a plugin that is resolved lazily — for example a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, or a third-party plugin from a repository — requires additional setup.
-See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying plugins from a lifecycle callback>>.
+See <<isolated_projects.adoc#sec:applying_plugins_from_a_lifecycle_callback,Applying plugins from a lifecycle callback>>.
 
 [[projects_evaluated]]
 ==== `projectsEvaluated`

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
@@ -361,8 +361,8 @@ include::sample[dir="snippets/reference/runtime-configuration/callbacks/kotlin",
 include::sample[dir="snippets/reference/runtime-configuration/callbacks/groovy",files="callbacks.init.gradle[tags=beforeproject]"]
 ====
 
-TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled and the plugin you want to apply lives in a build registered via `pluginManagement.includeBuild(...)`, additional setup is required.
-See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying convention plugins from an included build>>.
+TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled, applying a plugin that is resolved lazily — for example a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, or a third-party plugin from a repository — requires additional setup.
+See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying plugins from a lifecycle callback>>.
 
 [[after_project]]
 ==== `afterProject`
@@ -375,8 +375,8 @@ include::sample[dir="snippets/reference/runtime-configuration/callbacks/kotlin",
 include::sample[dir="snippets/reference/runtime-configuration/callbacks/groovy",files="callbacks.init.gradle[tags=afterproject]"]
 ====
 
-TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled and the plugin you want to apply lives in a build registered via `pluginManagement.includeBuild(...)`, additional setup is required.
-See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying convention plugins from an included build>>.
+TIP: When <<isolated_projects.adoc#isolated_projects,Isolated Projects>> is enabled, applying a plugin that is resolved lazily — for example a convention plugin from a build registered via `pluginManagement.includeBuild(...)`, or a third-party plugin from a repository — requires additional setup.
+See <<isolated_projects.adoc#sec:lifecycle_callbacks_with_included_plugin_builds,Applying plugins from a lifecycle callback>>.
 
 [[projects_evaluated]]
 ==== `projectsEvaluated`

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleConventionPluginApplicationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleConventionPluginApplicationIntegrationTest.groovy
@@ -86,7 +86,7 @@ class GradleLifecycleConventionPluginApplicationIntegrationTest extends Abstract
             "\nIf this plugin is provided by a build registered via `pluginManagement.includeBuild(...)`, " +
             "you can instead move the `gradle.lifecycle` callback registration into a settings convention plugin " +
             "published from that build (recommended).\n" +
-            documentationRegistry.getDocumentationRecommendationFor("information", "isolated_projects", "sec:lifecycle_callbacks_with_included_plugin_builds")
+            documentationRegistry.getDocumentationRecommendationFor("information", "isolated_projects", "sec:applying_plugins_from_a_lifecycle_callback")
         )
 
         where:
@@ -112,7 +112,7 @@ class GradleLifecycleConventionPluginApplicationIntegrationTest extends Abstract
         then:
         failureCauseContains("Plugin with id 'com.example.absent' not found.")
         failureCauseContains("Declare it in the settings `plugins {}` block with `apply false`")
-        failureCauseContains("userguide/isolated_projects.html#sec:lifecycle_callbacks_with_included_plugin_builds")
+        failureCauseContains("userguide/isolated_projects.html#sec:applying_plugins_from_a_lifecycle_callback")
         failure.assertThatCause(not(containsString("settings convention plugin")))
 
         where:


### PR DESCRIPTION
## Summary

Documents applying **third-party (repository) plugins** from a `gradle.lifecycle.beforeProject`/`afterProject` callback under Isolated Projects, and migrating a third-party plugin away from an `allprojects {}` block.

Rather than adding a parallel section, this generalizes the existing "Applying convention plugins from an included build" section into **"Applying plugins from a lifecycle callback"**, since the limitation and fix are the same for included-build convention plugins and repository plugins.

## Changes (`isolated_projects.adoc`)

- Generalize the limitation: a lifecycle callback can only apply a plugin already on the project's classpath; it doesn't resolve plugins. This affects both included-build convention plugins **and** repository plugins.
- Fold the third-party case into the shared `apply false` workaround, adding the version-bearing snippet (`id("com.example.foo") version "1.2.3" apply false`) and the `pluginManagement { plugins { … } }` alternative.
- Add a "Migrating from `allprojects {}`" note: the declaration must move from the root build script into `settings.gradle(.kts)` so the settings-registered callback can see it.
- The `sec:lifecycle_callbacks_with_included_plugin_builds` anchor is preserved (still referenced by the diagnostic hint and an existing NOTE).

## Test plan

- [x] `./gradlew :docs:checkDeadInternalLinks` — passes (docs parse, cross-references resolve).
- Examples are illustrative `[source]` blocks (a real repository plugin can't be exercised offline in a docs sample); the included-build workaround still uses the existing executed samples.
