### PR TITLE
Only fail m2/android cleanliness check when polluted dir is non-empty

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -39,10 +39,15 @@ fun checkCleanDirUnixLike(
 ) = """
     REPO=$dir
     if [ -e ${'$'}REPO ] ; then
-        tree ${'$'}REPO
-        rm -rf ${'$'}REPO
-        echo "${'$'}REPO was polluted during the build"
-        ${if (exitOnFailure) "exit 1" else ""}
+        if [ -n "${'$'}(ls -A ${'$'}REPO)" ] ; then
+            tree ${'$'}REPO
+            rm -rf ${'$'}REPO
+            echo "${'$'}REPO was polluted during the build"
+            ${if (exitOnFailure) "exit 1" else ""}
+        else
+            rm -rf ${'$'}REPO
+            echo "${'$'}REPO exists but is empty"
+        fi
     else
         echo "${'$'}REPO does not exist"
     fi
@@ -55,9 +60,13 @@ fun checkCleanDirWindows(
 ) = """
 
     IF exist $dir (
-        TREE $dir
-        RMDIR /S /Q $dir
-        ${if (exitOnFailure) "EXIT 1" else ""}
+        DIR /B /A "$dir" | findstr "^" >nul && (
+            TREE $dir
+            RMDIR /S /Q $dir
+            ${if (exitOnFailure) "EXIT 1" else ""}
+        ) || (
+            RMDIR /S /Q $dir
+        )
     )
     """.trimIndent()
 


### PR DESCRIPTION
The `CHECK_CLEAN_M2_ANDROID_USER_HOME` build step failed builds whenever `~/.m2/repository` (or the other checked dirs) merely *existed*, even when it was completely empty:

```
[Step 5/6] /home/tcagent1/.m2/repository
[Step 5/6]
[Step 5/6] 0 directories, 0 files
[Step 5/6] /home/tcagent1/.m2/repository was polluted during the build
[Step 5/6] Process exited with code 1
```

The check used `[ -e $REPO ]` (and `IF exist` on Windows), which is true for an empty directory. If anything during the build created the directory path without writing an artifact into it, the step reported "was polluted during the build" and failed — despite `tree` showing `0 directories, 0 files`.

This changes the check to only treat a directory as polluted when it is **non-empty** (`ls -A` on Unix-like, `DIR /B /A` on Windows). An empty leftover directory is still removed to keep the agent clean, but no longer fails the build.

Example failing build: `Gradle_Release_Check_PerformanceTestTestLinuxbucket45` #114936302.
