### PR TITLE
Isolate OS user home in integration test executer to prevent ~/.m2 pollution

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1182,9 +1182,17 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     protected Map<String, String> getImplicitJvmSystemProperties() {
         Map<String, String> properties = new LinkedHashMap<>();
 
-        if (getUserHomeDir() != null) {
-            properties.put("user.home", getUserHomeDir().getAbsolutePath());
+        File userHome = getUserHomeDir();
+        if (userHome == null) {
+            // Always isolate the OS user home for test builds. `mavenLocal()` defaults to
+            // <user.home>/.m2/repository, so without this a build that resolves from or publishes to
+            // Maven local without explicit isolation would pollute the real ~/.m2/repository of the build
+            // agent and trip the CHECK_CLEAN_M2_ANDROID_USER_HOME CI step. This is the Maven-local sibling
+            // of the .android isolation (see gradle-private#3380). Tests that need a specific user home
+            // (e.g. `using m2`) still override this via withUserHomeDir(...).
+            userHome = testDirectoryProvider.getTestDirectory().file("default-user-home");
         }
+        properties.put("user.home", userHome.getAbsolutePath());
 
         properties.put(DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY, "" + (daemonIdleTimeoutSecs * 1000));
         properties.put(DaemonBuildOptions.BaseDirOption.GRADLE_PROPERTY, daemonBaseDir.getAbsolutePath());


### PR DESCRIPTION
### Context

Windows *Quick* CI builds intermittently fail on the post-build `CHECK_CLEAN_M2_ANDROID_USER_HOME` step with an (often empty) leftover `~/.m2/repository`, even though all tests pass — e.g. [`Gradle_Release_Check_Quick_2_bucket32` #2420](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_Quick_2_bucket32/114914025). Recently this accounted for ~3 of the last 8 Windows-Quick failures, across three unrelated buckets (different subprojects each time), so it is not tied to any one test — the common factor is **Windows + the embedded-executer quick pipeline**.

**Root cause:** `AbstractGradleExecuter.getImplicitJvmSystemProperties()` only set the build's `user.home` when a test had explicitly configured a user home dir (`userHomeDir != null`); otherwise the build inherited the real OS `user.home`. `mavenLocal()` resolves its location as `<user.home>/.m2/repository` (`MavenUtil.getUserMavenDir()` → `SystemProperties.getUserHome()` → `System.getProperty("user.home")`, read live). So a build — embedded or forked — that resolved from or published to Maven local *without* the per-test `M2Installation` isolation being active would write into the agent's real `~/.m2/repository` and trip the cleanliness guard.

**Fix:** always isolate the OS `user.home` for test builds, falling back to a directory under the test's temporary folder when a test does not specify one. Now `mavenLocal()` for any executer-run build can only resolve inside the test's temp dir, never the real user home. This is the Maven-local sibling of the existing `.android` isolation added in gradle-private#3380 (`configureAndroidUserHome`), which already covers the other half of this same CI check. Tests that need a specific user home (e.g. `using m2`) still override this via `withUserHomeDir(...)`.

Note: builds that do **not** go through `AbstractGradleExecuter` (e.g. raw TestKit `GradleRunner` daemons declaring `mavenLocal()`) are not covered by this change, but none of the observed failures were that path.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

<!-- Note: this is a test-infrastructure-only change; validation requires a Windows CI run since the failure is Windows-only and non-deterministic. -->
