### PR TITLE
Fix release8x

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -31,7 +31,7 @@ class CheckProject(
             param("teamcity.ui.settings.readOnly", "true")
             // Avoid rebuilding same revision if it's already built on another branch
             param("teamcity.vcsTrigger.runBuildOnSameRevisionInEveryBranch", "false")
-            param("env.DEVELOCITY_ACCESS_KEY", "%ge.gradle.org.access.key%;%gbt-td.grdev.net.access.key%")
+            param("env.DEVELOCITY_SERVER_URL", "%gbt.public.develocity.server.url%")
             param("env.CHROME_BIN", "%linux.chrome.bin.path%")
 
             text(

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -44,10 +44,6 @@ abstract class BasePromotionBuildType(
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)
 
         params {
-            password(
-                "env.DEVELOCITY_ACCESS_KEY",
-                "%ge.gradle.org.access.key%;%develocity.grdev.net.access.key%;%develocity-ext-hetzner.grdev.net.access.key%",
-            )
             password("env.ORG_GRADLE_PROJECT_botGradleGitHubToken", "%github.bot-gradle.token%")
         }
 

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -61,6 +61,13 @@ class PromotionProject(
             param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
             param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
             param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
+            param("env.DEVELOCITY_SERVER_URL", "%gbt.internal.develocity.server.url%")
+            // https://github.com/gradle/gradle-private/issues/5256
+            param("env.PROMOTED_GBT_BUILD_DEVELOCITY_SERVER_URL", "%gbt.public.develocity.server.url%")
+            param(
+                "env.DEVELOCITY_ACCESS_KEY",
+                "%usw2-edge.gradle.org.access.key%;%eun-edge.gradle.org.access.key%;%develocity.grdev.net.access.key%;%develocity-ext-hetzner.grdev.net.access.key%;%gbt-td.grdev.net.access.key%",
+            )
         }
 
         buildTypesOrder =

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -34,6 +34,7 @@ import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
 import gradlebuild.basics.BuildParams.DEFAULT_PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.DEVELOCITY_SERVER_URL_ENV
 import gradlebuild.basics.BuildParams.ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS
 import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
@@ -123,6 +124,7 @@ object BuildParams {
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val RERUN_ALL_TESTS = "rerunAllTests"
     const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
+    const val DEVELOCITY_SERVER_URL_ENV = "DEVELOCITY_SERVER_URL"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
@@ -358,6 +360,10 @@ val Project.testSplitExcludeTestClasses: String
 
 val Project.testSplitOnlyTestGradleVersion: String
     get() = project.stringPropertyOrEmpty(TEST_SPLIT_ONLY_TEST_GRADLE_VERSION)
+
+
+val Project.develocityServerUrl: Provider<String>
+    get() = environmentVariable(DEVELOCITY_SERVER_URL_ENV)
 
 
 val Project.predictiveTestSelectionEnabled: Provider<Boolean>

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -21,6 +21,7 @@ import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
 import gradlebuild.basics.buildRunningOnCi
+import gradlebuild.basics.develocityServerUrl
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionLocalExecutors
@@ -462,12 +463,13 @@ fun configureTests() {
         }
 
         if (project.supportsPredictiveTestSelection() && !isUnitTest()) {
-            // GitHub actions for contributor PRs uses public build scan instance
-            // in this case we need to explicitly configure the PTS server
+            // Falling back to https://ge.gradle.org when absent (e.g. GitHub actions for contributor PRs,
+            // which use a public Build Scan instance).
             // Don't move this line into the lambda as it may cause config cache problems
+            val ptsServerUrl = project.develocityServerUrl.getOrElse("https://ge.gradle.org")
             extensions.findByType<DevelocityTestConfiguration>()?.predictiveTestSelection {
                 this as PredictiveTestSelectionConfigurationInternal
-                server = uri("https://ge.gradle.org")
+                server = uri(ptsServerUrl)
                 enabled.convention(project.predictiveTestSelectionEnabled)
             }
         }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -92,7 +92,13 @@ val propagatedEnvironmentVariables = listOf(
     OperatingSystem.current().pathVar,
     "PATHEXT",
     // Used by KotlinMultiplatformPluginSmokeTest, see https://github.com/gradle/gradle-private/issues/4223
-    "CHROME_BIN"
+    "CHROME_BIN",
+
+    // Propagate to smoke test JVMs so inner Gradle builds match the outer build's Develocity server
+    // and edge discovery, instead of falling back to https://ge.gradle.org as an explicit remote
+    // build cache server (which caused cache load stack traces to fail no-stack-trace assertions).
+    "DEVELOCITY_SERVER_URL",
+    "DEVELOCITY_EDGE_DISCOVERY"
 )
 
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -20,7 +20,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.internal.util.LongCommandLineDetectionUtil
-import org.gradle.test.fixtures.Flaky
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 
 import static org.gradle.util.Matchers.containsText
 
@@ -85,7 +86,11 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = ".* project.javaexec")
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/5122")
+    // On Linux the total command-line limit (ARG_MAX) is derived from the stack ulimit, so on agents with a
+    // large/unlimited stack the "too long" command line is accepted and the process starts successfully,
+    // making this assertion flaky. macOS and Windows have small fixed limits, so the failure is reliable there.
+    // See https://github.com/gradle/gradle-private/issues/5122
+    @Requires(UnitTestPreconditions.NotLinux)
     def "still fail when classpath doesn't shorten the command line enough with #method"() {
         def veryLongCommandLineArgs = getLongCommandLine(getMaxArgs() * 16)
         buildFile << """


### PR DESCRIPTION
Fixes for the `release8x` branch: backport three Develocity-related changes from `master`, plus quiet a Linux-only flaky test.

### Develocity env var handling (cherry-picks from master)
| Commit | Source PR | Notes |
|--------|-----------|-------|
| Update DV env vars | #38100 | Clean cherry-pick (`.teamcity/`) |
| Configure PTS server from `DEVELOCITY_SERVER_URL` env var | #38164 | Conflicts resolved — kept release8x's diverged code (performance baselines, PTS-selection getter, `SKIP_BUILD_LOGIC_TESTS`); added only `DEVELOCITY_SERVER_URL_ENV`, the `develocityServerUrl` provider, and the PTS-server fallback |
| Propagate `DEVELOCITY_SERVER_URL` to smoke test JVMs | #38178 | **Adapted** — release8x has no `inheritedEnvVars()` mechanism, so `DEVELOCITY_SERVER_URL` and `DEVELOCITY_EDGE_DISCOVERY` were added to the `propagatedEnvironmentVariables` allowlist in `propagated-env-variables.kt` instead |

Why 38178 is adapted, not verbatim: on `master`, smoke-test JVMs inherit env vars via `Test.inheritedEnvVars()` → `filterEnvironmentVariables(inheritedEnvVars())`, and #38178 just adds two entries to that list. `release8x` has no such mechanism: `filterEnvironmentVariables()` takes no arguments and replaces each Test JVM's environment with a fixed allowlist. Pasting master's function in would be dead code, so the two vars go into the allowlist to reproduce the same effect. Neither var trips release8x's `credentialsKeywords` guard.

### Flaky test fix
`JavaExecWithLongCommandLineIntegrationTest` — the "still fail when classpath doesn't shorten the command line enough" cases assert that a process launch fails because the command line exceeds OS limits. On Linux the total limit (`ARG_MAX`) is derived from the stack `ulimit`, so on agents with a large/unlimited stack the command line is accepted and the process starts successfully, making the assertion flaky (gradle-private#5122). macOS and Windows have small fixed limits where the failure is reliable. Replaced `@Flaky` with `@Requires(UnitTestPreconditions.NotLinux)` so the tests run deterministically where the limit is fixed and are skipped on Linux.

### Verification
`./gradlew sanityCheck` passes locally (a flaky first run failed on an unrelated Kotlin-plugin/parallel-config-cache data race; re-running with the parallel CC store disabled was green).