### PR TITLE
Do not publish checksums for signature files

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/publishing/publishing_maven.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/publishing/publishing_maven.adoc
@@ -280,7 +280,7 @@ The result is that the following artifacts will be published:
 * The sources JAR artifact that has been explicitly configured: `my-library-1.0-sources.jar`
 * The Javadoc JAR artifact that has been explicitly configured: `my-library-1.0-javadoc.jar`
 
-The <<signing_plugin.adoc#signing_plugin, Signing Plugin>> is used to generate a signature file for each artifact. In addition, checksum files will be generated for all artifacts and signature files.
+The <<signing_plugin.adoc#signing_plugin, Signing Plugin>> is used to generate a signature file for each artifact. In addition, checksum files will be generated for all artifacts (but not for signature files, since a signature is itself an integrity artifact).
 
 TIP: publishToMavenLocal` does not create checksum files in `$USER_HOME/.m2/repository`.
 If you want to verify that the checksum files are created correctly, or use them for later publishing, consider configuring a <<supported_repository_types.adoc#sec:maven-repo,custom Maven repository>> with a `file://` URL and using that as the publishing target instead.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,6 +41,14 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+[[publish_no_checksums_for_signature_files]]
+==== Checksum files are no longer published for signature files
+
+When publishing to Maven or Ivy repositories, Gradle no longer publishes checksum files (such as `.sha1` and `.md5`) for signature files like `.asc` and `.sig`.
+
+A signature is itself an integrity artifact, so a checksum of a signature provides no additional protection, and the standard Maven publishing tooling does not publish these files either.
+The signature files themselves continue to be published unchanged; only their checksum files are no longer produced.
+
 [[project_cache_dir_no_longer_watched]]
 ==== The project cache directory is no longer watched
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -321,7 +321,18 @@ public abstract class ExternalResourceResolver implements ConfiguredModuleCompon
 
     private void put(File src, ExternalResourceName destination) {
         repository.withProgressLogging().resource(destination).put(new FileReadableContent(src));
-        publishChecksums(destination, src);
+        if (!isSignatureFile(destination)) {
+            publishChecksums(destination, src);
+        }
+    }
+
+    /**
+     * Signature files (e.g. {@code .asc}, {@code .sig}) are themselves integrity artifacts, so we do not
+     * publish checksums for them.
+     */
+    private static boolean isSignatureFile(ExternalResourceName destination) {
+        String path = destination.getPath();
+        return path.endsWith(".asc") || path.endsWith(".sig");
     }
 
     private void publishChecksums(ExternalResourceName destination, File content) {

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -282,9 +282,18 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
                 LOGGER.info("Uploading {} to {}", externalResource.getShortDisplayName(), externalResource.getPath());
             }
             putResource(externalResource, new FileReadableContent(content));
