### PR TITLE
Declare input annotations for MavenPom

### DIFF
--- a/gradle/dependency-management/smoke-tested-plugins.properties
+++ b/gradle/dependency-management/smoke-tested-plugins.properties
@@ -2,6 +2,7 @@
 app.cash.paparazzi=2.0.0-alpha05
 biz.aQute.bnd=7.3.0
 com.bmuschko.docker-java-application=10.0.0
+dev.sigstore.sign=2.2.0
 com.diffplug.spotless=8.8.0
 com.github.ben-manes.versions=0.54.0
 com.github.davidmc24.gradle.plugin.avro=1.9.1

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -189,6 +189,29 @@ Gradle provides various incremental updates and performance optimizations to ens
 ADD RELEASE FEATURES ABOVE
 ========================================================== -->
 
+
+#### Faster Maven publishing with up-to-date POM generation
+
+The [`GenerateMavenPom`](javadoc/org/gradle/api/publish/maven/tasks/GenerateMavenPom.html) task was previously marked as untracked, so it executed on every build regardless of whether the underlying POM had changed.
+
+The task now declares each part of its source POM as a task input, so it participates in up-to-date checks:
+
+```text
+$ ./gradlew generatePomFileForMavenPublication
+> Task :generatePomFileForMavenPublication UP-TO-DATE
+
+BUILD SUCCESSFUL
+```
+
+When a `withXml` action is registered, task input tracking remains disabled, as `withXml` actions do not yet support snapshotting, so the task continues to run on every build.
+To restore up-to-date behavior, move the customization into the DSL properties on [`MavenPom`](javadoc/org/gradle/api/publish/maven/MavenPom.html) where possible.
+
+See the [Generate POM task](userguide/publishing_maven.html#publishing_maven:generate-pom) section in the Gradle User Manual for more details.
+
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ADD RELEASE FEATURES ABOVE
+========================================================== -->
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backward compatibility.

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.publish.maven
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenLocalRepository
 import org.gradle.util.SetSystemProperties
+import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.Issue
 
@@ -607,7 +608,7 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
         succeeds("generatePomFileForMavenPublication")
 
         then:
-        file("build/publications/maven/pom-default.xml").text.trim() == expected
+        TextUtil.convertLineSeparatorsToUnix(file("build/publications/maven/pom-default.xml").text.trim()) == expected
 
         when:
         succeeds("generatePomFileForMavenPublication")
@@ -626,6 +627,6 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
         succeeds("generatePomFileForMavenPublication")
 
         then:
-        file("build/publications/maven/pom-default.xml").text.trim() == expected.replace("<description>custom-description</description>", "<description>another-description</description>")
+        TextUtil.convertLineSeparatorsToUnix(file("build/publications/maven/pom-default.xml").text.trim()) == expected.replace("<description>custom-description</description>", "<description>another-description</description>")
     }
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -538,4 +538,94 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
         expect:
         succeeds("publish")
     }
