### PR TITLE
Fix flaky SIGINT taskbar progress reset test

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.test.preconditions.OsTestPreconditions
 import org.gradle.test.precondition.Requires
 import spock.lang.Issue
-import spock.lang.Ignore
 
 /**
  * Verifies that the OSC 9;4;0 taskbar progress reset sequence is emitted when a build ends,
@@ -49,7 +48,6 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
             .withConsole(ConsoleOutput.Rich)
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/5153')
     @Requires(value = [OsTestPreconditions.Unix, TestExecutionPreconditions.NotEmbeddedExecutor],
         reason = "sends SIGINT to a forked process works only on Unix and with a separate process")
     def "sends OSC 9;4;0 reset sequence when build receives SIGINT"() {
@@ -71,11 +69,21 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
         when:
         def gradle = executer.withTasks("block").start()
 
+        // Wait until the task is actually executing (the daemon has created the
+        // marker) before signalling, so the build is cancellable when SIGINT arrives.
         ConcurrentTestUtil.poll {
             assert readyFile.exists()
         }
 
-        gradle.sendSignal(SIGINT)
+        // A single SIGINT can be lost before the client JVM acts on it: on loaded
+        // machines the build is otherwise observed to run to normal completion
+        // instead of cancelling. Resend the signal until the process terminates.
+        ConcurrentTestUtil.poll(60, 0, 1) {
+            if (gradle.running) {
+                gradle.sendSignal(SIGINT)
+            }
+            assert !gradle.running
+        }
         gradle.waitForFailure()
 
         then:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

Re-enables `TaskbarProgressResetFunctionalTest > sends OSC 9;4;0 reset sequence when build receives SIGINT`, which was `@Ignore`d as flaky.

Investigation of the historical failures (via Develocity) showed two distinct failure modes:
- Early on, with a default 10s poll, the readiness wait (`readyFile.exists()`) timed out on slow cold-daemon starts. A later 60s timeout fixed that but the test stayed flaky.
- The remaining, dominant failure was **not** a timeout: the marker was created and the poll passed, but the `block` task then slept its full duration and the build reported `BUILD SUCCESSFUL` (exit 0). A single SIGINT sent to the forked client is sometimes not acted upon, so `waitForFailure()` failed with an unexpected success. The taskbar reset sequence itself was still emitted — the product behaviour is fine; the flakiness was entirely in the test reliably cancelling the build.

Fix: resend SIGINT until the process actually starts terminating (up to 60s), tolerating a lost or ignored signal, instead of firing once and hoping.

Verified locally with 15× reruns of both `:logging:forkingIntegTest` and `:logging:configCacheIntegTest` (the variant where failures clustered) — all green. The intermittent failure only manifests under CI load, so CI is the real validation.

Issue: https://github.com/gradle/gradle-private/issues/5153

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things