### PR TITLE
Clean up link reference warnings in build

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/IConventionAware.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/IConventionAware.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal;
 
 /**
  * <p>Allows default values for the properties of this object to be declared. Most implementations are generated at
- * run-time from existing classes, by a {@link org.gradle.api.internal.Instantiator} implementation.</p>
+ * run-time from existing classes, by a {@link org.gradle.internal.reflect.Instantiator} implementation.</p>
  *
  * <p>Each getter of an {@code IConventionAware} object should use the mappings to determine the value for the property,
  * when no value has been explicitly set for the property.</p>

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleExtractor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleExtractor.java
@@ -101,7 +101,7 @@ public class ModelRuleExtractor {
     /**
      * Creates a new rule source instance to be applied to a model element.
      *
-     * @throws InvalidModelRuleDeclarationException On badly formed rule source class.
+     * @throws org.gradle.model.InvalidModelRuleDeclarationException On badly formed rule source class.
      */
     public <T> ExtractedRuleSource<T> extract(Class<T> source) throws org.gradle.model.InvalidModelRuleDeclarationException {
         try {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/RuleApplicationScope.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/RuleApplicationScope.java
@@ -32,7 +32,7 @@ public enum RuleApplicationScope {
     DESCENDANTS;
 
     /**
-     * Detects if the subject of the rule has been annotated with {@literal @}{@link Each}.
+     * Detects if the subject of the rule has been annotated with {@literal @}{@link org.gradle.model.Each}.
      *
      * @throws IndexOutOfBoundsException If the rule definition has too few parameters.
      */

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ModelSchemaUtils.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ModelSchemaUtils.java
@@ -124,7 +124,7 @@ public class ModelSchemaUtils {
     }
 
     /**
-     * Returns whether the most specific of the given methods has been declared in a <code>@</code>{@link Managed} type or not.
+     * Returns whether the most specific of the given methods has been declared in a <code>@</code>{@link org.gradle.model.Managed} type or not.
      */
     public static boolean isMethodDeclaredInManagedType(Iterable<Method> declarations) {
         Method mostSpecificDeclaration = findMostSpecificMethod(declarations);
@@ -132,7 +132,7 @@ public class ModelSchemaUtils {
     }
 
     /**
-     * Returns whether the method has been declared in a <code>@</code>{@link Managed} type or not.
+     * Returns whether the method has been declared in a <code>@</code>{@link org.gradle.model.Managed} type or not.
      */
     public static boolean isMethodDeclaredInManagedType(Method method) {
         return method.getDeclaringClass().isAnnotationPresent(org.gradle.model.Managed.class);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/registry/ModelRegistry.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/registry/ModelRegistry.java
@@ -129,7 +129,7 @@ public interface ModelRegistry {
     ModelRegistry configureMatching(ModelSpec spec, ModelActionRole role, ModelAction action);
 
     /**
-     * Registers a listener and applies the given {@link RuleSource} whenever a node that matches the spec is discovered.
+     * Registers a listener and applies the given {@link org.gradle.model.RuleSource} whenever a node that matches the spec is discovered.
      * Matching nodes that are already discovered when {@code configureMatching()} is called are bound directly.
      * Unlike with {@link #configure(ModelActionRole, ModelAction)}, {@link #bindAllReferences()} will <em>not</em> fail
      * if no nodes match the given spec.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/reflect/DirectInstantiator.java
@@ -28,20 +28,20 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 
 /**
- * You should use the methods of {@link org.gradle.api.internal.InstantiatorFactory} instead of this type, as it will give better error reporting, more consistent behaviour and better performance.
- * This type will be retired in favor of {@link org.gradle.api.internal.InstantiatorFactory} at some point. Currently it is too tangled with a few things to just remove.
+ * You should use the methods of {@link org.gradle.internal.instantiation.InstantiatorFactory} instead of this type, as it will give better error reporting, more consistent behaviour and better performance.
+ * This type will be retired in favor of {@link org.gradle.internal.instantiation.InstantiatorFactory} at some point. Currently it is too tangled with a few things to just remove.
  */
 public class DirectInstantiator implements Instantiator {
 
     /**
-     * Please use {@link org.gradle.api.internal.InstantiatorFactory} instead.
+     * Please use {@link org.gradle.internal.instantiation.InstantiatorFactory} instead.
      */
     public static final Instantiator INSTANCE = new DirectInstantiator();
 
     private final ConstructorCache constructorCache = new ConstructorCache();
 
     /**
-     * Please use {@link org.gradle.api.internal.InstantiatorFactory} instead.
+     * Please use {@link org.gradle.internal.instantiation.InstantiatorFactory} instead.
      */
     public static <T> T instantiate(Class<? extends T> type, Object... params) {
         return INSTANCE.newInstance(type, params);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/GlobalUserInputReceiver.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/GlobalUserInputReceiver.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public interface GlobalUserInputReceiver {
     /**
-     * Requests that a line of text should be received from the user, for example via this process' stdin, and forwarded to the {@link UserInputReader} instance in the daemon.
+     * Requests that a line of text should be received from the user, for example via this process' stdin, and forwarded to the {@link org.gradle.api.internal.tasks.userinput.UserInputReader} instance in the daemon.
      * Does not block waiting for the input.
      *
      * @param event Specifies how to validate and normalize the text.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
-import org.gradle.api.specs.Spec;
 
 /**
  * Immutable representation of the state of dependency resolution. Can represent the result of resolving build
@@ -57,10 +56,10 @@ public interface ResolverResults {
      * <ul>
      *     <li>{@link ResolvedConfiguration}</li>
      *     <li>{@link org.gradle.api.artifacts.LenientConfiguration}</li>
-     *     <li>{@link org.gradle.api.artifacts.Configuration#fileCollection(Spec)} and related methods</li>
+     *     <li>{@link org.gradle.api.artifacts.Configuration#getResolvedConfiguration} and related methods</li>
+     *     <li>{@link org.gradle.api.artifacts.ArtifactView} and related filtered artifact resolution methods</li>
      * </ul>
      */
-    @SuppressWarnings("InvalidLink")
     interface LegacyResolverResults {
 
         /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingAccessCoordinator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingAccessCoordinator.java
@@ -29,7 +29,7 @@ public interface ArtifactCacheLockingAccessCoordinator extends ExclusiveCacheAcc
     /**
      * Creates a cache implementation that is managed by this locking manager. This method may be used at any time.
      *
-     * <p>The returned cache may only be used by an action being run from {@link #useCache(org.gradle.internal.Factory)}.
+     * <p>The returned cache may only be used by an action being run from {@link #useCache(Supplier)}.
      * In this instance, an exclusive lock will be held on the cache.
      *
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -119,8 +119,8 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
      * with dependencies, as the incomplete graph used to initially determine upstream transforms does
      * not represent the final dependency graph.
      * <p>
-     * See {@link org.gradle.integtests.resolve.transform.ArtifactTransformWithDependenciesParallelIntegrationTest}
-     * for the test that exercises the scenario that necessitates this behavior.
+     * See {@code ArtifactTransformWithDependenciesParallelIntegrationTest} in {@code :dependency-management}'s
+     * integration tests for the test that exercises the scenario that necessitates this behavior.
      */
     public DefaultTransformUpstreamDependenciesResolver(
         ResolutionHost resolutionHost,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleArtifactFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleArtifactFailure.java
@@ -24,7 +24,7 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import java.util.List;
 
 /**
- * An {@link ArtifactSelectionFailure} that represents the situation when an artifact variant cannot
+ * An {@link org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure} that represents the situation when an artifact variant cannot
  * be selected because no artifact variants were found that are compatible with the requested attributes.
  */
 public final class NoCompatibleArtifactFailure extends AbstractArtifactSelectionFailure {

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Gradle properties of a build or a project. Only build-scoped properties when injected as a service.
  * <p>
- * See {@link org.gradle.initialization.GradlePropertiesController GradlePropertiesController} on how these properties
+ * See {@link org.gradle.api.internal.properties.GradlePropertiesController GradlePropertiesController} on how these properties
  * are loaded and what contributes to their values at each scope.
  * <p>
  * Build-scoped properties are accessible by users via {@link ProviderFactory#gradleProperty(String)}.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -101,7 +101,6 @@ import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.extensibility.NoConventionMapping;
 import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.instantiation.generator.AsmBackedClassGenerator;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.BeanDynamicObject;
@@ -1155,9 +1154,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
      * @implNote This is an implementation of the {@link groovy.lang.GroovyObject}'s corresponding method.
      * The interface itself is mixed-in at runtime, but we want to keep this implementation
      * to dispatch through the extensible dynamic object.
-     * @see AsmBackedClassGenerator.ClassBuilderImpl#addDynamicMethods
+     * See {@code AsmBackedClassGenerator.ClassBuilderImpl.addDynamicMethods} for the wiring.
      */
-    @SuppressWarnings("JavadocReference")
     @Nullable
     public Object getProperty(String propertyName) {
         return withCallerContext(ExtensibleDynamicObject.CallerContext.Instances.GET_PROPERTY,
@@ -1168,9 +1166,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
      * @implNote This is an implementation of the {@link groovy.lang.GroovyObject}'s corresponding method.
      * The interface itself is mixed-in at runtime, but we want to keep this implementation
      * to dispatch through the extensible dynamic object.
-     * @see AsmBackedClassGenerator.ClassBuilderImpl#addDynamicMethods
+     * See {@code AsmBackedClassGenerator.ClassBuilderImpl.addDynamicMethods} for the wiring.
      */
-    @SuppressWarnings("JavadocReference")
     @Nullable
     public Object invokeMethod(String name, Object args) {
         if (args instanceof Object[]) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -119,7 +119,7 @@ import java.util.List;
  * Defines the extended global services of a given process. This includes the CLI, daemon and tooling API provider. The CLI
  * only needs these services if it is running in --no-daemon mode.
  *
- * <p>Do not use this type directly, but instead use it via {@link BuildProcessState}.</p>
+ * <p>Do not use this type directly, but instead use it via {@link org.gradle.internal.buildprocess.BuildProcessState}.</p>
  */
 public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -67,9 +67,7 @@ import java.util.stream.Stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * {@inheritDoc}
- *
- * This runner uses Gradle profiler to execute the actual experiment.
+ * An {@link AbstractBuildExperimentRunner} that uses Gradle profiler to execute the actual experiment.
  */
 @CompileStatic
 public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {


### PR DESCRIPTION
Corrects an assortment of Javadoc link issues, to remove warnings in build output.