### PR TITLE
Document guarding build logic under Isolated Projects

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -881,8 +881,8 @@ gradle.lifecycle.beforeProject {
 [[sec:guarding_build_logic]]
 ==== Guard incompatible build logic as a last resort
 
-During adoption you may hit build logic that is not yet compatible with Isolated Projects and that you cannot fix right away — for example, a piece of your own plugin, or a third-party plugin that is not essential to every workflow.
-As a last resort, you can _guard_ such logic so that it only runs when Isolated Projects is not active.
+During adoption, some build logic may not yet be compatible with Isolated Projects and cannot be fixed immediately — for example, a plugin that is still being migrated, or a third-party plugin that is not essential to every workflow.
+As a last resort, such logic can be _guarded_ so that it only runs when Isolated Projects is not active.
 
 [WARNING]
 ====
@@ -891,8 +891,8 @@ Prefer the refactoring strategies above.
 A conditional makes the build behave differently depending on whether Isolated Projects is active, which raises complexity, can hide problems, and can lead to different build results between the two modes.
 ====
 
-To detect whether Isolated Projects is active, inject the link:{javadocPath}/org/gradle/api/configuration/BuildFeatures.html[`BuildFeatures`] service and read `isolatedProjects.active`, whose value is always defined.
-See <<implementing_gradle_plugins_binary.adoc#sec:reacting_to_build_features,Reacting to build features>> for details on this API.
+To detect whether Isolated Projects is active, inject the link:{javadocPath}/org/gradle/api/configuration/BuildFeatures.html[`BuildFeatures`] service and read `isolatedProjects.active`.
+See <<implementing_gradle_plugins_binary.adoc#reacting_to_build_features,Reacting to build features>> for details on this API.
 
 [[sec:guard_own_plugin]]
 ===== Guard logic inside your own plugin
@@ -904,7 +904,7 @@ Guard the incompatible part of a plugin with an early return, so the rest of the
 include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/GuardedConventionPlugin.java[tags=guarded-plugin]
 ----
 <1> Inject the `BuildFeatures` service.
-<2> Check whether Isolated Projects is active; the `active` status is always defined.
+<2> Check whether Isolated Projects is active; it's safe to call `get()` on `active`, because it's always defined.
 <3> Skip the incompatible logic when Isolated Projects is active.
 
 [[sec:guard_third_party_plugin]]
@@ -918,13 +918,6 @@ Apply the plugin from a convention plugin rather than from a `plugins {}` block,
 include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java[tags=applier-plugin]
 ----
 <1> Apply the incompatible plugin only when Isolated Projects is not active.
-
-Apply the convention plugin in the projects that need it:
-
-====
-include::sample[dir="snippets/isolatedProjects/guardingBuildLogic/kotlin",files="build.gradle.kts[tags=apply]"]
-include::sample[dir="snippets/isolatedProjects/guardingBuildLogic/groovy",files="build.gradle[tags=apply]"]
-====
 
 [NOTE]
 ====

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -881,8 +881,9 @@ gradle.lifecycle.beforeProject {
 [[sec:guarding_build_logic]]
 ==== Guard incompatible build logic as a last resort
 
-During adoption, some build logic may not yet be compatible with Isolated Projects and cannot be fixed immediately — for example, a plugin that is still being migrated, or a third-party plugin that is not essential to every workflow.
-As a last resort, such logic can be _guarded_ so that it only runs when Isolated Projects is not active.
+During adoption, some build logic may not yet be compatible with Isolated Projects and cannot be fixed immediately.
+For example, a plugin that is still being migrated, or a third-party plugin that is not essential to every workflow.
+As a last resort, you can _guard_ such logic so that it only runs when Isolated Projects is *not* active.
 
 [WARNING]
 ====
@@ -910,14 +911,14 @@ include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/
 [[sec:guard_third_party_plugin]]
 ===== Guard the application of an incompatible third-party plugin
 
-If a third-party plugin is utterly incompatible with Isolated Projects and is not needed in every workflow, you can guard its _application_ in the same way.
-Apply the plugin from a convention plugin rather than from a `plugins {}` block, so that the decision to apply it can be made conditionally:
+If a third-party plugin is incompatible with Isolated Projects and is not needed in every workflow, you can guard its _application_ in the same way.
+Apply the plugin from a convention plugin rather than from a `plugins {}` block, so that you can apply it conditionally:
 
 [source,java]
 ----
 include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java[tags=applier-plugin]
 ----
-<1> Apply the incompatible plugin only when Isolated Projects is not active.
+<1> If Isolated Projects is active, skip applying the incompatible plugin.
 
 [NOTE]
 ====
@@ -933,7 +934,7 @@ A conditional baked into a published plugin changes behavior for every consuming
 This multiplies the complexity and divergent-behavior concerns above across the whole ecosystem.
 
 As a plugin author, strongly prefer making the plugin compatible with Isolated Projects over guarding.
-If you must guard, make the guarded behavior observable — for example, by logging a warning as shown above — and document it clearly, so that consumers are not surprised by build logic that silently changes when Isolated Projects is enabled.
+If you must guard, make the guarded behavior observable (for example, by logging a warning as shown above) and document it clearly, so that consumers are not surprised by build logic that silently changes when Isolated Projects is enabled.
 
 [[sec:vs_other_features]]
 == Isolated Projects and other Gradle features

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -878,6 +878,70 @@ gradle.lifecycle.beforeProject {
 ----
 =====
 
+[[sec:guarding_build_logic]]
+==== Guard incompatible build logic as a last resort
+
+During adoption you may hit build logic that is not yet compatible with Isolated Projects and that you cannot fix right away — for example, a piece of your own plugin, or a third-party plugin that is not essential to every workflow.
+As a last resort, you can _guard_ such logic so that it only runs when Isolated Projects is not active.
+
+[WARNING]
+====
+Guarding with a conditional is not advised if it is possible to fix the incompatibility instead.
+Prefer the refactoring strategies above.
+A conditional makes the build behave differently depending on whether Isolated Projects is active, which raises complexity, can hide problems, and can lead to different build results between the two modes.
+====
+
+To detect whether Isolated Projects is active, inject the link:{javadocPath}/org/gradle/api/configuration/BuildFeatures.html[`BuildFeatures`] service and read `isolatedProjects.active`, whose value is always defined.
+See <<implementing_gradle_plugins_binary.adoc#sec:reacting_to_build_features,Reacting to build features>> for details on this API.
+
+[[sec:guard_own_plugin]]
+===== Guard logic inside your own plugin
+
+Guard the incompatible part of a plugin with an early return, so the rest of the build is unaffected:
+
+[source,java]
+----
+include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/GuardedConventionPlugin.java[tags=guarded-plugin]
+----
+<1> Inject the `BuildFeatures` service.
+<2> Check whether Isolated Projects is active; the `active` status is always defined.
+<3> Skip the incompatible logic when Isolated Projects is active.
+
+[[sec:guard_third_party_plugin]]
+===== Guard the application of an incompatible third-party plugin
+
+If a third-party plugin is utterly incompatible with Isolated Projects and is not needed in every workflow, you can guard its _application_ in the same way.
+Apply the plugin from a convention plugin rather than from a `plugins {}` block, so that the decision to apply it can be made conditionally:
+
+[source,java]
+----
+include::{snippetsPath}/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java[tags=applier-plugin]
+----
+<1> Apply the incompatible plugin only when Isolated Projects is not active.
+
+Apply the convention plugin in the projects that need it:
+
+====
+include::sample[dir="snippets/isolatedProjects/guardingBuildLogic/kotlin",files="build.gradle.kts[tags=apply]"]
+include::sample[dir="snippets/isolatedProjects/guardingBuildLogic/groovy",files="build.gradle[tags=apply]"]
+====
+
+[NOTE]
+====
+Guarding the _application_ of a plugin means the tasks and configuration it contributes are absent when Isolated Projects is active.
+Any build logic that depends on that plugin must tolerate its absence, or be guarded as well.
+====
+
+[[sec:guarding_for_plugin_authors]]
+===== A note for plugin authors
+
+Be especially cautious about shipping such conditionals in a *published* plugin.
+A conditional baked into a published plugin changes behavior for every consuming build, and consumers cannot easily see or override it.
+This multiplies the complexity and divergent-behavior concerns above across the whole ecosystem.
+
+As a plugin author, strongly prefer making the plugin compatible with Isolated Projects over guarding.
+If you must guard, make the guarded behavior observable — for example, by logging a warning as shown above — and document it clearly, so that consumers are not surprised by build logic that silently changes when Isolated Projects is enabled.
+
 [[sec:vs_other_features]]
 == Isolated Projects and other Gradle features
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
@@ -591,7 +591,7 @@ include::{snippetsPath}/reference/plugin-development/reactingToBuildFeatures/gro
 [WARNING]
 ====
 Disabling functionality based on a feature's `active` status makes the plugin behave differently depending on whether the feature is enabled, which raises complexity and can lead to divergent build results.
-Treat it as a last resort, and prefer making the functionality compatible with the feature instead.
+Treat such conditionals as a last resort, and prefer making the functionality compatible with the feature instead.
 For the <<isolated_projects.adoc#isolated_projects,Isolated Projects>> feature specifically, see <<isolated_projects.adoc#sec:guarding_build_logic,Guard incompatible build logic as a last resort>>.
 ====
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
@@ -588,6 +588,13 @@ include::{snippetsPath}/reference/plugin-development/reactingToBuildFeatures/gro
 <2> Accessing the `requested` status of a feature for reporting.
 <3> Using the `active` status of a feature to disable incompatible functionality.
 
+[WARNING]
+====
+Disabling functionality based on a feature's `active` status makes the plugin behave differently depending on whether the feature is enabled, which raises complexity and can lead to divergent build results.
+Treat it as a last resort, and prefer making the functionality compatible with the feature instead.
+For the <<isolated_projects.adoc#isolated_projects,Isolated Projects>> feature specifically, see <<isolated_projects.adoc#sec:guarding_build_logic,Guard incompatible build logic as a last resort>>.
+====
+
 [[build_feature_properties]]
 === Build feature properties
 

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/build.gradle
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java-gradle-plugin'
+}
+
+gradlePlugin {
+    plugins {
+        guardedConvention {
+            id = 'my.guarded-convention'
+            implementationClass = 'com.example.GuardedConventionPlugin'
+        }
+        incompatible {
+            id = 'com.example.incompatible'
+            implementationClass = 'com.example.ThirdPartyPlugin'
+        }
+        applier {
+            id = 'my.applier'
+            implementationClass = 'com.example.ApplierConventionPlugin'
+        }
+    }
+}

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java
@@ -14,13 +14,13 @@ public abstract class ApplierConventionPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        if (getBuildFeatures().getIsolatedProjects().getActive().get()) {
+        if (getBuildFeatures().getIsolatedProjects().getActive().get()) { // <1>
             project.getLogger().warn(
                 "Not applying com.example.incompatible on " + project.getPath()
                     + " because it is incompatible with Isolated Projects");
             return;
         }
-        project.getPluginManager().apply("com.example.incompatible"); // <1>
+        project.getPluginManager().apply("com.example.incompatible");
     }
 }
 // end::applier-plugin[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ApplierConventionPlugin.java
@@ -1,0 +1,26 @@
+package com.example;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.configuration.BuildFeatures;
+
+import javax.inject.Inject;
+
+// tag::applier-plugin[]
+public abstract class ApplierConventionPlugin implements Plugin<Project> {
+
+    @Inject
+    protected abstract BuildFeatures getBuildFeatures();
+
+    @Override
+    public void apply(Project project) {
+        if (getBuildFeatures().getIsolatedProjects().getActive().get()) {
+            project.getLogger().warn(
+                "Not applying com.example.incompatible on " + project.getPath()
+                    + " because it is incompatible with Isolated Projects");
+            return;
+        }
+        project.getPluginManager().apply("com.example.incompatible"); // <1>
+    }
+}
+// end::applier-plugin[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/GuardedConventionPlugin.java
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/GuardedConventionPlugin.java
@@ -1,0 +1,30 @@
+package com.example;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.configuration.BuildFeatures;
+
+import javax.inject.Inject;
+
+// tag::guarded-plugin[]
+public abstract class GuardedConventionPlugin implements Plugin<Project> {
+
+    @Inject
+    protected abstract BuildFeatures getBuildFeatures(); // <1>
+
+    @Override
+    public void apply(Project project) {
+        if (getBuildFeatures().getIsolatedProjects().getActive().get()) { // <2>
+            project.getLogger().warn(
+                "Skipping " + getClass().getSimpleName() + " on " + project.getPath()
+                    + ", because Isolated Projects is enabled");
+            return; // <3>
+        }
+        configureIncompatibleBuildLogic(project);
+    }
+
+    private void configureIncompatibleBuildLogic(Project project) {
+        // Build logic that is not (yet) compatible with Isolated Projects.
+    }
+}
+// end::guarded-plugin[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ThirdPartyPlugin.java
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/buildSrc/src/main/java/com/example/ThirdPartyPlugin.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+// A stand-in for a third-party plugin that is not compatible with Isolated Projects.
+public class ThirdPartyPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        // ...
+    }
+}

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/common/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.isolated-projects=true

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/build.gradle
@@ -1,6 +1,4 @@
-// tag::apply[]
 plugins {
     id 'my.guarded-convention'
     id 'my.applier'
 }
