### PR TITLE
Update Documentation: minor fixes in doc pre markdown migration

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_testing.adoc
@@ -40,13 +40,12 @@ The plugin adds multiple custom tasks that print a greeting using properties def
 This is a common pattern for prototyping new functionality, but it lacks tests to verify the behavior of the custom types.
 The only way to verify that the task and plugin work as intended is to run the build manually and inspect the output.
 
+There are several problems with the sample below:
+
 ====
 include::sample[dir="snippets/best-practices/useTestKit-avoid/kotlin",files="build.gradle.kts[]"]
 include::sample[dir="snippets/best-practices/useTestKit-avoid/groovy",files="build.gradle[]"]
 ====
-
-In this case, there are several problems:
-
 <1> *The Task is declared as cacheable*: However, the task's output differs depending on when it is run, so it should not be cached.
 <2> *The current time is used as an undeclared input*: Inputs to a task must be explicitly declared using the appropriate annotations, otherwise Gradle cannot track changes to them.
 <3> *Error in task property wiring*: The `lastName` property is linked to the `firstName` property on the extension, which is likely a mistake.
@@ -159,12 +158,11 @@ To run them, you must explicitly invoke the tasks: `./gradlew :build-logic:check
 
 In the functional test class, we use TestKit to initialize a temporary Gradle project, apply our plugin, and verify that it behaves as expected.
 
+The example tests below show various techniques used to verify the plugin's behavior against actual, ad-hoc Gradle builds defined within the tests:
+
 ====
 include::sample[dir="snippets/best-practices/useTestKit-do/common/build-logic/src/functionalTest/java/org/example",files="MyPluginFunctionalTest.java"]
 ====
-
-Looking at the example tests here, you can see various techniques used to verify the plugin's behavior against actual, ad-hoc Gradle builds defined within the tests:
-
 <1> *testTaskRegistration*: This test runs the `tasks` report and verifies the output.
 <2> *testTaskExecution*: This test runs the custom task and verifies its output file.
 <3> *testTaskDeterminism*: This test runs the build twice - forcing tasks to rerun the second time - to ensure the output is identical, which is necessary for caching.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
@@ -14,6 +14,7 @@
 
 [[variant-attributes]]
 = Variants and Attributes
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
 
 **Variants** represent different versions or aspects of a component, like `api` vs `implementation`.
 **Attributes** define which variant is selected based on the consumer's requirements.

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -797,7 +797,7 @@ When you use the `ReplaceTokens` class with `filter()`, you create a template en
 [[using_copyspec_expand]]
 === Using `CopySpec.expand()`
 
-The `expand()` method treats the source files as https://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html[Groovy templates], which evaluates and expands expressions of the form `${expression}.`
+The `expand()` method treats the source files as https://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html[Groovy templates], which evaluates and expands expressions of the form `$\{expression}.`
 
 You can pass in property names and values that are then expanded in the source files. `expand()` allows for more than basic token substitution as the embedded expressions are full-blown Groovy expressions.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
@@ -191,17 +191,17 @@ _Default value_: `layout.buildDirectory.dir("resources/$name")`, e.g. _build/res
 The directory to generate the resources of this source set into.
 
 `compileClasspath` — link:{javadocPath}/org/gradle/api/file/FileCollection.html[FileCollection]::
-_Default value_: `${name}CompileClasspath` configuration
+_Default value_: `$\{name}CompileClasspath` configuration
 +
 The classpath to use when compiling the source files of this source set.
 
 `annotationProcessorPath` — link:{javadocPath}/org/gradle/api/file/FileCollection.html[FileCollection]::
-_Default value_: `${name}AnnotationProcessor` configuration
+_Default value_: `$\{name}AnnotationProcessor` configuration
 +
 The processor path to use when compiling the source files of this source set.
 
 `runtimeClasspath` — link:{javadocPath}/org/gradle/api/file/FileCollection.html[FileCollection]::
-_Default value_: `$output`, `${name}RuntimeClasspath` configuration
+_Default value_: `$output`, `$\{name}RuntimeClasspath` configuration
 +
 The classpath to use when executing the classes of this source set.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_testing.adoc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-:metadata-file-spec: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
 
 [[java_testing]]
 = Testing in Java & JVM projects

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/native/native_software.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/native/native_software.adoc
@@ -464,7 +464,7 @@ C++ language support is provided by means of the `'cpp'` plugin.
 include::{snippetsPath}/reference/platforms/native/cpp/groovy/build.gradle[tag=apply-plugin]
 ----
 
-$$C++$$ sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.cpp.CppSourceSet.html[CppSourceSet], which defines a set of C++ source files and optionally a set of exported header files (for a library). By default, for any named component the link:{groovyDslPath}/org.gradle.language.cpp.CppSourceSet.html[CppSourceSet] contains `.cpp` source files in `src/${name}/cpp`, and header files in `src/${name}/headers`.
+$$C++$$ sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.cpp.CppSourceSet.html[CppSourceSet], which defines a set of C++ source files and optionally a set of exported header files (for a library). By default, for any named component the link:{groovyDslPath}/org.gradle.language.cpp.CppSourceSet.html[CppSourceSet] contains `.cpp` source files in `src/$\{name}/cpp`, and header files in `src/$\{name}/headers`.
 
 While the `cpp` plugin defines these default locations for each link:{groovyDslPath}/org.gradle.language.cpp.CppSourceSet.html[CppSourceSet], it is possible to extend or override these defaults to allow for a different project layout.
 
@@ -493,7 +493,7 @@ C language support is provided by means of the `'c'` plugin.
 include::{snippetsPath}/reference/platforms/native/c/groovy/build.gradle[tag=apply-plugin]
 ----
 
-C sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.c.CSourceSet.html[CSourceSet], which defines a set of C source files and optionally a set of exported header files (for a library). By default, for any named component the link:{groovyDslPath}/org.gradle.language.c.CSourceSet.html[CSourceSet] contains `.c` source files in `src/${name}/c`, and header files in `src/${name}/headers`.
+C sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.c.CSourceSet.html[CSourceSet], which defines a set of C source files and optionally a set of exported header files (for a library). By default, for any named component the link:{groovyDslPath}/org.gradle.language.c.CSourceSet.html[CSourceSet] contains `.c` source files in `src/$\{name}/c`, and header files in `src/$\{name}/headers`.
 
 While the `c` plugin defines these default locations for each link:{groovyDslPath}/org.gradle.language.c.CSourceSet.html[CSourceSet], it is possible to extend or override these defaults to allow for a different project layout.
 
@@ -522,7 +522,7 @@ Assembly language support is provided by means of the `'assembler'` plugin.
 include::{snippetsPath}/reference/platforms/native/assembler/groovy/build.gradle[tag=apply-plugin]
 ----
 
-Assembler sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.assembler.AssemblerSourceSet.html[AssemblerSourceSet], which defines a set of Assembler source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.assembler.AssemblerSourceSet.html[AssemblerSourceSet] contains `.s` source files under `src/${name}/asm`.
+Assembler sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.assembler.AssemblerSourceSet.html[AssemblerSourceSet], which defines a set of Assembler source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.assembler.AssemblerSourceSet.html[AssemblerSourceSet] contains `.s` source files under `src/$\{name}/asm`.
 
 [[sec:objectivec_sources]]
 === Objective-C sources
@@ -538,7 +538,7 @@ Objective-C language support is provided by means of the `'objective-c'` plugin.
 include::{snippetsPath}/reference/platforms/native/objective-c/groovy/build.gradle[tag=apply-plugin]
 ----
 
-Objective-C sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.objectivec.ObjectiveCSourceSet.html[ObjectiveCSourceSet], which defines a set of Objective-C source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.objectivec.ObjectiveCSourceSet.html[ObjectiveCSourceSet] contains `.m` source files under `src/${name}/objectiveC`.
+Objective-C sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.objectivec.ObjectiveCSourceSet.html[ObjectiveCSourceSet], which defines a set of Objective-C source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.objectivec.ObjectiveCSourceSet.html[ObjectiveCSourceSet] contains `.m` source files under `src/$\{name}/objectiveC`.
 
 [[sec:objectivecpp_sources]]
 === Objective-C++ sources
@@ -554,7 +554,7 @@ Objective-C++ language support is provided by means of the `'objective-cpp'` plu
 include::{snippetsPath}/reference/platforms/native/objective-cpp/groovy/build.gradle[tag=apply-plugin]
 ----
 
-Objective-C$$++$$ sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.objectivecpp.ObjectiveCppSourceSet.html[ObjectiveCppSourceSet], which defines a set of Objective-C++ source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.objectivecpp.ObjectiveCppSourceSet.html[ObjectiveCppSourceSet] contains `.mm` source files under `src/${name}/objectiveCpp`.
+Objective-C$$++$$ sources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.objectivecpp.ObjectiveCppSourceSet.html[ObjectiveCppSourceSet], which defines a set of Objective-C++ source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.objectivecpp.ObjectiveCppSourceSet.html[ObjectiveCppSourceSet] contains `.mm` source files under `src/$\{name}/objectiveCpp`.
 
 [[sec:configuring_the_compiler_assembler_and_linker]]
 == Configuring the compiler, assembler and linker
@@ -621,7 +621,7 @@ When using the link:{groovyDslPath}/org.gradle.nativeplatform.toolchain.VisualCp
 include::{snippetsPath}/reference/platforms/native/windows-resources/groovy/build.gradle[tag=apply-plugin]
 ----
 
-Windows resources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.rc.WindowsResourceSet.html[WindowsResourceSet], which defines a set of Windows Resource source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.rc.WindowsResourceSet.html[WindowsResourceSet] contains `.rc` source files under `src/${name}/rc`.
+Windows resources to be included in a native binary are provided via a link:{groovyDslPath}/org.gradle.language.rc.WindowsResourceSet.html[WindowsResourceSet], which defines a set of Windows Resource source files. By default, for any named component the link:{groovyDslPath}/org.gradle.language.rc.WindowsResourceSet.html[WindowsResourceSet] contains `.rc` source files under `src/$\{name}/rc`.
 
 As with other source types, you can configure the location of the windows resources that should be included in the binary.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_binary.adoc
@@ -832,16 +832,14 @@ The following sample demonstrates how to add a variant that is compatible with G
 include::sample[dir="snippets/reference/plugin-development/pluginWithVariants/kotlin",files="build.gradle.kts[tags=add-plugin-variant]"]
 include::sample[dir="snippets/reference/plugin-development/pluginWithVariants/groovy",files="build.gradle[tags=add-plugin-variant]"]
 ====
-
-NOTE: Only Gradle versions 7 or higher can be explicitly targeted by a variant, as support for this was only added in Gradle 7.
-
-First, we declare a separate _source set_ and a _feature variant_ for our Gradle 7 plugin variant.
-Then, we do some specific wiring to turn the feature into a proper Gradle plugin variant:
-
 <1> Assign the <<component_capabilities.adoc#sec:declaring-component-capabilities,implicit capability that corresponds to the components GAV>> to the variant.
 <2> Assign the <<variant_attributes.adoc#sec:gradle-plugins-default-attributes,Gradle API version attribute>> to all <<declaring_configurations.adoc#sec:resolvable-consumable-configs,consumable configurations>> of our Gradle7 variant. Gradle uses this information to determine which variant to select during plugin resolution.
 <3> Configure the `processGradle7Resources` task to ensure the plugin descriptor file is added to the Gradle7 variant Jar.
 <4> Add a dependency to the `gradleApi()` for our new variant so that the API is visible during compilation time.
+
+The sample declares a separate _source set_ and a _feature variant_ for our Gradle 7 plugin variant, then wires the feature into a proper Gradle plugin variant.
+
+NOTE: Only Gradle versions 7 or higher can be explicitly targeted by a variant, as support for this was only added in Gradle 7.
 
 Note that there is currently no convenient way to access the API of other Gradle versions as the one you are building the plugin with.
 Ideally, every variant should be able to declare a dependency on the API of the minimal Gradle version it supports.

--- a/platforms/documentation/docs/src/docs/userguide/reference/task-development/custom_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/task-development/custom_tasks.adoc
@@ -412,6 +412,12 @@ Verification failures are also useful for tasks that need to report a failure ev
 include::sample[dir="snippets/reference/task-development/verificationFailure/kotlin",files="build.gradle.kts[tags=verification-failure]"]
 include::sample[dir="snippets/reference/task-development/verificationFailure/groovy",files="build.gradle[tags=verification-failure]"]
 ====
+<1> *Register Output*: The `process` task writes its output to a log file.
+<2> *Modify Output*: The task writes to its output file as it executes.
+<3> *Task Failure*: The task throws a `VerificationException` and fails at this point.
+<4> *Continue to Modify Output*: This line never runs due to the exception stopping the task.
+<5> *Consume Output*: The `postProcess` task depends on the output of the `process` task due to using that task's outputs as its own inputs.
+<6> *Use Partial Result*: With the `--continue` flag set, Gradle still runs the requested `postProcess` task despite the `process` task's failure.  `postProcess` can read and display the partial (though still valid) result.
 
 [source,bash]
 ----
@@ -421,9 +427,3 @@ $ ./gradlew postProcess --continue
 ----
 include::{snippetsPath}/reference/task-development/verificationFailure/tests/verificationFailure.out[]
 ----
-<1> *Register Output*: The `process` task writes its output to a log file.
-<2> *Modify Output*: The task writes to its output file as it executes.
-<3> *Task Failure*: The task throws a `VerificationException` and fails at this point.
-<4> *Continue to Modify Output*: This line never runs due to the exception stopping the task.
-<5> *Consume Output*: The `postProcess` task depends on the output of the `process` task due to using that task's outputs as its own inputs.
-<6> *Use Partial Result*: With the `--continue` flag set, Gradle still runs the requested `postProcess` task despite the `process` task's failure.  `postProcess` can read and display the partial (though still valid) result.


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
  - Issues in docs found pre markdown migration

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description