### PR TITLE
Have Codenarc only output failures in Gradle build

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -230,6 +230,7 @@ tasks.withType<CodeNarc>().configureEach {
     if (name.contains("IntegTest")) {
         config = configFile("codenarc-integtests.xml")
     }
+    logging.captureStandardOutput(LogLevel.INFO)
 }
 
 val SourceSet.allGroovy: SourceDirectorySet


### PR DESCRIPTION
This removes lots of unhelpful success confirmation message like this from the build output:

```
> Task :performance:codenarcPerformanceTest
[ant:codenarc] CodeNarc Report - Jul 8, 2026, 11:47:40 AM
[ant:codenarc] 
[ant:codenarc] Summary: TotalFiles=40 FilesWithViolations=0 P1=0 P2=0 P3=0
[ant:codenarc] 
[ant:codenarc] [CodeNarc (https://codenarc.org) v3.7.0]
[ant:codenarc] CodeNarc completed: (p1=0; p2=0; p3=0) 12126ms
```