### PR TITLE
Fix module accessibility in javadoc

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -30,7 +30,28 @@ pluginManager.withPlugin("gradlebuild.code-quality") {
     }
 }
 
+// Extra classpath for the per-module `javadoc` task so cross-module `{@link}` targets resolve.
+// Modules declare additions via `dependencies { javadocReferences(projects.someProject) }`.
+// This is javadoc-only — it does NOT participate in `compileClasspath` or `runtimeClasspath`,
+// so it cannot introduce compile/runtime dependency cycles (see JDK-21+ standard doclet, which
+// emits `reference not found` warnings independent of `-Xdoclint`).
+val javadocReferences = configurations.dependencyScope("javadocReferences")
+val javadocReferencesClasspath = configurations.resolvable("javadocReferencesClasspath") {
+    extendsFrom(javadocReferences)
+    // Non-transitive: javadoc only needs the direct jar of each declared module to resolve
+    // its own types. Pulling transitives can introduce version conflicts (e.g. junit strict
+    // constraints in test-fixture chains) that have nothing to do with reference resolution.
+    isTransitive = false
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>(Category.LIBRARY))
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named<Usage>(Usage.JAVA_API))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named<LibraryElements>(LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named<Bundling>(Bundling.EXTERNAL))
+    }
+}
+
 tasks.withType<Javadoc>().configureEach {
+    classpath += javadocReferencesClasspath.get()
     assert(name != "javadocAll") // This plugin should not be applied to the :docs project.
 
     onlyIf("Do not run the task if there are no java sources") {

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -51,7 +51,7 @@ val javadocReferencesClasspath = configurations.resolvable("javadocReferencesCla
 }
 
 tasks.withType<Javadoc>().configureEach {
-    classpath += javadocReferencesClasspath.get()
+    classpath += files(javadocReferencesClasspath)
     assert(name != "javadocAll") // This plugin should not be applied to the :docs project.
 
     onlyIf("Do not run the task if there are no java sources") {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
@@ -108,6 +108,9 @@ public abstract class GradleJavadocsPlugin implements Plugin<Project> {
             options.addStringOption("Xdoclint:syntax,html", "-quiet");
             options.addStringOption("-add-stylesheet", javadocs.getJavadocCss().get().getAsFile().getAbsolutePath());
             options.addStringOption("source", "8");
+            // Gradle sources are classpath-mode (unnamed module) but the linked JDK 17 API is modularized.
+            // Downgrade the mismatch from `warn` to `info` so the link is still emitted without a warning.
+            options.addStringOption("-link-modularity-mismatch", "info");
             options.tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:");
             task.getInputs().dir(javadocs.getJavaPackageListLoc());
             var javaApiLink = javadocs.getJavaApi().map(URI::toString).map(v -> {

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -70,6 +70,9 @@ dependencies {
     }
 
     jmhImplementation(platform(projects.distributionsDependencies))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.core)
 }
 
 gradleModule {

--- a/platforms/core-execution/daemon-server-worker/build.gradle.kts
+++ b/platforms/core-execution/daemon-server-worker/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
     testImplementation(testFixtures(projects.hashing))
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.workers)
 }
 
 gradleModule {

--- a/platforms/core-execution/persistent-cache/build.gradle.kts
+++ b/platforms/core-execution/persistent-cache/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     integTestImplementation(projects.messaging)
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.scopedPersistentCache)
 }
 
 gradleModule {

--- a/platforms/core-execution/worker-main/build.gradle.kts
+++ b/platforms/core-execution/worker-main/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     implementation(libs.slf4jApi)
 
     testImplementation(testFixtures(projects.core))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.workerProcessServices)
 }
 
 gradleModule {

--- a/platforms/core-runtime/base-services/build.gradle.kts
+++ b/platforms/core-runtime/base-services/build.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     jmh(platform(projects.distributionsDependencies))
     jmh(libs.bouncycastleProvider)
     jmh(libs.guava)
+
+    // Javadoc-only: needed to resolve cross-module {@link} references (BuildService, ExtensionAware, InstantiatorFactory)
+    javadocReferences(projects.coreApi)
+    javadocReferences(projects.modelCore)
 }
 
 gradleModule {

--- a/platforms/core-runtime/build-process-services/build.gradle.kts
+++ b/platforms/core-runtime/build-process-services/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     testImplementation(libs.asmTree)
 
     testRuntimeOnly(projects.resources)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.launcher)
 }
 
 gradleModule {

--- a/platforms/core-runtime/daemon-protocol/build.gradle.kts
+++ b/platforms/core-runtime/daemon-protocol/build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
 
     testImplementation(testFixtures(projects.serialization))
     testImplementation(testFixtures(projects.core))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.launcher)
 }
 
 gradleModule {

--- a/platforms/core-runtime/logging-api/build.gradle.kts
+++ b/platforms/core-runtime/logging-api/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     compileOnly(libs.jspecify)
 
     implementation(projects.internalInstrumentationApi)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
 }
 
 gradleModule {

--- a/platforms/core-runtime/logging/build.gradle.kts
+++ b/platforms/core-runtime/logging/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
     testFixturesImplementation(libs.slf4jApi)
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.daemonServices)
 }
 
 gradleModule {

--- a/platforms/core-runtime/service-provider/build.gradle.kts
+++ b/platforms/core-runtime/service-provider/build.gradle.kts
@@ -10,6 +10,11 @@ dependencies {
 
     api(libs.jspecify)
     api(libs.errorProneAnnotations)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.concurrent)
+    javadocReferences(projects.serviceRegistryImpl)
+    javadocReferences(projects.baseServices) // for ServiceLocator
 }
 
 gradleModule {

--- a/platforms/core-runtime/start-parameter/build.gradle.kts
+++ b/platforms/core-runtime/start-parameter/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     implementation(libs.commonsLang)
 
     testImplementation(testFixtures(projects.core))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
+    javadocReferences(projects.fileCollections)
 }
 
 gradleModule {

--- a/platforms/extensibility/test-kit/build.gradle.kts
+++ b/platforms/extensibility/test-kit/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
         because("Tests instantiate DefaultClassLoaderRegistry which requires a 'gradle-plugins.properties' through DefaultPluginModuleRegistry")
     }
     integTestDistributionRuntimeOnly(projects.distributionsBasics)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
 }
 
 gradleModule {

--- a/platforms/ide/ide/build.gradle.kts
+++ b/platforms/ide/ide/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
         because("ProjectBuilder tests load services from a Gradle distribution.")
     }
     integTestDistributionRuntimeOnly(projects.distributionsJvm)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.idePlugins)
 }
 
 gradleModule {

--- a/platforms/ide/problems-api/build.gradle.kts
+++ b/platforms/ide/problems-api/build.gradle.kts
@@ -50,6 +50,10 @@ dependencies {
     testFixturesImplementation(projects.enterpriseOperations)
     testFixturesImplementation(projects.baseServices)
     testFixturesImplementation(projects.internalDistributionTesting)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
+    javadocReferences(projects.configurationProblemsBase)
 }
 
 gradleModule {

--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -91,6 +91,10 @@ dependencies {
     crossVersionTestLocalRepository(project(path)) {
         because("ToolingApiVersionSpecification uses the Tooling API Jar")
     }
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
+    javadocReferences(projects.startParameter) // for org.gradle.StartParameter
 }
 
 gradleModule {

--- a/platforms/jvm/jvm-compiler-worker/build.gradle.kts
+++ b/platforms/jvm/jvm-compiler-worker/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(libs.commonsLang)
 
     integTestDistributionRuntimeOnly(projects.distributionsJvm)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.languageJava)
+    javadocReferences(projects.languageJvm)
 }
 
 gradleModule {

--- a/platforms/jvm/language-jvm/build.gradle.kts
+++ b/platforms/jvm/language-jvm/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
         because("AbstractOptionsTest instantiates DefaultClassLoaderRegistry which requires a 'gradle-plugins.properties' through DefaultPluginModuleRegistry")
     }
     integTestDistributionRuntimeOnly(projects.distributionsJvm)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.pluginsJavaBase)
 }
 
 gradleModule {

--- a/platforms/jvm/plugins-java-base/build.gradle.kts
+++ b/platforms/jvm/plugins-java-base/build.gradle.kts
@@ -60,6 +60,9 @@ dependencies {
 
     testFixturesImplementation(projects.internalIntegTesting)
     testFixturesImplementation(projects.logging)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.pluginsJava)
 }
 
 gradleModule {

--- a/platforms/software/ant-api/build.gradle.kts
+++ b/platforms/software/ant-api/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     compileOnly(projects.internalInstrumentationApi)  // @NotToBeMigratedToLazy annotation — compile-time only
     compileOnly(libs.jspecify)
     compileOnly(libs.jetbrainsAnnotations)
+
+    // Javadoc-only: needed to resolve {@link Project ...} references in AntBuilder and package-info
+    javadocReferences(projects.coreApi)
 }
 
 gradleModule {

--- a/platforms/software/credentials-api/build.gradle.kts
+++ b/platforms/software/credentials-api/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
     compileOnly(projects.internalInstrumentationApi) {
         because("Provides @ToBeReplacedByLazyProperty annotation, following the same pattern as core-api")
     }
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
 }
 
 gradleModule {

--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -150,6 +150,9 @@ dependencies {
     crossVersionTestImplementation(projects.internalIntegTesting)
 
     crossVersionTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.coreApi)
 }
 
 gradleModule {

--- a/platforms/software/publish/build.gradle.kts
+++ b/platforms/software/publish/build.gradle.kts
@@ -37,6 +37,10 @@ dependencies {
         because("Tests instantiate DefaultClassLoaderRegistry which requires a 'gradle-plugins.properties' through DefaultPluginModuleRegistry")
     }
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: needed to resolve {@link MavenPublication ...}/{@link IvyPublication ...} references (downstream modules)
+    javadocReferences(projects.maven)
+    javadocReferences(projects.ivy)
 }
 
 gradleModule {

--- a/platforms/software/testing-base-infrastructure/build.gradle.kts
+++ b/platforms/software/testing-base-infrastructure/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
     integTestImplementation(testFixtures(projects.testingBase))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.toolingApiBuilders)
 }
 
 gradleModule {

--- a/platforms/software/testing-base/build.gradle.kts
+++ b/platforms/software/testing-base/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
         because("ProjectBuilder tests load services from a Gradle distribution.")
     }
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.testingJvm)
 }
 
 gradleModule {

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -50,6 +50,16 @@ dependencies {
     testFixturesImplementation(projects.baseServices)
 
     integTestDistributionRuntimeOnly(projects.distributionsBasics)
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.core)
+    javadocReferences(projects.modelCore)
+    javadocReferences(projects.dependencyManagement)
+    javadocReferences(projects.testingBase)
+    javadocReferences(projects.testingJvm)
+    javadocReferences(projects.kotlinDsl)
+    javadocReferences(projects.coreFlowServicesApi)
+    javadocReferences(libs.groovyTemplates) // for groovy.text.SimpleTemplateEngine references in ContentFilterable / ExpandDetails
 }
 
 gradleModule {

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -268,6 +268,9 @@ dependencies {
     annotationProcessor(projects.internalInstrumentationProcessor)
     annotationProcessor(platform(projects.distributionsDependencies))
 
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.credentials)
+    javadocReferences(projects.buildState)
 }
 
 gradleModule {

--- a/testing/internal-distribution-testing/build.gradle.kts
+++ b/testing/internal-distribution-testing/build.gradle.kts
@@ -78,6 +78,10 @@ dependencies {
     compileOnly(libs.jspecify)
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
+
+    // Javadoc-only: for {@link} references to types in internal-integ-testing and tooling-api test fixtures
+    javadocReferences(projects.internalIntegTesting)
+    javadocReferences(testFixtures(projects.toolingApi))
 }
 
 val prepareVersionsInfo = tasks.register<PrepareVersionsInfo>("prepareVersionsInfo") {

--- a/testing/internal-testing/build.gradle.kts
+++ b/testing/internal-testing/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
 
     runtimeOnly(libs.groovyJson)
     runtimeOnly(testLibs.bytebuddy)
+
+    // Javadoc-only: for groovy.test.NotYetImplemented reference in ToBeImplemented
+    javadocReferences(testLibs.groovyTest)
 }
 
 jvmCompile {


### PR DESCRIPTION
Properly sets up the classpath for the `javadoc` tasks in the build so that cross-module `{@link}` targets can be resolved, silencing lots of spurious warnings in the output.