### PR TITLE
Update Documentation: Fix misleading dependency resolution example

### DIFF
--- a/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/groovy/build.gradle
@@ -72,12 +72,8 @@ configurations.all {
 
 // tag::defer-resolution[]
 task printDeps {
-    doFirst {
-        configurations.compileClasspath.files.each { println it } // Deferring Dependency Resolution
-    }
-    doLast {
-        configurations.compileClasspath.files.each { println it } // Resolving Dependencies During Configuration
-    }
+    // BAD: Resolving dependencies during configuration phase
+    configurations.compileClasspath.files.each { println it }
 }
 // end::defer-resolution[]
 

--- a/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/groovy/build.gradle
@@ -70,13 +70,6 @@ configurations.all {
 }
 // end::cache-dynamic-versions[]
 
-// tag::defer-resolution[]
-task printDeps {
-    // BAD: Resolving dependencies during configuration phase
-    configurations.compileClasspath.files.each { println it }
-}
-// end::defer-resolution[]
-
 // tag::custom-resolution-logic[]
 configurations.all {
     resolutionStrategy.eachDependency { details ->
@@ -87,3 +80,10 @@ configurations.all {
     }
 }
 // end::custom-resolution-logic[]
+
+// tag::defer-resolution[]
+task printDeps {
+    // BAD: Resolving dependencies during configuration phase
+    configurations.compileClasspath.files.each { println it }
+}
+// end::defer-resolution[]

--- a/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/kotlin/build.gradle.kts
@@ -70,13 +70,6 @@ configurations.all {
 }
 // end::cache-dynamic-versions[]
 
-// tag::defer-resolution[]
-tasks.register("printDeps") {
-    // BAD: Resolving dependencies during configuration phase
-    configurations.getByName("compileClasspath").files.forEach { println(it) }
-}
-// end::defer-resolution[]
-
 // tag::custom-resolution-logic[]
 configurations.all {
     resolutionStrategy.eachDependency {
@@ -87,3 +80,10 @@ configurations.all {
     }
 }
 // end::custom-resolution-logic[]
+
+// tag::defer-resolution[]
+tasks.register("printDeps") {
+    // BAD: Resolving dependencies during configuration phase
+    configurations.getByName("compileClasspath").files.forEach { println(it) }
+}
+// end::defer-resolution[]

--- a/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/optimizing-builds/performanceTips/kotlin/build.gradle.kts
@@ -72,12 +72,8 @@ configurations.all {
 
 // tag::defer-resolution[]
 tasks.register("printDeps") {
-    doFirst {
-        configurations.getByName("compileClasspath").files.forEach { println(it) } // Deferring Dependency Resolution
-    }
-    doLast {
-        configurations.getByName("compileClasspath").files.forEach { println(it) } // Resolving Dependencies During Configuration
-    }
+    // BAD: Resolving dependencies during configuration phase
+    configurations.getByName("compileClasspath").files.forEach { println(it) }
 }
 // end::defer-resolution[]
 


### PR DESCRIPTION
Fixes #34657

### Context
The code example in the "Avoid dependency resolution during configuration" section was misleading. It showed both `doFirst` and `doLast` blocks, which both run during the execution phase and properly defer dependency resolution. This didn't demonstrate the actual problem this section warns against.

The updated example now shows dependency resolution happening directly in the task configuration block (during configuration phase), which is the actual bad practice that causes performance issues.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

**Note:** No integration or unit tests are needed as this only corrects misleading code snippets to properly demonstrate the anti-pattern.
