### PR TITLE
Update Documentation: clarify project property resolution

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -31,6 +31,11 @@ import kotlin.reflect.KProperty
 /**
  * The extra properties extension in this object's extension container.
  *
+ * For a [org.gradle.api.Project], this accesses only that project's extra properties. Values set explicitly
+ * on the extension take precedence over Gradle properties with the same name when those properties are not mapped
+ * directly to a `Project` property. This does not perform the broader lookup used by
+ * [org.gradle.api.Project.findProperty].
+ *
  * @see [ExtensionContainer.getExtraProperties]
  */
 val ExtensionAware.extra: ExtraPropertiesExtension

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -157,7 +157,8 @@ You have four options to add project properties, listed in order of priority:
 ----
 $ ./gradlew build -PmyProperty='Hi, world'
 ----
-2. *System Property:* Gradle creates specially-named system properties for project properties which you can set using the `-D` command line flag or `gradle.properties` file. For the project property `myProperty`, the system property created is called `org.gradle.project.__myProperty__`.
+2. *System Property:* Gradle creates specially-named system properties for project properties which you can set using the `-D` command line flag or `gradle.properties` file.
+For the project property `myProperty`, the system property created is called `org.gradle.project.__myProperty__`.
 +
 [source,text]
 ----
@@ -167,20 +168,10 @@ $ ./gradlew build -Dorg.gradle.project.myProperty='Hi, world'
 .gradle.properties
 [source,properties]
 ----
-org.gradle.project.myProperty='Hi, world'
+systemProp.org.gradle.project.myProperty='Hi, world'
 ----
-3. *Gradle Properties File:* You can also set project properties in `gradle.properties` files.
-+
-.gradle.properties
-[source,text]
-----
-myProperty='Hi, world'
-----
-+
-The `gradle.properties` file can be located in a number of places, including `<GRADLE_USER_HOME>/gradle.properties`, `./gradle.properties` (the project root) and `<GRADLE_HOME>/gradle.properties`.
-+
-If the same property is defined in multiple locations, the file’s location determines its <<#priority-table-gradle-properties,precedence>>.
-4. *Environment Variables:* You can set project properties with environment variables. If the environment variable name looks like `ORG_GRADLE_PROJECT___myProperty__='Hi, world'`, then Gradle will set a `myProperty` property on your project object, with the value of `Hi, world`.
+3. *Environment Variables:* You can set project properties with environment variables.
+If the environment variable name looks like `ORG_GRADLE_PROJECT___myProperty__='Hi, world'`, then Gradle will set a `myProperty` property on your project object, with the value of `Hi, world`.
 +
 [source,text]
 ----
@@ -188,6 +179,16 @@ $ export ORG_GRADLE_PROJECT_myProperty='Hi, world'
 ----
 +
 This is typically the preferred method for supplying project properties, especially secrets, to unattended builds like those running on CI servers.
+4. *Gradle Properties File:* You can also set project properties in `gradle.properties` files.
++
+.gradle.properties
+[source,text]
+----
+myProperty='Hi, world'
+----
++
+The `gradle.properties` file can be located in the Gradle User Home, a project directory, the build root directory, or the Gradle installation directory.
+The exact files considered depend on the API used to read the property, as described below.
 
 [[accessing_a_project_property]]
 === Accessing a project property
@@ -202,17 +203,39 @@ val myProperty: Provider<String> = providers.gradleProperty("myProperty")
 The returned `Provider` is lazy and compatible with the <<configuration_cache_requirements.adoc#config_cache:requirements:reading_sys_props_and_env_vars,Configuration Cache>>.
 The provider resolves the property from the build-level sources listed above: command-line `-P` arguments, `org.gradle.project.pass:[*]` system properties, `ORG_GRADLE_PROJECT_pass:[*]` environment variables, and `gradle.properties` files in the Gradle User Home, build root, and Gradle installation directories.
 
