### PR TITLE
Clarify Kotlin DSL plugin example requires Gradle 7.x/8.x build in Gr…

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -144,12 +144,15 @@ This only applies to plugins written in Groovy 3.x, from Gradle 8.x and earlier.
 [[plugins_written_with_the_kotlin_dsl_require_gradle_8_11]]
 === Plugins written with the Kotlin DSL require Gradle >= 8.11
 
-When building and publishing plugins using the Kotlin DSL on Gradle 9.x.x, those plugins will only be usable on Gradle 8.11 or newer.
+When building and publishing plugins using the Kotlin DSL on Gradle 9.x, those plugins are only usable on Gradle 8.11 or newer.
 This is because Gradle 8.11 is the first release that embeds Kotlin 2.0 or higher, which is required to interpret Kotlin metadata version 2.
 
-If you want your plugin to remain compatible with older Gradle versions, you must explicitly compile it against an earlier Kotlin version (1.x).
+If your plugin must support Gradle versions older than 8.11, build the plugin with Gradle 8.x.
 
-For example, to support Gradle 6.8 and newer, configure your plugin to target Kotlin 1.7 like this:
+*Downgrading the Kotlin target under Gradle 9.x is not a workaround*: Gradle 9.x embeds Kotlin 2.2, which rejects `languageVersion` and `apiVersion` values below 1.8 and always emits Kotlin metadata version 2.
+
+When building with Gradle 8.x, you can additionally target an earlier Kotlin language version to broaden consumer compatibility.
+For example, to support Gradle 6.8 and newer, target Kotlin 1.7:
 
 .build.gradle.kts
 [source,kotlin]
@@ -169,10 +172,15 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 ----
 
+[WARNING]
+====
+The example above must be built with Gradle 7.x or 8.x.
+On Gradle 9.x the build fails because Kotlin 2.2 rejects `languageVersion` values below 1.8.
+====
+
 Refer to Gradle’s link:compatibility.html#kotlin[compatibility matrix] for details on which Kotlin version is embedded in each Gradle release.
 
 NOTE: Plugins written using the Kotlin DSL and published with Gradle 7.x or 8.x remain compatible with Gradle 6.8 and newer.
-This example specifically requires building with Gradle 7.x or 8.x — Gradle 9.x embeds Kotlin 2.2, which no longer allows `languageVersion` or `apiVersion` below 1.8, so this configuration cannot be applied when building with Gradle 9.x itself.
 
 [[plugins_written_with_the_groovy_dsl_require_gradle_7_0]]
 === Plugins written with the Groovy DSL require Gradle >= 7.0

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -172,6 +172,7 @@ tasks.withType<KotlinCompile>().configureEach {
 Refer to Gradle’s link:compatibility.html#kotlin[compatibility matrix] for details on which Kotlin version is embedded in each Gradle release.
 
 NOTE: Plugins written using the Kotlin DSL and published with Gradle 7.x or 8.x remain compatible with Gradle 6.8 and newer.
+This example specifically requires building with Gradle 7.x or 8.x — Gradle 9.x embeds Kotlin 2.2, which no longer allows `languageVersion` or `apiVersion` below 1.8, so this configuration cannot be applied when building with Gradle 9.x itself.
 
 [[plugins_written_with_the_groovy_dsl_require_gradle_7_0]]
 === Plugins written with the Groovy DSL require Gradle >= 7.0


### PR DESCRIPTION
…adle 9 upgrade guide

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
Fixes #38472.

The "Upgrading to Gradle 9.0.0" guide showed an example for targeting
Kotlin 1.7 to keep a Kotlin DSL plugin compatible with Gradle 6.8+.
Followed on a Gradle 9.x build, this example fails, since Gradle 9
requires Kotlin language version 1.8+ and no longer supports compiling
against 1.7.

Added a note clarifying this example only applies when the plugin
itself is built with Gradle 7.x or 8.x — not Gradle 9.x, where
targeting Kotlin below 1.8 isn't possible. Anyone needing a Gradle
6.8-compatible plugin should build with Gradle 8.x instead.

Proposed in #38472 and confirmed by @ghale.

---
Note: I used Claude (Anthropic) to help research the doc source and
draft this PR description.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
