### PR TITLE
Detect Kotlin 2.4+ compile daemon in CI leak killer

### DIFF
--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -87,7 +87,12 @@ public class KillLeakingJavaProcesses {
     }
 
     static String generateLeakingProcessKillPattern(String rootProjectDir) {
-        String kotlinCompilerDaemonPattern = "(?:" + quote("-Dkotlin.environment.keepalive") + ".+org\\.jetbrains\\.kotlin\\.daemon\\.KotlinCompileDaemon)";
+        // Match the Kotlin compile daemon by its main class, which is stable across Kotlin versions.
+        // Older Kotlin releases launched the daemon with `-Dkotlin.environment.keepalive`, but Kotlin 2.4+
+        // (Build Tools API) no longer passes that flag and instead uses `-Dkotlin.daemon.initiator.marker.file`
+        // / `--daemon-logsPath`. Keying on the flag left 2.4+ daemons undetected, so they leaked and kept
+        // `<subproject>/build/tmp/kotlin-daemon.*.log` open, breaking the next build's `clean` on Windows.
+        String kotlinCompilerDaemonPattern = "(?:org\\.jetbrains\\.kotlin\\.daemon\\.KotlinCompileDaemon)";
         String quotedRootProjectDir = quote(rootProjectDir);
         String perfTestClasspathPattern = "(?:-cp.+\\\\build\\\\tmp\\\\performance-test-files.+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
         String buildDirClasspathPattern = "(?:-(classpath|cp) \"?" + quotedRootProjectDir + ".+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";

--- a/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
+++ b/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
@@ -77,6 +77,17 @@ class LeakingProcessKillPatternTest extends Specification {
         (line =~ KillLeakingJavaProcesses.generateLeakingProcessKillPattern(projectDir)).find()
     }
 
+    def "matches kotlin 2.4 compile daemon without keepalive flag on windows"() {
+        // Kotlin 2.4+ (Build Tools API) no longer passes `-Dkotlin.environment.keepalive`; it uses
+        // `-Dkotlin.daemon.initiator.marker.file` and `--daemon-logsPath` (pointing into build/tmp) instead.
+        def line = '38972 "C:\\tcagent1\\JdkProvider\\jdks\\windows-amd64-temurin-jdk-25.0.3_9\\bin\\java.exe" -cp C:\\tcagent1\\work\\f63322e10dd6b396\\intTestHomeDir\\distributions-full\\caches\\modules-2\\files-2.1\\org.jetbrains.kotlin\\kotlin-compiler-embeddable\\2.4.0\\f1a24af8bd111a83950236b1aec7a6d72a97e92c\\kotlin-compiler-embeddable-2.4.0.jar;C:\\tcagent1\\work\\f63322e10dd6b396\\intTestHomeDir\\distributions-full\\caches\\modules-2\\files-2.1\\org.jetbrains.kotlin\\kotlin-daemon-embeddable\\2.4.0\\1ecabef3a8ba6a8e25654573d54edb7e4136e903\\kotlin-daemon-embeddable-2.4.0.jar -Djava.awt.headless=true -Djava.rmi.server.hostname=127.0.0.1 -Xmx1024m -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=320m -ea -Dkotlin.daemon.custom.run.files.path.for.tests=C:\\Users\\tcagent1\\AppData\\Local\\kotlin\\daemon -XX:+UseCodeCacheFlushing -XX:+UseParallelGC -Dkotlin.daemon.initiator.marker.file=C:\\tcagent1\\work\\f63322e10dd6b396\\platforms\\core-configuration\\configuration-cache\\build\\tmp\\kotlin-compiler-client-10732081455334371727-is-running --add-exports java.base/sun.nio.ch=ALL-UNNAMED org.jetbrains.kotlin.daemon.KotlinCompileDaemon --daemon-logsPath C:\\tcagent1\\work\\f63322e10dd6b396\\platforms\\core-configuration\\configuration-cache\\build\\tmp --daemon-logsFileSizeLimit=1048576 --daemon-logsFileCountLimit=3 --daemon-runFilesPath C:\\Users\\tcagent1\\AppData\\Local\\kotlin\\daemon --daemon-autoshutdownIdleSeconds=7200 --daemon-compilerClasspath C:\\tcagent1\\work\\f63322e10dd6b396\\intTestHomeDir\\distributions-full\\caches\\modules-2\\files-2.1\\org.jetbrains.kotlin\\kotlin-build-tools-impl\\2.4.0\\3dde5b4075cd7963afd0b0b2835627f40abc1149\\kotlin-build-tools-impl-2.4.0.jar'
+
+        def projectDir = "C:\\tcagent1\\work\\f63322e10dd6b396\\"
+
+        expect:
+        (line =~ KillLeakingJavaProcesses.generateLeakingProcessKillPattern(projectDir)).find()
+    }
+
     def "matches google-chrome-for-testing"() {
         def line = '3723579 /usr/bin/google-chrome-for-testing --allow-pre-commit-input --disable-background-networking --disable-client-side-phishing-detection --disable-default-apps --disable-gpu --disable-hang-monitor --disable-popup-blocking --disab'
 


### PR DESCRIPTION
### Context

Since the embedded Kotlin upgrade to 2.4.x, many builds on Windows CI agents started failing at build start with:

```
Unable to delete directory 'C:\...\configuration-cache\build'
Failed to delete some children. This might happen because a process has files open...
  - ...\configuration-cache\build\tmp\kotlin-daemon.<date>.log
```

**Root cause:** The CI leak killer (`KillLeakingJavaProcesses`) identifies the Kotlin compile daemon by the `-Dkotlin.environment.keepalive` JVM flag. Kotlin 2.4+ (Build Tools API) no longer passes that flag — it launches the daemon with `-Dkotlin.daemon.initiator.marker.file` / `--daemon-logsPath` instead. As a result, 2.4+ daemons were never recognized as leaked processes, so they lingered on the reused Windows agents (2h idle timeout) holding `<subproject>/build/tmp/kotlin-daemon.*.log` open. On Windows an open file can't be deleted, so the next build's `clean` task failed.

**Fix:** Match the daemon by its stable main class `org.jetbrains.kotlin.daemon.KotlinCompileDaemon` instead of an incidental JVM flag, so detection is robust across Kotlin versions.

Verified the updated pattern matches the Kotlin 2.4.0 daemon command line (captured from a failing build), still matches the legacy 1.9.10 form, and still does not match a Gradle worker running from the `.gradle` cache.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