-// end::apply[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/build.gradle
@@ -1,0 +1,6 @@
+// tag::apply[]
+plugins {
+    id 'my.guarded-convention'
+    id 'my.applier'
+}
+// end::apply[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'guarding-build-logic'
+include 'sub'

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/sub/build.gradle
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/groovy/sub/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'my.guarded-convention'
+    id 'my.applier'
+}

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/build.gradle.kts
@@ -1,0 +1,6 @@
+// tag::apply[]
+plugins {
+    id("my.guarded-convention")
+    id("my.applier")
+}
+// end::apply[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/build.gradle.kts
@@ -1,6 +1,4 @@
-// tag::apply[]
 plugins {
     id("my.guarded-convention")
     id("my.applier")
 }
-// end::apply[]

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "guarding-build-logic"
+include("sub")

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/sub/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/kotlin/sub/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("my.guarded-convention")
+    id("my.applier")
+}

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/tests/guardingBuildLogic.out
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/tests/guardingBuildLogic.out
@@ -1,0 +1,1 @@
+> Task :help

--- a/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/tests/guardingBuildLogic.sample.conf
+++ b/platforms/documentation/docs/src/snippets/isolatedProjects/guardingBuildLogic/tests/guardingBuildLogic.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: help
+expected-output-file: guardingBuildLogic.out
+allow-additional-output: true


