### PR TITLE
Depend on the task generating precompiled script plugin sources

### DIFF
--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -1102,6 +1102,27 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
             .assertHasResolution(getDocLinkMessage())
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37135")
+    def "precompiled script plugin tasks depend on the task generating the script sources"() {
+        given:
+        file("templates/foo.gradle") << REGISTER_SAMPLE_TASK
+        buildFile << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+            def expandTemplates = tasks.register("expandTemplates", Copy) {
+                from("templates")
+                into(layout.buildDirectory.dir("generated/sources/templates"))
+                include("*.gradle")
+            }
+            sourceSets.main.groovy.srcDir(expandTemplates)
+        """
+
+        expect: "the second run does not fail with a missing task-dependency validation error on the generated sources"
+        succeeds("compileGroovyPlugins")
+        succeeds("compileGroovyPlugins")
+    }
+
     private getDocLinkMessage() {
         documentationRegistry.getDocumentationRecommendationFor("information", "custom_plugins", "sec:precompiled_plugins")
     }

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
@@ -58,6 +58,7 @@ public abstract class PrecompiledGroovyPluginsPlugin implements Plugin<Project> 
         GradlePluginDevelopmentExtension pluginExtension = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
 
         SourceSet pluginSourceSet = pluginExtension.getPluginSourceSet();
+        SourceDirectorySet groovySource = pluginSourceSet.getExtensions().getByType(GroovySourceDirectorySet.class);
         Set<File> scriptPluginFiles = pluginSourceSet.getAllSource().matching(PrecompiledGroovyScript::filterPluginFiles).getFiles();
 
         List<PrecompiledGroovyScript> scriptPlugins = scriptPluginFiles.stream()
@@ -73,6 +74,10 @@ public abstract class PrecompiledGroovyPluginsPlugin implements Plugin<Project> 
         TaskProvider<ExtractPluginRequestsTask> extractPluginRequests = tasks.register("extractPluginRequests", ExtractPluginRequestsTask.class, task -> {
             task.getScriptPlugins().convention(scriptPlugins);
             task.getScriptFiles().from(scriptPluginFiles);
+            // Getting the files eagerly above drops the source's build dependencies, so carry them explicitly:
+            // this makes the task run after any task that generates script plugins into a Groovy srcDir.
+            // See https://github.com/gradle/gradle/issues/37135.
+            task.getScriptFiles().builtBy(groovySource);
             task.getExtractedPluginRequestsClassesDirectory().convention(buildDir.dir("groovy-dsl-plugins/output/plugin-requests"));
             task.getExtractedPluginRequestsClassesStagingDirectory().convention(buildDir.dir("groovy-dsl-plugins/output/plugin-requests-staging"));
         });
@@ -86,10 +91,10 @@ public abstract class PrecompiledGroovyPluginsPlugin implements Plugin<Project> 
         TaskProvider<CompileGroovyScriptPluginsTask> precompilePlugins = tasks.register("compileGroovyPlugins", CompileGroovyScriptPluginsTask.class, task -> {
             task.getScriptPlugins().convention(scriptPlugins);
             task.getScriptFiles().from(scriptPluginFiles);
+            task.getScriptFiles().builtBy(groovySource);
             task.getPrecompiledGroovyScriptsOutputDirectory().convention(buildDir.dir("groovy-dsl-plugins/output/plugin-classes"));
 
             SourceDirectorySet javaSource = pluginSourceSet.getJava();
-            SourceDirectorySet groovySource = pluginSourceSet.getExtensions().getByType(GroovySourceDirectorySet.class);
             task.getClasspath().from(pluginSourceSet.getCompileClasspath(), javaSource.getClassesDirectory(), groovySource.getClassesDirectory());
         });
 


### PR DESCRIPTION
Fixes #37135

> This supersedes #38486, which got closed by accident. The only change from that PR is that the coding-agent attribution has been dropped from the commit message per @ghale's request (the `Signed-off-by` is kept). The code is identical.

### Context

When a `groovy-gradle-plugin` project generates its `.gradle` script plugins with a task and registers that task's output as a Groovy source directory:

```groovy
sourceSets.main.groovy.srcDir(tasks.named('expandTemplates'))
```

a subsequent build fails execution-time validation:

```
Task ':extractPluginRequests' uses this output of task ':expandTemplates'
without declaring an explicit or implicit dependency.
```

`ExtractPluginRequestsTask` and `CompileGroovyScriptPluginsTask` received the script plugin files as an eagerly resolved `Set<File>`, which discards the build dependencies of the source directories, so the tasks gained no dependency on the task producing the scripts.

File discovery still uses the source set's full file tree, but the tasks' `getScriptFiles()` inputs now carry the Groovy source's build dependencies via `builtBy`, so they run after the generating task. The dependency is taken from the Groovy source alone to avoid a cycle with the generated plugin-adapter sources added to the Java source set.

Verified locally: on `master` the added integration test fails with the exact reported validation error on the second run; with the fix the full `PrecompiledGroovyPluginsIntegrationTest` class passes (44 tests). `:plugin-development` checkstyle and codenarc also pass.

_Implementation was done with AI assistance (disclosed here, since attributions are kept out of the commit message per project policy); I have reviewed and understand every line._

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check "Allow edit from maintainers" option in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. _(Behavior is task-dependency wiring, verified via the integration test.)_
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. _(No public-facing API change.)_
- [x] Ensure that tests pass locally: `./gradlew :plugin-development:embeddedIntegTest --tests "*PrecompiledGroovyPluginsIntegrationTest"`.
