### PR TITLE
Fix Worker API metaspace leak by allowing cross-session cache Class keys to be GC'ed

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -66,8 +66,6 @@ public interface CrossBuildInMemoryCacheFactory extends ClassCacheFactory {
     /**
      * {@inheritDoc}
      * <p>
-     * The current implementation does not remove an entry during a build session that the entry has been used in, but this is not part of the contract.
-     * <p>
      * Note: this should be used to create _only_ global scoped instances.
      */
     @Override

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -84,7 +84,6 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         return cache;
     }
 
-
     @Override
     public <K, V> CrossBuildInMemoryCache<K, V> newCacheRetainingDataFromPreviousBuild(Predicate<V> retentionFilter) {
         CrossBuildCacheRetainingDataFromPreviousBuild<K, V> cache = new CrossBuildCacheRetainingDataFromPreviousBuild<>(retentionFilter);
@@ -253,7 +252,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
          * re-introduce the pin this cache exists to avoid.
          */
         private static class Slot<V> {
-            volatile V value;
+            volatile @Nullable V value;
             volatile int epoch;
         }
 
@@ -276,15 +275,17 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
             }
             synchronized (slot) {
                 epoch = currentEpoch.get();
-                if (slot.value == null || slot.epoch != epoch) {
+                V cached = slot.value;
+                if (cached == null || slot.epoch != epoch) {
                     V computed = factory.apply(key);
                     if (computed == null) {
                         throw new IllegalStateException("Factory '" + factory + "' failed to produce a value for key '" + key + "'!");
                     }
                     slot.value = computed;
                     slot.epoch = epoch;
+                    return computed;
                 }
-                return slot.value;
+                return cached;
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -28,7 +28,6 @@ import java.lang.ref.SoftReference;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,7 +36,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static java.util.Collections.synchronizedMap;
 
 /**
  * A factory for {@link CrossBuildInMemoryCache} instances.
@@ -63,14 +61,14 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
 
     @Override
     public <K, V> CrossBuildInMemoryCache<K, V> newCache() {
-        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<>(KeyRetentionPolicy.STRONG);
+        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<>();
         listenerManager.addListener(cache);
         return cache;
     }
 
     @Override
     public <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse) {
-        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<K, V>(KeyRetentionPolicy.STRONG) {
+        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<K, V>() {
             @Nullable
             @Override
             protected V maybeGetRetainedValue(K key) {
@@ -192,30 +190,12 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         }
     }
 
-    private enum KeyRetentionPolicy {
-        WEAK,
-        STRONG
-    }
-
     private static class DefaultCrossBuildInMemoryCache<K, V> extends AbstractCrossBuildInMemoryCache<K, V> {
 
         // This is used only to retain strong references to the values
         private final Set<V> valuesForPreviousSession = new HashSet<>();
-        private final Map<K, SoftReference<V>> allValues;
-
-        public DefaultCrossBuildInMemoryCache(KeyRetentionPolicy retentionPolicy) {
-            this.allValues = mapFor(retentionPolicy);
-        }
-
-        private Map<K, SoftReference<V>> mapFor(KeyRetentionPolicy retentionPolicy) {
-            switch (retentionPolicy) {
-                case WEAK:
-                    return synchronizedMap(new WeakHashMap<>());
-                case STRONG:
-                    return new ConcurrentHashMap<>();
-            }
-            throw new IllegalArgumentException("Unknown retention policy: " + retentionPolicy);
-        }
+        // Keys are held strongly; values are held via soft references so they may be collected under memory pressure.
+        private final Map<K, SoftReference<V>> allValues = new ConcurrentHashMap<>();
 
         @Override
         protected void retainValuesFromCurrentSession(Stream<V> values) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 
 import org.gradle.cache.ManualEvictionInMemoryCache;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.session.BuildSessionLifecycleListener;
@@ -32,6 +31,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -43,9 +43,15 @@ import static java.util.Collections.synchronizedMap;
  * A factory for {@link CrossBuildInMemoryCache} instances.
  *
  * Note that this implementation should only be used to create global scoped services.
- * Note that this implementation currently retains strong references to keys and values during the whole lifetime of a build session.
  *
- * Uses a simple algorithm to collect unused values, by retaining strong references to all keys and values used during the current build session, and the previous build session. All other values are referenced only by soft references.
+ * The general-purpose caches ({@link #newCache()}) retain strong references to all keys and values used during the
+ * current and previous build session, and reference all other values only by soft references, so they may be
+ * collected under memory pressure.
+ *
+ * The class caches ({@link #newClassCache()} and {@link #newClassMap()}) instead associate each value with its key
+ * {@link Class} via {@link ClassValue}, so a value lives exactly as long as its key class and is evicted only when
+ * that class is unloaded, never under memory pressure. This lets classes -- and the ClassLoaders that define them --
+ * be collected as soon as they are otherwise unused, including within a single build session.
  */
 @ThreadSafe
 public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFactory {
@@ -90,18 +96,12 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
 
     @Override
     public <V> CrossBuildInMemoryCache<Class<?>, V> newClassCache() {
-        // TODO: Should use some variation of DefaultClassMap below to associate values with classes, as currently we retain a strong reference to each value for one session after the ClassLoader
-        //       for the entry's key is discarded, which is unnecessary because we won't attempt to locate the entry again once the ClassLoader has been discarded
-        DefaultCrossBuildInMemoryCache<Class<?>, V> cache = new DefaultCrossBuildInMemoryCache<>(KeyRetentionPolicy.WEAK);
-        listenerManager.addListener(cache);
-        return cache;
+        return new ClassValueCache<>();
     }
 
     @Override
     public <V> CrossBuildInMemoryCache<Class<?>, V> newClassMap() {
-        DefaultClassMap<V> map = new DefaultClassMap<>();
-        listenerManager.addListener(map);
-        return map;
+        return new ClassValueCache<>();
     }
 
     private abstract static class AbstractCrossBuildInMemoryCache<K, V> implements CrossBuildInMemoryCache<K, V>, BuildSessionLifecycleListener {
@@ -251,40 +251,82 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
     }
 
     /**
-     * Retains strong references to the keys and values via the key's ClassLoader. This allows the ClassLoader to be collected.
+     * A {@link CrossBuildInMemoryCache} of values computed per {@link Class} key, backed by {@link ClassValue} so
+     * that each value is stored on its key {@code Class} itself. A value therefore lives exactly as long as its key
+     * class (and the {@link ClassLoader} that defined it) is reachable, and imposes no other retention. This lets
+     * classes -- and the ClassLoaders that define them -- be collected as soon as they are otherwise unused, even
+     * within a single build session, without this long-lived cache pinning them (see gradle/gradle#18313).
+     *
+     * <p>This deliberately does <em>not</em> extend {@link AbstractCrossBuildInMemoryCache}: that base strongly
+     * retains every value in its {@code valuesForThisSession} map for the whole build session, which would
+     * re-introduce exactly the pin this class exists to avoid.
+     *
+     * <p>Invariant: a value cached under a key {@code Class} must not strongly reference any other, shorter-lived
+     * class, or that class would be retained for the key's lifetime. This holds for the current consumers, which
+     * cache values describing their own key class (constructors, generated subclasses, type metadata).
      */
-    private static class DefaultClassMap<V> extends AbstractCrossBuildInMemoryCache<Class<?>, V> {
-        // Currently retains strong references to types that are not loaded using a VisitableURLClassLoader
-        // This is fine for JVM types, but a problem when a custom ClassLoader is used (which should probably be deprecated instead of supported)
-        private final Map<Class<?>, V> leakyValues = new ConcurrentHashMap<>();
+    private static class ClassValueCache<V> implements CrossBuildInMemoryCache<Class<?>, V> {
 
-        @Override
-        protected void retainValuesFromCurrentSession(Stream<V> values) {
-            // Ignore
+        /**
+         * Holds the cached value on the key {@code Class}. The {@code epoch} lets {@link #clear()} invalidate every
+         * entry in O(1) without keeping a registry of keys -- such a registry would reference the keys and so
+         * re-introduce the pin this cache exists to avoid.
+         */
+        private static class Slot<V> {
+            volatile V value;
+            volatile int epoch;
         }
 
-        @Override
-        protected void discardRetainedValues() {
-            throw new UnsupportedOperationException();
-        }
+        private final ClassValue<Slot<V>> slots = new ClassValue<Slot<V>>() {
+            @Override
+            protected Slot<V> computeValue(Class<?> type) {
+                return new Slot<>();
+            }
+        };
+
+        private final AtomicInteger currentEpoch = new AtomicInteger();
 
         @Override
-        protected void retainValue(Class<?> key, V v) {
-            getCacheScope(key).put(key, v);
+        public V get(Class<?> key, Function<? super Class<?>, ? extends V> factory) {
+            Slot<V> slot = slots.get(key);
+            int epoch = currentEpoch.get();
+            V value = slot.value;
+            if (value != null && slot.epoch == epoch) {
+                return value;
+            }
+            synchronized (slot) {
+                epoch = currentEpoch.get();
+                if (slot.value == null || slot.epoch != epoch) {
+                    V computed = factory.apply(key);
+                    if (computed == null) {
+                        throw new IllegalStateException("Factory '" + factory + "' failed to produce a value for key '" + key + "'!");
+                    }
+                    slot.value = computed;
+                    slot.epoch = epoch;
+                }
+                return slot.value;
+            }
         }
 
         @Nullable
         @Override
-        protected V maybeGetRetainedValue(Class<?> key) {
-            return getCacheScope(key).get(key);
+        public V getIfPresent(Class<?> key) {
+            Slot<V> slot = slots.get(key);
+            return slot.epoch == currentEpoch.get() ? slot.value : null;
         }
 
-        private Map<Class<?>, V> getCacheScope(Class<?> type) {
-            ClassLoader classLoader = type.getClassLoader();
-            if (classLoader instanceof VisitableURLClassLoader) {
-                return ((VisitableURLClassLoader) classLoader).getUserData(this, ConcurrentHashMap::new);
+        @Override
+        public void put(Class<?> key, V value) {
+            Slot<V> slot = slots.get(key);
+            synchronized (slot) {
+                slot.value = value;
+                slot.epoch = currentEpoch.get();
             }
-            return leakyValues;
+        }
+
+        @Override
+        public void clear() {
+            currentEpoch.incrementAndGet();
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
@@ -20,12 +20,10 @@ import groovy.transform.CompileStatic
 import org.gradle.internal.session.BuildSessionLifecycleListener
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import spock.lang.Issue
-import spock.lang.TempDir
 import spock.lang.Timeout
 
 import java.lang.ref.WeakReference
 import java.util.function.Function
-import javax.tools.ToolProvider
 
 class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemoryCacheTest {
 
@@ -134,37 +132,21 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemo
         }
     }
 
-    @TempDir
-    File tempDir
-
-    // Compiles a trivial pure-Java class and loads it in a fresh, isolated URLClassLoader (a pure-Java class avoids
-    // Groovy's global ClassInfo/globalClassSet retention), then caches a value against it. Stays dynamic Groovy --
-    // the JavaCompiler.run varargs call does not resolve under @CompileStatic -- but never dispatches a method ON
-    // the throwaway Class; that reflection is isolated in cacheConstructor() below. Returns ONLY a weak probe on
-    // the loader, so no strong local escapes to the caller.
-    private WeakReference<ClassLoader> populate(CrossBuildInMemoryCache<Class<?>, Object> cache) {
-        String name = "Throwaway"
-        File src = new File(tempDir, "src" + System.nanoTime())
-        File out = new File(tempDir, "out" + System.nanoTime())
-        src.mkdirs()
-        out.mkdirs()
-        File javaFile = new File(src, name + ".java")
-        javaFile.text = "public class " + name + " {}"
-        assert ToolProvider.systemJavaCompiler.run(null, null, null, "-d", out.absolutePath, javaFile.absolutePath) == 0
-
-        URLClassLoader loader = new URLClassLoader([out.toURI().toURL()] as URL[], getClass().classLoader)
-        cacheConstructor(cache, loader.loadClass(name))
-        return new WeakReference<ClassLoader>(loader)
-    }
-
-    // @CompileStatic so the reflective call on the throwaway Class compiles to a plain Java invocation. Under
-    // dynamic Groovy, invoking a method on a Class instance registers a ClassInfo in the global
+    // Loads the prebuilt, pure-Java Throwaway class in a fresh URLClassLoader whose parent is the bootstrap loader,
+    // so the loader defines its OWN copy of the class rather than delegating to this test's (never-collectible)
+    // ClassLoader. A pure-Java class also avoids Groovy's global ClassInfo/globalClassSet retention. Then caches a
+    // value against it. @CompileStatic so the reflective call on that Class compiles to a plain Java invocation:
+    // under dynamic Groovy, dispatching a method on a Class instance registers a ClassInfo in the global
     // ClassInfo.globalClassSet, which would pin the class (and its loader) regardless of the cache under test and
     // defeat the collection this test asserts. The cached value (a Constructor) transitively strong-references its
     // declaring Class (the cache key), exactly like the value cached on the real worker path in issue #18313.
+    // Returns ONLY a weak probe on the loader, so no strong local escapes to the caller.
     @CompileStatic
-    private static void cacheConstructor(CrossBuildInMemoryCache<Class<?>, Object> cache, Class<?> throwaway) {
+    private static WeakReference<ClassLoader> populate(CrossBuildInMemoryCache<Class<?>, Object> cache) {
+        URLClassLoader loader = new URLClassLoader([Throwaway.protectionDomain.codeSource.location] as URL[], null as ClassLoader)
+        Class<?> throwaway = loader.loadClass(Throwaway.name)
         Function<Class<?>, Object> factory = { Class<?> k -> (Object) k.getDeclaredConstructors()[0] }
         cache.get(throwaway, factory)
+        return new WeakReference<ClassLoader>(loader)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
@@ -16,9 +16,16 @@
 
 package org.gradle.cache.internal
 
+import groovy.transform.CompileStatic
 import org.gradle.internal.session.BuildSessionLifecycleListener
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import spock.lang.Issue
+import spock.lang.TempDir
+import spock.lang.Timeout
 
+import java.lang.ref.WeakReference
 import java.util.function.Function
+import javax.tools.ToolProvider
 
 class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemoryCacheTest {
 
@@ -95,5 +102,69 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemo
 
         cache.put(String, c)
         cache.getIfPresent(String) == c
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18313")
+    @Timeout(30)
+    def "class cache releases a value WITHIN a session once its Class is unreachable"() {
+        given:
+        def cache = factory.newClassCache()
+        // Deliberately NO beforeComplete()/clear(): the build session is still open. That single omission is
+        // what makes this a within-session guard (the value must die with its Class), not a cross-session one.
+        WeakReference<ClassLoader> loaderProbe = populate(cache)
+
+        expect: "no session-lived strong reference pins the worker ClassLoader, so a GC reclaims it mid-session"
+        ConcurrentTestUtil.poll(10) {
+            System.gc()
+            assert loaderProbe.get() == null
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18313")
+    @Timeout(30)
+    def "class map releases a value WITHIN a session once its Class is unreachable"() {
+        given:
+        def cache = factory.newClassMap()
+        WeakReference<ClassLoader> loaderProbe = populate(cache)
+
+        expect:
+        ConcurrentTestUtil.poll(10) {
+            System.gc()
+            assert loaderProbe.get() == null
+        }
+    }
+
+    @TempDir
+    File tempDir
+
+    // Compiles a trivial pure-Java class and loads it in a fresh, isolated URLClassLoader (a pure-Java class avoids
+    // Groovy's global ClassInfo/globalClassSet retention), then caches a value against it. Stays dynamic Groovy --
+    // the JavaCompiler.run varargs call does not resolve under @CompileStatic -- but never dispatches a method ON
+    // the throwaway Class; that reflection is isolated in cacheConstructor() below. Returns ONLY a weak probe on
+    // the loader, so no strong local escapes to the caller.
+    private WeakReference<ClassLoader> populate(CrossBuildInMemoryCache<Class<?>, Object> cache) {
+        String name = "Throwaway"
+        File src = new File(tempDir, "src" + System.nanoTime())
+        File out = new File(tempDir, "out" + System.nanoTime())
+        src.mkdirs()
+        out.mkdirs()
+        File javaFile = new File(src, name + ".java")
+        javaFile.text = "public class " + name + " {}"
+        assert ToolProvider.systemJavaCompiler.run(null, null, null, "-d", out.absolutePath, javaFile.absolutePath) == 0
+
+        URLClassLoader loader = new URLClassLoader([out.toURI().toURL()] as URL[], getClass().classLoader)
+        cacheConstructor(cache, loader.loadClass(name))
+        return new WeakReference<ClassLoader>(loader)
+    }
+
+    // @CompileStatic so the reflective call on the throwaway Class compiles to a plain Java invocation. Under
+    // dynamic Groovy, invoking a method on a Class instance registers a ClassInfo in the global
+    // ClassInfo.globalClassSet, which would pin the class (and its loader) regardless of the cache under test and
+    // defeat the collection this test asserts. The cached value (a Constructor) transitively strong-references its
+    // declaring Class (the cache key), exactly like the value cached on the real worker path in issue #18313.
+    @CompileStatic
+    private static void cacheConstructor(CrossBuildInMemoryCache<Class<?>, Object> cache, Class<?> throwaway) {
+        Function<Class<?>, Object> factory = { Class<?> k -> (Object) k.getDeclaredConstructors()[0] }
+        cache.get(throwaway, factory)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/Throwaway.java
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/Throwaway.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+// Prebuilt, dependency-free class loaded in an isolated URLClassLoader by
+// DefaultCrossBuildInMemoryCacheFactoryTest to prove a class cache lets a key Class (and its
+// ClassLoader) be garbage-collected. Kept as pure Java so loading it never registers a ClassInfo
+// in Groovy's global ClassInfo.globalClassSet, which would otherwise pin the loader.
+public class Throwaway {}

--- a/testing/soak/build.gradle.kts
+++ b/testing/soak/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     integTestImplementation(projects.launcher)
     integTestImplementation(projects.logging)
     integTestImplementation(projects.persistentCache)
+    integTestImplementation(testFixtures(projects.workers))
     integTestImplementation(libs.commonsCompress)
     integTestImplementation(libs.slf4jApi)
     integTestImplementation(testLibs.assertj) {

--- a/testing/soak/src/integTest/groovy/org/gradle/workers/WorkerClassLoaderMetaspaceLeakSoakTest.groovy
+++ b/testing/soak/src/integTest/groovy/org/gradle/workers/WorkerClassLoaderMetaspaceLeakSoakTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+import spock.lang.Issue
+
+/**
+ * Soak/acceptance guard for the within-session Worker API Metaspace leak (issue #18313).
+ *
+ * This is deliberately a soak test, not a per-PR integration test: it is calibration-sensitive (the {@code (N, M, cap)}
+ * triple depends on the daemon's Metaspace baseline, which is host/JDK-specific and elastic per JEP-387), and on the
+ * pre-fix baseline it exhausts Metaspace slowly (via GC thrashing under the cap) rather than failing instantly.
+ */
+class WorkerClassLoaderMetaspaceLeakSoakTest extends AbstractIntegrationSpec {
+
+    def fixture = new WorkerExecutorFixture(temporaryFolder)
+
+    def setup() {
+        fixture.prepareTaskTypeUsingWorker()
+    }
+
+    @Override
+    TestFile getBuildFile() {
+        return fixture.getBuildFile()
+    }
+
+    @Requires(
+        value = TestExecutionPreconditions.NotEmbeddedExecutor,
+        reason = "needs an isolated daemon with a bounded Metaspace"
+    )
+    @IntegrationTestTimeout(300)
+    @Issue("https://github.com/gradle/gradle/issues/18313")
+    def "worker classLoaderIsolation does not leak class metadata across items within a single build session"() {
+        given: "calibration knobs"
+        // Sized so an UNFIXED daemon's cumulative class metadata (~N*M classes strong-pinned in valuesForThisSession
+        // for the whole session, ~200MB) exceeds the cap, while a FIXED daemon collects each per-item ClassValue-backed
+        // loader mid-build and its steady state stays a small fraction of it.
+        // NOTE: this is a calibration-sensitive soak/acceptance guard -- the exact (N, M, cap) triple depends on the
+        // daemon's Metaspace baseline (host/JDK-specific, elastic per JEP-387); if the FIXED run flakes on a
+        // higher-baseline host, loosen the cap; if the baseline case stops OOMing, raise N/M.
+        int workerItems = 40          // N tasks == N fresh per-item VisitableURLClassLoaders (reuseClassloader=false)
+        int classesPerJar = 500       // M distinct (non-trivial) classes each item force-loads into its own loader
+        String metaspaceCap = "128m"
+
+        and: "an isolated daemon under a bounded Metaspace cap"
+        executer
+            .requireDaemon()
+            .requireIsolatedDaemons()
+            .withStackTraceChecksDisabled()
+            .withArgument("--max-workers=1")                            // strictly sequential -> deterministic peak
+        // implicit -XX:MaxMetaspaceSize=512m is appended first; this later flag wins (last-flag-wins).
+        // Do NOT call useOnlyRequestedJvmOpts() (it would strip -ea and the base heap args).
+            .withBuildJvmOpts("-XX:MaxMetaspaceSize=${metaspaceCap}")
+
+        and: "a network-free payload jar of many distinct classes"
+        def payloadJar = file("libs/payload.jar")
+        def builder = artifactBuilder()
+        // Non-trivial classes (fields + many methods) so each carries several KB of class metadata -- this lets the
+        // UNFIXED cumulative footprint cross the cap after far fewer loads (i.e. quickly), avoiding a timeout.
+        def methods = (0..<20).collect { m -> "public long m${m}(long p) { return f${m % 8} + p + ${m}L; }" }.join("\n")
+        (0..<classesPerJar).each { i ->
+            builder.sourceFile("gen/Gen${i}.java").text =
+                "package gen; public class Gen${i} { long f0,f1,f2,f3,f4,f5,f6,f7;\n${methods}\n}"
+        }
+        builder.buildJar(payloadJar)
+
+        and: "the work action force-loads every payload class into its own per-item classloader"
+        fixture.workActionThatCreatesFiles.action += """
+            try {
+                ClassLoader cl = getClass().getClassLoader();
+                for (int i = 0; i < ${classesPerJar}; i++) {
+                    Class.forName("gen.Gen" + i, true, cl);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        """
+        fixture.withWorkActionClassInBuildSrc()
+
+        and: "N tasks, each submitting one classLoaderIsolation work item on a fresh loader"
+        buildFile << """
+            def payload = files('libs/payload.jar')
+            def loadTasks = (0..<${workerItems}).collect { n ->
+                tasks.register("load\$n", WorkerTask) {
+                    isolationMode = 'classLoaderIsolation'
+                    additionalClasspath = payload
+                }
+            }
+            tasks.register("loadAll") { dependsOn loadTasks }
+        """
+
+        expect: "on FIXED (ClassValue-backed) code the per-item loaders are collected mid-build, so a bounded Metaspace suffices"
+        // On UNFIXED code each item's Class is strong-pinned in valuesForThisSession for the whole session; ~N*M
+        // metadata copies accumulate under the cap and the daemon exhausts Metaspace
+        succeeds("loadAll")
+
+        and: "exactly one private, isolated daemon existed and is still alive/idle (no crash, no leak)"
+        def daemons = new DaemonLogsAnalyzer(executer.daemonBaseDir)
+        daemons.daemons.size() == 1
+        daemons.daemon.assertIdle()
+    }
+}


### PR DESCRIPTION
Fixes #18313

Before this change, `newClassCache()` and `newClassMap()` stored values in the
session-lived, strongly-referenced `valuesForThisSession` map inherited from
`AbstractCrossBuildInMemoryCache`. For a class cache, the key is a `Class`, so
every `classLoaderIsolation` worker's `Class` (and hence its `ClassLoader` and
all classes it defined) stayed pinned for the whole build session. A single
build that spawns many worker classloaders therefore exhausts Metaspace
(#18313).

This PR backs both factories with a new `ClassValueCache` that stores each value
on its key `Class` via `java.lang.ClassValue`. The value now lives exactly as
long as its class, imposing no external retention, so the class and its
ClassLoader become collectible as soon as they are otherwise unused -- including
within a single build session. This also subsumes the previous soft/weak
cross-session tiers for class caches and the `DefaultClassMap`
ClassLoader-user-data scheme, which is removed.