### PR TITLE
Isolate Maven local repository for unisolated integration test builds

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1184,6 +1184,16 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         if (getUserHomeDir() != null) {
             properties.put("user.home", getUserHomeDir().getAbsolutePath());
+        } else if (args.stream().noneMatch(arg -> arg.startsWith("-Dmaven.repo.local="))) {
+            // Isolate the Maven local repository for builds that neither set their own user home nor already
+            // isolate maven.repo.local. `mavenLocal()` resolves to <user.home>/.m2/repository when
+            // maven.repo.local is unset, so such a build - e.g. an auto-tested sample, a cross-version test,
+            // or any executer that does not go through AbstractIntegrationSpec's M2Installation - would
+            // otherwise resolve from or publish into the build agent's real ~/.m2/repository and trip the
+            // CHECK_CLEAN_M2_ANDROID_USER_HOME CI step. AbstractIntegrationSpec tests already pass
+            // -Dmaven.repo.local via M2Installation, and `using m2` sets a user home, so both are left
+            // untouched by this default.
+            properties.put("maven.repo.local", testDirectoryProvider.getTestDirectory().file("maven-local-should-not-leak").getAbsolutePath());
         }
 
         properties.put(DaemonBuildOptions.IdleTimeoutOption.GRADLE_PROPERTY, "" + (daemonIdleTimeoutSecs * 1000));


### PR DESCRIPTION
### Context

Windows *Quick* CI builds intermittently fail on the post-build `CHECK_CLEAN_M2_ANDROID_USER_HOME` step with a leftover (often empty) `~/.m2/repository`, even though all tests pass — e.g. [`Gradle_Release_Check_Quick_2_bucket32` #2420](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_Quick_2_bucket32/114914025). Recently ~3 of the last 8 Windows-Quick failures were this, across three unrelated buckets (different subprojects each time), so it is not tied to any one test — the common factor is builds run through the embedded executer.

**Root cause:** `mavenLocal()` resolves to `<user.home>/.m2/repository` when `maven.repo.local` is unset (`DefaultLocalMavenRepositoryLocator` reads it via `CurrentSystemPropertyAccess`, i.e. the real JVM `System.getProperty`). `AbstractIntegrationSpec` (Spock) tests isolate this per test via `M2Installation.isolateMavenLocalRepo` (`-Dmaven.repo.local=<temp>`). But `AbstractIntegrationTest` (JUnit) based tests — notably the **auto-tested samples**, which run in *every* build bucket — create an `M2Installation` but never call `isolateMavenLocalRepo`. Such a build that resolves from or publishes to Maven local therefore writes into the build agent's real `~/.m2/repository` and trips the cleanliness guard.

**Fix:** in `AbstractGradleExecuter.getImplicitJvmSystemProperties()`, default `maven.repo.local` to a directory under the test's temporary folder **only when the build neither sets its own user home nor already passes `-Dmaven.repo.local`**. This targets exactly the previously-unisolated builds:

- `AbstractIntegrationSpec` tests already pass `-Dmaven.repo.local` (M2Installation) → **unchanged**.
- `using m2` tests set a user home → **unchanged**.
- Everything else (auto-tested samples, cross-version, ad-hoc executers) → now isolated.

The `user.home` branch is left byte-for-byte as before; the new behavior is purely additive.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

<!-- Test-infrastructure-only change; final validation requires a Windows CI run since the failure is Windows-only and non-deterministic. Blast radius is limited to builds that were previously unisolated (AbstractIntegrationSpec/`using m2` tests are untouched). -->
