### PR TITLE
ProjectInternal no longer implements DomainObjectContext

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -70,7 +70,6 @@ import org.gradle.internal.logging.StandardOutputCapture
 import org.gradle.internal.metaobject.DynamicInvokeResult
 import org.gradle.internal.metaobject.DynamicObject
 import org.gradle.internal.metaobject.HierarchicalDynamicObject
-import org.gradle.internal.model.ModelContainer
 import org.gradle.internal.model.RuleBasedPluginListener
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.ServiceRegistry
@@ -396,34 +395,6 @@ class ProblemReportingCrossProjectModelAccess(
         override fun getGradle(): GradleInternal {
             onIsolationViolation("gradle")
             return super.getGradle()
-        }
-
-        override fun identityPath(name: String): Path {
-            shouldNotBeUsed()
-        }
-
-        override fun projectPath(name: String): Path {
-            shouldNotBeUsed()
-        }
-
-        override fun getModel(): ModelContainer<*> {
-            shouldNotBeUsed()
-        }
-
-        override fun getBuildPath(): Path {
-            shouldNotBeUsed()
-        }
-
-        override fun isScript(): Boolean {
-            shouldNotBeUsed()
-        }
-
-        override fun isRootScript(): Boolean {
-            shouldNotBeUsed()
-        }
-
-        override fun isPluginContext(): Boolean {
-            shouldNotBeUsed()
         }
 
         override fun getFileOperations(): FileOperations {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
@@ -111,11 +111,10 @@ public class ResolveExceptionMapper {
     }
 
     private boolean settingsRepositoriesIgnored() {
-        if (!(domainObjectContext instanceof ProjectInternal)) {
+        ProjectInternal project = domainObjectContext.getProject();
+        if (project == null) {
             return false;
         }
-
-        ProjectInternal project = (ProjectInternal) domainObjectContext;
 
         boolean hasSettingsRepos;
         try {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -53,6 +53,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
@@ -385,14 +386,15 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                 localResolveStateFactory
             );
 
-            if (owner.getProjectIdentity() == null) {
+            ProjectState projectState = owner.getProjectState();
+            if (projectState == null) {
                 return adhocRootComponentProvider;
             }
 
             // TODO #1629: Eventually, resolutions within a project should live within
             //  an adhoc root component, and should use an AdhocRootComponentProvider.
             return new ProjectRootComponentProvider(
-                owner.getProject().getOwner(),
+                projectState,
                 moduleIdentity,
                 schema,
                 configurations,

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleBeforeProjectEagerExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleBeforeProjectEagerExecutionIntegrationTest.groovy
@@ -136,7 +136,6 @@ class GradleLifecycleBeforeProjectEagerExecutionIntegrationTest extends Abstract
             "group",
             "hasProperty('foo')",
             "layout",
-            "model",
             "modelRegistry",
             "normalization",
             "normalization{}",

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -18,13 +18,17 @@ package org.gradle.api.internal;
 import org.gradle.api.Describable;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.model.ModelContainer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 /**
- * The owner/context of a Dependency Management instance.
+ * Models and controls access to an abstract set of related mutable objects.
  */
+@ServiceScope(Scope.Project.class)
 public interface DomainObjectContext extends Describable {
 
     /**
@@ -40,17 +44,20 @@ public interface DomainObjectContext extends Describable {
     /**
      * If this context represents a project, its identity.
      */
-    @Nullable
-    ProjectIdentity getProjectIdentity();
+    @Nullable ProjectIdentity getProjectIdentity();
 
     /**
      * If this context represents a project, the project.
      *
      * NOTE: This method should be avoided if at all possible. Instead, rely on
-     * {@link #getProjectIdentity()}, or if not possible, prefer {@code getProject().getOwner()}.
+     * {@link #getProjectIdentity()}, or if not possible, prefer {@link #getProjectState()}.
      */
-    @Nullable
-    ProjectInternal getProject();
+    @Nullable ProjectInternal getProject();
+
+    /**
+     * If this context represents a project, the project state.
+     */
+    @Nullable ProjectState getProjectState();
 
     /**
      * The container that holds the model for this context, to allow synchronized access to the model.
@@ -90,4 +97,5 @@ public interface DomainObjectContext extends Describable {
     default boolean isDetachedState() {
         return false;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.initialization;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
@@ -80,12 +81,12 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
     /**
      * A domain object context for resolution within a project's buildscript.
      */
-    public static StandaloneDomainObjectContext forProjectBuildscript(ProjectInternal project) {
+    public static StandaloneDomainObjectContext forProjectBuildscript(ProjectState project) {
         return new StandaloneDomainObjectContext() {
 
             @Override
             public Path getBuildPath() {
-                return project.getBuildPath();
+                return project.getIdentity().getBuildPath();
             }
 
             @Override
@@ -97,6 +98,7 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
             public boolean isRootScript() {
                 return false;
             }
+
         };
     }
 
@@ -136,15 +138,18 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
         return Path.path(name);
     }
 
-    @Nullable
     @Override
-    public ProjectIdentity getProjectIdentity() {
+    public @Nullable ProjectIdentity getProjectIdentity() {
         return null;
     }
 
-    @Nullable
     @Override
-    public ProjectInternal getProject() {
+    public @Nullable ProjectInternal getProject() {
+        return null;
+    }
+
+    @Override
+    public @Nullable ProjectState getProjectState() {
         return null;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -46,6 +46,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SyncSpec;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.GradleInternal;
@@ -91,6 +92,7 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.buildoption.InternalOption;
 import org.gradle.internal.buildoption.InternalOptions;
@@ -106,7 +108,6 @@ import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.metaobject.HierarchicalDynamicObject;
-import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.TextUriResourceLoader;
@@ -135,6 +136,7 @@ import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.ConfigureUtil;
 import org.jspecify.annotations.Nullable;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
@@ -148,9 +150,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.inject.Inject;
 
-import org.gradle.internal.build.BuildState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonMap;
 import static org.gradle.util.internal.ConfigureUtil.configureUsing;
@@ -634,11 +634,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
-    public Path identityPath(String name) {
-        return getIdentityPath().child(name);
-    }
-
-    @Override
     public Path getProjectPath() {
         return owner.getProjectPath();
     }
@@ -649,38 +644,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
-    public ModelContainer<ProjectInternal> getModel() {
-        return getOwner();
-    }
-
-    @Override
     public PluginContainer getPlugins() {
         return super.getPlugins();
-    }
-
-    @Override
-    public Path getBuildPath() {
-        return getBuildState().getIdentityPath();
-    }
-
-    @Override
-    public Path projectPath(String name) {
-        return getProjectPath().child(name);
-    }
-
-    @Override
-    public boolean isScript() {
-        return false;
-    }
-
-    @Override
-    public boolean isRootScript() {
-        return false;
-    }
-
-    @Override
-    public boolean isPluginContext() {
-        return false;
     }
 
     @Override
@@ -1580,7 +1545,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         DependencyResolutionServices resolver = dms.newDetachedResolver(
             services.get(FileResolver.class),
             services.get(FileCollectionFactory.class),
-            StandaloneDomainObjectContext.detachedFrom(this)
+            StandaloneDomainObjectContext.detachedFrom(services.get(DomainObjectContext.class))
         );
 
         return new LocalDetachedResolver(resolver);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -73,7 +73,6 @@ import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.metaobject.HierarchicalDynamicObject;
-import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.model.internal.registry.ModelRegistry;
@@ -671,16 +670,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public Path identityPath(String name) {
-        return delegate.identityPath(name);
-    }
-
-    @Override
-    public Path projectPath(String name) {
-        return delegate.projectPath(name);
-    }
-
-    @Override
     public Path getProjectPath() {
         return delegate.getProjectPath();
     }
@@ -917,11 +906,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public boolean isScript() {
-        return delegate.isScript();
-    }
-
-    @Override
     public void addDeferredConfiguration(Runnable configuration) {
         onMutableStateAccess("deferredConfiguration");
         delegate.addDeferredConfiguration(configuration);
@@ -931,27 +915,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     public void fireDeferredConfiguration() {
         onMutableStateAccess("deferredConfiguration");
         delegate.fireDeferredConfiguration();
-    }
-
-    @Override
-    public ModelContainer<?> getModel() {
-        onMutableStateAccess("model");
-        return delegate.getModel();
-    }
-
-    @Override
-    public Path getBuildPath() {
-        return delegate.getBuildPath();
-    }
-
-    @Override
-    public boolean isRootScript() {
-        return delegate.isRootScript();
-    }
-
-    @Override
-    public boolean isPluginContext() {
-        return delegate.isPluginContext();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.file.FileResolver;
@@ -56,7 +55,7 @@ import java.util.Set;
 
 @UsedByScanPlugin("scan, test-retry")
 @ServiceScope(Scope.Project.class)
-public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptServices, DomainObjectContext, ModelRegistryScope, PluginAwareInternal {
+public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptServices, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced
     // in the ‘core’ modules, which don't depend on ‘plugins’ where HelpTasksPlugin is defined.
@@ -158,7 +157,6 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     void fireDeferredConfiguration();
 
-    @Override
     ProjectIdentity getProjectIdentity();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -775,7 +775,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         if (cause instanceof DuplicateTaskException) {
             return (RuntimeException) cause;
         }
-        return new TaskCreationException(String.format("Could not create task '%s'.", project.identityPath(name)), cause);
+        return new TaskCreationException(String.format("Could not create task '%s'.", project.getIdentityPath().child(name)), cause);
     }
 
     private static BuildOperationDescriptor.Builder realizeDescriptor(TaskIdentity<?> identity, boolean replacement, boolean eager) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.model.ModelContainer;
+import org.gradle.util.Path;
+
+/**
+ * The domain object context modeling a {@link org.gradle.api.Project}.
+ */
+public class ProjectDomainObjectContext implements DomainObjectContext {
+
+    private final ProjectState projectState;
+
+    public ProjectDomainObjectContext(
+        ProjectState projectState
+    ) {
+        this.projectState = projectState;
+    }
+
+    @Override
+    public Path identityPath(String name) {
+        return getProjectIdentity().getBuildTreePath().child(name);
+    }
+
+    @Override
+    public Path projectPath(String name) {
+        return getProjectIdentity().getProjectPath().child(name);
+    }
+
+    @Override
+    public ProjectIdentity getProjectIdentity() {
+        return projectState.getIdentity();
+    }
+
+    @Override
+    public ProjectInternal getProject() {
+        return projectState.getMutableModel();
+    }
+
+    @Override
+    public ProjectState getProjectState() {
+        return projectState;
+    }
+
+    @Override
+    public ModelContainer<ProjectInternal> getModel() {
+        return projectState;
+    }
+
+    @Override
+    public Path getBuildPath() {
+        return getProjectIdentity().getBuildPath();
+    }
+
+    @Override
+    public boolean isScript() {
+        return false;
+    }
+
+    @Override
+    public boolean isRootScript() {
+        return false;
+    }
+
+    @Override
+    public boolean isPluginContext() {
+        return false;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return getProjectIdentity().getDisplayName();
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -19,6 +19,7 @@ package org.gradle.internal.service.scopes;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
@@ -142,7 +143,11 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         DependencyManagementServices dependencyManagementServices
     ) {
         registration.add(ProjectInternal.class, project);
-        dependencyManagementServices.addDslServices(registration, project);
+
+        ProjectDomainObjectContext domainObjectContext = new ProjectDomainObjectContext(project.getOwner());
+        registration.add(DomainObjectContext.class, domainObjectContext);
+
+        dependencyManagementServices.addDslServices(registration, domainObjectContext);
         for (GradleModuleServices services : gradleModuleServiceProviders) {
             services.registerProjectServices(registration);
         }
@@ -310,7 +315,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             project.getClassLoaderScope(),
             fileResolver,
             fileCollectionFactory,
-            StandaloneDomainObjectContext.forProjectBuildscript(project)
+            StandaloneDomainObjectContext.forProjectBuildscript(project.getOwner())
         );
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -62,23 +62,17 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
     private buildState = Stub(BuildState) {
         getIdentityPath() >> Path.ROOT
     }
-    private projectIdentity = ProjectIdentity.forRootProject(
+    private projectIdentity = ProjectIdentity.forSubproject(
         Path.ROOT,
-        "project"
+        Path.path(":project")
     )
     private project = Mock(ProjectInternal, name: "<project>") {
-        identityPath(_) >> { String name ->
-            Path.path(":project").child(name)
-        }
-        projectPath(_) >> { String name ->
-            Path.path(":project").child(name)
-        }
+        getIdentityPath() >> projectIdentity.buildTreePath
         getGradle() >> Mock(GradleInternal) {
-            getIdentityPath() >> Path.path(":")
+            getIdentityPath() >> projectIdentity.buildPath
         }
         getOwner() >> Mock(ProjectState) {
-            getDepth() >> 0
-            getProjectPath() >> Path.path(":project")
+            getProjectPath() >> projectIdentity.projectPath
             getOwner() >> buildState
             getIdentity() >> projectIdentity
         }
@@ -489,7 +483,7 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
     void "finds task by relative path"() {
         when:
         Task task = task("task")
-        expectTaskLookupInOtherProject(":sub", "task", task)
+        expectTaskLookupInOtherProject("::project:sub", "task", task)
 
         then:
         container.findByPath("sub:task") == task
@@ -500,7 +494,7 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
         Task task = addTask("task")
 
         then:
-        container.findByPath(":task") == task
+        container.findByPath(":project:task") == task
     }
 
     void "finds tasks by absolute path in different project"() {
@@ -559,7 +553,7 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
         Task task = addTask("task")
 
         then:
-        container.getByPath(":task") == task
+        container.getByPath(":project:task") == task
     }
 
     void "realizes task graph"() {


### PR DESCRIPTION
DomainObjectContext intends to model some abstract mutable 'context' under which 'domain objects' are created. It includes accessors to determine the context's identity and type (are you a script, project, etc).

In practice, only DependencyManagement uses this to figure out what sort of 'environment' it is running under, as behavior might change if DM is running in a settings context vs project.

We should expand this to better model contexts other than Project, but this PR specifically intends to decouple the domain object context for a Project from that Project itself. Currently, ProjectInternal _is_ a DomainObjectContext, which means users of this interface may unknowingly be carrying around a
 Project instance without knowing.

This is the first step to cleaning up this pattern, decoupling the DOC from the Project itself.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
