### PR TITLE
[DO NOT MERGE] gradle-bot failure-summary probe

### DIFF
--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/BotFailureSummaryProbeTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/BotFailureSummaryProbeTest.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal
+
+import spock.lang.Specification
+
+/**
+ * Intentional failure used to verify the gradle-bot Build Scan failure summary. DO NOT MERGE.
+ */
+class BotFailureSummaryProbeTest extends Specification {
+    def "intentional failure to exercise gradle-bot failure summary"() {
+        expect:
+        1 == 2
+    }
+}


### PR DESCRIPTION
**Do not merge / do not review.**

Temporary PR with a single intentional unit-test failure in `base-services`,
used to verify that gradle-bot now includes a Develocity failure-summary in its
build-result comment. Will be closed and the branch deleted once verified.

Triggering: \`@bot-gradle test qfl\`