-[NOTE]
-====
-`providers.gradleProperty()` does not include properties from `gradle.properties` files in subproject directories, nor extra properties or other properties set dynamically on individual `Project` instances.
-To access those, use `project.findProperty("name")` or extra properties directly.
-====
+[[sec:project_property_lookup]]
+==== How the lookup APIs differ
 
-For other ways to access properties, see the following methods on the link:{groovyDslPath}/org.gradle.api.Project.html[Project] object:
+The property APIs do not all search the same sources.
+Use link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#gradleProperty(java.lang.String)[`providers.gradleProperty()`] when the value comes from the build environment and should remain lazy.
+It searches build-level Gradle properties only.
+It does not include `gradle.properties` files in subproject directories, extra properties, or other values added dynamically to a link:{groovyDslPath}/org.gradle.api.Project.html[`Project`] instance.
 
-- `findProperty("name")` — returns the value or `null`, checking dynamically configured containers, like extra properties, and parent projects as well.
-- `property("name")` — returns the value or throws if the property is missing
-- `hasProperty("name")` — checks if the property exists
+link:{javadocPath}/org/gradle/api/Project.html#findProperty(java.lang.String)[`Project.findProperty()`], link:{javadocPath}/org/gradle/api/Project.html#property(java.lang.String)[`Project.property()`], and link:{javadocPath}/org/gradle/api/Project.html#hasProperty(java.lang.String)[`Project.hasProperty()`] search the dynamic project model in this order:
+
+. The current `Project` object's own properties.
+. The current project's extra properties.
+Gradle properties not mapped directly to a `Project` property are available here.
+Values added explicitly to the extra properties extension take precedence over Gradle properties with the same name.
+. An extension with the requested name.
+. A task with the requested name.
+. Extra properties and extensions on ancestor projects, starting with the parent project and continuing to the root project.
+
+Gradle properties not mapped directly to a `Project` property use the following precedence in the extra properties extension, from highest to lowest:
+
+. Command-line project properties passed with `-P`.
+. System properties with the `org.gradle.project.` prefix.
+. Environment variables with the `ORG_GRADLE_PROJECT_` prefix.
+. `gradle.properties` in the Gradle User Home directory.
+. `gradle.properties` in the current project directory.
+. `gradle.properties` in the build root directory.
+. `gradle.properties` in the Gradle installation directory.
+
+The three dynamic lookup methods use the same search order but handle a missing value differently.
+`findProperty()` returns `null`, `property()` throws a `MissingPropertyException`, and `hasProperty()` returns `false`.
+
+The Kotlin DSL `project.extra` accessor and `project.extensions.extraProperties` expose only the current project's extra properties from step 2.
+They do not search the project's own properties, extensions, tasks, or ancestor projects.
 
 It is possible to change the behavior of a task based on project properties specified at invocation time.
 Suppose you’d like to ensure release builds are only triggered by CI.
@@ -340,8 +363,8 @@ If an option is configured in multiple locations, the _first one_ found in any o
 
 |3
 |`gradle.properties` file
-|Project Root Dir
-|Stored in a `gradle.properties` file in a project directory, then its parent project’s directory up to the project’s root directory.
+|Build Root Dir
+|Stored in the `gradle.properties` file in the build root directory.
 
 |4
 |`gradle.properties` file
@@ -615,4 +638,3 @@ When present and non-empty, disables color output while preserving other styling
 +
 Follows the link:https://no-color.org/[no-color.org] convention.
 See <<command_line_interface.adoc#sec:command_line_customizing_log_format,Customizing log format>> for more options.
-

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_environment.adoc
@@ -214,6 +214,8 @@ It does not include `gradle.properties` files in subproject directories, extra p
 link:{javadocPath}/org/gradle/api/Project.html#findProperty(java.lang.String)[`Project.findProperty()`], link:{javadocPath}/org/gradle/api/Project.html#property(java.lang.String)[`Project.property()`], and link:{javadocPath}/org/gradle/api/Project.html#hasProperty(java.lang.String)[`Project.hasProperty()`] search the dynamic project model in this order:
 
 . The current `Project` object's own properties.
