### PR TITLE
Clean up ~/.m2/.develocity in smoke-test artifact-cache hook

### DIFF
--- a/.teamcity/hooks/hooks.sh
+++ b/.teamcity/hooks/hooks.sh
@@ -77,3 +77,11 @@ for dist in ${INT_TEST_DISTRIBUTIONS}; do
     "${GRADLE_UNIVERSAL_CACHE_CLI_PATH}" --store "${imageName}" "${gradleHome}" || true
   fi
 done
+
+# Every Artifact Cache CLI invocation above (restore and store) autodetects the Maven home
+# (~/.m2) and injects Develocity restore-metrics instrumentation into ~/.m2/.develocity; there
+# is no CLI flag to disable that autodetect. We only cache Gradle homes here, never Maven, so
+# that directory is pure pollution: the CHECK_CLEAN_M2_ANDROID_USER_HOME build step fails the
+# build if ~/.m2/.develocity survives. The agent-side pre-build hook already removes it after
+# its own bootstrap restore; mirror that cleanup for the restores/stores we trigger.
+rm -rf "${HOME}/.m2/.develocity"


### PR DESCRIPTION
## Problem

Otherwise-green smoke-test builds fail on the final `CHECK_CLEAN_M2_ANDROID_USER_HOME` step (e.g. [build 114895258](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SmokeTest_IsolatedProjectsSmokeTestsMaxJavaVersion_virtual_Batch_2_1/114895258)):

```
/home/tcagent1/.m2/.develocity
├── artifact-cache/restore/metrics.properties
└── custom-user-data/DevelocityInjectRestoreMetrics.groovy
/home/tcagent1/.m2/.develocity was polluted during the build
```

## Root cause

The Develocity Artifact Cache CLI autodetects the Maven home (`~/.m2`) on **every** restore/store and injects restore-metrics instrumentation into `~/.m2/.develocity`, with no flag to disable that autodetect.

`.teamcity/hooks/hooks.sh` (added in `8206ea20708`) invokes the CLI once per distribution home for smoke-test builds, but never cleaned up the resulting `~/.m2/.develocity`. So it survived to the end of the build and tripped `CHECK_CLEAN_M2_ANDROID_USER_HOME`. This is smoke-test-specific because the hook early-exits for all other build types.

The agent-side `pre-build` hook already removes `~/.m2/.develocity` after its own bootstrap restore — this change mirrors that cleanup for the restores/stores the repo hook triggers.

## Change

Add `rm -rf "${HOME}/.m2/.develocity"` after the restore/store loop in `hooks.sh`.

## Verification

Simulated the hook locally with a fake CLI that reproduces the pollution:
- pre phase → `~/.m2/.develocity` cleaned; gradle-home init script still removed
- post phase → `~/.m2/.develocity` cleaned
- non-smoke-test build / local build (no CLI path) → still early-exit 0, never reach the new line
- `bash -n` syntax check passes

## Follow-up

The offending hook is on `master` too. After this merges to `release` it should reach `master` via the usual release→master forward-merge; otherwise master-only smoke-test runs stay broken.