### PR DESCRIPTION
Fixes #37449

### Context

Adopting Isolated Projects surfaces build logic that is not yet compatible with the feature, and it cannot always be fixed right away — for example an in-progress plugin, or a third-party plugin that is not essential to every workflow. This adds documentation on how to *guard* such logic behind `BuildFeatures.isolatedProjects.active` as a last resort, while emphasizing that fixing the incompatibility is preferred.

Changes:

- **Isolated Projects page** — a new "Guard incompatible build logic as a last resort" strategy under _Build-logic refactoring strategies_, covering:
  - guarding a plugin's own IP-incompatible logic with an early return, and
  - guarding the *application* of an incompatible third-party plugin from a convention plugin (the issue's open question),
  - plus a caution for authors of *published* plugins about shipping such conditionals.
- **Plugin development page** — cross-linked the existing "Reacting to build features" section and added the same "prefer fixing" caveat.
- A new **tested snippet** under `snippets/isolatedProjects/guardingBuildLogic` (Kotlin + Groovy variants, shared `buildSrc` plugins) backs the examples. It is exercised by `:docs:docsTest` and runs cleanly under Isolated Projects with no violations.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — _N/A: documentation-only; examples are covered by a tested docs snippet (`:docs:docsTest`)._
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. — _N/A: documentation-only._
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — _This PR is the User Guide update._
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`. — _Not run locally; relying on CI._
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`. — _`:docs:docsTest` for the new snippet passed locally._

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
