### PR TITLE
Add Best Practice: Favor Collection Properties

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
@@ -80,6 +80,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_tasks.adoc#dont_hardcode_task_names,Don't hardcode task names when referring to them>> | Task | 9.7.0
 | <<best_practices_tasks.adoc#dont_access_project_instance_inside_task,Don't access a `Project` instance during Task Execution>> | Task | 9.7.0
 | <<best_practices_tasks.adoc#map_versus_flatmap,Wiring Task Outputs with `map` and `flatMap`>> | Task | 9.7.0
+| <<best_practices_tasks.adoc#favor_collection_properties,Favor collection property types over a `Property` holding a collection>> | Task | 9.8.0
 
 | <<best_practices_performance.adoc#use_utf8_encoding,Enable UTF‑8>> | Performance | 9.0.0
 | <<best_practices_performance.adoc#use_build_cache,Use the Build Cache>> | Performance | 9.1.0

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -870,3 +870,88 @@ include::sample[dir="snippets/best-practices/beCarefulWithMapFlatmap-do/groovy",
 === Tags
 
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:task-configuration-avoidance,#task-configuration-avoidance>>`
+
+[[favor_collection_properties]]
+== Favor collection property types over a `Property` holding a collection
+
+Declare collection-valued properties as `ListProperty<T>`, `SetProperty<T>`, or `MapProperty<K, V>` rather than wrapping a collection inside a plain `Property`, such as a `Property<Collection<T>>`.
+
+=== Explanation
+
+A `Property` treats its value as a single, opaque unit.
+When that value happens to be a collection, Gradle cannot see the elements inside it, so the only way to change the property is to replace the entire collection.
+
+The dedicated collection types lift the collection into the property itself, so Gradle understands its structure.
+This is what makes incremental composition possible:
+
+* *Contributions are additive.* `add(T)`, `addAll(Iterable<T>)`, and `put(K, V)` let a plugin, a convention plugin, and a build script each contribute independently, without knowing what the others contributed.
+* *Individual elements can be lazy.* `add(Provider<T>)` accepts a provider for a _single element_. If that provider is a task output, the collection property carries the producing task's dependency automatically, so no explicit `dependsOn` is required.
+* *No eager reads are needed.* Appending to a plain `Property` forces you to call `get()` at configuration time to read the current collection before writing a new one back, which violates <<avoid_provider_get_outside_task_action,Do not call `get()` on a Provider outside a Task action>>.
+
+Gradle rejects the most common forms of this mistake outright.
+Creating a `Property<List<T>>`, `Property<Set<T>>`, or `Property<Map<K, V>>` fails with an error directing you to the corresponding collection type.
+However, several equivalent declarations are _not_ rejected and are just as wrong:
+
+* `Property<Collection<T>>` and `Property<Iterable<T>>`
+* `Property<T[]>`, a property holding an array
+* A plain, non-lazy `List<T>` or `Map<K, V>` field with a getter and setter
+
+Treat all of these the same way, and prefer the collection property type that matches the data.
+For file-valued collections, use `ConfigurableFileCollection` instead.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/best-practices/favorCollectionProperties-avoid/kotlin",files="build.gradle.kts[tags=setup]"]
+include::sample[dir="snippets/best-practices/favorCollectionProperties-avoid/groovy",files="build.gradle[tags=setup]"]
+====
+
+<1> *`WriteVersion` task*: writes the version string `"1.0"` to `versionFile` at execution time.
+
+====
+include::sample[dir="snippets/best-practices/favorCollectionProperties-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/best-practices/favorCollectionProperties-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *A `Property` cannot expose its elements*: `Collection<String>` is an opaque value here, so there is no `add` method and no way to contribute a single message.
+Gradle would reject `Property<List<String>>` outright, but `Property<Collection<String>>` is accepted despite being the same mistake.
+<2> *Appending requires an eager read*: the only way to add a message is to `get()` the current collection at configuration time, copy it, and write the result back.
+This resolves the property before the build has finished configuring, in violation of <<avoid_provider_get_outside_task_action,Do not call `get()` on a Provider outside a Task action>>.
+<3> *A lazy contribution destroys the others*: there is no way to _add_ a single `writeVersion`-derived element to a `Property<Collection<T>>`.
+The only way to consume a task output is to replace the entire property with a `Provider<Collection<T>>`, silently discarding every other contribution.
+
+The two earlier messages are silently lost, and the build does not fail or warn:
+
+----
+include::{snippetsPath}/best-practices/favorCollectionProperties-avoid/tests/favorCollectionProperties-avoid.out[]
+----
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/best-practices/favorCollectionProperties-do/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/best-practices/favorCollectionProperties-do/groovy",files="build.gradle[tags=do-this]"]
+====
+
+<1> *`ListProperty` exposes `add` and `addAll`*: contributors can append elements directly instead of replacing the whole collection.
+<2> *Contributors are independent*: `add` appends a message without reading, copying, or replacing the existing collection, so each caller can ignore the others.
+<3> *Elements can be providers*: `add(Provider<T>)` contributes a single lazily computed message.
+The provider carries the dependency on `writeVersion`, so `report` runs after it without an explicit `dependsOn`.
+
+All three messages survive:
+
+----
+include::{snippetsPath}/best-practices/favorCollectionProperties-do/tests/favorCollectionProperties-do.out[]
+----
+
+=== References
+
+- <<lazy_configuration.adoc#working_with_collections,Working with Collections>>
+- <<lazy_configuration.adoc#working_with_maps,Working with Maps>>
+- <<properties_providers.adoc#managed_properties,Managed Properties>>
+
+=== Tags
+
+`<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:properties,#properties>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -884,12 +884,13 @@ When that value happens to be a collection, Gradle cannot see the elements insid
 The dedicated collection types lift the collection into the property itself, so Gradle understands its structure.
 This is what makes incremental composition possible:
 
-* *Contributions are additive.* `add(T)`, `addAll(Iterable<T>)`, and `put(K, V)` let a plugin, a convention plugin, and a build script each contribute independently, without knowing what the others contributed.
-* *Individual elements can be lazy.* `add(Provider<T>)` accepts a provider for a _single element_. If that provider is a task output, the collection property carries the producing task's dependency automatically, so no explicit `dependsOn` is required.
-* *No eager reads are needed.* Appending to a plain `Property` forces you to call `get()` at configuration time to read the current collection before writing a new one back, which violates <<avoid_provider_get_outside_task_action,Do not call `get()` on a Provider outside a Task action>>.
+* *Contributions are additive:* `add(T)`, `addAll(Iterable<T>)`, and `put(K, V)` let a plugin, a convention plugin, and a build script each contribute independently, without knowing what the others contributed.
+* *Individual elements can be lazy:* `add(Provider<T>)` accepts a provider for a _single element_. If that provider is a task output, the collection property carries the producing task's dependency automatically, so no explicit `dependsOn` is required.
+* *No eager reads are needed:* Appending to a plain `Property` forces you to call `get()` at configuration time to read the current collection before writing a new one back, which violates <<avoid_provider_get_outside_task_action,Do not call `get()` on a Provider outside a Task action>>.
 
 Gradle rejects the most common forms of this mistake outright.
 Creating a `Property<List<T>>`, `Property<Set<T>>`, or `Property<Map<K, V>>` fails with an error directing you to the corresponding collection type.
+
 However, several equivalent declarations are _not_ rejected and are just as wrong:
 
 * `Property<Collection<T>>` and `Property<Iterable<T>>`

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/groovy/build.gradle
@@ -1,0 +1,37 @@
+// tag::setup[]
+abstract class WriteVersion extends DefaultTask { // <1>
+    @OutputFile
+    abstract RegularFileProperty getVersionFile()
+
+    @TaskAction
+    void write() {
+        versionFile.get().asFile.text = "1.0"
+    }
+}
+
+def writeVersion = tasks.register("writeVersion", WriteVersion) {
+    versionFile = layout.buildDirectory.file("version.txt")
+}
+// end::setup[]
+
+// tag::avoid-this[]
+abstract class Report extends DefaultTask {
+    @Input
+    abstract Property<Collection<String>> getMessages() // <1>
+
+    @TaskAction
+    void report() {
+        messages.get().each { logger.lifecycle(it) }
+    }
+}
+
+def report = tasks.register("report", Report) {
+    messages = ["Project: ${project.name}".toString()]
+}
+
+report.configure {
+    messages = messages.get() + "Built with Gradle" // <2>
+    messages = writeVersion.flatMap { it.versionFile }
+        .map { ["Version: ${it.asFile.text}".toString()] } // <3>
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "favor-collection-properties-avoid"

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,37 @@
+// tag::setup[]
+abstract class WriteVersion : DefaultTask() { // <1>
+    @get:OutputFile
+    abstract val versionFile: RegularFileProperty
+
+    @TaskAction
+    fun write() {
+        versionFile.get().asFile.writeText("1.0")
+    }
+}
+
+val writeVersion = tasks.register<WriteVersion>("writeVersion") {
+    versionFile = layout.buildDirectory.file("version.txt")
+}
+// end::setup[]
+
+// tag::avoid-this[]
+abstract class Report : DefaultTask() {
+    @get:Input
+    abstract val messages: Property<Collection<String>> // <1>
+
+    @TaskAction
+    fun report() {
+        messages.get().forEach { logger.lifecycle(it) }
+    }
+}
+
+val report = tasks.register<Report>("report") {
+    messages = listOf("Project: ${project.name}")
+}
+
+report.configure {
+    messages = messages.get() + "Built with Gradle" // <2>
+    messages = writeVersion.flatMap { it.versionFile }
+        .map { listOf("Version: ${it.asFile.readText()}") } // <3>
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "favor-collection-properties-avoid"

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/tests/favorCollectionProperties-avoid.out
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/tests/favorCollectionProperties-avoid.out
@@ -1,0 +1,7 @@
+> Task :writeVersion
+
+> Task :report
+Version: 1.0
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/tests/favorCollectionProperties-avoid.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-avoid/tests/favorCollectionProperties-avoid.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: report
+expected-output-file: favorCollectionProperties-avoid.out
+allow-additional-output: true

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/groovy/build.gradle
@@ -1,0 +1,37 @@
+// tag::setup[]
+abstract class WriteVersion extends DefaultTask { // <1>
+    @OutputFile
+    abstract RegularFileProperty getVersionFile()
+
+    @TaskAction
+    void write() {
+        versionFile.get().asFile.text = "1.0"
+    }
+}
+
+def writeVersion = tasks.register("writeVersion", WriteVersion) {
+    versionFile = layout.buildDirectory.file("version.txt")
+}
+// end::setup[]
+
+// tag::do-this[]
+abstract class Report extends DefaultTask {
+    @Input
+    abstract ListProperty<String> getMessages() // <1>
+
+    @TaskAction
+    void report() {
+        messages.get().each { logger.lifecycle(it) }
+    }
+}
+
+def report = tasks.register("report", Report) {
+    messages.add("Project: ${project.name}".toString())
+}
+
+report.configure {
+    messages.add("Built with Gradle") // <2>
+    messages.add(writeVersion.flatMap { it.versionFile }
+        .map { "Version: ${it.asFile.text}".toString() }) // <3>
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "favor-collection-properties-do"

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/kotlin/build.gradle.kts
@@ -1,0 +1,37 @@
+// tag::setup[]
+abstract class WriteVersion : DefaultTask() { // <1>
+    @get:OutputFile
+    abstract val versionFile: RegularFileProperty
+
+    @TaskAction
+    fun write() {
+        versionFile.get().asFile.writeText("1.0")
+    }
+}
+
+val writeVersion = tasks.register<WriteVersion>("writeVersion") {
+    versionFile = layout.buildDirectory.file("version.txt")
+}
+// end::setup[]
+
+// tag::do-this[]
+abstract class Report : DefaultTask() {
+    @get:Input
+    abstract val messages: ListProperty<String> // <1>
+
+    @TaskAction
+    fun report() {
+        messages.get().forEach { logger.lifecycle(it) }
+    }
+}
+
+val report = tasks.register<Report>("report") {
+    messages.add("Project: ${project.name}")
+}
+
+report.configure {
+    messages.add("Built with Gradle") // <2>
+    messages.add(writeVersion.flatMap { it.versionFile }
+        .map { "Version: ${it.asFile.readText()}" }) // <3>
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "favor-collection-properties-do"

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/tests/favorCollectionProperties-do.out
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/tests/favorCollectionProperties-do.out
@@ -1,0 +1,9 @@
+> Task :writeVersion
+
+> Task :report
+Project: favor-collection-properties-do
+Built with Gradle
+Version: 1.0
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/tests/favorCollectionProperties-do.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/favorCollectionProperties-do/tests/favorCollectionProperties-do.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: report
+expected-output-file: favorCollectionProperties-do.out
+allow-additional-output: true


### PR DESCRIPTION
Declare collection-valued properties as `ListProperty<T>`, `SetProperty<T>`, or `MapProperty<K, V>` rather than wrapping a collection inside a plain `Property`, such as a `Property<Collection<T>>`.