### PR TITLE
Deprecate implicit opt-in into parallel model building

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -70,6 +70,9 @@ object BuildModelParametersProvider {
      *
      * It exists as a transitionary measure to allow IDEs to effectively require a separate user opt-in
      * into parallel model building via the explicit `org.gradle.tooling.parallel` property.
+     *
+     * This is transitional: once `org.gradle.parallel` and `org.gradle.tooling.parallel` become
+     * independent in Gradle 10, this property is redundant and will no longer be read (it becomes a no-op).
      */
     @JvmStatic
     val parallelModelBuildingIgnoreLegacyDefault = "org.gradle.tooling.parallel.ignore-legacy-default"

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 @TargetGradleVersion(">=8.3")
@@ -32,6 +33,9 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         // See https://github.com/gradle/gradle/pull/34665
         requireIsolatedUserHome()
         propertiesFile << gradleProperties
+        if (targetVersion >= GradleVersion.version("9.8.0")) {
+            expectImplicitParallelModelBuildingDeprecation()
+        }
 
         expect:
         loadToolingModel(KotlinDslScriptsModel)
@@ -42,6 +46,9 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         given:
         withSingleSubproject()
         propertiesFile << gradleProperties
+        if (targetVersion >= GradleVersion.version("9.8.0")) {
+            expectImplicitParallelModelBuildingDeprecation()
+        }
 
         expect:
         loadToolingModel(KotlinDslScriptsModel)

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -120,6 +120,10 @@ public class RootBuildLifecycleBuildActionExecutor {
      * This applies only to Vintage model building, which is the only mode where the implicit
      * {@code org.gradle.parallel} -> parallel model building link exists.
      * <p>
+     * "Vintage" refers to the resolved {@link BuildModelParameters} mode, not the user-facing opt-in:
+     * model building with Configuration Cache enabled currently falls back to Vintage (models cannot be
+     * cached yet), so such builds are in scope of this deprecation. Isolated Projects model building is not.
+     * <p>
      * The nag is intentionally emitted regardless of the {@code org.gradle.tooling.parallel.ignore-legacy-default}
      * system property: in a future major, having {@code org.gradle.parallel} enabled without an explicit value
      * for {@code org.gradle.tooling.parallel} during model building will be an error, so users relying on the

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.problems.internal.ProblemsInternal;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildActionRunner;
@@ -93,6 +94,7 @@ public class RootBuildLifecycleBuildActionExecutor {
             try {
                 initDeprecationLogging(startParameter);
                 maybeNagOnDeprecatedJavaRuntimeVersion();
+                maybeNagOnImplicitParallelModelBuildingOptIn(startParameter);
                 RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(startParameter, null));
                 return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));
             } finally {
@@ -109,6 +111,34 @@ public class RootBuildLifecycleBuildActionExecutor {
         ShowStacktrace showStacktrace = startParameter.getShowStacktrace();
         LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(showStacktrace.equals(ShowStacktrace.ALWAYS) || showStacktrace.equals(ShowStacktrace.ALWAYS_FULL));
         DeprecationLogger.init(startParameter.getWarningMode(), eventEmitter, problemsService, problemsStream);
+    }
+
+    /**
+     * Deprecates relying on the legacy default where parallel model building (used by the Tooling API,
+     * e.g. during IDE sync) is derived from the {@code org.gradle.parallel} property.
+     * <p>
+     * This applies only to Vintage model building, which is the only mode where the implicit
+     * {@code org.gradle.parallel} -> parallel model building link exists.
+     * <p>
+     * The nag is intentionally emitted regardless of the {@code org.gradle.tooling.parallel.ignore-legacy-default}
+     * system property: in a future major, having {@code org.gradle.parallel} enabled without an explicit value
+     * for {@code org.gradle.tooling.parallel} during model building will be an error, so users relying on the
+     * default must make it explicit now to avoid breaking on upgrade.
+     */
+    private void maybeNagOnImplicitParallelModelBuildingOptIn(StartParameterInternal startParameter) {
+        boolean relyingOnLegacyDefault = buildModelParameters.isModelBuilding()
+            && buildModelParameters.isVintage()
+            && !startParameter.getParallelToolingModelBuilding().isExplicit()
+            && startParameter.isParallelProjectExecutionEnabled();
+        if (relyingOnLegacyDefault) {
+            String toolingParallelProperty = StartParameterBuildOptions.ParallelToolingModelBuildingOption.PROPERTY_NAME;
+            DeprecationLogger.deprecateBehaviour("Relying on the default value of the '" + toolingParallelProperty + "' property while 'org.gradle.parallel' is enabled.")
+                .withContext("Whether the Tooling API builds project models in parallel (for example, during IDE sync) should be controlled explicitly via '" + toolingParallelProperty + "'.")
+                .withAdvice("Set '" + toolingParallelProperty + "' to 'true' or 'false' explicitly.")
+                .willBecomeAnErrorInGradle10()
+                .withUpgradeGuideSection(9, "deprecate_implicit_parallel_model_building")
+                .nagUser();
+        }
     }
 
     private static void maybeNagOnDeprecatedJavaRuntimeVersion() {

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -201,8 +201,8 @@ However, both Gradle and the IDE need to be configured to allow it.
 
 On the Gradle side, parallel model building must be allowed in the build definition.
 It is *automatically allowed with Isolated Projects*.
-It can also be <<performance.adoc#sec:configure_tooling_api_actions_parallelism,allowed without Isolated Projects>>
-via `org.gradle.tooling.parallel` or `org.gradle.parallel` Gradle properties.
+It can also be <<performance.adoc#sec:configure_tooling_api_actions_parallelism,allowed without Isolated Projects>> by setting the `org.gradle.tooling.parallel` Gradle property to `true`.
+Historically it was also enabled implicitly by `org.gradle.parallel`, but relying on that default is <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, deprecated>>.
 
 [WARNING]
 ====

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -202,7 +202,6 @@ However, both Gradle and the IDE need to be configured to allow it.
 On the Gradle side, parallel model building must be allowed in the build definition.
 It is *automatically allowed with Isolated Projects*.
 It can also be <<performance.adoc#sec:configure_tooling_api_actions_parallelism,allowed without Isolated Projects>> by setting the `org.gradle.tooling.parallel` Gradle property to `true`.
-Historically it was also enabled implicitly by `org.gradle.parallel`, but relying on that default is <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, deprecated>>.
 
 [WARNING]
 ====

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
@@ -194,6 +194,10 @@ At the same time, it is rare for builds to have problems with tasks _and_ Toolin
 Since Gradle 9.4.0, there is an additional option `org.gradle.tooling.parallel`
 that allows controlling parallelism of Tooling API actions independently of task execution parallelism.
 
+NOTE: Relying on `org.gradle.parallel` alone to enable parallel model building is deprecated and will become an error in Gradle 10.
+Set `org.gradle.tooling.parallel` explicitly.
+See <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, Deprecation of implicit opt-in to parallel model building>> for details.
+
 For instance, you can enable Tooling parallelism without task parallelism:
 
 [source,properties]

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
@@ -194,9 +194,7 @@ At the same time, it is rare for builds to have problems with tasks _and_ Toolin
 Since Gradle 9.4.0, there is an additional option `org.gradle.tooling.parallel`
 that allows controlling parallelism of Tooling API actions independently of task execution parallelism.
 
-NOTE: Relying on `org.gradle.parallel` alone to enable parallel model building is deprecated and will become an error in Gradle 10.
-Set `org.gradle.tooling.parallel` explicitly.
-See <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, Deprecation of implicit opt-in to parallel model building>> for details.
+Set `org.gradle.tooling.parallel` explicitly; relying on the default derived from `org.gradle.parallel` is <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building,deprecated>>.
 
 For instance, you can enable Tooling parallelism without task parallelism:
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -481,8 +481,7 @@ Allows running <<service_injection.adoc#toolingmodelbuilderregistry,Tooling Mode
 An explicit value will override `org.gradle.parallel` in this context.
 +
 _Default is the value of `org.gradle.parallel`._
-Relying on that default during model building is deprecated and will become an error in Gradle 10.
-See <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, Deprecation of implicit opt-in to parallel model building>>.
+Prefer setting an explicit value; relying on the default is <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building,deprecated>>.
 
 `org.gradle.isolated-projects=(true,false)` since-gradle-label:9.7.0[]::
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -481,6 +481,8 @@ Allows running <<service_injection.adoc#toolingmodelbuilderregistry,Tooling Mode
 An explicit value will override `org.gradle.parallel` in this context.
 +
 _Default is the value of `org.gradle.parallel`._
+Relying on that default during model building is deprecated and will become an error in Gradle 10.
+See <<upgrading_version_9.adoc#deprecate_implicit_parallel_model_building, Deprecation of implicit opt-in to parallel model building>>.
 
 `org.gradle.isolated-projects=(true,false)` since-gradle-label:9.7.0[]::
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -70,7 +70,7 @@ If you relied on mutable state surviving a cache hit, move it into a task proper
 === Deprecations
 
 [[deprecate_implicit_parallel_model_building]]
-==== Deprecation of implicit opt-in into parallel model building
+==== Deprecation of implicit opt-in to parallel model building
 
 Parallel model building lets Tooling API clients (most commonly IDEs during project synchronization) build project models in parallel.
 Historically, it had no dedicated control and was enabled implicitly whenever parallel execution (`org.gradle.parallel=true` or `--parallel`) was enabled.
@@ -89,10 +89,9 @@ To avoid the warning and prepare for Gradle 10, set `org.gradle.tooling.parallel
 org.gradle.tooling.parallel=true
 ----
 
-Relatedly, the transitional system property `org.gradle.tooling.parallel.ignore-legacy-default` (used by some IDEs during sync to opt out of the legacy default) will no longer be honored in Gradle 10.
+Additionally, the transitional system property `org.gradle.tooling.parallel.ignore-legacy-default` (used by some IDEs during sync to opt out of the legacy default) will no longer be honored in Gradle 10.
 Once `org.gradle.parallel` and `org.gradle.tooling.parallel` are independent, the flag is redundant, so Gradle 10 simply ignores it.
 No action is required in Gradle 9.x; if you set it explicitly, you can remove it when upgrading to Gradle 10.
-
 
 [[changes_9.7.0]]
 == Upgrading from 9.6.0 and earlier

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -67,6 +67,32 @@ As a consequence, only the singleton's identity is restored, not any mutable sta
 Previously, each `object` was serialized as a regular bean and rebuilt as a _new_ instance on a cache hit, so `deserialized === TheObject` was `false`.
 If you relied on mutable state surviving a cache hit, move it into a task property or another bean type that is serialized by value.
 
+=== Deprecations
+
+[[deprecate_implicit_parallel_model_building]]
+==== Deprecation of implicit opt-in into parallel model building
+
+Parallel model building lets Tooling API clients (most commonly IDEs during project synchronization) build project models in parallel.
+Historically, it had no dedicated control and was enabled implicitly whenever parallel execution (`org.gradle.parallel=true` or `--parallel`) was enabled.
+
+Gradle 9.4.0 introduced the dedicated `org.gradle.tooling.parallel` property to control parallel model building explicitly.
+When that property is not set, its value is currently derived from `org.gradle.parallel` to preserve backward compatibility.
+
+Relying on this implicit behavior is now deprecated.
+When `org.gradle.parallel` is enabled and `org.gradle.tooling.parallel` is not set explicitly during model building, Gradle emits a deprecation warning.
+In Gradle 10, the two properties will become independent, and enabling `org.gradle.parallel` without an explicit value for `org.gradle.tooling.parallel` during model building will be an error.
+
+To avoid the warning and prepare for Gradle 10, set `org.gradle.tooling.parallel` explicitly to either `true` or `false`, for example in `gradle.properties`:
+
+[source,properties]
+----
+org.gradle.tooling.parallel=true
+----
+
+Relatedly, the transitional system property `org.gradle.tooling.parallel.ignore-legacy-default` (used by some IDEs during sync to opt out of the legacy default) will no longer be honored in Gradle 10.
+Once `org.gradle.parallel` and `org.gradle.tooling.parallel` are independent, the flag is redundant, so Gradle 10 simply ignores it.
+No action is required in Gradle 9.x; if you set it explicitly, you can remove it when upgrading to Gradle 10.
+
 
 [[changes_9.7.0]]
 == Upgrading from 9.6.0 and earlier

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -46,6 +46,8 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
     def "resolving configuration from a project other than its target fails in newer Gradle versions"() {
         given:
         setupBuild()
+        // The build enables --parallel without an explicit org.gradle.tooling.parallel, which is deprecated.
+        expectImplicitParallelModelBuildingDeprecation()
 
         when:
         fails { connection ->

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r900/GradleProjectModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r900/GradleProjectModelCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.tooling.r900
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.GradleProject
+import org.gradle.util.GradleVersion
 
 @TargetGradleVersion(">=9.0.0")
 class GradleProjectModelCrossVersionSpec extends ToolingApiSpecification {
@@ -36,6 +37,9 @@ class GradleProjectModelCrossVersionSpec extends ToolingApiSpecification {
                something.resolve()
             }
             """
+        if (parallel && targetVersion >= GradleVersion.version("9.8.0")) {
+            expectImplicitParallelModelBuildingDeprecation()
+        }
 
         when:
         GradleProject model = loadToolingModel(GradleProject)
@@ -60,6 +64,9 @@ class GradleProjectModelCrossVersionSpec extends ToolingApiSpecification {
             def something = configurations.create('something')
             something.resolve()
             """
+        if (parallel && targetVersion >= GradleVersion.version("9.8.0")) {
+            expectImplicitParallelModelBuildingDeprecation()
+        }
 
         when:
         GradleProject model = loadToolingModel(GradleProject)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
@@ -44,6 +44,7 @@ class ParallelModelBuildingDeprecationCrossVersionSpec extends ToolingApiSpecifi
         args << [
             [],
             ["-Dorg.gradle.tooling.parallel.ignore-legacy-default=true"],
+            ["-Dorg.gradle.tooling.parallel.ignore-legacy-default=false"],
         ]
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
@@ -66,4 +66,11 @@ class ParallelModelBuildingDeprecationCrossVersionSpec extends ToolingApiSpecifi
             connection.model(GradleProject).get()
         }
     }
+
+    def "no deprecation is reported when running tasks with parallel execution enabled"() {
+        expect:
+        withBuild { build ->
+            build.forTasks("help").withArguments("--parallel")
+        }
+    }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r980/ParallelModelBuildingDeprecationCrossVersionSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r980
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.tooling.model.GradleProject
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/36001")
+@TargetGradleVersion("current")
+class ParallelModelBuildingDeprecationCrossVersionSpec extends ToolingApiSpecification {
+
+    def setup() {
+        settingsFile "rootProject.name = 'root'"
+    }
+
+    def "deprecation is reported when parallel execution implicitly enables parallel model building with #args"() {
+        when:
+        expectImplicitParallelModelBuildingDeprecation()
+
+        then:
+        succeeds { connection ->
+            connection.model(GradleProject).withArguments(["--parallel"] + args).get()
+        }
+
+        where:
+        // The deprecation must fire regardless of ignore-legacy-default, because in Gradle 10 having
+        // 'org.gradle.parallel' enabled without an explicit 'org.gradle.tooling.parallel' will be an error.
+        args << [
+            [],
+            ["-Dorg.gradle.tooling.parallel.ignore-legacy-default=true"],
+        ]
+    }
+
+    def "no deprecation is reported when parallel model building is set explicitly with #args"() {
+        expect:
+        succeeds { connection ->
+            connection.model(GradleProject).withArguments(["--parallel"] + args).get()
+        }
+
+        where:
+        args << [
+            ["-Dorg.gradle.tooling.parallel=true"],
+            ["-Dorg.gradle.tooling.parallel=false"],
+        ]
+    }
+
+    def "no deprecation is reported when parallel execution is not enabled"() {
+        expect:
+        succeeds { connection ->
+            connection.model(GradleProject).get()
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.tooling.r56.DefaultEclipseWorkspaceProject
 import org.gradle.integtests.tooling.r56.IntermediateResultHandlerCollector
 import org.gradle.integtests.tooling.r56.ParameterizedLoadCompositeEclipseModels
 import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies
+import org.gradle.util.GradleVersion
 
 @TargetGradleVersion('>=9.0.0')
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
@@ -40,6 +41,10 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
             temporaryFolder.file("workspace"),
             [new DefaultEclipseWorkspaceProject("root", projectDir, true)]
         )
+
+        if (parallel && targetVersion >= GradleVersion.version("9.8.0")) {
+            expectImplicitParallelModelBuildingDeprecation()
+        }
 
         expect:
         succeeds { connection ->

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -578,6 +578,20 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
         expectedDeprecations << normalizeDeprecationWarning(message)
     }
 
+    /**
+     * Expects the deprecation for relying on {@code org.gradle.parallel} to implicitly enable parallel
+     * model building, emitted by Gradle 9.8.0 and later during model building. See gradle/gradle#36001.
+     */
+    void expectImplicitParallelModelBuildingDeprecation() {
+        expectDocumentedDeprecationWarning(
+            "Relying on the default value of the 'org.gradle.tooling.parallel' property while 'org.gradle.parallel' is enabled. " +
+                "This behavior has been deprecated. This will fail with an error in Gradle 10. " +
+                "Whether the Tooling API builds project models in parallel (for example, during IDE sync) should be controlled explicitly via 'org.gradle.tooling.parallel'. " +
+                "Set 'org.gradle.tooling.parallel' to 'true' or 'false' explicitly. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_implicit_parallel_model_building"
+        )
+    }
+
     private String normalizeDeprecationWarning(String message) {
         def normalizedLink = DocumentationUtils.normalizeDocumentationLink(message, targetDist.version)
 


### PR DESCRIPTION
<!-- Fixes #? -->
Fixes #36001

### Context

Parallel model building (used by the Tooling API, most notably during IDE sync) was historically enabled implicitly whenever parallel execution (`org.gradle.parallel` / `--parallel`) was enabled. Gradle 9.4.0 (#35948) introduced the dedicated `org.gradle.tooling.parallel` property, which defaults to the value of `org.gradle.parallel` when unset to preserve backward compatibility.

Per #35996, we intend to make the two properties independent in Gradle 10, and to make it an error to enable `org.gradle.parallel` without an explicit `org.gradle.tooling.parallel` during model building (so users don't silently lose IDE-sync performance on upgrade). This PR is the deprecation that must precede that change.

**What it does:** when a build action builds models in Vintage mode with `org.gradle.parallel` enabled and `org.gradle.tooling.parallel` not set explicitly, Gradle emits a deprecation warning advising the user to set `org.gradle.tooling.parallel` explicitly. The remedy (setting the property) both silences the warning and pre-empts the Gradle 10 error.

**Trigger scope:** only model-building (Tooling API) invocations are affected — plain `--parallel` CLI builds never nag. The nag fires regardless of the transitional `org.gradle.tooling.parallel.ignore-legacy-default` system property, because that property will no longer be honored in Gradle 10 (it becomes redundant once the properties are independent). This is documented in the upgrade guide.

**Implementation note:** the deprecation is emitted from `RootBuildLifecycleBuildActionExecutor` (after the `DeprecationLogger` is initialized) rather than during build-model-parameter computation, where the logger is not yet available.

Relevant issues:
- #36001 (this deprecation)
- #35996 (the eventual Gradle 10 behavior change)
- #35948 (introduced `org.gradle.tooling.parallel`)

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things

### Decisions made (please confirm)

- **The nag fires regardless of `org.gradle.tooling.parallel.ignore-legacy-default`.** This is intentionally broader than the "narrowest case" sketched in #36001 (which would exempt the flag and thereby spare IntelliJ 2026.1.1+ users). Rationale: it mirrors the intended Gradle 10 error, so no one passes clean in 9.x and then breaks on upgrade. This assumes the Gradle 10 error fires even when the flag is set — please confirm.
- **`org.gradle.tooling.parallel.ignore-legacy-default` will no longer be honored in Gradle 10** (documented in the upgrade guide). It is not separately nagged: it is IDE-passed and undocumented, so a runtime nag would spam IDE syncs for something users did not set.
- **End state = require explicitness → error in Gradle 10** (alllex's option 2 from #36001), which is what `willBecomeAnErrorInGradle10()` encodes.

### Open questions

- **Exact Gradle 10 error semantics**, especially the interaction with `ignore-legacy-default` — this is the keystone for the first decision above.
- **Does a standard deprecation warning actually surface to Android Studio sync users?** They are the primary audience, and IDE sync UIs often swallow end-of-build deprecation warnings. If not, a Problems-API report or a louder channel may be needed (alllex's "louder / in more contexts" point).
- **IDE coordination:** how/when IntelliJ stops passing `ignore-legacy-default`, and whether Android Studio should start writing an explicit `org.gradle.tooling.parallel` rather than the nag landing on end users.