+
+    def "GenerateMavenPom is cacheable"() {
+        mavenRepo.module("org", "foo", "1.1").publish()
+
+        settingsFile << """
+            rootProject.name = "bar"
+        """
+
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org:foo:1+")
+            }
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from(components.java)
+                        versionMapping {
+                            allVariants {
+                                fromResolutionResult()
+                            }
+                        }
+                        pom {
+                            description = "custom-description"
+                        }
+                    }
+                }
+            }
+        """
+
+        def expected = """
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId></groupId>
+  <artifactId>bar</artifactId>
+  <version>unspecified</version>
+  <description>custom-description</description>
+  <dependencies>
+    <dependency>
+      <groupId>org</groupId>
+      <artifactId>foo</artifactId>
+      <version>1.1</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>
+""".trim()
+
+        expect:
+        succeeds("dependencies", "--configuration", "runtimeClasspath")
+
+        when:
+        succeeds("generatePomFileForMavenPublication")
+
+        then:
+        file("build/publications/maven/pom-default.xml").text.trim() == expected
+
+        when:
+        succeeds("generatePomFileForMavenPublication")
+
+        then:
+        result.assertAllTasksSkipped()
+
+        when:
+        buildFile << """
+            publishing.publications.maven.pom {
+                description = "another-description"
+            }
+        """
+
+        and:
+        succeeds("generatePomFileForMavenPublication")
+
+        then:
+        file("build/publications/maven/pom-default.xml").text.trim() == expected.replace("<description>custom-description</description>", "<description>another-description</description>")
+    }
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -629,4 +629,39 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
         then:
         TextUtil.convertLineSeparatorsToUnix(file("build/publications/maven/pom-default.xml").text.trim()) == expected.replace("<description>custom-description</description>", "<description>another-description</description>")
     }
+
+    // Eventually, we will want to serialize the XML action and allow the task to be be up-to-date
+    def "GenerateMavenPom with a withXml block is never up-to-date"() {
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from(components.java)
+                        pom {
+                            withXml {
+                                asNode().appendNode("description", "custom-description")
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("generatePomFileForMavenPublication")
+
+        then:
+        executedAndNotSkipped(":generatePomFileForMavenPublication")
+
+        when:
+        succeeds("generatePomFileForMavenPublication")
+
+        then:
+        executedAndNotSkipped(":generatePomFileForMavenPublication")
+    }
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -20,6 +20,8 @@ import org.gradle.api.Action;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
@@ -43,6 +45,7 @@ public interface MavenPom {
      * Returns the packaging (for example: jar, war) for the publication represented by this POM.
      * @since 1.7
      */
+    @Input
     @ToBeReplacedByLazyProperty
     String getPackaging();
 
@@ -57,6 +60,8 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
@@ -64,6 +69,8 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getDescription();
 
     /**
@@ -71,6 +78,8 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
@@ -78,6 +87,8 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getInceptionYear();
 
     /**
@@ -148,6 +159,7 @@ public interface MavenPom {
      *
      * @since 5.3
      */
+    @Input
     MapProperty<String, String> getProperties();
 
     /**

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomCiManagement.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomCiManagement.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * The CI management system of a Maven publication.
@@ -30,12 +32,16 @@ public interface MavenPomCiManagement {
      * The name of this CI management system.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getSystem();
 
     /**
      * The URL of this CI management system.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
@@ -19,6 +19,8 @@ package org.gradle.api.publish.maven;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * A contributor of a Maven publication.
@@ -33,48 +35,63 @@ public interface MavenPomContributor {
      * The name of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
      * The email
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getEmail();
 
     /**
      * The URL of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
      * The organization name of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getOrganization();
 
     /**
      * The organization's URL of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getOrganizationUrl();
 
     /**
      * The roles of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     SetProperty<String> getRoles();
 
     /**
      * The timezone of this contributor.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getTimezone();
 
     /**
      * The properties of this contributor.
      * @since 4.8
      */
+    @Input
     MapProperty<String, String> getProperties();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
@@ -76,7 +76,6 @@ public interface MavenPomContributor {
      * @since 4.8
      */
     @Input
-    @Optional
     SetProperty<String> getRoles();
 
     /**

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeploymentRepository.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeploymentRepository.java
@@ -18,6 +18,8 @@ package org.gradle.api.publish.maven;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -35,6 +37,8 @@ public interface MavenPomDeploymentRepository {
      *
      * @since 9.1.0
      */
+    @Input
+    @Optional
     Property<String> getId();
 
     /**
@@ -42,6 +46,8 @@ public interface MavenPomDeploymentRepository {
      *
      * @since 9.1.0
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
@@ -51,6 +57,8 @@ public interface MavenPomDeploymentRepository {
      *
      * @since 9.1.0
      */
+    @Input
+    @Optional
     Property<Boolean> getUniqueVersion();
 
     /**
@@ -58,6 +66,8 @@ public interface MavenPomDeploymentRepository {
      *
      * @since 9.1.0
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
@@ -67,5 +77,7 @@ public interface MavenPomDeploymentRepository {
      *
      * @since 9.1.0
      */
+    @Input
+    @Optional
     Property<String> getLayout();
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
@@ -19,6 +19,8 @@ package org.gradle.api.publish.maven;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * A developer of a Maven publication.
@@ -33,54 +35,70 @@ public interface MavenPomDeveloper {
      * The unique ID of this developer in the SCM.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getId();
 
     /**
      * The name of this developer.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
      * The email
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getEmail();
 
     /**
      * The URL of this developer.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
      * The organization name of this developer.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getOrganization();
 
     /**
      * The organization's URL of this developer.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getOrganizationUrl();
 
     /**
      * The roles of this developer.
      * @since 4.8
      */
+    @Input
     SetProperty<String> getRoles();
 
     /**
      * The timezone of this developer.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getTimezone();
 
     /**
      * The properties of this developer.
      * @since 4.8
      */
+    @Input
     MapProperty<String, String> getProperties();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
@@ -19,6 +19,8 @@ package org.gradle.api.publish.maven;
 import org.gradle.api.Incubating;
 import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -34,6 +36,8 @@ public interface MavenPomDistributionManagement {
      * The download URL of the corresponding Maven publication.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getDownloadUrl();
 
     /**

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomIssueManagement.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomIssueManagement.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * The issue management system of a Maven publication.
@@ -30,12 +32,16 @@ public interface MavenPomIssueManagement {
      * The name of this issue management system.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getSystem();
 
     /**
      * The URL of this issue management system.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicense.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicense.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * A license of a Maven publication.
@@ -31,24 +33,32 @@ public interface MavenPomLicense {
      * The name of this license.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
      * The URL of this license.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
      * The distribution of this license.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getDistribution();
 
     /**
      * The comments of this license.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getComments();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingList.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingList.java
@@ -18,6 +18,8 @@ package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * A mailing list of a Maven publication.
@@ -32,36 +34,47 @@ public interface MavenPomMailingList {
      * The name of this mailing list.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
      * The email address or link that can be used to subscribe to this mailing list.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getSubscribe();
 
     /**
      * The email address or link that can be used to subscribe to this mailing list.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUnsubscribe();
 
     /**
      * The email address or link that can be used to post to this mailing list.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getPost();
 
     /**
      * The URL where you can browse the archive of this mailing list.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getArchive();
 
     /**
      * The alternate URLs where you can browse the archive of this mailing list.
      * @since 4.8
      */
+    @Input
     SetProperty<String> getOtherArchives();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomOrganization.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomOrganization.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * The organization of a Maven publication.
@@ -30,12 +32,16 @@ public interface MavenPomOrganization {
      * The name of this organization.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getName();
 
     /**
      * The URL of this organization.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomRelocation.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomRelocation.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -34,24 +36,32 @@ public interface MavenPomRelocation {
      * The new group ID of the artifact.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getGroupId();
 
     /**
      * The new artifact ID of the artifact.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getArtifactId();
 
     /**
      * The new version of the artifact.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getVersion();
 
     /**
      * The message to show the user for this relocation.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getMessage();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomScm.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPomScm.java
@@ -17,6 +17,8 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * The SCM (source control management) of a Maven publication.
@@ -30,24 +32,32 @@ public interface MavenPomScm {
      * The connection URL of this SCM.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getConnection();
 
     /**
      * The developer connection URL of this SCM.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getDeveloperConnection();
 
     /**
      * The browsable repository URL of this SCM.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getUrl();
 
     /**
      * The tag of current code in this SCM.
      * @since 4.8
      */
+    @Input
+    @Optional
     Property<String> getTag();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenDependency.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenDependency.java
@@ -16,6 +16,9 @@
 package org.gradle.api.publish.maven.internal.dependencies;
 
 import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
@@ -29,44 +32,56 @@ public interface MavenDependency {
     /**
      * The group ID of this dependency.
      */
+    @Input
     String getGroupId();
 
     /**
      * The artifact ID of this dependency.
      */
+    @Input
     String getArtifactId();
 
     /**
      * The version of this dependency.
      */
+    @Input
+    @Optional
     @Nullable
     String getVersion();
 
     /**
      * The type of this dependency.
      */
+    @Input
+    @Optional
     @Nullable
     String getType();
 
     /**
      * The classifier of this dependency.
      */
+    @Input
+    @Optional
     @Nullable
     String getClassifier();
 
     /**
      * The scope of this dependency.
      */
+    @Input
+    @Optional
     @Nullable
     String getScope();
 
     /**
      * The exclude rules of this dependency.
      */
+    @Nested
     Set<ExcludeRule> getExcludeRules();
 
     /**
      * If this dependency is marked optional.
      */
+    @Input
     boolean isOptional();
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenPomDependencies.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/dependencies/MavenPomDependencies.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.publish.maven.internal.dependencies;
 
+import org.gradle.api.tasks.Nested;
+
 import java.util.List;
 
 /**
@@ -23,8 +25,10 @@ import java.util.List;
  */
 public interface MavenPomDependencies {
 
+    @Nested
     List<MavenDependency> getDependencies();
 
+    @Nested
     List<MavenDependency> getDependencyManagement();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
@@ -63,7 +63,7 @@ public abstract class DefaultMavenPom implements MavenPomInternal, MavenPomLicen
     }
 
     @Override
-    public Action<XmlProvider> getXmlAction() {
+    public MutableActionSet<XmlProvider> getXmlAction() {
         return xmlAction;
     }
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomDistributionManagementInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomDistributionManagementInternal.java
@@ -16,16 +16,22 @@
 
 package org.gradle.api.publish.maven.internal.publication;
 
+import org.gradle.api.publish.maven.MavenPomDeploymentRepository;
 import org.gradle.api.publish.maven.MavenPomDistributionManagement;
 import org.gradle.api.publish.maven.MavenPomRelocation;
-import org.gradle.api.publish.maven.MavenPomDeploymentRepository;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.jspecify.annotations.Nullable;
 
 public interface MavenPomDistributionManagementInternal extends MavenPomDistributionManagement {
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomRelocation getRelocation();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomDeploymentRepository getRepository();
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven.internal.publication;
 
-import org.gradle.api.Action;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.maven.MavenPom;
@@ -30,45 +29,68 @@ import org.gradle.api.publish.maven.MavenPomOrganization;
 import org.gradle.api.publish.maven.MavenPomScm;
 import org.gradle.api.publish.maven.internal.dependencies.MavenPomDependencies;
 import org.gradle.api.publish.maven.internal.publisher.MavenPublicationCoordinates;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.internal.MutableActionSet;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
 public interface MavenPomInternal extends MavenPom {
 
+    @Internal
     Property<String> getPackagingProperty();
 
+    @Nested
     List<MavenPomLicense> getLicenses();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomOrganization getOrganization();
 
+    @Nested
     List<MavenPomDeveloper> getDevelopers();
 
+    @Nested
     List<MavenPomContributor> getContributors();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomScm getScm();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomIssueManagement getIssueManagement();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomCiManagement getCiManagement();
 
+    @Nested
+    @Optional
     @Nullable
     MavenPomDistributionManagementInternal getDistributionManagement();
 
+    @Nested
     List<MavenPomMailingList> getMailingLists();
 
     @Nested
     MavenPublicationCoordinates getCoordinates();
 
+    @Nested
+    @Optional
     Property<MavenPomDependencies> getDependencies();
 
-    Action<XmlProvider> getXmlAction();
+    @Internal
+    MutableActionSet<XmlProvider> getXmlAction();
 
+    @Input
     Property<Boolean> getWriteGradleMetadataMarker();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenPublicationCoordinates.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenPublicationCoordinates.java
@@ -17,13 +17,17 @@
 package org.gradle.api.publish.maven.internal.publisher;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 
 public interface MavenPublicationCoordinates {
 
+    @Input
     Property<String> getGroupId();
 
+    @Input
     Property<String> getArtifactId();
 
+    @Input
     Property<String> getVersion();
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -26,19 +26,13 @@ import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.publish.maven.MavenPom;
 import org.gradle.api.publish.maven.internal.publication.MavenPomInternal;
 import org.gradle.api.publish.maven.internal.tasks.MavenPomFileGenerator;
-import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.UntrackedTask;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
-import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
-import org.gradle.internal.serialization.Cached;
-import org.gradle.internal.serialization.Transient;
 
 import javax.inject.Inject;
 import java.io.File;
-
-import static org.gradle.internal.serialization.Transient.varOf;
 
 /**
  * Generates a Maven module descriptor (POM) file.
@@ -46,13 +40,16 @@ import static org.gradle.internal.serialization.Transient.varOf;
  * @since 1.5
  */
 @SuppressWarnings("this-escape")
-@UntrackedTask(because = "Gradle doesn't understand the data structures used to configure this task")
 public abstract class GenerateMavenPom extends DefaultTask {
 
-    private final Transient.Var<MavenPom> pom = varOf();
-    private final Cached<MavenPomFileGenerator.MavenPomSpec> mavenPomSpec = Cached.of(() ->
-        MavenPomFileGenerator.generateSpec((MavenPomInternal) getPom())
-    );
+    private MavenPom pom;
+
+    public GenerateMavenPom() {
+        this.doNotTrackStateIf(
+            "withXml actions cannot be snapshotted",
+            task -> !((MavenPomInternal) ((GenerateMavenPom) task).getPom()).getXmlAction().isEmpty()
+        );
+    }
 
     @Inject
     protected abstract FileResolver getFileResolver();
@@ -66,10 +63,9 @@ public abstract class GenerateMavenPom extends DefaultTask {
      * @return The Maven POM.
      * @since 1.5
      */
-    @Internal
-    @ToBeReplacedByLazyProperty
+    @Nested
     public MavenPom getPom() {
-        return pom.get();
+        return pom;
     }
 
     /**
@@ -78,7 +74,7 @@ public abstract class GenerateMavenPom extends DefaultTask {
      * @since 1.5
      */
     public void setPom(MavenPom pom) {
-        this.pom.set(pom);
+        this.pom = pom;
     }
 
     /**
@@ -135,7 +131,7 @@ public abstract class GenerateMavenPom extends DefaultTask {
      */
     @TaskAction
     public void doGenerate() {
-        mavenPomSpec.get().writeTo(getDestinationFile().get().getAsFile());
+        MavenPomFileGenerator.generateSpec((MavenPomInternal) getPom()).writeTo(getDestinationFile().get().getAsFile());
     }
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -40,6 +41,7 @@ import java.io.File;
  * @since 1.5
  */
 @SuppressWarnings("this-escape")
+@DisableCachingByDefault(because = "Not worth caching")
 public abstract class GenerateMavenPom extends DefaultTask {
 
     private MavenPom pom;

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -27,6 +27,7 @@ import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInte
 import java.io.File;
 
 public interface PublicationInternal<T extends PublicationArtifact> extends Publication, ProjectComponentPublication {
+
     ModuleVersionIdentifier getCoordinates();
 
     ImmutableAttributes getAttributes();
@@ -38,8 +39,12 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
      */
     PublicationArtifactSet<T> getPublishableArtifacts();
 
+    // Used by sigstore plugin:
+    // https://github.com/sigstore/sigstore-java/blob/671f1b59b33754367b4d126d1c4a185bba7fac4d/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt#L92
     void allPublishableArtifacts(Action<? super T> action);
 
+    // Used by sigstore plugin:
+    // https://github.com/sigstore/sigstore-java/blob/671f1b59b33754367b4d126d1c4a185bba7fac4d/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt#L127
     void whenPublishableArtifactRemoved(Action<? super T> action);
 
     /**
@@ -55,8 +60,12 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
      * @param file The file to be used for publishing the derived artifact.
      * @return The newly created derived artifact.
      */
+    // Used by sigstore plugin
+    // https://github.com/sigstore/sigstore-java/blob/671f1b59b33754367b4d126d1c4a185bba7fac4d/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt#L102
     T addDerivedArtifact(T originalArtifact, DerivedArtifact file);
 
+    // Used by sigstore plugin
+    // https://github.com/sigstore/sigstore-java/blob/671f1b59b33754367b4d126d1c4a185bba7fac4d/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt#L141
     void removeDerivedArtifact(T artifact);
 
     /**
@@ -78,8 +87,11 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
         String getUri();
     }
 
+    // Used by sigstore plugin:
+    // https://github.com/sigstore/sigstore-java/blob/671f1b59b33754367b4d126d1c4a185bba7fac4d/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/DefaultDerivedArtifactFile.kt#L32
     interface DerivedArtifact {
         boolean shouldBePublished();
         File create();
     }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExcludeRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExcludeRule.java
@@ -15,6 +15,9 @@
  */
 package org.gradle.api.artifacts;
 
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
 /**
  * An {@code ExcludeRule} is used to describe transitive dependencies that should be excluded when resolving
  * dependencies.
@@ -38,11 +41,15 @@ public interface ExcludeRule {
      * The exact name of the organization or group that should be excluded.
       * @since 1.0
       */
+    @Input
+    @Optional
     String getGroup();
 
     /**
      * The exact name of the module that should be excluded.
      * @since 1.0
      */
+    @Input
+    @Optional
     String getModule();
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -90,6 +90,7 @@ abstract class AbstractSmokeTest extends Specification {
         static gradleGitProperties = SMOKE_TESTED_PLUGINS.get("com.gorylenko.gradle-git-properties")
         static flyway = SMOKE_TESTED_PLUGINS.get("org.flywaydb.flyway")
         static detekt = SMOKE_TESTED_PLUGINS.get("dev.detekt")
+        static sigstore = SMOKE_TESTED_PLUGINS.get("dev.sigstore.sign")
         static spotless = SMOKE_TESTED_PLUGINS.get("com.diffplug.spotless")
         static jib = SMOKE_TESTED_PLUGINS.get("com.google.cloud.tools.jib")
         static lombok = SMOKE_TESTED_PLUGINS.get("io.freefair.lombok")

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SigstoreSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SigstoreSmokeTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.integtests.fixtures.modes.ToBeFixedForIsolatedProjects
+import org.gradle.util.GradleVersion
+
+class SigstoreSmokeTest extends AbstractPluginValidatingSmokeTest {
+
+    @Override
+    Map<String, Versions> getPluginsToValidate() {
+        [
+            'dev.sigstore.sign': TestedVersions.sigstore
+        ]
+    }
+
+    @ToBeFixedForIsolatedProjects(because = "Uses BuildServicesRegistry.getRegistrations().getByName(String)")
+    def "can configure sigstore for java maven publication"() {
+        given:
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("maven-publish")
+                id("dev.sigstore.sign").version("${TestedVersions.sigstore}")
+            }
+
+            ${mavenCentralRepository()}
+
+            publishing {
+                repositories {
+                    maven {
+                        url = uri(layout.buildDirectory.dir('repo'))
+                    }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        when:
+        // Actually running sigstore's signing tasks requires authentication,
+        // so just make sure configuration works correctly
+        def result = runner('tasks', '--all')
+            .expectLegacyDeprecationWarning("The 'val name by creating { }' property delegate syntax has been deprecated. This is scheduled to be removed in Gradle 10. Use 'val element = create(name) { }' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#kotlin_dsl_delegated_properties")
+            .expectLegacyDeprecationWarning("The 'val name by creating { }' property delegate syntax has been deprecated. This is scheduled to be removed in Gradle 10. Use 'val element = create(name) { }' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#kotlin_dsl_delegated_properties")
+            .run()
+
+        then:
+        result.output.contains("sigstoreSignMavenPublication - Sign all artifacts in maven publication in Sigstore")
+    }
+
+}


### PR DESCRIPTION
This allows us to use it as a real task input and avoid Transient.Var and Cached
like we were using before. Now, CC can see the providers that make up the maven
pom and if they have task dependencies, can properly serialize the providers
without eagerly realizing tasks.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
