### PR TITLE
Fix HTML dependency report configuration filtering across projects

### DIFF
--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -223,6 +223,40 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         jsonB.project.name == "b"
     }
 
+    @ToBeFixedForIsolatedProjects(because = "configure subprojects from root")
+    def "html report respects configured configurations across projects"() {
+        given:
+        createDirs("submodule-a", "submodule-b")
+
+        settingsFile """
+        include "submodule-a", "submodule-b"
+    """
+
+        buildFile """
+        apply plugin: 'project-report'
+
+        subprojects {
+            apply plugin: 'java'
+        }
+
+        htmlDependencyReport {
+            projects = project.subprojects
+
+            configurations = [
+                project(":submodule-a").configurations.runtimeClasspath,
+                project(":submodule-b").configurations.runtimeClasspath
+            ] as Set
+        }
+    """
+
+        when:
+        run "htmlDependencyReport"
+
+        then:
+        readGeneratedJson("root.submodule-a").project.configurations*.name == ["runtimeClasspath"]
+        readGeneratedJson("root.submodule-b").project.configurations*.name == ["runtimeClasspath"]
+    }
+
     def "copies necessary css, images and js files"() {
         given:
         buildFile << """

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -35,6 +35,8 @@ import org.gradle.api.tasks.diagnostics.AbstractDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.internal.ConfigurationDetails;
 import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
 import org.gradle.api.tasks.diagnostics.internal.ProjectsWithConfigurations;
+import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.Describables;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.serialization.Cached;
@@ -135,14 +137,25 @@ public abstract class HtmlDependencyReportTask extends AbstractDependencyReportT
         return ProjectsWithConfigurations.from(
             getProjects(),
             ProjectDetails::withNameAndPath,
-            HtmlDependencyReportTask::getConfigurationsWhichCouldHaveDependencyInfo
+            this::getConfigurationsForProject
         );
     }
 
-    private static Stream<? extends ConfigurationDetails> getConfigurationsWhichCouldHaveDependencyInfo(Project project) {
-        return project.getConfigurations().stream()
+    private Stream<? extends ConfigurationDetails> getConfigurationsForProject(Project project) {
+        if (getConfigurations() == null) {
+            return project.getConfigurations().stream()
+                .map(ConfigurationInternal.class::cast)
+                .filter(c -> c.isDeclarableByExtension())
+                .map(ConfigurationDetails::of);
+        }
+
+        ProjectIdentity projectIdentity = ((ProjectInternal) project).getProjectIdentity();
+
+        return getConfigurations().stream()
             .map(ConfigurationInternal.class::cast)
-            .filter(c -> c.isDeclarableByExtension())
+            .filter(configuration ->
+                projectIdentity.equals(configuration.getDomainObjectContext().getProjectIdentity())
+            )
             .map(ConfigurationDetails::of);
     }
 }


### PR DESCRIPTION
<!-- Fixes #38492 -->

### Context

When `HtmlDependencyReportTask.configurations` is explicitly configured for a multi-project build, the HTML dependency report includes all configured configurations in every project's report. This differs from the ASCII dependency report, which correctly scopes configurations to their owning project.

This change filters explicitly configured configurations so that each generated HTML report only contains configurations belonging to the corresponding project, making the HTML report consistent with the ASCII report.

A regression integration test has been added to verify the behavior for multi-project builds with explicitly configured `runtimeClasspath` configurations.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :software-diagnostics:forkingIntegTest`.