### PR TITLE
Stream served files in HTTP test fixture to avoid OOM

### DIFF
--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -588,7 +588,7 @@ class HttpServer extends ServerWithExpectations implements HttpServerFixture {
         }
         response.setContentType(contentType ?: mimeTypeOf(file))
 
-        if (sendSha1Header || etags != null || contentLength != null) {
+        if (sendSha1Header || (etags != null && etags != EtagStrategy.NONE) || contentLength != null) {
             def content = file.bytes
             if (sendSha1Header) {
                 response.addHeader("X-Checksum-Sha1", Hashing.sha1().hashBytes(content).toZeroPaddedString(Hashing.sha1().hexDigits))

--- a/testing/internal-distribution-testing/src/test/groovy/org/gradle/test/fixtures/server/http/HttpServerLargeFileStreamingTest.groovy
+++ b/testing/internal-distribution-testing/src/test/groovy/org/gradle/test/fixtures/server/http/HttpServerLargeFileStreamingTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.http
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+/**
+ * Regression coverage for the HTTP fixture serving files by streaming rather than
+ * buffering them entirely in memory.
+ *
+ * The served file is larger than the maximum size of a Java array ({@code Integer.MAX_VALUE}
+ * bytes, ~2 GiB). Reading such a file into a single {@code byte[]} (as the buffering path did
+ * when {@code EtagStrategy.NONE} incorrectly selected it) fails with an {@link OutOfMemoryError}
+ * no matter how large the heap is, so this test reproduces the failure deterministically without
+ * having to constrain the JVM heap. Streaming has no such limit. The file is sparse, so it is
+ * created instantly and occupies effectively no disk.
+ */
+class HttpServerLargeFileStreamingTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def server = new HttpServer()
+
+    def setup() {
+        server.start()
+    }
+
+    def cleanup() {
+        server.stop()
+    }
+
+    def "serves a file larger than the maximum Java array size without buffering it in memory"() {
+        given:
+        long size = 2L * 1024 * 1024 * 1024 + 1 // just over Integer.MAX_VALUE, so it cannot fit in a byte[]
+        def file = tmpDir.file("large.bin")
+        createSparseFile(file, size)
+
+        // Chunked transfer avoids the fixture's 32-bit Content-Length header, which cannot
+        // represent a response body larger than 2 GiB.
+        server.chunkedTransfer = true
+        server.expectGet("/large.bin", file)
+
+        when:
+        long received = 0
+        new URL("${server.uri}/large.bin").openStream().withCloseable { input ->
+            byte[] buffer = new byte[1024 * 1024]
+            int read
+            while ((read = input.read(buffer)) != -1) {
+                received += read
+            }
+        }
+
+        then:
+        received == size
+    }
+
+    private static void createSparseFile(File file, long size) {
+        new RandomAccessFile(file, "rw").withCloseable { it.setLength(size) }
+    }
+}


### PR DESCRIPTION
### Context

The JDK-`com.sun.net.httpserver`-based `HttpServer` test fixture (introduced by `14e5c2cde98` "Remove jetty dependency from test infrastructure") buffers whole response bodies in memory. It *has* a streaming fast path — `response.sendFile(file)`, which copies the file in 8 KB chunks — but the guard that selects it is never reached:

```groovy
if (sendSha1Header || etags != null || contentLength != null) {
    def content = file.bytes   // loads the ENTIRE file into memory
    ...
    response.outputStream << content
} else {
    response.sendFile(file)    // streaming — effectively dead code
}
```

`etags` defaults to `EtagStrategy.NONE`, a **non-null** enum constant, so `etags != null` is always `true`. Every served file was therefore:

1. read fully into a `byte[]` via `file.bytes`,
2. buffered again into `HttpResponse`'s `ByteArrayOutputStream`,
3. copied once more by `buffer.toByteArray()` in `commit()`,
4. and copied a final time by the JDK httpserver's `ByteBuffer.allocate(len)`.

That's roughly **four simultaneous full-size copies** of the served file.

`SourceDistributionResolverSmokeTest` serves the multi-tens-of-MB Gradle `-src.zip` on a smoke-test worker capped at `-Xmx700m`. Under concurrent test load this exhausted the heap and produced flaky `OutOfMemoryError: Java heap space` build failures (e.g. [this ConfigCacheSmokeTest run](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SmokeTest_ConfigCacheSmokeTestsMinJavaVersion_virtual_Batch_3_1/114967961)), where the OOM in the `http-fixture` thread truncated the response, triggered a client retry, and surfaced as an "unexpected GET request" assertion.

### Change

Treat `EtagStrategy.NONE` as "no etag needed" so the default `expectGet(path, file)` (no sha1 header, no etag, no explicit content length) falls through to the streaming `response.sendFile(file)` path. Behaviour is unchanged — `EtagStrategy.NONE` never adds an `ETag` header — only the redundant in-memory buffering is removed, capping fixture memory use regardless of served-file size.

### Regression test

`HttpServerLargeFileStreamingTest` serves a file just over the maximum Java array size (~2 GiB) through the fixture. Reading such a file into a single `byte[]` fails with an `OutOfMemoryError` **regardless of heap size**, so the regression is caught deterministically without any heap tuning. The file is sparse (created via `RandomAccessFile.setLength`), so it is instant to create and uses no disk.

Verified locally, red→green:
- With the previous `etags != null` condition: the fixture throws `OutOfMemoryError: Java heap space`, the client receives HTTP 500, and the test **fails** — reproducing the original CI signature.
- With the fix: the response streams and the test **passes**.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Provide integration tests to verify changes from a user perspective.
- [x] Provide unit tests to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :internal-distribution-testing:test --tests "*HttpServerLargeFileStreamingTest"`.

_Note: test-fixture-only change (no product code, no public API). The fix itself was compile-checked via `:internal-distribution-testing:compileGroovy`; the new test was run both ways to confirm the red→green behaviour above. `sanityCheck` was not run locally._
