### PR TITLE
Add Documentation: Document Kotlin daemon memory management in convention plugins

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_convention.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_convention.adoc
@@ -96,3 +96,118 @@ include::sample[dir="snippets/reference/plugin-development/managingTransitiveDep
 include::sample[dir="snippets/reference/plugin-development/managingTransitiveDependencies-dependencyAlignmentWithPlatform/groovy",files="platform/build.gradle[tags=convention]"]
 ====
 
+
+
+[[managing_kotlin_daemon_memory]]
+== Managing Kotlin daemon memory
+
+When using convention plugins with the `kotlin-dsl` plugin, you may encounter unexpected memory usage due to multiple Kotlin compiler daemons running simultaneously.
+Understanding how these daemons are created and how to control their memory usage is important for managing build performance, especially in CI environments.
+
+[[why_multiple_kotlin_daemons]]
+=== Why multiple Kotlin daemons spawn
+
+The Kotlin compiler daemon is spawned separately for each distinct Kotlin version used in your build.
+This can happen when:
+
+1. Your project uses a specific Kotlin version (e.g., Kotlin 2.1.20)
+2. The `kotlin-dsl` plugin embedded in your Gradle version uses a different Kotlin version (e.g., Kotlin 2.2)
+3. Dependencies bring in transitive Kotlin libraries with yet another version (e.g., Spring Boot → Jackson → jackson-module-kotlin uses Kotlin 1.9.25)
+
+In this scenario, three separate Kotlin compiler daemons will be created, one for each version.
+
+[[memory_implications]]
+=== Memory implications
+
+By default, each Kotlin daemon inherits the JVM arguments from the Gradle daemon, including memory settings.
+If your `gradle.properties` contains:
+
+[source,properties]
+----
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+----
+
+Each Kotlin daemon will attempt to use similar memory settings, potentially consuming:
+
+* 3 daemons × ~1GB heap each = ~3GB heap memory
+* 3 daemons × 512MB metaspace each = ~1.5GB metaspace
+* Total: ~4.5GB+ just for Kotlin compilation
+
+This can quickly exhaust available memory, especially in resource-constrained CI environments.
+
+[[controlling_kotlin_daemon_memory]]
+=== Controlling Kotlin daemon memory
+
+To manage Kotlin daemon memory independently from the Gradle daemon, use the `kotlin.daemon.jvmargs` property.
+Add this to your `gradle.properties`:
+
+[source,properties]
+----
+# Gradle daemon memory
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+
+# Kotlin daemon memory (separate, more conservative settings)
+kotlin.daemon.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=256m
+----
+
+This gives each Kotlin daemon only 512MB heap and 256MB metaspace, which is usually sufficient for compiling build scripts and convention plugins.
+
+[[important_note_included_builds]]
+==== Important: Included builds and buildSrc
+
+The `gradle.properties` file is **not inherited** by included builds or `buildSrc`.
+If you use convention plugins in an included build (commonly named `build-logic/`), you must create a separate `gradle.properties` file in that directory:
+
+[source]
+----
+.
+├── gradle.properties              # Main project settings
+├── settings.gradle.kts
+├── build.gradle.kts
+├── app/
+├── core/
+└── build-logic/                   # Included build for convention plugins
+    ├── gradle.properties          # Must create this separately!
+    ├── settings.gradle.kts
+    └── src/
+        └── main/
+            └── kotlin/
+                └── my-conventions.gradle.kts
+----
+
+Each `gradle.properties` file should contain the `kotlin.daemon.jvmargs` setting:
+
+.build-logic/gradle.properties
+[source,properties]
+----
+kotlin.daemon.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=256m
+----
+
+[[verifying_kotlin_daemon_configuration]]
+=== Verifying Kotlin daemon configuration
+
+To verify which Kotlin daemons are running and their memory usage, you can:
+
+1. Check running Kotlin daemons on Unix-like systems:
++
+[source,shell]
+----
+ps aux | grep kotlin
+----
+
+2. Check running Kotlin daemons on Windows:
++
+[source,shell]
+----
+tasklist /FI "IMAGENAME eq java.exe" /V
+----
+
+3. Review Kotlin compiler logs by enabling verbose output:
++
+[source,properties]
+----
+# In gradle.properties
+kotlin.daemon.verbose=true
+----
+
+For more details on Kotlin daemon configuration, see the https://kotlinlang.org/docs/gradle-compilation-and-caches.html#setting-kotlin-daemon-s-jvm-arguments[Kotlin documentation on Gradle compilation and caches].


### PR DESCRIPTION
Fixes #34755

### Context
When using convention plugins with included builds, multiple Kotlin compiler daemons can spawn when different Kotlin versions are present in the dependency tree. Each daemon inherits the full Gradle daemon memory settings by default, which can lead to excessive memory usage.

For example, a project with:
- Kotlin 2.1.20 for project code
- Kotlin 2.2 embedded in Gradle's kotlin-dsl plugin
- Kotlin 1.9.25 from transitive dependencies (Spring Boot → Jackson → jackson-module-kotlin)

...will spawn 3 separate daemons, each consuming 2GB+ heap and 512MB metaspace if using standard Gradle daemon settings, totaling 4.5GB+ just for Kotlin compilation.

This PR adds comprehensive documentation to the convention plugins guide explaining this issue and how to manage it.

### Changes
Added a new section "Managing Kotlin daemon memory" that covers:
- Why multiple Kotlin daemons spawn when different versions are present
- Memory implications when daemons inherit Gradle daemon settings
- How to configure `kotlin.daemon.jvmargs` independently from `org.gradle.jvmargs`
- Important note that `gradle.properties` is not inherited by included builds
- How to verify Kotlin daemon configuration
- Link to Kotlin documentation for additional details

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

**Note:** No integration or unit tests are needed as this adds explanatory content to help users understand and manage Kotlin daemon memory.
