### PR TITLE
Fix deadlock when reading the resolution result concurrently

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -42,8 +42,8 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     private final IntList nodeIndices;
     private final ResolvedGraphResult graph;
 
-    private @Nullable ImmutableList<ResolvedVariantResult> variants;
-    private @Nullable ComponentDependencies dependencies;
+    private volatile @Nullable ImmutableList<ResolvedVariantResult> variants;
+    private volatile @Nullable ComponentDependencies dependencies;
 
     public DefaultResolvedComponentResult(
         int index,
@@ -107,11 +107,23 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     }
 
     @Override
-    public synchronized List<ResolvedVariantResult> getVariants() {
-        if (variants == null) {
-            variants = computeVariants(graph, nodeIndices);
+    public List<ResolvedVariantResult> getVariants() {
+        ImmutableList<ResolvedVariantResult> result = variants;
+        if (result == null) {
+            // Compute the value without holding this component's monitor, since computing it calls
+            // back into the shared graph. Holding this monitor while locking the graph, when other
+            // threads lock the graph before this component (see getDependents), would deadlock.
+            // Racing threads may compute the value redundantly, but only one result is published.
+            result = computeVariants(graph, nodeIndices);
+            synchronized (this) {
+                if (variants == null) {
+                    variants = result;
+                } else {
+                    result = variants;
+                }
+            }
         }
-        return variants;
+        return result;
     }
 
     private static ImmutableList<ResolvedVariantResult> computeVariants(
@@ -152,11 +164,21 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         return getAllDependencies().variantDependencies().get(indexInComponent);
     }
 
-    private synchronized ComponentDependencies getAllDependencies() {
-        if (dependencies == null) {
-            dependencies = computeAllDependencies(graph, nodeIndices, this);
+    private ComponentDependencies getAllDependencies() {
+        ComponentDependencies result = dependencies;
+        if (result == null) {
+            // Compute outside this component's monitor to avoid a lock-ordering deadlock with the
+            // shared graph; see the comment in getVariants().
+            result = computeAllDependencies(graph, nodeIndices, this);
+            synchronized (this) {
+                if (dependencies == null) {
+                    dependencies = result;
+                } else {
+                    result = dependencies;
+                }
+            }
         }
-        return dependencies;
+        return result;
     }
 
     private static ComponentDependencies computeAllDependencies(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -30,20 +30,20 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
+import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
+public final class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
 
     private final int index;
-    private final IntList nodeIndices;
     private final ResolvedGraphResult graph;
 
-    private volatile @Nullable ImmutableList<ResolvedVariantResult> variants;
-    private volatile @Nullable ComponentDependencies dependencies;
+    private final Lazy<ImmutableList<ResolvedVariantResult>> variants;
+    private final Lazy<ComponentDependencies> dependencies;
 
     public DefaultResolvedComponentResult(
         int index,
@@ -51,8 +51,12 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         ResolvedGraphResult graph
     ) {
         this.index = index;
-        this.nodeIndices = nodeIndices;
         this.graph = graph;
+
+        // Atomic (not locking) Lazy: a lock held while these suppliers call into the graph would
+        // deadlock with getIncomingEdges.
+        this.variants = Lazy.atomic().of(() -> computeVariants(graph, nodeIndices));
+        this.dependencies = Lazy.atomic().of(() -> computeAllDependencies(graph, nodeIndices, this));
     }
 
     @Override
@@ -108,22 +112,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public List<ResolvedVariantResult> getVariants() {
-        ImmutableList<ResolvedVariantResult> result = variants;
-        if (result == null) {
-            // Compute the value without holding this component's monitor, since computing it calls
-            // back into the shared graph. Holding this monitor while locking the graph, when other
-            // threads lock the graph before this component (see getDependents), would deadlock.
-            // Racing threads may compute the value redundantly, but only one result is published.
-            result = computeVariants(graph, nodeIndices);
-            synchronized (this) {
-                if (variants == null) {
-                    variants = result;
-                } else {
-                    result = variants;
-                }
-            }
-        }
-        return result;
+        return variants.get();
     }
 
     private static ImmutableList<ResolvedVariantResult> computeVariants(
@@ -165,20 +154,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     }
 
     private ComponentDependencies getAllDependencies() {
-        ComponentDependencies result = dependencies;
-        if (result == null) {
-            // Compute outside this component's monitor to avoid a lock-ordering deadlock with the
-            // shared graph; see the comment in getVariants().
-            result = computeAllDependencies(graph, nodeIndices, this);
-            synchronized (this) {
-                if (dependencies == null) {
-                    dependencies = result;
-                } else {
-                    result = dependencies;
-                }
-            }
-        }
-        return result;
+        return dependencies.get();
     }
 
     private static ComponentDependencies computeAllDependencies(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
@@ -44,7 +44,7 @@ public class ResolvedGraphResult {
 
     private @Nullable ResolvedComponentResultInternal @Nullable [] components;
     private @Nullable ResolvedVariantResult @Nullable [] variants;
-    private @Nullable List<Set<ResolvedDependencyResult>> resolvedEdgesByTarget;
+    private volatile @Nullable List<Set<ResolvedDependencyResult>> resolvedEdgesByTarget;
 
     public ResolvedGraphResult(
         GraphStructure structure,
@@ -129,11 +129,24 @@ public class ResolvedGraphResult {
     /**
      * Get all incoming edges for the component at the given index.
      */
-    public synchronized Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
-        if (resolvedEdgesByTarget == null) {
-            resolvedEdgesByTarget = computeResolvedEdgesByTarget(structure, this::getComponent);
+    public Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
+        List<Set<ResolvedDependencyResult>> result = resolvedEdgesByTarget;
+        if (result == null) {
+            // Compute without holding this graph's monitor, since computing the incoming edges reads
+            // each component's dependencies, which locks the component. Holding the graph monitor
+            // while locking a component, when other threads lock a component before the graph (see
+            // DefaultResolvedComponentResult.getVariants), would deadlock. Racing threads may compute
+            // the value redundantly, but only one result is published.
+            result = computeResolvedEdgesByTarget(structure, this::getComponent);
+            synchronized (this) {
+                if (resolvedEdgesByTarget == null) {
+                    resolvedEdgesByTarget = result;
+                } else {
+                    result = resolvedEdgesByTarget;
+                }
+            }
         }
-        return resolvedEdgesByTarget.get(targetComponentIndex);
+        return result.get(targetComponentIndex);
     }
 
     private static List<Set<ResolvedDependencyResult>> computeResolvedEdgesByTarget(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedGraphResult.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphStructure;
 import org.gradle.internal.Describables;
+import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import java.util.function.IntFunction;
  * Shared state that all components and variants of a
  * {@link org.gradle.api.artifacts.result.ResolutionResult} share.
  */
-public class ResolvedGraphResult {
+public final class ResolvedGraphResult {
 
     private final GraphStructure structure;
     private final @Nullable List<List<ResolvedVariantResult>> availableVariantsByComponent;
@@ -44,7 +45,7 @@ public class ResolvedGraphResult {
 
     private @Nullable ResolvedComponentResultInternal @Nullable [] components;
     private @Nullable ResolvedVariantResult @Nullable [] variants;
-    private volatile @Nullable List<Set<ResolvedDependencyResult>> resolvedEdgesByTarget;
+    private final Lazy<List<Set<ResolvedDependencyResult>>> resolvedEdgesByTarget;
 
     public ResolvedGraphResult(
         GraphStructure structure,
@@ -54,6 +55,9 @@ public class ResolvedGraphResult {
         this.availableVariantsByComponent = availableVariantsByComponent;
 
         this.nodesByComponent = computeNodeIndices(structure);
+        // Atomic (not locking) Lazy: a lock held while this supplier reads component dependencies
+        // would deadlock with DefaultResolvedComponentResult.
+        this.resolvedEdgesByTarget = Lazy.atomic().of(() -> computeResolvedEdgesByTarget(structure, this::getComponent));
     }
 
     /**
@@ -130,23 +134,7 @@ public class ResolvedGraphResult {
      * Get all incoming edges for the component at the given index.
      */
     public Set<ResolvedDependencyResult> getIncomingEdges(int targetComponentIndex) {
-        List<Set<ResolvedDependencyResult>> result = resolvedEdgesByTarget;
-        if (result == null) {
-            // Compute without holding this graph's monitor, since computing the incoming edges reads
-            // each component's dependencies, which locks the component. Holding the graph monitor
-            // while locking a component, when other threads lock a component before the graph (see
-            // DefaultResolvedComponentResult.getVariants), would deadlock. Racing threads may compute
-            // the value redundantly, but only one result is published.
-            result = computeResolvedEdgesByTarget(structure, this::getComponent);
-            synchronized (this) {
-                if (resolvedEdgesByTarget == null) {
-                    resolvedEdgesByTarget = result;
-                } else {
-                    result = resolvedEdgesByTarget;
-                }
-            }
-        }
-        return result.get(targetComponentIndex);
+        return resolvedEdgesByTarget.get().get(targetComponentIndex);
     }
 
     private static List<Set<ResolvedDependencyResult>> computeResolvedEdgesByTarget(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/AbstractResolutionResultBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/AbstractResolutionResultBuilderTest.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
+
+import org.gradle.api.artifacts.result.ComponentSelectionReason
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.capability.CapabilitySelectorSerializer
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
+import org.gradle.api.internal.attributes.AttributeDesugaring
+import org.gradle.cache.internal.Store
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata
+import org.gradle.internal.component.model.ComponentGraphResolveState
+import org.gradle.internal.resolve.ModuleVersionResolveException
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+/**
+ * Shared fixtures for building a resolved dependency graph via {@link StreamingResolutionResultBuilder}
+ * and stubbing the graph nodes/edges it visits.
+ */
+abstract class AbstractResolutionResultBuilderTest extends Specification {
+
+    class DummyStore implements Store<GraphStructure> {
+        GraphStructure load(Supplier<GraphStructure> createIfNotPresent) {
+            return createIfNotPresent.get()
+        }
+    }
+
+    def builder = new StreamingResolutionResultBuilder(
+        new DummyBinaryStore(),
+        new DummyStore(),
+        new ThisBuildTreeOnlyGraphElementStore(),
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
+        new CapabilitySelectorSerializer(),
+        DependencyManagementTestUtil.componentSelectionDescriptorFactory(),
+        new DefaultImmutableModuleIdentifierFactory(),
+        AttributeTestUtil.attributesFactory(),
+        TestUtil.objectInstantiator(),
+        false
+    )
+
+    int nodeIds = 0
+    int componentIds = 0
+
+    protected DependencyGraphComponent component(String org, String name, String ver, ComponentSelectionReason reason = ComponentSelectionReasons.requested()) {
+        def componentId = componentIds++
+        def componentMetadata = Stub(ComponentGraphResolveMetadata) {
+            getModuleVersionId() >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+        }
+
+        def componentState = Stub(ComponentGraphResolveState) {
+            getInstanceId() >> componentId
+            getId() >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+            getMetadata() >> componentMetadata
+        }
+
+        return Stub(DependencyGraphComponent) {
+            getResultId() >> componentId
+            getSelectionReason() >> reason
+            getResolveState() >> componentState
+            getSelectedVariants() >> []
+        }
+    }
+
+    protected DependencyGraphEdge dep(DependencyGraphNode node) {
+        def moduleVersionId = node.owner.resolveState.metadata.moduleVersionId
+        def selector = selector(moduleVersionId.group, moduleVersionId.name, moduleVersionId.version)
+        return dep(selector, node)
+    }
+
+    protected DependencyGraphEdge dep(DependencyGraphSelector selector, DependencyGraphNode selected) {
+        def edge = Stub(DependencyGraphEdge)
+        _ * edge.requested >> selector.requested
+        _ * edge.selector >> selector
+        _ * edge.failure >> null
+        _ * edge.targetNodes >> [selected]
+        return edge
+    }
+
+    protected DependencyGraphEdge dep(DependencyGraphSelector selector, Throwable failure) {
+        def edge = Stub(DependencyGraphEdge)
+        _ * edge.selector >> selector
+        _ * edge.requested >> selector.requested
+        _ * edge.reason >> ComponentSelectionReasons.requested()
+        _ * edge.failure >> new ModuleVersionResolveException(selector.requested, failure)
+        return edge
+    }
+
+    protected DependencyGraphNode node(DependencyGraphComponent component) {
+        int nodeId = nodeIds++
+        def node = Stub(DependencyGraphNode) {
+            getOwner() >> component
+            getNodeId() >> nodeId
+            getExternalVariant() >> null
+        }
+        component.selectedVariants.add(node)
+        return node
+    }
+
+    protected RootGraphNode rootNode(String org, String name, String ver) {
+        def component = component(org, name, ver, ComponentSelectionReasons.root())
+        int nodeId = nodeIds++
+        def node = Stub(RootGraphNode) {
+            getOwner() >> component
+            getNodeId() >> nodeId
+            getExternalVariant() >> null
+            getMetadata() >> Mock(LocalVariantGraphResolveMetadata) {
+                getAttributes() >> AttributeTestUtil.attributes(["org.foo": "v1", "org.bar": 2, "org.baz": true])
+            }
+        }
+        component.selectedVariants.add(node)
+        return node
+    }
+
+    protected DependencyGraphSelector selector(String org, String name, String ver) {
+        def selector = Stub(DependencyGraphSelector)
+        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
+        return selector
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
+
+import org.gradle.api.artifacts.result.ComponentSelectionReason
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.capability.CapabilitySelectorSerializer
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
+import org.gradle.api.internal.artifacts.result.ResolvedGraphResult
+import org.gradle.api.internal.attributes.AttributeDesugaring
+import org.gradle.cache.internal.Store
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata
+import org.gradle.internal.component.model.ComponentGraphResolveState
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.function.Supplier
+
+/**
+ * Verifies that the lazily-computed {@link ResolvedGraphResult} /
+ * {@link org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult} API can be
+ * read concurrently without deadlocking.
+ *
+ * <p>The build scan and github-dependency-graph plugins read the resolution result from build
+ * operation listeners, which run without holding the project lock and therefore may read the
+ * same result graph in parallel. Two access paths lazily compute values while holding a monitor
+ * and then call into the other object, and previously acquired these two monitors in opposite
+ * orders:
+ * <ul>
+ *     <li>{@code getVariants()} locks the component, then calls {@code graph.getVariant()}.</li>
+ *     <li>{@code getDependents()} locks the graph (in {@code getIncomingEdges()}), then calls
+ *     {@code component.getDependencies()}, which locks the component.</li>
+ * </ul>
+ * Racing these two paths could deadlock.
+ */
+class ResolutionResultConcurrencyTest extends Specification {
+
+    class DummyStore implements Store<GraphStructure> {
+        GraphStructure load(Supplier<GraphStructure> createIfNotPresent) {
+            return createIfNotPresent.get()
+        }
+    }
+
+    def builder = new StreamingResolutionResultBuilder(
+        new DummyBinaryStore(),
+        new DummyStore(),
+        new ThisBuildTreeOnlyGraphElementStore(),
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
+        new CapabilitySelectorSerializer(),
+        DependencyManagementTestUtil.componentSelectionDescriptorFactory(),
+        new DefaultImmutableModuleIdentifierFactory(),
+        AttributeTestUtil.attributesFactory(),
+        TestUtil.objectInstantiator(),
+        false
+    )
+
+    int nodeIds = 0
+    int componentIds = 0
+
+    def "concurrent reads of variants and dependents do not deadlock"() {
+        given: "a resolved graph with a root depending on two other components"
+        def dep1 = node(component("org", "dep1", "1.0"))
+        def dep2 = node(component("org", "dep2", "1.0"))
+        def root = rootNode("org", "root", "1.0")
+        root.outgoingEdges >> [dep(dep1), dep(dep2)]
+
+        builder.start(root)
+        builder.visitNode(root)
+        builder.visitNode(dep1)
+        builder.visitNode(dep2)
+        builder.finish(root)
+
+        def resolvedGraph = builder.getResolvedDependencyGraph([] as Set)
+        def structure = resolvedGraph.graphSource().get()
+        def componentCount = structure.components().count()
+
+        def executor = Executors.newFixedThreadPool(2)
+
+        when: "the variants and dependents of every component are read in parallel on a fresh, uncached graph"
+        // The caches are one-shot: once populated the racy compute paths are never re-entered.
+        // So each iteration wraps the (immutable) structure in a fresh ResolvedGraphResult and
+        // aligns the two reader threads on a barrier to maximise the chance of interleaving.
+        200.times {
+            def graph = new ResolvedGraphResult(structure, resolvedGraph.availableVariantsByComponent())
+            def barrier = new CyclicBarrier(2)
+
+            Future<?> variantsReader = executor.submit({
+                barrier.await()
+                for (int i = 0; i < componentCount; i++) {
+                    graph.getComponent(i).getVariants()
+                }
+            } as Callable)
+
+            Future<?> dependentsReader = executor.submit({
+                barrier.await()
+                for (int i = 0; i < componentCount; i++) {
+                    (graph.getComponent(i) as ResolvedComponentResultInternal).getDependents()
+                }
+            } as Callable)
+
+            awaitOrReportDeadlock(variantsReader, dependentsReader)
+        }
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    private static void awaitOrReportDeadlock(Future<?>... futures) {
+        try {
+            for (Future<?> future : futures) {
+                future.get(30, TimeUnit.SECONDS)
+            }
+        } catch (TimeoutException ignored) {
+            def deadlocked = ManagementFactory.threadMXBean.findDeadlockedThreads()
+            def detail = deadlocked == null
+                ? "reader threads did not complete within the timeout"
+                : "deadlocked threads: " + ManagementFactory.threadMXBean.getThreadInfo(deadlocked, true, true)
+            throw new AssertionError("Concurrent read of the resolution result deadlocked: " + detail as Object)
+        }
+    }
+
+    private DependencyGraphComponent component(String org, String name, String ver, ComponentSelectionReason reason = ComponentSelectionReasons.requested()) {
+        def componentId = componentIds++
+        def componentMetadata = Stub(ComponentGraphResolveMetadata) {
+            getModuleVersionId() >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+        }
+
+        def componentState = Stub(ComponentGraphResolveState) {
+            getInstanceId() >> componentId
+            getId() >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+            getMetadata() >> componentMetadata
+        }
+
+        return Stub(DependencyGraphComponent) {
+            getResultId() >> componentId
+            getSelectionReason() >> reason
+            getResolveState() >> componentState
+            getSelectedVariants() >> []
+        }
+    }
+
+    private DependencyGraphEdge dep(DependencyGraphNode node) {
+        def moduleVersionId = node.owner.resolveState.metadata.moduleVersionId
+        def selector = selector(moduleVersionId.group, moduleVersionId.name, moduleVersionId.version)
+        def edge = Stub(DependencyGraphEdge)
+        _ * edge.requested >> selector.requested
+        _ * edge.selector >> selector
+        _ * edge.failure >> null
+        _ * edge.targetNodes >> [node]
+        return edge
+    }
+
+    private DependencyGraphNode node(DependencyGraphComponent component) {
+        int nodeId = nodeIds++
+        def node = Stub(DependencyGraphNode) {
+            getOwner() >> component
+            getNodeId() >> nodeId
+            getExternalVariant() >> null
+        }
+        component.selectedVariants.add(node)
+        return node
+    }
+
+    private RootGraphNode rootNode(String org, String name, String ver) {
+        def component = component(org, name, ver, ComponentSelectionReasons.root())
+        int nodeId = nodeIds++
+        def node = Stub(RootGraphNode) {
+            getOwner() >> component
+            getNodeId() >> nodeId
+            getExternalVariant() >> null
+            getMetadata() >> Mock(LocalVariantGraphResolveMetadata) {
+                getAttributes() >> AttributeTestUtil.attributes(["org.foo": "v1", "org.bar": 2, "org.baz": true])
+            }
+        }
+        component.selectedVariants.add(node)
+        return node
+    }
+
+    private DependencyGraphSelector selector(String org, String name, String ver) {
+        def selector = Stub(DependencyGraphSelector)
+        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
+        return selector
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
@@ -16,207 +16,76 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
-import org.gradle.api.artifacts.result.ComponentSelectionReason
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
-import org.gradle.api.internal.artifacts.capability.CapabilitySelectorSerializer
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
-import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
 import org.gradle.api.internal.artifacts.result.ResolvedGraphResult
-import org.gradle.api.internal.attributes.AttributeDesugaring
-import org.gradle.cache.internal.Store
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
-import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
-import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata
-import org.gradle.internal.component.model.ComponentGraphResolveMetadata
-import org.gradle.internal.component.model.ComponentGraphResolveState
-import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
-import spock.lang.Specification
 
 import java.lang.management.ManagementFactory
-import java.util.concurrent.Callable
-import java.util.concurrent.CyclicBarrier
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import java.util.function.Supplier
+import java.util.concurrent.CountDownLatch
 
-/**
- * Verifies that the lazily-computed {@link ResolvedGraphResult} /
- * {@link org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult} API can be
- * read concurrently without deadlocking.
- *
- * <p>The build scan and github-dependency-graph plugins read the resolution result from build
- * operation listeners, which run without holding the project lock and therefore may read the
- * same result graph in parallel. Two access paths lazily compute values while holding a monitor
- * and then call into the other object, and previously acquired these two monitors in opposite
- * orders:
- * <ul>
- *     <li>{@code getVariants()} locks the component, then calls {@code graph.getVariant()}.</li>
- *     <li>{@code getDependents()} locks the graph (in {@code getIncomingEdges()}), then calls
- *     {@code component.getDependencies()}, which locks the component.</li>
- * </ul>
- * Racing these two paths could deadlock.
- */
-class ResolutionResultConcurrencyTest extends Specification {
+class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTest {
 
-    class DummyStore implements Store<GraphStructure> {
-        GraphStructure load(Supplier<GraphStructure> createIfNotPresent) {
-            return createIfNotPresent.get()
-        }
-    }
-
-    def builder = new StreamingResolutionResultBuilder(
-        new DummyBinaryStore(),
-        new DummyStore(),
-        new ThisBuildTreeOnlyGraphElementStore(),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
-        new CapabilitySelectorSerializer(),
-        DependencyManagementTestUtil.componentSelectionDescriptorFactory(),
-        new DefaultImmutableModuleIdentifierFactory(),
-        AttributeTestUtil.attributesFactory(),
-        TestUtil.objectInstantiator(),
-        false
-    )
-
-    int nodeIds = 0
-    int componentIds = 0
-
-    def "concurrent reads of variants and dependents do not deadlock"() {
-        given: "a resolved graph with a root depending on two other components"
-        def dep1 = node(component("org", "dep1", "1.0"))
-        def dep2 = node(component("org", "dep2", "1.0"))
+    def "reading a component's variants and dependents concurrently does not deadlock"() {
+        given: "a resolved graph and a component read from two threads"
+        def depNode = node(component("org", "dep", "1.0"))
         def root = rootNode("org", "root", "1.0")
-        root.outgoingEdges >> [dep(dep1), dep(dep2)]
-
+        root.outgoingEdges >> [dep(depNode)]
         builder.start(root)
         builder.visitNode(root)
-        builder.visitNode(dep1)
-        builder.visitNode(dep2)
+        builder.visitNode(depNode)
         builder.finish(root)
 
         def resolvedGraph = builder.getResolvedDependencyGraph([] as Set)
-        def structure = resolvedGraph.graphSource().get()
-        def componentCount = structure.components().count()
+        def graph = new ResolvedGraphResult(resolvedGraph.graphSource().get(), resolvedGraph.availableVariantsByComponent())
+        def targetComponent = graph.getComponent(0)
 
-        def executor = Executors.newFixedThreadPool(2)
+        def graphMonitorHeld = new CountDownLatch(1)
+        def variantsReaderParked = new CountDownLatch(1)
 
-        when: "the variants and dependents of every component are read in parallel on a fresh, uncached graph"
-        // The caches are one-shot: once populated the racy compute paths are never re-entered.
-        // So each iteration wraps the (immutable) structure in a fresh ResolvedGraphResult and
-        // aligns the two reader threads on a barrier to maximise the chance of interleaving.
-        200.times {
-            def graph = new ResolvedGraphResult(structure, resolvedGraph.availableVariantsByComponent())
-            def barrier = new CyclicBarrier(2)
+        def dependentsReader = new Thread({
+            synchronized (graph) {
+                graphMonitorHeld.countDown()
+                variantsReaderParked.await()
+                targetComponent.getDependents()
+            }
+        }, "dependents-reader")
 
-            Future<?> variantsReader = executor.submit({
-                barrier.await()
-                for (int i = 0; i < componentCount; i++) {
-                    graph.getComponent(i).getVariants()
-                }
-            } as Callable)
+        def variantsReader = new Thread({
+            graphMonitorHeld.await()
+            targetComponent.getVariants()
+        }, "variants-reader")
 
-            Future<?> dependentsReader = executor.submit({
-                barrier.await()
-                for (int i = 0; i < componentCount; i++) {
-                    (graph.getComponent(i) as ResolvedComponentResultInternal).getDependents()
-                }
-            } as Callable)
-
-            awaitOrReportDeadlock(variantsReader, dependentsReader)
-        }
+        when:
+        dependentsReader.start()
+        variantsReader.start()
+        graphMonitorHeld.await()
+        // Wait until the variants reader parks trying to acquire the graph monitor, then let the
+        // dependents reader (holding the graph monitor) attempt to read the same component.
+        waitUntilParkedOrDone(variantsReader)
+        variantsReaderParked.countDown()
+        failIfDeadlocked(variantsReader, dependentsReader)
 
         then:
         noExceptionThrown()
 
         cleanup:
-        executor.shutdownNow()
+        variantsReader?.interrupt()
+        dependentsReader?.interrupt()
     }
 
-    private static void awaitOrReportDeadlock(Future<?>... futures) {
-        try {
-            for (Future<?> future : futures) {
-                future.get(30, TimeUnit.SECONDS)
+    private static void waitUntilParkedOrDone(Thread thread) {
+        while (thread.alive && thread.state != Thread.State.BLOCKED) {
+            Thread.onSpinWait()
+        }
+    }
+
+    private static void failIfDeadlocked(Thread... readers) {
+        def threadMXBean = ManagementFactory.threadMXBean
+        while (readers.any { it.alive }) {
+            long[] deadlocked = threadMXBean.findDeadlockedThreads()
+            if (deadlocked != null) {
+                def dump = threadMXBean.getThreadInfo(deadlocked, true, true).join("\n")
+                throw new AssertionError("Reading the resolution result deadlocked:\n" + dump as Object)
             }
-        } catch (TimeoutException ignored) {
-            def deadlocked = ManagementFactory.threadMXBean.findDeadlockedThreads()
-            def detail = deadlocked == null
-                ? "reader threads did not complete within the timeout"
-                : "deadlocked threads: " + ManagementFactory.threadMXBean.getThreadInfo(deadlocked, true, true)
-            throw new AssertionError("Concurrent read of the resolution result deadlocked: " + detail as Object)
+            Thread.sleep(1)
         }
-    }
-
-    private DependencyGraphComponent component(String org, String name, String ver, ComponentSelectionReason reason = ComponentSelectionReasons.requested()) {
-        def componentId = componentIds++
-        def componentMetadata = Stub(ComponentGraphResolveMetadata) {
-            getModuleVersionId() >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
-        }
-
-        def componentState = Stub(ComponentGraphResolveState) {
-            getInstanceId() >> componentId
-            getId() >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
-            getMetadata() >> componentMetadata
-        }
-
-        return Stub(DependencyGraphComponent) {
-            getResultId() >> componentId
-            getSelectionReason() >> reason
-            getResolveState() >> componentState
-            getSelectedVariants() >> []
-        }
-    }
-
-    private DependencyGraphEdge dep(DependencyGraphNode node) {
-        def moduleVersionId = node.owner.resolveState.metadata.moduleVersionId
-        def selector = selector(moduleVersionId.group, moduleVersionId.name, moduleVersionId.version)
-        def edge = Stub(DependencyGraphEdge)
-        _ * edge.requested >> selector.requested
-        _ * edge.selector >> selector
-        _ * edge.failure >> null
-        _ * edge.targetNodes >> [node]
-        return edge
-    }
-
-    private DependencyGraphNode node(DependencyGraphComponent component) {
-        int nodeId = nodeIds++
-        def node = Stub(DependencyGraphNode) {
-            getOwner() >> component
-            getNodeId() >> nodeId
-            getExternalVariant() >> null
-        }
-        component.selectedVariants.add(node)
-        return node
-    }
-
-    private RootGraphNode rootNode(String org, String name, String ver) {
-        def component = component(org, name, ver, ComponentSelectionReasons.root())
-        int nodeId = nodeIds++
-        def node = Stub(RootGraphNode) {
-            getOwner() >> component
-            getNodeId() >> nodeId
-            getExternalVariant() >> null
-            getMetadata() >> Mock(LocalVariantGraphResolveMetadata) {
-                getAttributes() >> AttributeTestUtil.attributes(["org.foo": "v1", "org.bar": 2, "org.baz": true])
-            }
-        }
-        component.selectedVariants.add(node)
-        return node
-    }
-
-    private DependencyGraphSelector selector(String org, String name, String ver) {
-        def selector = Stub(DependencyGraphSelector)
-        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
-        return selector
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
@@ -16,17 +16,20 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
-import org.gradle.api.artifacts.result.ResolvedDependencyResult
-import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
 import org.gradle.api.internal.artifacts.result.ResolvedGraphResult
+import spock.lang.Timeout
 
 import java.lang.management.ManagementFactory
+import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicReference
 
 class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTest {
 
+    @Timeout(30)
     def "reading a component's variants and dependents concurrently does not deadlock and returns the correct result"() {
         given: "a resolved graph where root depends on dep, and dep is read from two threads"
         def depNode = node(component("org", "dep", "1.0"))
@@ -41,42 +44,42 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         def graph = new ResolvedGraphResult(resolvedGraph.graphSource().get(), resolvedGraph.availableVariantsByComponent())
         def depComponent = componentByDisplayName(graph, "org:dep:1.0")
 
+        def pool = Executors.newFixedThreadPool(2)
         def graphMonitorHeld = new CountDownLatch(1)
         def variantsReaderParked = new CountDownLatch(1)
-        def variants = new AtomicReference<List<ResolvedVariantResult>>()
-        def dependents = new AtomicReference<Set<? extends ResolvedDependencyResult>>()
+        def variantsReaderThread = new AtomicReference<Thread>()
 
-        def dependentsReader = new Thread({
+        when:
+        def dependents = pool.submit({
             synchronized (graph) {
                 graphMonitorHeld.countDown()
                 variantsReaderParked.await()
-                dependents.set(depComponent.getDependents())
+                depComponent.getDependents()
             }
-        }, "dependents-reader")
+        } as Callable)
 
-        def variantsReader = new Thread({
+        def variants = pool.submit({
+            variantsReaderThread.set(Thread.currentThread())
             graphMonitorHeld.await()
-            variants.set(depComponent.getVariants())
-        }, "variants-reader")
+            depComponent.getVariants()
+        } as Callable)
 
-        when:
-        dependentsReader.start()
-        variantsReader.start()
         graphMonitorHeld.await()
-        // Wait until the variants reader parks trying to acquire the graph monitor, then let the
-        // dependents reader (holding the graph monitor) attempt to read the same component.
-        waitUntilParkedOrDone(variantsReader)
+        // Let the variants reader park trying to acquire the graph monitor (while holding the
+        // component monitor), then release the dependents reader to read the same component.
+        waitUntilParked(variantsReaderThread)
         variantsReaderParked.countDown()
-        failIfDeadlocked(variantsReader, dependentsReader)
+        awaitCompletionOrFailOnDeadlock(dependents, variants)
 
-        then: "both reads completed and returned dep's one variant and its single incoming edge from root"
-        variants.get()*.owner*.displayName == ["org:dep:1.0"]
-        dependents.get()*.from*.id*.displayName == ["org:root:1.0"]
-        dependents.get()*.selected*.id*.displayName == ["org:dep:1.0"]
+        then: "both reads returned dep's one variant and its single incoming edge from root"
+        def readVariants = variants.get()
+        def readDependents = dependents.get()
+        readVariants*.owner*.displayName == ["org:dep:1.0"]
+        readDependents*.from*.id*.displayName == ["org:root:1.0"]
+        readDependents*.selected*.id*.displayName == ["org:dep:1.0"]
 
         cleanup:
-        variantsReader?.interrupt()
-        dependentsReader?.interrupt()
+        pool.shutdownNow()
     }
 
     private static ResolvedComponentResultInternal componentByDisplayName(ResolvedGraphResult graph, String displayName) {
@@ -85,15 +88,19 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         graph.getComponent(index)
     }
 
-    private static void waitUntilParkedOrDone(Thread thread) {
-        while (thread.alive && thread.state != Thread.State.BLOCKED) {
+    private static void waitUntilParked(AtomicReference<Thread> threadRef) {
+        while (true) {
+            def thread = threadRef.get()
+            if (thread != null && (!thread.alive || thread.state == Thread.State.BLOCKED)) {
+                return
+            }
             Thread.onSpinWait()
         }
     }
 
-    private static void failIfDeadlocked(Thread... readers) {
+    private static void awaitCompletionOrFailOnDeadlock(Future<?>... readers) {
         def threadMXBean = ManagementFactory.threadMXBean
-        while (readers.any { it.alive }) {
+        while (readers.any { !it.done }) {
             long[] deadlocked = threadMXBean.findDeadlockedThreads()
             if (deadlocked != null) {
                 def dump = threadMXBean.getThreadInfo(deadlocked, true, true).join("\n")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
 import org.gradle.api.internal.artifacts.result.ResolvedGraphResult
 
 import java.lang.management.ManagementFactory
@@ -37,9 +38,8 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         builder.finish(root)
 
         def resolvedGraph = builder.getResolvedDependencyGraph([] as Set)
-        def structure = resolvedGraph.graphSource().get()
-        def graph = new ResolvedGraphResult(structure, resolvedGraph.availableVariantsByComponent())
-        def depComponent = (0..<structure.components().count()).collect { graph.getComponent(it) }.find { it.id.displayName == "org:dep:1.0" }
+        def graph = new ResolvedGraphResult(resolvedGraph.graphSource().get(), resolvedGraph.availableVariantsByComponent())
+        def depComponent = componentByDisplayName(graph, "org:dep:1.0")
 
         def graphMonitorHeld = new CountDownLatch(1)
         def variantsReaderParked = new CountDownLatch(1)
@@ -77,6 +77,12 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         cleanup:
         variantsReader?.interrupt()
         dependentsReader?.interrupt()
+    }
+
+    private static ResolvedComponentResultInternal componentByDisplayName(ResolvedGraphResult graph, String displayName) {
+        def components = graph.structure().components()
+        def index = (0..<components.count()).find { components.id(it).displayName == displayName }
+        graph.getComponent(index)
     }
 
     private static void waitUntilParkedOrDone(Thread thread) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultConcurrencyTest.groovy
@@ -16,15 +16,18 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.result.ResolvedGraphResult
 
 import java.lang.management.ManagementFactory
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
 
 class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTest {
 
-    def "reading a component's variants and dependents concurrently does not deadlock"() {
-        given: "a resolved graph and a component read from two threads"
+    def "reading a component's variants and dependents concurrently does not deadlock and returns the correct result"() {
+        given: "a resolved graph where root depends on dep, and dep is read from two threads"
         def depNode = node(component("org", "dep", "1.0"))
         def root = rootNode("org", "root", "1.0")
         root.outgoingEdges >> [dep(depNode)]
@@ -34,23 +37,26 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         builder.finish(root)
 
         def resolvedGraph = builder.getResolvedDependencyGraph([] as Set)
-        def graph = new ResolvedGraphResult(resolvedGraph.graphSource().get(), resolvedGraph.availableVariantsByComponent())
-        def targetComponent = graph.getComponent(0)
+        def structure = resolvedGraph.graphSource().get()
+        def graph = new ResolvedGraphResult(structure, resolvedGraph.availableVariantsByComponent())
+        def depComponent = (0..<structure.components().count()).collect { graph.getComponent(it) }.find { it.id.displayName == "org:dep:1.0" }
 
         def graphMonitorHeld = new CountDownLatch(1)
         def variantsReaderParked = new CountDownLatch(1)
+        def variants = new AtomicReference<List<ResolvedVariantResult>>()
+        def dependents = new AtomicReference<Set<? extends ResolvedDependencyResult>>()
 
         def dependentsReader = new Thread({
             synchronized (graph) {
                 graphMonitorHeld.countDown()
                 variantsReaderParked.await()
-                targetComponent.getDependents()
+                dependents.set(depComponent.getDependents())
             }
         }, "dependents-reader")
 
         def variantsReader = new Thread({
             graphMonitorHeld.await()
-            targetComponent.getVariants()
+            variants.set(depComponent.getVariants())
         }, "variants-reader")
 
         when:
@@ -63,8 +69,10 @@ class ResolutionResultConcurrencyTest extends AbstractResolutionResultBuilderTes
         variantsReaderParked.countDown()
         failIfDeadlocked(variantsReader, dependentsReader)
 
-        then:
-        noExceptionThrown()
+        then: "both reads completed and returned dep's one variant and its single incoming edge from root"
+        variants.get()*.owner*.displayName == ["org:dep:1.0"]
+        dependents.get()*.from*.id*.displayName == ["org:root:1.0"]
+        dependents.get()*.selected*.id*.displayName == ["org:dep:1.0"]
 
         cleanup:
         variantsReader?.interrupt()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -16,57 +16,12 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
-import org.gradle.api.artifacts.result.ComponentSelectionReason
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
-import org.gradle.api.internal.artifacts.capability.CapabilitySelectorSerializer
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
-import org.gradle.api.internal.attributes.AttributeDesugaring
-import org.gradle.cache.internal.Store
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
-import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
-import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata
-import org.gradle.internal.component.model.ComponentGraphResolveMetadata
-import org.gradle.internal.component.model.ComponentGraphResolveState
-import org.gradle.internal.resolve.ModuleVersionResolveException
-import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
-import spock.lang.Specification
-
-import java.util.function.Supplier
 
 import static GraphStructurePrinter.printGraph
 
-class StreamingResolutionResultBuilderTest extends Specification {
-
-    class DummyStore implements Store<GraphStructure> {
-        GraphStructure load(Supplier<GraphStructure> createIfNotPresent) {
-            return createIfNotPresent.get()
-        }
-    }
-
-    def builder = new StreamingResolutionResultBuilder(
-        new DummyBinaryStore(),
-        new DummyStore(),
-        new ThisBuildTreeOnlyGraphElementStore(),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
-        new CapabilitySelectorSerializer(),
-        DependencyManagementTestUtil.componentSelectionDescriptorFactory(),
-        new DefaultImmutableModuleIdentifierFactory(),
-        AttributeTestUtil.attributesFactory(),
-        TestUtil.objectInstantiator(),
-        false
-    )
-
-    int nodeIds = 0
-    int componentIds = 0
+class StreamingResolutionResultBuilderTest extends AbstractResolutionResultBuilderTest {
 
     def "result can be read multiple times"() {
         def rootNode = rootNode("org", "root", "1.0")
@@ -175,81 +130,5 @@ class StreamingResolutionResultBuilderTest extends Specification {
   org:dep2:2.0
     org:dep1:5.0 -> org:dep1:5.0 - Could not resolve org:dep1:5.0.
 """
-    }
-
-    private DependencyGraphComponent component(String org, String name, String ver, ComponentSelectionReason reason = ComponentSelectionReasons.requested()) {
-        def componentId = componentIds++
-        def componentMetadata = Stub(ComponentGraphResolveMetadata) {
-            getModuleVersionId() >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
-        }
-
-        def componentState = Stub(ComponentGraphResolveState) {
-            getInstanceId() >> componentId
-            getId() >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
-            getMetadata() >> componentMetadata
-        }
-
-        return Stub(DependencyGraphComponent) {
-            getResultId() >> componentId
-            getSelectionReason() >> reason
-            getResolveState() >> componentState
-            getSelectedVariants() >> []
-        }
-    }
-
-    private DependencyGraphEdge dep(DependencyGraphNode node) {
-        def moduleVersionId = node.owner.resolveState.metadata.moduleVersionId
-        def selector = selector(moduleVersionId.group, moduleVersionId.name, moduleVersionId.version)
-        return dep(selector, node)
-    }
-
-    private DependencyGraphEdge dep(DependencyGraphSelector selector, DependencyGraphNode selected) {
-        def edge = Stub(DependencyGraphEdge)
-        _ * edge.requested >> selector.requested
-        _ * edge.selector >> selector
-        _ * edge.failure >> null
-        _ * edge.targetNodes >> [selected]
-        return edge
-    }
-
-    private DependencyGraphEdge dep(DependencyGraphSelector selector, Throwable failure) {
-        def edge = Stub(DependencyGraphEdge)
-        _ * edge.selector >> selector
-        _ * edge.requested >> selector.requested
-        _ * edge.reason >> ComponentSelectionReasons.requested()
-        _ * edge.failure >> new ModuleVersionResolveException(selector.requested, failure)
-        return edge
-    }
-
-    private DependencyGraphNode node(DependencyGraphComponent component) {
-        int nodeId = nodeIds++
-        def node = Stub(DependencyGraphNode) {
-            getOwner() >> component
-            getNodeId() >> nodeId
-            getExternalVariant() >> null
-        }
-        component.selectedVariants.add(node)
-        return node
-    }
-
-    private RootGraphNode rootNode(String org, String name, String ver) {
-        def component = component(org, name, ver, ComponentSelectionReasons.root())
-        int nodeId = nodeIds++
-        def node = Stub(RootGraphNode) {
-            getOwner() >> component
-            getNodeId() >> nodeId
-            getExternalVariant() >> null
-            getMetadata() >> Mock(LocalVariantGraphResolveMetadata) {
-                getAttributes() >> AttributeTestUtil.attributes(["org.foo": "v1", "org.bar": 2, "org.baz": true])
-            }
-        }
-        component.selectedVariants.add(node)
-        return node
-    }
-
-    private DependencyGraphSelector selector(String org, String name, String ver) {
-        def selector = Stub(DependencyGraphSelector)
-        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
-        return selector
     }
 }


### PR DESCRIPTION
### Context

Reading a `ResolutionResult` concurrently can deadlock the build. Making the API thread-safe in #37928 added `synchronized` to the lazily-computed caches, but the two read paths take the component and graph monitors in opposite orders: `getVariants()` locks the component then the graph, while `getDependents()` locks the graph then the component. Consumers that read the result from build-operation listeners run without the project lock and can race these two paths, deadlocking the build.

Each lazily-cached value is now computed outside the monitor via `Lazy.atomic()` and published once, so neither object holds its own lock while calling into the other. `DefaultResolvedComponentResult` and `ResolvedGraphResult` are made `final` so their `this`-capturing suppliers don't trip the `this-escape` lint.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under \`<subproject>/src/integTest\`) to verify changes from a user perspective.
- [x] Provide unit tests (under \`<subproject>/src/test\`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: \`./gradlew sanityCheck\`.
- [x] Ensure that tests pass locally: \`./gradlew <changed-subproject>:quickTest\`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things