-            if (!localRepo) {
+            if (!localRepo && !isSignatureFile(externalResource)) {
                 publishChecksums(externalResource, content);
             }
+        }
+
+        /**
+         * Signature files (e.g. {@code .asc}, {@code .sig}) are themselves integrity artifacts, so we do not
+         * publish checksums for them. This matches the behavior of the Maven publishing tooling.
+         */
+        private static boolean isSignatureFile(ExternalResourceName destination) {
+            String path = destination.getPath();
+            return path.endsWith(".asc") || path.endsWith(".sig");
         }
 
         private void publishChecksums(ExternalResourceName destination, File content) {

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -302,6 +302,16 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         m2RepoFile("$artifactId-${version}-sources.jar.asc").assertExists()
         m2RepoFile("$artifactId-${version}.module").assertExists()
         m2RepoFile("$artifactId-${version}.module.asc").assertExists()
+
+        and: "checksums are published for regular artifacts but not for signature files"
+        m2RepoFile("${jarFileName}.sha1").assertExists()
+        m2RepoFile("${jarFileName}.md5").assertExists()
+        m2RepoFile("${jarFileName}.asc.sha1").assertDoesNotExist()
+        m2RepoFile("${jarFileName}.asc.md5").assertDoesNotExist()
+        m2RepoFile("$artifactId-${version}-sources.jar.asc.sha1").assertDoesNotExist()
+        m2RepoFile("$artifactId-${version}.module.asc.sha1").assertDoesNotExist()
+        m2RepoFile("$artifactId-${version}.pom.asc.sha1").assertDoesNotExist()
+        m2RepoFile("$artifactId-${version}.pom.asc.md5").assertDoesNotExist()
     }
 
     def "publishes signature files for Ivy publication with #layout pattern layout"() {
@@ -350,7 +360,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
 
         where:
         layout     | declaration | expectedFiles                               | unexpectedFiles
-        "standard" | ""          | this.&expectedFilesIvyPublishStandardLayout | { [] }
+        "standard" | ""          | this.&expectedFilesIvyPublishStandardLayout | this.&unexpectedFilesIvyPublishStandardLayout
         "custom"   | """
                      patternLayout {
                        artifact "[artifact]-[revision](-[classifier])(.[ext])"
@@ -380,6 +390,20 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         ]
     }
 
+    private static List<TestFile> unexpectedFilesIvyPublishStandardLayout(SigningPublicationsIntegrationSpec spec) {
+        def standardIvyRepoFile = { String... path ->
+            spec.file("build", "ivyRepo", "sign", *path)
+        }
+
+        // Signature files must not get their own checksum files
+        [
+            standardIvyRepoFile(spec.artifactId, spec.version, "${spec.jarFileName}.asc.sha1"),
+            standardIvyRepoFile(spec.artifactId, spec.version, "ivy-${spec.version}.xml.asc.sha1"),
+            standardIvyRepoFile(spec.artifactId, spec.version, "$spec.artifactId-${spec.version}-source.jar.asc.sha1"),
+            standardIvyRepoFile(spec.artifactId, spec.version, "$spec.artifactId-${spec.version}.module.asc.sha1")
+        ]
+    }
+
     private static List<TestFile> expectedFilesIvyPublishCustomLayout(SigningPublicationsIntegrationSpec spec) {
         [
             spec.ivyRepoFile(spec.jarFileName),
@@ -394,7 +418,11 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
     private static List<TestFile> unexpectedFilesIvyPublishCustomLayout(SigningPublicationsIntegrationSpec spec) {
         [
             spec.ivyRepoFile("$spec.artifactId-${spec.version}.module"),
-            spec.ivyRepoFile("$spec.artifactId-${spec.version}.module.asc")
+            spec.ivyRepoFile("$spec.artifactId-${spec.version}.module.asc"),
+            // Signature files must not get their own checksum files
+            spec.ivyRepoFile("${spec.jarFileName}.asc.sha1"),
+            spec.ivyRepoFile("ivy-${spec.version}.xml.asc.sha1"),
+            spec.ivyRepoFile("$spec.artifactId-${spec.version}-source.jar.asc.sha1")
         ]
     }
 

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -643,9 +643,14 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     void assertArtifactsPublished(String... names) {
         def expectedArtifacts = [] as Set
         for (name in names) {
-            expectedArtifacts.addAll([name, "${name}.sha1"])
-            if (withExtraChecksums) {
-                expectedArtifacts.addAll(["${name}.sha256", "${name}.sha512"])
+            if (isSignatureFile(name)) {
+                // Signature files are not published with checksums
+                expectedArtifacts.add(name)
+            } else {
+                expectedArtifacts.addAll([name, "${name}.sha1"])
+                if (withExtraChecksums) {
+                    expectedArtifacts.addAll(["${name}.sha256", "${name}.sha512"])
+                }
             }
         }
 
@@ -653,8 +658,14 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         expectedArtifacts = (expectedArtifacts as List).sort()
         assert publishedArtifacts == expectedArtifacts
         for (name in names) {
-            assertChecksumPublishedFor(moduleDir.file(name))
+            if (!isSignatureFile(name)) {
+                assertChecksumPublishedFor(moduleDir.file(name))
+            }
         }
+    }
+
+    private static boolean isSignatureFile(String name) {
+        return name.endsWith(".asc") || name.endsWith(".sig")
     }
 
     void assertChecksumPublishedFor(TestFile testFile) {

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -329,16 +329,27 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     void assertArtifactsPublished(String[] names) {
         TreeSet allFileNames = []
         for (name in names) {
-            allFileNames.addAll([name, "${name}.sha1", "${name}.md5"]*.toString())
-            if (extraChecksums && !(name in missingExtraChecksums)) {
-                allFileNames.addAll(["${name}.sha256", "${name}.sha512"]*.toString())
+            if (isSignatureFile(name)) {
+                // Signature files are not published with checksums
+                allFileNames.add(name.toString())
+            } else {
+                allFileNames.addAll([name, "${name}.sha1", "${name}.md5"]*.toString())
+                if (extraChecksums && !(name in missingExtraChecksums)) {
+                    allFileNames.addAll(["${name}.sha256", "${name}.sha512"]*.toString())
+                }
             }
         }
         def actualModuleDirFiles = moduleDir.list() as TreeSet
         assert actualModuleDirFiles == allFileNames
         for (name in names) {
-            assertChecksumsPublishedFor(moduleDir.file(name))
+            if (!isSignatureFile(name)) {
+                assertChecksumsPublishedFor(moduleDir.file(name))
+            }
         }
+    }
+
+    private static boolean isSignatureFile(String name) {
+        return name.endsWith(".asc") || name.endsWith(".sig")
     }
 
     /**


### PR DESCRIPTION
This is Part 2 of reducing the number of files Gradle publishes. Part 1 (#38519) stopped publishing SHA-256/SHA-512 checksums for Maven and Ivy publications. This change stops publishing checksum files (`.sha1`, `.md5`) for signature files (`.asc`, `.sig`).

Checksums of signature files provide no value: a signature already protects the integrity of the artifact it signs, and consumers verify the signature directly rather than its checksum. Publishing them just adds noise to the repository.

## Changes

- **maven-publish** (`AbstractMavenPublisher`): skip checksum generation when the published resource is a signature file.
- **ivy-publish** (`ExternalResourceResolver`): same guard for the Ivy publishing path.
- Both use an `isSignatureFile()` helper matching `.asc`/`.sig` suffixes.
- Added assertions to `SigningPublicationsIntegrationSpec` verifying that signature files have no checksums while artifacts still do.
- Documented in the 9.x upgrade guide.

## Reviewing

Take each commit in isolation.