+This includes the Gradle properties `version`, `group`, `status`, `buildDir`, and `description`, which Gradle applies directly to the `Project` object.
+All other Gradle properties are exposed via extra properties in step 2.
 . The current project's extra properties.
 Gradle properties not mapped directly to a `Project` property are available here.
 Values added explicitly to the extra properties extension take precedence over Gradle properties with the same name.
@@ -221,7 +223,15 @@ Values added explicitly to the extra properties extension take precedence over G
 . A task with the requested name.
 . Extra properties and extensions on ancestor projects, starting with the parent project and continuing to the root project.
 
-Gradle properties not mapped directly to a `Project` property use the following precedence in the extra properties extension, from highest to lowest:
+[WARNING]
+====
+Implicit lookup of properties and methods in parent projects (step 5) is deprecated in Gradle 9.6 and will be removed in Gradle 10.
+See <<upgrading_version_9.adoc#deprecated_implicit_lookup_in_parent_projects,the upgrade guide entry>> and <<isolated_projects.adoc#sec:no_implicit_parents_lookup,No implicit lookup of properties and methods in parent projects>>.
+Declare the property in the current project instead, or use `rootProject.ext.foo` or `parent.ext.foo` to make the cross-project reference explicit.
+====
+
+Explicit `set()` calls on the extra properties extension always take precedence over any Gradle-property source.
+Among the Gradle-property sources that feed extra properties, precedence is as follows (highest to lowest):
 
 . Command-line project properties passed with `-P`.
 . System properties with the `org.gradle.project.` prefix.
@@ -234,7 +244,7 @@ Gradle properties not mapped directly to a `Project` property use the following 
 The three dynamic lookup methods use the same search order but handle a missing value differently.
 `findProperty()` returns `null`, `property()` throws a `MissingPropertyException`, and `hasProperty()` returns `false`.
 
-The Kotlin DSL `project.extra` accessor and `project.extensions.extraProperties` expose only the current project's extra properties from step 2.
+The `project.extra` Kotlin DSL accessor and the `project.extensions.extraProperties` API expose only the current project's extra properties (step 2).
 They do not search the project's own properties, extensions, tasks, or ancestor projects.
 
 It is possible to change the behavior of a task based on project properties specified at invocation time.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -143,8 +143,11 @@ import java.util.concurrent.Callable;
  * <code>rootProject</code> property.  The properties of this scope are readable or writable depending on the presence
  * of the corresponding getter or setter method.</li>
  *
- * <li>The <em>extra</em> properties of the project.  Each project maintains a map of extra properties, which
- * can contain any arbitrary name -&gt; value pair.  Once defined, the properties of this scope are readable and writable.
+ * <li>The <em>extra</em> properties of the project. Each project maintains a map of extra properties, which
+ * can contain any arbitrary name -&gt; value pair. Project-scoped Gradle properties that are not mapped directly to a
+ * {@code Project} property are also available in this scope. Values added explicitly to the extra properties extension
+ * take precedence over Gradle properties with the same name.
+ * Once defined, the properties of this scope are readable and writable.
  * See <a href="#extraproperties">extra properties</a> for more details.</li>
  *
  * <li>The <em>extensions</em> added to the project by the plugins. Each extension is available as a read-only property with the same name as the extension.</li>
@@ -153,8 +156,8 @@ import java.util.concurrent.Callable;
  * scope are read-only. For example, a task called <code>compile</code> is accessible as the <code>compile</code>
  * property.</li>
  *
- * <li>The extra properties and convention properties are inherited from the project's parent, recursively up to the root
- * project. The properties of this scope are read-only.</li>
+ * <li>The extra properties and extensions of ancestor projects, starting with the parent project and continuing to
+ * the root project. The properties of this scope are read-only.</li>
  *
  * </ul>
  *
