### PR TITLE
Fix configuration cache toggling in performance tests

### DIFF
--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -42,7 +42,10 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
         AndroidTestProject.useKotlinLatestStableOrRcVersion(runner)
         runner.args.add('-Dorg.gradle.parallel=true')
         runner.args.addAll(["--no-build-cache", "--no-scan"])
-        // use the deprecated property so it works with previous versions
+        // Pass the current property name too: it takes precedence over the deprecated one, so it cannot be
+        // shadowed by a value in the test project's gradle.properties. The deprecated property is kept for
+        // baseline versions older than 8.1.
+        runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheProblemsOption.PROPERTY_NAME}=warn")
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheProblemsOption.DEPRECATED_PROPERTY_NAME}=warn")
         runner.warmUpRuns = 20
         applyDevelocityPlugin()

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
@@ -37,7 +37,11 @@ class AbstractIncrementalExecutionPerformanceTest extends AbstractCrossVersionPe
     }
 
     protected boolean enableConfigurationCaching(boolean configurationCachingEnabled) {
-        // use the deprecated property so it works with previous versions
+        // The current property name must be passed as well: build options resolve it before the deprecated one,
+        // so a test project enabling the configuration cache in its gradle.properties (e.g. nowInAndroidBuild)
+        // would otherwise silently win over the deprecated -D flag and keep the cache on in the "disabled" iterations.
+        // The deprecated property is kept for baseline versions older than 8.1.
+        runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME}=${configurationCachingEnabled}")
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=${configurationCachingEnabled}")
     }
 

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -51,8 +51,10 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
     def "assemble #action configuration cache state with #daemon daemon"() {
         given:
         runner.tasksToRun = ["assemble"]
-        // use the deprecated property so it works with previous versions
-        runner.args = ["-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=true"]
+        // Pass the current property name too: it takes precedence over the deprecated one, so it cannot be
+        // shadowed by a value in the test project's gradle.properties. The deprecated property is kept for
+        // baseline versions older than 8.1.
+        runner.args = ["-D${ConfigurationCacheOption.PROPERTY_NAME}=true", "-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=true"]
 
         runner.addInterceptor { builder ->
             builder.invocation {


### PR DESCRIPTION
### Problem

`AbstractIncrementalExecutionPerformanceTest.enableConfigurationCaching()` toggles the configuration cache via the deprecated system property only (`org.gradle.unsafe.configuration-cache`). Build options resolve the **current** property name before the deprecated one (`AbstractBuildOption.getFromProperties`), regardless of where each value comes from. The `nowInAndroidBuild` template sets `org.gradle.configuration-cache=true` in its `gradle.properties`, so the deprecated `-D...=false` flag is silently ignored and **the "disabled" iterations run with the configuration cache on**.

As a result, the `non-abi change` iteration of `AndroidIncrementalExecutionPerformanceTest` has been measuring ~0.4s configuration-cache-hit builds instead of full configuration — on both sides of the cross-version comparison, so it went unnoticed. Verified via JFR + `benchmark.csv` from an ad-hoc profiled run: warm-up build 1 takes ~120s (real configuration), all subsequent builds ~0.4s (CC hit), with CC entry decode/decryption stacks in the profile; both 9.6.1 and 9.7.0 medians were identical (~420ms).

Consequences of the bug:
* the `non-abi change` and `non-abi change with configuration caching` iterations are effectively the same scenario — a sub-second microbenchmark where environment noise easily produces large, high-confidence, non-reproducible deltas (e.g. the bogus -42% for `non-abi change | nowInAndroidBuild` in the 9.7.0 RC1 validation, and likely the flakiness that led to disabling the `abi change with configuration caching` iteration in gradle/gradle-private#5247)

### Fix

Pass the current property name in addition to the deprecated one. Command-line `-D` properties take precedence over the project's `gradle.properties` for the same key (`LayoutToPropertiesConverter.convert` applies them last), so the flag now actually controls the cache. The deprecated name is kept for baseline versions older than 8.1.

Also applied the same treatment to the CC-problems flag in `AndroidIncrementalExecutionPerformanceTest` and the CC-enable flag in `JavaConfigurationCachePerformanceTest` — currently harmless (values happen to match the templates), but the same trap.

### Expected fallout

With the cache genuinely off, the affected iterations will get much slower (full configuration each build): expect duration bumps in `performance-test-durations.json` and possibly a rebaseline for these scenarios.

### Not changed here

Tests that pass no CC flag at all and therefore inherit CC=true from the `nowInAndroidBuild` template while their other test projects run without it: `JavaIDETaskExecutionPerformanceTest`, `RealLifeAndroidBuildPerformanceTest`, `RealLifeAndroidStudioPerformanceTest`. These make no claim about CC — they measure the project as configured, and version-to-version comparisons remain fair — so their semantics are left as-is. Be aware that on `nowInAndroidBuild` their scenarios skip the configuration phase (CC hits), so cross-project comparisons and noise sensitivity differ from the CC-off projects.


