### PR TITLE
Reduce ArchUnit classpath to speed up tests

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/DistributionArtifactScope.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/DistributionArtifactScope.kt
@@ -22,16 +22,25 @@ import org.gradle.api.attributes.Attribute
 /**
  * Marks variants of a Gradle distribution collector project.
  * <p>
- * The standard runtime variant of a distribution collector (e.g. `:distributions-full`) publishes
- * every packaged artifact — including `runtime-api-info.jar`.  This means that tasks that depend
- * on it rely on the tasks that build it, which scan the entire codebase's classes and sources.
- * Variants advertising a value can here expose only a subset, skipping the packaging metadata
- * pipeline for consumers that don't need it.
+ * A distribution collector (e.g. `:distributions-full`) exposes multiple consumable runtime
+ * variants that differ in how much of the packaging pipeline they include.  This attribute
+ * distinguishes them so consumers can opt into a narrower artifact set.
  * <p>
- * Consumers targeting a narrower scope declare a value in their request; the standard runtime
- * variant does not declare this attribute at all.
+ * Every runtime variant of a collector declares a value.  Consumers that don't declare a value
+ * fall back to `STANDARD` via the disambiguation rule registered in the packaging plugin.
  */
 enum class DistributionArtifactScope {
+    /**
+     * The full runtime artifact set — every packaged JAR the collector publishes, including
+     * `runtime-api-info.jar` and its metadata-derivation task subtree (relocated package list,
+     * plugins manifest, instrumented super-types merge, upgraded properties merge, DSL meta,
+     * api mapping, default imports).
+     * <p>
+     * Advertised by the standard `runtime` variant of each collector; also selected by consumers
+     * that don't declare a `DistributionArtifactScope` value in their request.
+     */
+    STANDARD,
+
     /**
      * Only the transitively-resolved module JARs (via the collector's `coreRuntimeOnly` and
      * `pluginsRuntimeOnly` buckets) plus the Kotlin DSL extensions JAR.

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/DistributionArtifactScope.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/DistributionArtifactScope.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.basics
+
+import org.gradle.api.attributes.Attribute
+
+
+/**
+ * Marks variants of a Gradle distribution collector project.
+ * <p>
+ * The standard runtime variant of a distribution collector (e.g. `:distributions-full`) publishes
+ * every packaged artifact — including `runtime-api-info.jar`.  This means that tasks that depend
+ * on it rely on the tasks that build it, which scan the entire codebase's classes and sources.
+ * Variants advertising a value can here expose only a subset, skipping the packaging metadata
+ * pipeline for consumers that don't need it.
+ * <p>
+ * Consumers targeting a narrower scope declare a value in their request; the standard runtime
+ * variant does not declare this attribute at all.
+ */
+enum class DistributionArtifactScope {
+    /**
+     * Only the transitively-resolved module JARs (via the collector's `coreRuntimeOnly` and
+     * `pluginsRuntimeOnly` buckets) plus the Kotlin DSL extensions JAR.
+     * <p>
+     * Notably excludes `runtime-api-info.jar` and any other packaging-derived artifacts. Consumed
+     * by `:architecture-test` to keep the packaging metadata pipeline off the ArchUnit scan's critical
+     * path and allow for faster `sanityCheck` execution by shortening the critical path to start ArchUnit.
+     */
+    RUNTIME_ONLY;
+
+    companion object {
+        val attribute: Attribute<DistributionArtifactScope> = Attribute.of(DistributionArtifactScope::class.java)
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import gradlebuild.basics.DistributionArtifactScope
 import gradlebuild.basics.GradleModuleApiAttribute
 import gradlebuild.basics.PublicApi
 import gradlebuild.basics.PublicApiVariants
@@ -334,6 +335,26 @@ consumableVariant("api", listOf(coreRuntimeOnly, pluginsRuntimeOnly), listOf(run
 consumableSourcesVariant("transitiveSources", listOf(coreRuntimeOnly, pluginsRuntimeOnly), gradleApiKotlinExtensions.map { it.destinationDirectory })
 // A platform variant without 'runtime-api-info' artifact such that distributions can depend on each other
 consumablePlatformVariant("runtimePlatform", listOf(coreRuntimeOnly, pluginsRuntimeOnly))
+
+// A runtime variant exposing just the module JARs of this distribution — the transitively-resolved
+// core + plugin module JARs plus the Kotlin DSL extensions jar — WITHOUT the runtime-api-info jar
+// and its metadata-derivation task subtree (relocated package list, plugins manifest,
+// instrumented super-types merge, upgraded properties merge, DSL meta, api mapping, default imports).
+//
+// Consumers that only need module bytecode for classpath scanning (e.g. architecture-test)
+// should select this variant to keep the packaging metadata pipeline off their critical path.
+//
+// Distinguished from the standard `runtime` variant by DistributionArtifactScope. Keeping the
+// distinguisher on a dedicated custom attribute (rather than overloading LibraryElements) lets
+// Gradle's default variant-matching behavior handle transitive resolution: dependencies that do
+// not declare DistributionArtifactScope (regular library projects like :daemon-server) remain
+// compatible with the request via Gradle's "producer-missing attribute = compatible" default.
+consumableVariant("runtimeJarsOnly", listOf(coreRuntimeOnly, pluginsRuntimeOnly), listOf(gradleApiKotlinExtensionsJar)) {
+    configureAsRuntimeElements(objects)
+    attributes {
+        attribute(DistributionArtifactScope.attribute, DistributionArtifactScope.RUNTIME_ONLY)
+    }
+}
 
 // A lifecycle task to build all the distribution zips for publishing
 val buildDists = tasks.register("buildDists")

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -44,6 +44,8 @@ import gradlebuild.packaging.tasks.GenerateLicenseFile
 import gradlebuild.packaging.tasks.PluginsManifest
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.attributes.AttributeDisambiguationRule
+import org.gradle.api.attributes.MultipleCandidatesDetails
 import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.jar.Attributes
@@ -322,9 +324,14 @@ fun generateModulePropertiesFor(moduleJar: TaskProvider<Jar>, registryModuleName
 generateModulePropertiesFor(runtimeApiInfoJar, runtimeApiJarName)
 generateModulePropertiesFor(gradleApiKotlinExtensionsJar, "gradle-kotlin-dsl-extensions")
 
-// A standard Java runtime variant for embedded integration testing
+// A standard Java runtime variant for embedded integration testing.
+// Declares DistributionArtifactScope.STANDARD so it can be disambiguated from the `runtimeJarsOnly`
+// variant below when a consumer requests JAVA_RUNTIME without specifying a scope.
 consumableVariant("runtime", listOf(coreRuntimeOnly, pluginsRuntimeOnly), listOf(runtimeApiInfoJar, gradleApiKotlinExtensionsJar)) {
     configureAsRuntimeElements(objects)
+    attributes {
+        attribute(DistributionArtifactScope.attribute, DistributionArtifactScope.STANDARD)
+    }
 }
 
 consumableVariant("api", listOf(coreRuntimeOnly, pluginsRuntimeOnly), listOf(runtimeApiInfoJar, gradleApiKotlinExtensionsJar)) {
@@ -344,15 +351,33 @@ consumablePlatformVariant("runtimePlatform", listOf(coreRuntimeOnly, pluginsRunt
 // Consumers that only need module bytecode for classpath scanning (e.g. architecture-test)
 // should select this variant to keep the packaging metadata pipeline off their critical path.
 //
-// Distinguished from the standard `runtime` variant by DistributionArtifactScope. Keeping the
-// distinguisher on a dedicated custom attribute (rather than overloading LibraryElements) lets
-// Gradle's default variant-matching behavior handle transitive resolution: dependencies that do
-// not declare DistributionArtifactScope (regular library projects like :daemon-server) remain
-// compatible with the request via Gradle's "producer-missing attribute = compatible" default.
+// Distinguished from the standard `runtime` variant by DistributionArtifactScope. Consumers that
+// do not declare a scope fall back to `STANDARD` via the disambiguation rule registered below.
+// Transitive projects like :daemon-server do not declare this attribute at all and remain
+// compatible with any scoped request via Gradle's "producer-missing attribute = compatible" default.
 consumableVariant("runtimeJarsOnly", listOf(coreRuntimeOnly, pluginsRuntimeOnly), listOf(gradleApiKotlinExtensionsJar)) {
     configureAsRuntimeElements(objects)
     attributes {
         attribute(DistributionArtifactScope.attribute, DistributionArtifactScope.RUNTIME_ONLY)
+    }
+}
+
+// When a consumer resolves a distribution collector (e.g. via `testRuntimeOnly(projects.distributionsFull)`)
+// without declaring a `DistributionArtifactScope`, both the `runtime` and `runtimeJarsOnly` variants
+// are compatible on all requested attributes. This rule selects `STANDARD` in that case so existing
+// consumers keep getting the standard runtime variant they always did — only consumers explicitly
+// requesting `RUNTIME_ONLY` see the leaner variant.
+abstract class DistributionArtifactScopeDisambiguationRule : AttributeDisambiguationRule<DistributionArtifactScope> {
+    override fun execute(details: MultipleCandidatesDetails<DistributionArtifactScope>) {
+        if (details.consumerValue == null) {
+            details.candidateValues.firstOrNull { it == DistributionArtifactScope.STANDARD }?.let(details::closestMatch)
+        }
+    }
+}
+
+dependencies.attributesSchema {
+    attribute(DistributionArtifactScope.attribute) {
+        disambiguationRules.add(DistributionArtifactScopeDisambiguationRule::class.java)
     }
 }
 

--- a/testing/architecture-test/build.gradle.kts
+++ b/testing/architecture-test/build.gradle.kts
@@ -1,5 +1,8 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.ArchitectureDataType
+import gradlebuild.basics.DistributionArtifactScope
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.PublicApi
 import gradlebuild.basics.PublicKotlinDslApi
@@ -29,6 +32,23 @@ val packageInfoDataResolvable = configurations.resolvable("packageInfoDataResolv
     }
 }
 
+// Bucket for declaring the runtime-only distribution dependency, extended by the resolvable below.
+val distributionRuntimeDependencies = configurations.dependencyScope("distributionRuntimeDependencies")
+
+// Resolves to the module JARs of the full distribution WITHOUT triggering the packaging metadata
+// pipeline (runtime-api-info jar and its whole-codebase-scanning derivation tasks).
+// Selects the `runtimeJarsOnly` variant exposed by gradlebuild.distributions via the
+// DistributionArtifactScope attribute. Transitive projects that do not advertise this attribute
+// remain compatible via Gradle's default compatibility process.
+val distributionRuntime = configurations.resolvable("distributionRuntime") {
+    extendsFrom(distributionRuntimeDependencies)
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named<Usage>(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>(Category.LIBRARY))
+        attribute(DistributionArtifactScope.attribute, DistributionArtifactScope.RUNTIME_ONLY)
+    }
+}
+
 dependencies {
     add(rootProjectDependency.name, projects.gradle)
 
@@ -46,7 +66,7 @@ dependencies {
     testImplementation(testLibs.junitJupiter)
     testImplementation(testLibs.assertj)
 
-    testRuntimeOnly(projects.distributionsFull)
+    add(distributionRuntimeDependencies.name, projects.distributionsFull)
 
     testRuntimeOnly(testLibs.junitPlatform)
 }
@@ -78,6 +98,11 @@ tasks {
 
         // Only use one fork, so freezing doesn't have concurrency issues
         maxParallelForks = 1
+
+        // Provide the whole-distribution module bytecode via the leaner `runtimeJarsOnly`
+        // variant. This is the classpath the ArchUnit @AnalyzeClasses(packages = "org.gradle")
+        // scan reflects on.
+        classpath += files(distributionRuntime)
 
         inputs.dir(ruleStoreDir).withPathSensitivity(PathSensitivity.RELATIVE)
 


### PR DESCRIPTION
## The Problem

`:architecture-test:test` needs the compiled bytecode of every Gradle module (so ArchUnit can scan `org.gradle.*` classes). The obvious way to get that classpath is `testRuntimeOnly(projects.distributionsFull`) — but `:distributions-full`'s standard `runtimeElements` variant also declares `runtimeApiInfoJar` as its outgoing artifacts. Consuming that variant induces task-graph edges to that jars and everything it transitively depends on.

None of that packaging metadata is bytecode. ArchUnit doesn't need it. But because it's declared as an outgoing artifact of the variant we consume, it lands on the critical path of `:architecture-test:test` — which seems to always run last and extend the wall-clock time of `sanityCheck`.

## The goal

Introduce a specialized distribution variant that excludes the `runtime-api-info.jar` and its associated metadata-derivation tasks. This allows the `:architecture-test` project to resolve a leaner distribution, shortening its critical path and improving `sanityCheck` execution time.

## The net effect
Off the critical path of :architecture-test:test (what this removes):

:distributions-full:runtimeApiInfoJar
:distributions-full:generateRelocatedPackageList
:distributions-full:pluginsManifest
:distributions-full:implementationPluginsManifest
:distributions-full:instrumentedSuperTypesMerge
:distributions-full:upgradedPropertiesMerge
:distributions-full:dslMetaData
:distributions-full:apiMapping

