### PR TITLE
Fix stale capability conflict replacements after component eviction

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -1261,6 +1261,253 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
         output.contains("project ':reproducer' (c)")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/38361")
+    def "capability conflict winner evicted by a later version conflict re-resolves correctly"() {
+        // ya's dependency on xa:2.0 is not processed until ya wins capY, which happens after capX
+        // has already selected xa:1.0. xa:2.0 then evicts xa:1.0 via version conflict, and xb's
+        // edge (adopted onto xa:1.0 when it lost capX) must re-contest capX against xa:2.0 instead
+        // of following the stale capability replacement back to the evicted xa:1.0.
+        def xa20 = mavenRepo.module("org", "xa", "2.0").publish()
+        mavenRepo.module("org", "xa", "1.0").publish()
+        mavenRepo.module("org", "xb", "1.0").publish()
+        mavenRepo.module("org", "ya", "1.0").dependsOn(xa20).publish()
+        mavenRepo.module("org", "yb", "1.0").publish()
+
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:xa:1.0")
+                implementation("org:xb:1.0")
+                implementation("org:ya:1.0")
+                implementation("org:yb:1.0")
+            }
+        """
+
+        capability("org", "capX") {
+            forModule("org:xa")
+            forModule("org:xb")
+            selectModule("org", "xa")
+        }
+
+        capability("org", "capY") {
+            forModule("org:ya")
+            forModule("org:yb")
+            selectModule("org", "ya")
+        }
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xa:1.0", "org:xa:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
+                edge("org:xb:1.0", "org:xa:2.0") {
+                    byConflictResolution("Explicit selection of org:xa:2.0 variant runtime")
+                }
+                module("org:ya:1.0") {
+                    module("org:xa:2.0")
+                }
+                edge("org:yb:1.0", "org:ya:1.0") {
+                    byConflictResolution("Explicit selection of org:ya:1.0 variant runtime")
+                }
+            }
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38361")
+    def "capability conflict winner evicted by a later version conflict re-resolves multiple losers"() {
+        // As above, but the evicted winner defeated two modules, so two stale capability
+        // replacements must be released and re-contested when it is evicted.
+        def xa20 = mavenRepo.module("org", "xa", "2.0").publish()
+        mavenRepo.module("org", "xa", "1.0").publish()
+        mavenRepo.module("org", "xb", "1.0").publish()
+        mavenRepo.module("org", "xc", "1.0").publish()
+        mavenRepo.module("org", "ya", "1.0").dependsOn(xa20).publish()
+        mavenRepo.module("org", "yb", "1.0").publish()
+
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:xa:1.0")
+                implementation("org:xb:1.0")
+                implementation("org:xc:1.0")
+                implementation("org:ya:1.0")
+                implementation("org:yb:1.0")
+            }
+        """
+
+        capability("org", "capX") {
+            forModule("org:xa")
+            forModule("org:xb")
+            forModule("org:xc")
+            selectModule("org", "xa")
+        }
+
+        capability("org", "capY") {
+            forModule("org:ya")
+            forModule("org:yb")
+            selectModule("org", "ya")
+        }
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xa:1.0", "org:xa:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
+                edge("org:xb:1.0", "org:xa:2.0") {
+                    byConflictResolution("Explicit selection of org:xa:2.0 variant runtime")
+                }
+                edge("org:xc:1.0", "org:xa:2.0") {
+                    byConflictResolution("Explicit selection of org:xa:2.0 variant runtime")
+                }
+                module("org:ya:1.0") {
+                    module("org:xa:2.0")
+                }
+                edge("org:yb:1.0", "org:ya:1.0") {
+                    byConflictResolution("Explicit selection of org:ya:1.0 variant runtime")
+                }
+            }
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38361")
+    def "capability conflict winner evicted by a later module conflict re-resolves correctly"() {
+        // As above, but the capX winner xa is displaced by a module replacement (xz, arriving late
+        // via the capY winner) instead of a version conflict, leaving xb the sole capX provider.
+        // Note: this shape currently resolves correctly even without stale-replacement validation,
+        // because module conflicts are resolved before capability conflicts when the queue drains;
+        // it pins the seam and becomes load-bearing for the validation if that ordering changes.
+        mavenRepo.module("org", "xa", "1.0").publish()
+        mavenRepo.module("org", "xb", "1.0").publish()
+        def xz10 = mavenRepo.module("org", "xz", "1.0").publish()
+        mavenRepo.module("org", "ya", "1.0").dependsOn(xz10).publish()
+        mavenRepo.module("org", "yb", "1.0").publish()
+
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:xa:1.0")
+                implementation("org:xb:1.0")
+                implementation("org:ya:1.0")
+                implementation("org:yb:1.0")
+
+                modules {
+                    module("org:xa") {
+                        replacedBy("org:xz")
+                    }
+                }
+            }
+        """
+
+        capability("org", "capX") {
+            forModule("org:xa")
+            forModule("org:xb")
+            selectModule("org", "xa")
+        }
+
+        capability("org", "capY") {
+            forModule("org:ya")
+            forModule("org:yb")
+            selectModule("org", "ya")
+        }
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xa:1.0", "org:xz:1.0") {
+                    selectedByRule("org:xa replaced with org:xz")
+                }
+                module("org:xb:1.0")
+                module("org:ya:1.0") {
+                    module("org:xz:1.0")
+                }
+                edge("org:yb:1.0", "org:ya:1.0") {
+                    byConflictResolution("Explicit selection of org:ya:1.0 variant runtime")
+                }
+            }
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38361")
+    def "capability replacement chain whose end is evicted by a version conflict re-resolves correctly"() {
+        // a loses capX to w1, then w1 loses capY to w2, chaining a -> w1 -> w2:1.0. A later version
+        // conflict (via the capZ winner za) evicts w2:1.0; the stale hop w1 -> w2:1.0 must be
+        // released so w1 re-contests capY against w2:2.0, re-chaining everything onto w2:2.0.
+        def w220 = mavenRepo.module("org", "w2", "2.0").publish()
+        mavenRepo.module("org", "a", "1.0").publish()
+        mavenRepo.module("org", "w1", "1.0").publish()
+        mavenRepo.module("org", "w2", "1.0").publish()
+        mavenRepo.module("org", "za", "1.0").dependsOn(w220).publish()
+        mavenRepo.module("org", "zb", "1.0").publish()
+
+        buildFile << """
+            $common
+
+            dependencies {
+                implementation("org:a:1.0")
+                implementation("org:w1:1.0")
+                implementation("org:w2:1.0")
+                implementation("org:za:1.0")
+                implementation("org:zb:1.0")
+            }
+        """
+
+        capability("org", "capX") {
+            forModule("org:a")
+            forModule("org:w1")
+            selectModule("org", "w1")
+        }
+
+        capability("org", "capY") {
+            forModule("org:w1")
+            forModule("org:w2")
+            selectModule("org", "w2")
+        }
+
+        capability("org", "capZ") {
+            forModule("org:za")
+            forModule("org:zb")
+            selectModule("org", "za")
+        }
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:a:1.0", "org:w2:2.0") {
+                    byConflictResolution("Explicit selection of org:w2:2.0 variant runtime")
+                }
+                edge("org:w1:1.0", "org:w2:2.0") {
+                    byConflictResolution("Explicit selection of org:w2:2.0 variant runtime")
+                }
+                edge("org:w2:1.0", "org:w2:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
+                module("org:za:1.0") {
+                    module("org:w2:2.0")
+                }
+                edge("org:zb:1.0", "org:za:1.0") {
+                    byConflictResolution("Explicit selection of org:za:1.0 variant runtime")
+                }
+            }
+        }
+    }
+
     // region test fixtures
 
     class CapabilityClosure {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -307,6 +307,7 @@ public class DependencyGraphBuilder {
         }
     }
 
+    @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
     private static void validateGraph(
         ResolveState resolveState,
         boolean denyDynamicSelectors,
@@ -325,7 +326,7 @@ public class DependencyGraphBuilder {
                     // We need to attach failures on unattached dependencies too, in case a node wasn't selected
                     // at all, but we still want to see an error message for it.
                     module.visitAllIncomingEdges(edge -> edge.failWith(error));
-                } else if (Iterables.any(selected.getNodes(), node -> node.getReplacement() == null)) {
+                } else if (Iterables.any(selected.getNodes(), node -> node.maybeResolveCapabilityReplacement() == node)) {
                     for (NodeState node : selected.getNodes()) {
                         if (node.isRejectedForCapabilityConflict()) {
                             GradleException error = resolutionFailureHandler.nodeRejectedDueToCapabilityConflict(node);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -259,7 +259,7 @@ class EdgeState implements DependencyGraphEdge {
 
             // A constraint by definition attaches to any other nodes in the component it constrains.
             for (NodeState node : targetComponent.getNodes()) {
-                node = node.maybeResolveReplacement();
+                node = node.maybeResolveCapabilityReplacement();
                 if (node.isSelected() && !node.isRoot()) {
                     targetNodes.add(node);
                 }
@@ -307,7 +307,7 @@ class EdgeState implements DependencyGraphEdge {
 
         for (VariantGraphResolveState targetVariant : targetVariants.getVariants()) {
             NodeState requestedNode = resolveState.getNode(targetComponent, targetVariant, targetVariants.isSelectedByVariantAwareResolution());
-            NodeState resolvedNode = requestedNode.maybeResolveReplacement();
+            NodeState resolvedNode = requestedNode.maybeResolveCapabilityReplacement();
             this.targetNodes.add(resolvedNode);
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -259,7 +259,7 @@ public class ModuleResolveState implements CandidateModule {
 
         if (oldSelected != null && oldSelected != newSelection) {
             for (NodeState node : oldSelected.getNodes()) {
-                node.maybeResolveReplacement().restartIncomingEdges();
+                node.maybeResolveCapabilityReplacement().restartIncomingEdges();
             }
         }
         for (SelectorState selector : selectors) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -96,8 +96,13 @@ public class NodeState implements DependencyGraphNode {
      * The node this node has been replaced by in a capability conflict, if this
      * node has been previously involved in a resolved capability conflict and
      * has lost that conflict.
+     * <p>
+     * This value may be stale. This pointer records the result of capability conflict resolution
+     * and only remains valid while the winner's component is present in the graph. Nothing updates this
+     * value when a participating module changes selection. This field must only be read by
+     * {@link #maybeResolveCapabilityReplacement()}, which ensures target replacement nodes are still valid.
      */
-    private @Nullable NodeState replacement;
+    private @Nullable NodeState capabilityReplacement;
     private @Nullable Pair<Capability, Collection<NodeState>> capabilityReject;
 
     private int transitiveEdgeCount;
@@ -172,10 +177,26 @@ public class NodeState implements DependencyGraphNode {
         this.dependenciesMayChange = component.getModule().isVirtualPlatform();
     }
 
-    NodeState maybeResolveReplacement() {
+    /**
+     * Follow the chain of capability replacement results to determine the node, if any, that should
+     * be targeted instead of this one. Otherwise, return this node if it has not been replaced.
+     */
+    @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
+    NodeState maybeResolveCapabilityReplacement() {
         NodeState node = this;
-        while (node.getReplacement() != null) {
-            node = node.getReplacement();
+        while (node.capabilityReplacement != null) {
+            NodeState winner = node.capabilityReplacement;
+            // Validate that this replacement is still valid. If the winning node's component is no
+            // longer selected, the target node is no longer present in the graph and the current node
+            // should be returned. Note, that node may still end up conflicting with the corresponding
+            // version-upgraded node that we originally conflicted with. We clear the stale pointer
+            // rather than just skipping it, so that it cannot reactivate a superseded decision if the
+            // evicted component is later re-selected.
+            if (winner.getComponent() != winner.getComponent().getModule().getSelected()) {
+                node.capabilityReplacement = null;
+                break;
+            }
+            node = winner;
         }
         return node;
     }
@@ -794,7 +815,7 @@ public class NodeState implements DependencyGraphNode {
         if (winner == this) {
             resolveState.onMoreSelected(this);
         } else {
-            this.replacement = winner;
+            this.capabilityReplacement = winner;
             restartIncomingEdges();
         }
     }
@@ -837,14 +858,6 @@ public class NodeState implements DependencyGraphNode {
 
     private static String formatCapability(Capability capability) {
         return capability.getGroup() + ":" + capability.getName() + ":" + capability.getVersion();
-    }
-
-    /**
-     * The node in the same component as this node, that won against this node
-     * during capability conflict resolution, if any.
-     */
-    public @Nullable NodeState getReplacement() {
-        return replacement;
     }
 
     private ExcludeSpec computeModuleResolutionFilter(List<EdgeState> incomingEdges) {
@@ -1241,26 +1254,31 @@ public class NodeState implements DependencyGraphNode {
      * Retarget all incoming edges of this node. Called in two contexts:
      * <ul>
      *     <li>On losing nodes of capability conflicts, to move their edges to the winner.</li>
-     *     <li>On nodes (and their replacements) of components losing version or module conflicts
+     *     <li>On nodes (and their capability replacements) of components losing version or module conflicts
      *         in {@link ModuleResolveState#changeSelection}, to retarget edges to the new selection.</li>
      * </ul>
-     * In the second case, the node may be a capability conflict replacement that has its own
+     * In the second case, the node may be a capability conflict winner that has its own
      * legitimate incoming edges from other modules. Those edges re-attach to this node after
      * retargeting, so the node may still have incoming edges when this method returns.
      */
     void restartIncomingEdges() {
         if (incomingEdges.size() == 1) {
-            EdgeState singleEdge = incomingEdges.get(0);
-            singleEdge.retarget();
-            // The edge should have retargeted away from this node, unless it targets
-            // this node's own module and re-attached (replacement during version change).
-            assert !singleEdge.getTargetNodes().contains(this) || singleEdge.getSelector().getTargetModule() == getComponent().getModule();
+            retargetSingleEdge(incomingEdges.get(0));
         } else if (incomingEdges.size() > 1) {
             for (EdgeState edge : new ArrayList<>(incomingEdges)) {
-                edge.retarget();
-                assert !edge.getTargetNodes().contains(this) || edge.getSelector().getTargetModule() == getComponent().getModule();
+                retargetSingleEdge(edge);
             }
         }
+    }
+
+    @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
+    private void retargetSingleEdge(EdgeState edge) {
+        edge.retarget();
+        // The edge should have retargeted away from this node. If it still targets us, we must be
+        // the winner of a capability conflict, and the edge either targets us natively or was
+        // redirected to us via a loser's still-valid capability replacement. In both cases, our
+        // component must still be its module's selection.
+        assert !edge.getTargetNodes().contains(this) || getComponent() == getComponent().getModule().getSelected();
     }
 
     void prepareForConstraintNoLongerPending(ModuleIdentifier moduleIdentifier) {


### PR DESCRIPTION
When a node loses a capability conflict, it records a pointer to the winning node, and its incoming edges are retargeted to the winner. A later version or module conflict may then evict the winner's component, selecting a different component of the same module in its place. Nothing updates the loser's pointer when this happens, so edges recomputed after the eviction would follow the stale pointer and re-attach to a component no longer in the graph. This corrupted the resolution graph, surfacing as "Cannot find node index for target node" during result assembly, or as a graph-shape assertion failure when assertions are enabled.

The replacement pointer is now validated each time it is followed: a replacement whose component is no longer its module's selected component is stale, and is cleared so it cannot reactivate later. The affected edge then re-resolves to its original target, which re-enters capability conflict detection against the newly selected component and is re-resolved by the existing conflict resolution machinery.

Also:
- Rename NodeState.replacement to capabilityReplacement, to disambiguate node-level capability replacement from module replacement (replacedBy rules).
- Strengthen the post-retarget assertion in restartIncomingEdges to state the invariant this bug violated: an edge may only remain attached to a node whose component is its module's current selection.

Fixes https://github.com/gradle/gradle/issues/38361


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
