### PR TITLE
Allow no-op re-set of worker working directory

### DIFF
--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.test.preconditions.JdkVersionTestPreconditions
 import org.gradle.workers.fixtures.OptionsVerifier
 import org.gradle.workers.fixtures.WorkerExecutorFixture
 import org.junit.Assume
+import spock.lang.Issue
 
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
@@ -102,7 +103,26 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         fails("runInWorker")
 
         then:
-        failureCauseContains("The value for property 'workingDirectory' cannot be changed any further")
+        failureCauseContains("Setting the working directory of a worker is not supported.")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38455")
+    def "re-setting the working directory of a worker to its default value is supported"() {
+        fixture.withWorkActionClassInBuildScript()
+        workActionThatPrintsWorkingDirectory.writeToBuildFile()
+        buildFile << """
+            task runInWorker(type: WorkerTask) {
+                isolationMode = 'processIsolation'
+                workActionClass = ${workActionThatPrintsWorkingDirectory.name}.class
+                additionalForkOptions = { it.workingDir = it.workingDir }
+            }
+        """
+
+        when:
+        succeeds("runInWorker")
+
+        then:
+        assertWorkerExecuted("runInWorker")
     }
 
     def "interesting worker daemon fork options are honored"() {

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -132,10 +132,12 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     @Override
     public WorkQueue processIsolation(Action<? super ProcessWorkerSpec> action) {
         DefaultProcessWorkerSpec spec = instantiator.newInstance(DefaultProcessWorkerSpec.class, forkOptionsFactory.newDecoratedJavaForkOptions());
-        // Setting the working directory of a worker is not supported, so we set it eagerly and disallow changes
-        spec.getForkOptions().getWorkingDirectory().set(workerDirectoryProvider.getWorkingDirectory());
-        spec.getForkOptions().getWorkingDirectory().disallowChanges();
+        File defaultWorkingDir = spec.getForkOptions().getWorkingDir();
         action.execute(spec);
+        if (!defaultWorkingDir.equals(spec.getForkOptions().getWorkingDir())) {
+            throw new IllegalArgumentException("Setting the working directory of a worker is not supported.");
+        }
+        spec.getForkOptions().getWorkingDirectory().set(workerDirectoryProvider.getWorkingDirectory());
 
         return instantiator.newInstance(DefaultWorkQueue.class, this, spec, daemonWorkerFactory);
     }

--- a/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerSpec
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 
 @UsesNativeServices
@@ -140,6 +141,29 @@ class DefaultWorkerExecutorTest extends Specification {
             assert spec.implementationClass == TestExecutable.class
             return new DefaultWorkResult(true, null)
         }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38455")
+    def "can re-set the working directory to its default value in a process isolation action"() {
+        when:
+        workerExecutor.processIsolation { spec ->
+            spec.forkOptions.workingDir = spec.forkOptions.workingDir
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38455")
+    def "cannot change the working directory in a process isolation action"() {
+        when:
+        workerExecutor.processIsolation { spec ->
+            spec.forkOptions.workingDir = temporaryFolder.createDir("other")
+        }
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Setting the working directory of a worker is not supported."
     }
 
     def "executor executes a given runnable in-process"() {


### PR DESCRIPTION
Run the process isolation action before pinning the working directory, and reject only a genuine change to it.

Fixes #38455