@@ -1494,17 +1497,14 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <li>If this project object has a property with the given name, return the value of the property.</li>
      *
-     * <li>If this project has an extension with the given name, return the extension.</li>
-     *
-     * <li>If this project's convention object has a property with the given name, return the value of the
-     * property.</li>
-     *
      * <li>If this project has an extra property with the given name, return the value of the property.</li>
+     *
+     * <li>If this project has an extension with the given name, return the extension.</li>
      *
      * <li>If this project has a task with the given name, return the task.</li>
      *
-     * <li>Search up through this project's ancestor projects for a convention property or extra property with the
-     * given name.</li>
+     * <li>Search up through this project's ancestor projects, starting with the parent project, for an extra property
+     * or extension with the given name.</li>
      *
      * <li>If not found, a {@link MissingPropertyException} is thrown.</li>
      *
@@ -1527,17 +1527,14 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <li>If this project object has a property with the given name, return the value of the property.</li>
      *
-     * <li>If this project has an extension with the given name, return the extension.</li>
-     *
-     * <li>If this project's convention object has a property with the given name, return the value of the
-     * property.</li>
-     *
      * <li>If this project has an extra property with the given name, return the value of the property.</li>
+     *
+     * <li>If this project has an extension with the given name, return the extension.</li>
      *
      * <li>If this project has a task with the given name, return the task.</li>
      *
-     * <li>Search up through this project's ancestor projects for a convention property or extra property with the
-     * given name.</li>
+     * <li>Search up through this project's ancestor projects, starting with the parent project, for an extra property
+     * or extension with the given name.</li>
      *
      * <li>If not found, null value is returned.</li>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -233,8 +233,13 @@ public interface ExtensionContainer {
      * The extra properties extension in this extension container.
      *
      * This extension is always present in the container, with the name "ext".
+     * When this container belongs to a {@link org.gradle.api.Project}, the extension also exposes Gradle properties
+     * loaded for that project that are not mapped directly to a {@code Project} property. Values set explicitly on
+     * the extension take precedence over Gradle properties with the same name.
      *
      * @return The extra properties extension in this extension container.
+     * @see ExtraPropertiesExtension
+     * @see org.gradle.api.Project#findProperty(String)
      */
     ExtraPropertiesExtension getExtraProperties();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtraPropertiesExtension.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtraPropertiesExtension.java
@@ -30,6 +30,14 @@ import java.util.Map;
  * <p>
  * An important feature of extra properties extensions is that all of its properties are exposed for reading and writing via the {@link ExtensionAware}
  * object that owns the extension.
+ * <p>
+ * A project's extra properties also contain Gradle properties loaded for that project that are not mapped directly to a
+ * {@code Project} property. A value added explicitly with {@link #set(String, Object)} takes precedence over a Gradle
+ * property with the same name. Accessing the extra properties extension only searches this map; unlike
+ * {@link org.gradle.api.Project#findProperty(String)}, it does not search the project's own properties, extensions,
+ * tasks, or ancestor projects.
+ * See the <a href="https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties">
+ * project properties documentation</a> for the precedence of Gradle property sources.
  *
  * <pre class='autoTested'>
  * project.ext.set("myProp", "myValue")


### PR DESCRIPTION
Fixes #35979

## What changed

Clarifies the documented resolution order for project properties, Gradle properties, and extra properties.

## Why

The previous documentation mixed build-level Gradle-property precedence with the dynamic project-property lookup APIs and described an outdated convention-object order.
It also used an invalid `gradle.properties` example for a system property.

## Impact

Build authors can now choose the appropriate API and property source with a clear, accurate reference.
Kotlin DSL extra-property access is distinguished from the broader project-property lookup.

## Validation

- `git diff --check`
- `:docs:tasks`

