### PR TITLE
Add Documentation: Document lazy Jar manifest attributes

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/building_java_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/building_java_projects.adoc
@@ -484,6 +484,14 @@ include::sample[dir="snippets/reference/platforms/jvm/manifest/kotlin",files="bu
 include::sample[dir="snippets/reference/platforms/jvm/manifest/groovy",files="build.gradle[tags=add-to-manifest]"]
 ====
 
+Manifest attribute values can be provided lazily using the Provider API.
+The provider value is resolved when Gradle writes the manifest:
+
+====
+include::sample[dir="snippets/reference/platforms/jvm/manifest/kotlin",files="build.gradle.kts[tags=provider-manifest]"]
+include::sample[dir="snippets/reference/platforms/jvm/manifest/groovy",files="build.gradle[tags=provider-manifest]"]
+====
+
 See link:{javadocPath}/org/gradle/api/java/archives/Manifest.html[Manifest] for the configuration options it provides.
 
 You can also create standalone instances of `Manifest`. One reason for doing so is to share manifest information between JARs. The following example demonstrates how to share common attributes between JARs:

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
@@ -471,6 +471,8 @@ The basename to use for archives, such as JAR or ZIP files. Default value: `__pr
 
 `link:{javadocPath}/org/gradle/api/java/archives/Manifest.html[Manifest] manifest`::
 The manifest to include in all JAR files. Default value: an empty manifest.
++
+See <<building_java_projects.adoc#sec:jar_manifest, Modifying the JAR manifest>> for examples of configuring attributes and using Provider values.
 
 [[sec:java_test]]
 == Testing

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/manifest/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/manifest/groovy/build.gradle
@@ -12,6 +12,16 @@ jar {
 }
 // end::add-to-manifest[]
 
+// tag::provider-manifest[]
+def buildNumber = providers.gradleProperty('buildNumber').orElse('0')
+
+jar {
+    manifest {
+        attributes('Build-Number': buildNumber)
+    }
+}
+// end::provider-manifest[]
+
 // tag::custom-manifest[]
 def sharedManifest = java.manifest {
     attributes("Implementation-Title": "Gradle",

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/manifest/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/manifest/kotlin/build.gradle.kts
@@ -14,6 +14,16 @@ tasks.jar {
 }
 // end::add-to-manifest[]
 
+// tag::provider-manifest[]
+val buildNumber = providers.gradleProperty("buildNumber").orElse("0")
+
+tasks.jar {
+    manifest {
+        attributes("Build-Number" to buildNumber)
+    }
+}
+// end::provider-manifest[]
+
 // tag::custom-manifest[]
 val sharedManifest = java.manifest {
     attributes (

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -201,6 +201,20 @@ public abstract class Jar extends Zip {
      *
      * <p>The given action is executed to configure the manifest.</p>
      *
+     * <pre class='autoTested'>
+     * plugins {
+     *     id 'java'
+     * }
+     *
+     * def buildNumber = providers.gradleProperty('buildNumber').orElse('0')
+     *
+     * tasks.named('jar', Jar) {
+     *     manifest {
+     *         attributes('Build-Number': buildNumber)
+     *     }
+     * }
+     * </pre>
+     *
      * @param configureAction The action.
      * @return This.
      * @since 3.5


### PR DESCRIPTION
Fixes #25266

### Summary
- Adds Jar manifest configuration examples to the Java plugin reference
- Documents using Provider values for manifest attributes
- Adds the Provider example to Jar.manifest(Action) Javadoc

### Verification
- ./gradlew docs:docsTest --tests "org.gradle.docs.samples.*manifest*"