### PR TITLE
DomainObjectContext updates

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedModelValue.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  * be used by multiple threads.
  */
 @ThreadSafe
-public interface CalculatedModelValue<T> {
+public interface CalculatedModelValue<T extends @Nullable Object> {
     /**
      * Returns the current value, failing if not present.
      *
@@ -39,7 +39,6 @@ public interface CalculatedModelValue<T> {
      *
      * <p>May be called by any thread. This method returns immediately and does not block to wait for any currently running or pending calls to {@link #update(Function)} to complete.
      */
-    @Nullable
     T getOrNull();
 
     /**

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ModelContainer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ModelContainer.java
@@ -30,8 +30,6 @@ public interface ModelContainer<T> {
     /**
      * Runs the given function to calculate a value from the public mutable model. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads.
      * However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
-     *
-     * <p>It is usually a better option to use {@link #newCalculatedValue(Object)} instead of this method.</p>
      */
     <S extends @Nullable Object> S fromMutableState(Function<? super T, ? extends S> factory);
 
@@ -57,8 +55,4 @@ public interface ModelContainer<T> {
      */
     boolean hasMutableState();
 
-    /**
-     * Creates a new container for a value that is calculated from the mutable state of this container, and then reused by multiple threads.
-     */
-    <S> CalculatedModelValue<S> newCalculatedValue(@Nullable S initialValue);
 }

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins.internal;
 
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Project;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.FeatureSpec;
@@ -80,7 +81,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpec {
         }
 
         if (capabilities.isEmpty()) {
-            capabilities.add(new ProjectDerivedCapability(project, name));
+            capabilities.add(new ProjectDerivedCapability((Project) project, name));
         }
 
         if (SourceSet.isMain(sourceSet)) {

--- a/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -69,7 +69,7 @@ public abstract class JavaTestFixturesPlugin implements Plugin<Project> {
         JvmFeatureInternal feature = new DefaultJvmFeature(
             TEST_FIXTURES_FEATURE_NAME,
             testFixturesSourceSet,
-            Collections.singleton(new ProjectDerivedCapability((ProjectInternal) project, TEST_FIXTURES_FEATURE_NAME)),
+            Collections.singleton(new ProjectDerivedCapability(project, TEST_FIXTURES_FEATURE_NAME)),
             (ProjectInternal) project,
             false
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
@@ -29,6 +29,7 @@ import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -55,4 +56,5 @@ public interface ConfigurationServicesBundle {
     AttributeDesugaring getAttributeDesugaring();
     ResolveExceptionMapper getExceptionMapper();
     ProviderFactory getProviderFactory();
+    ProjectLeaseRegistry getProjectLeaseRegistry();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -99,11 +99,9 @@ import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
-import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FilePropertyFactory;
@@ -258,6 +256,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(ConfigurationResolver.Factory.class, DefaultConfigurationResolver.Factory.class);
             registration.add(ArtifactTypeRegistry.class);
             registration.add(GlobalDependencyResolutionRules.class);
+            registration.add(ConfigurationServicesBundle.class, DefaultConfigurationServicesBundle.class);
         }
 
         @Provides
@@ -620,37 +619,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 }
                 return repositories;
             };
-        }
-
-        @Provides
-        ConfigurationServicesBundle createConfigurationServicesBundle(BuildOperationRunner buildOperationRunner,
-                                                                      ProjectStateRegistry projectStateRegistry,
-                                                                      FileCollectionFactory fileCollectionFactory,
-                                                                      ObjectFactory objectFactory,
-                                                                      AttributesFactory attributesFactory,
-                                                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator,
-                                                                      DomainObjectCollectionFactory domainObjectCollectionFactory,
-                                                                      CalculatedValueContainerFactory calculatedValueContainerFactory,
-                                                                      TaskDependencyFactory taskDependencyFactory,
-                                                                      ProblemsInternal problems,
-                                                                      AttributeDesugaring attributeDesugaring,
-                                                                      ResolveExceptionMapper exceptionMapper,
-                                                                      ProviderFactory providerFactory) {
-            return new DefaultConfigurationServicesBundle(
-                buildOperationRunner,
-                projectStateRegistry,
-                calculatedValueContainerFactory,
-                objectFactory,
-                fileCollectionFactory,
-                taskDependencyFactory,
-                attributesFactory,
-                domainObjectCollectionFactory,
-                collectionCallbackActionDecorator,
-                problems,
-                attributeDesugaring,
-                exceptionMapper,
-                providerFactory
-            );
         }
 
         private static List<ResolutionAwareRepository> collectRepositories(RepositoryHandler repositoryHandler) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.service.scopes.Scope;
@@ -111,10 +112,12 @@ public class ResolveExceptionMapper {
     }
 
     private boolean settingsRepositoriesIgnored() {
-        ProjectInternal project = domainObjectContext.getProject();
-        if (project == null) {
+        ProjectState projectState = domainObjectContext.getProjectState();
+        if (projectState == null) {
             return false;
         }
+
+        ProjectInternal project = projectState.getMutableModel();
 
         boolean hasSettingsRepos;
         try {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -99,6 +99,7 @@ import org.gradle.internal.exceptions.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.CalculatedValue;
+import org.gradle.internal.model.DefaultCalculatedModelValue;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.CallableBuildOperation;
@@ -109,6 +110,7 @@ import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.ConfigureUtil;
 import org.gradle.util.internal.WrapUtil;
 import org.jspecify.annotations.Nullable;
+
 import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayDeque;
@@ -131,6 +133,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.UNRESOLVED;
 import static org.gradle.util.internal.ConfigureUtil.configure;
 
@@ -263,7 +266,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.artifacts = new DefaultPublishArtifactSet(Describables.of(displayName, "artifacts"), ownArtifacts, configurationServices.getFileCollectionFactory(), taskDependencyFactory);
 
         this.outgoing = configurationServices.getObjectFactory().newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, artifactNotationParser, capabilityNotationParser, configurationServices.getFileCollectionFactory(), configurationServices.getAttributesFactory(), configurationServices.getDomainObjectCollectionFactory(), taskDependencyFactory);
-        this.currentResolveState = domainObjectContext.getModel().newCalculatedValue(Optional.empty());
+        this.currentResolveState = new DefaultCalculatedModelValue<>(domainObjectContext.getModel(), configurationServices.getProjectLeaseRegistry(), Optional.empty());
         this.defaultConfigurationFactory = defaultConfigurationFactory;
 
         this.canBeConsumed = roleAtCreation.isConsumable();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -161,7 +161,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners;
 
     private final Path identityPath;
-    private final Path projectPath;
 
     private final String name;
     private final boolean isDetached;
@@ -237,8 +236,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     ) {
         super(configurationServices.getTaskDependencyFactory());
         this.userCodeApplicationContext = userCodeApplicationContext;
-        this.identityPath = domainObjectContext.identityPath(name);
-        this.projectPath = domainObjectContext.projectPath(name);
+        this.identityPath = getIdentityPath(domainObjectContext, name);
         this.name = name;
         this.isDetached = isDetached;
         this.resolver = resolver;
@@ -298,6 +296,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             }
         };
         this.extendsFrom = new ExtendedConfigurations(validateExtendedConfiguration, configurationServices.getProviderFactory());
+    }
+
+    private static Path getIdentityPath(DomainObjectContext domainObjectContext, String name) {
+        Path ownerIdPath = domainObjectContext.getIdentityPath();
+        if (ownerIdPath == null) {
+            return Path.path(name);
+        }
+        return ownerIdPath.child(name);
     }
 
     private static Action<String> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
@@ -1686,7 +1692,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public String getPath() {
-            return configuration.projectPath.asString();
+            return configuration.identityPath.asString();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
@@ -30,6 +30,9 @@ import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.resources.ProjectLeaseRegistry;
+
+import javax.inject.Inject;
 
 /**
  * Default implementation of services bundle used by {@link DefaultConfiguration}.
@@ -40,6 +43,7 @@ import org.gradle.internal.operations.BuildOperationRunner;
  * Every service, factory, or other type in this bundle <strong>must</strong> be effectively immutable.
  */
 public final class DefaultConfigurationServicesBundle implements ConfigurationServicesBundle {
+
     private final BuildOperationRunner buildOperationRunner;
     private final ProjectStateRegistry projectStateRegistry;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
@@ -53,20 +57,25 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     private final AttributeDesugaring attributeDesugaring;
     private final ResolveExceptionMapper exceptionMapper;
     private final ProviderFactory providerFactory;
+    private final ProjectLeaseRegistry projectLeaseRegistry;
 
-    public DefaultConfigurationServicesBundle(BuildOperationRunner buildOperationRunner,
-                                              ProjectStateRegistry projectStateRegistry,
-                                              CalculatedValueContainerFactory calculatedValueContainerFactory,
-                                              ObjectFactory objectFactory,
-                                              FileCollectionFactory fileCollectionFactory,
-                                              TaskDependencyFactory taskDependencyFactory,
-                                              AttributesFactory attributesFactory,
-                                              DomainObjectCollectionFactory domainObjectCollectionFactory,
-                                              CollectionCallbackActionDecorator collectionCallbackActionDecorator,
-                                              ProblemsInternal problems,
-                                              AttributeDesugaring attributeDesugaring,
-                                              ResolveExceptionMapper exceptionMapper,
-                                              ProviderFactory providerFactory) {
+    @Inject
+    public DefaultConfigurationServicesBundle(
+        BuildOperationRunner buildOperationRunner,
+        ProjectStateRegistry projectStateRegistry,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
+        ObjectFactory objectFactory,
+        FileCollectionFactory fileCollectionFactory,
+        TaskDependencyFactory taskDependencyFactory,
+        AttributesFactory attributesFactory,
+        DomainObjectCollectionFactory domainObjectCollectionFactory,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
+        ProblemsInternal problems,
+        AttributeDesugaring attributeDesugaring,
+        ResolveExceptionMapper exceptionMapper,
+        ProviderFactory providerFactory,
+        ProjectLeaseRegistry projectLeaseRegistry
+    ) {
         this.buildOperationRunner = buildOperationRunner;
         this.projectStateRegistry = projectStateRegistry;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
@@ -80,6 +89,7 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         this.attributeDesugaring = attributeDesugaring;
         this.exceptionMapper = exceptionMapper;
         this.providerFactory = providerFactory;
+        this.projectLeaseRegistry = projectLeaseRegistry;
     }
 
     @Override
@@ -146,4 +156,10 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     public ProviderFactory getProviderFactory() {
         return providerFactory;
     }
+
+    @Override
+    public ProjectLeaseRegistry getProjectLeaseRegistry() {
+        return projectLeaseRegistry;
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
@@ -23,9 +23,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
-import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.deprecation.DocumentedFailure;
 import org.jspecify.annotations.Nullable;
 
@@ -40,9 +38,10 @@ import java.util.stream.Collectors;
 public class VariantIdentityUniquenessVerifier {
 
     /**
-     * Build a report of all possible variant uniqueness failures for the given configurations.
+     * Build a report of all possible variant uniqueness failures for the given configurations. If configurations
+     * do not declare capabilities, they assume the given default capability.
      */
-    public static VerificationReport buildReport(ConfigurationsProvider configurations) {
+    public static VerificationReport buildReport(ConfigurationsProvider configurations, ImmutableCapabilities defaultCapabilities) {
         ListMultimap<VariantIdentity, ConfigurationInternal> byIdentity =
             MultimapBuilder.linkedHashKeys().arrayListValues().build();
 
@@ -51,7 +50,7 @@ public class VariantIdentityUniquenessVerifier {
                 return;
             }
 
-            byIdentity.put(VariantIdentity.from(configuration), configuration);
+            byIdentity.put(VariantIdentity.from(configuration, defaultCapabilities), configuration);
         });
 
         return new VerificationReport(byIdentity);
@@ -78,12 +77,13 @@ public class VariantIdentityUniquenessVerifier {
         }
 
         /**
-         * Get a failure that only checks variant uniqueness for the given configuration.
+         * Get a failure that only checks variant uniqueness for the given configuration. If the configuration does
+         * not declare capabilities, it assumes the given default capability.
          */
         @Nullable
-        public GradleException failureFor(ConfigurationInternal configuration, boolean withTaskAdvice) {
+        public GradleException failureFor(ConfigurationInternal configuration, ImmutableCapabilities defaultCapabilities, boolean withTaskAdvice) {
             List<ConfigurationInternal> collisions =
-                byIdentity.get(VariantIdentity.from(configuration)).stream()
+                byIdentity.get(VariantIdentity.from(configuration, defaultCapabilities)).stream()
                     .filter(it -> !it.getName().equals(configuration.getName()))
                     .collect(Collectors.toList());
 
@@ -146,25 +146,16 @@ public class VariantIdentityUniquenessVerifier {
             this.capabilities = capabilities;
         }
 
-        public static VariantIdentity from(ConfigurationInternal configuration) {
+        public static VariantIdentity from(ConfigurationInternal configuration, ImmutableCapabilities defaultCapabilities) {
+            Collection<? extends Capability> declaredCapabilities = configuration.getOutgoing().getCapabilities();
+            ImmutableCapabilities capabilities = !declaredCapabilities.isEmpty()
+                ? ImmutableCapabilities.of(declaredCapabilities)
+                : defaultCapabilities;
+
             return new VariantIdentity(
                 configuration.getAttributes().asImmutable(),
-                allCapabilitiesIncludingDefault(configuration)
+                capabilities
             );
-        }
-
-        private static ImmutableCapabilities allCapabilitiesIncludingDefault(ConfigurationInternal conf) {
-            Collection<? extends Capability> declaredCapabilities = conf.getOutgoing().getCapabilities();
-            if (!declaredCapabilities.isEmpty()) {
-                return ImmutableCapabilities.of(declaredCapabilities);
-            }
-
-            // If no capabilities are declared, use the implicit capability.
-            ProjectInternal project = conf.getDomainObjectContext().getProject();
-            if (project == null) {
-                return ImmutableCapabilities.EMPTY;
-            }
-            return ImmutableCapabilities.of(new ProjectDerivedCapability(project));
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -17,13 +17,13 @@
 package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.capability.DefaultSpecificCapabilitySelector;
 import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector;
 import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 
@@ -120,7 +120,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
      * project, and should not retain any reference to the actual project instance.
      */
     @Deprecated
-    private ProjectInternal unsafeGetProject() {
+    private Project unsafeGetProject() {
         return projectState.getMutableModel();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -54,7 +54,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
@@ -65,12 +64,12 @@ import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
-import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 
 /**
  * Responsible for resolving a configuration. Delegates to a {@link ShortCircuitingResolutionExecutor} to perform
@@ -405,15 +404,16 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                 localResolveStateFactory
             );
 
-            ProjectState projectState = owner.getProjectState();
-            if (projectState == null) {
+            ProjectIdentity projectIdentity = owner.getProjectIdentity();
+            if (projectIdentity == null) {
                 return adhocRootComponentProvider;
             }
 
             // TODO #1629: Eventually, resolutions within a project should live within
             //  an adhoc root component, and should use an AdhocRootComponentProvider.
             return new ProjectRootComponentProvider(
-                projectState,
+                owner.getModel(),
+                projectIdentity,
                 moduleIdentity,
                 schema,
                 configurations,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/ProjectRootComponentProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/ProjectRootComponentProvider.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
@@ -24,10 +25,11 @@ import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvid
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory;
-import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveMetadata;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory;
+import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
@@ -42,7 +44,8 @@ import org.jspecify.annotations.Nullable;
 public class ProjectRootComponentProvider implements RootComponentProvider {
 
     // Services
-    private final ProjectState owner;
+    private final ModelContainer<?> owner;
+    private final ProjectIdentity projectIdentity;
     private final DependencyMetaDataProvider componentIdentity;
     private final AttributesSchemaInternal schema;
     private final ConfigurationsProvider configurationsProvider;
@@ -55,7 +58,8 @@ public class ProjectRootComponentProvider implements RootComponentProvider {
     private @Nullable LocalComponentGraphResolveState cachedValue;
 
     public ProjectRootComponentProvider(
-        ProjectState owner,
+        ModelContainer<?> owner,
+        ProjectIdentity projectIdentity,
         DependencyMetaDataProvider componentIdentity,
         AttributesSchemaInternal schema,
         ConfigurationsProvider configurationsProvider,
@@ -65,6 +69,7 @@ public class ProjectRootComponentProvider implements RootComponentProvider {
         AdhocRootComponentProvider adhocRootComponentProvider
     ) {
         this.owner = owner;
+        this.projectIdentity = projectIdentity;
         this.componentIdentity = componentIdentity;
         this.schema = schema;
         this.configurationsProvider = configurationsProvider;
@@ -91,7 +96,7 @@ public class ProjectRootComponentProvider implements RootComponentProvider {
         Module module = componentIdentity.getModule();
 
         ModuleVersionIdentifier moduleVersionId = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
-        ComponentIdentifier componentIdentifier = owner.getComponentIdentifier();
+        ComponentIdentifier componentIdentifier = new DefaultProjectComponentIdentifier(projectIdentity);
         String status = module.getStatus();
         ImmutableAttributesSchema immutableSchema = attributesSchemaFactory.create(schema);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.properties.FileParameterUtils;
@@ -43,9 +44,9 @@ import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.internal.Describables;
-import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.InputVisitor.InputFileValueSupplier;
+import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.model.InputNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
@@ -609,13 +610,17 @@ public class DefaultTransform implements Transform {
 
         @Override
         public boolean usesMutableProjectState() {
-            return owner.getProject() != null;
+            return owner.getProjectState() != null;
         }
 
         @Nullable
         @Override
         public ProjectInternal getOwningProject() {
-            return owner.getProject();
+            ProjectState projectState = owner.getProjectState();
+            if (projectState != null) {
+                return projectState.getMutableModel();
+            }
+            return null;
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -332,12 +333,16 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
 
         @Override
         public boolean usesMutableProjectState() {
-            return owner.getProject() != null;
+            return owner.getProjectState() != null;
         }
 
         @Override
-        public ProjectInternal getOwningProject() {
-            return owner.getProject();
+        public @Nullable ProjectInternal getOwningProject() {
+            ProjectState projectState = owner.getProjectState();
+            if (projectState != null) {
+                return projectState.getMutableModel();
+            }
+            return null;
         }
 
         @Nullable

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStep.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStep.java
@@ -21,6 +21,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -42,14 +43,14 @@ import java.io.File;
 public class TransformStep implements TaskDependencyContainer, Describable {
     private final Transform transform;
     private final TransformInvocationFactory transformInvocationFactory;
-    private final ProjectInternal owningProject;
+    private final @Nullable ProjectState owningProject;
     private final InputFingerprinter globalInputFingerprinter;
 
     public TransformStep(Transform transform, TransformInvocationFactory transformInvocationFactory, DomainObjectContext owner, InputFingerprinter globalInputFingerprinter) {
         this.transform = transform;
         this.transformInvocationFactory = transformInvocationFactory;
         this.globalInputFingerprinter = globalInputFingerprinter;
-        this.owningProject = owner.getProject();
+        this.owningProject = owner.getProjectState();
     }
 
     public Transform getTransform() {
@@ -58,7 +59,10 @@ public class TransformStep implements TaskDependencyContainer, Describable {
 
     @Nullable
     public ProjectInternal getOwningProject() {
-        return owningProject;
+        if (owningProject != null) {
+            return owningProject.getMutableModel();
+        }
+        return null;
     }
 
     public Deferrable<Try<TransformStepSubject>> createInvocation(TransformStepSubject subjectToTransform, TransformUpstreamDependencies upstreamDependencies, @Nullable NodeExecutionContext context) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -16,7 +16,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
-import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.capabilities.CapabilityInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -25,15 +25,23 @@ import org.jspecify.annotations.Nullable;
 
 public class ProjectDerivedCapability implements CapabilityInternal {
 
-    private final ProjectInternal project;
-    private final String featureName;
+    private final Project project;
+    private final @Nullable String featureName;
 
-    private volatile String capabilityName;
+    private volatile @Nullable String capabilityName;
 
-    public ProjectDerivedCapability(ProjectInternal project) {
+    public ProjectDerivedCapability(Project project) {
         this(project, null);
     }
 
+    public ProjectDerivedCapability(Project project, @Nullable String featureName) {
+        this.project = project;
+        this.featureName = featureName;
+    }
+
+    // Used by third-party plugin:
+    // https://github.com/vanniktech/gradle-maven-publish-plugin/blob/b3054e792a5d20fcc92b9eeb595ae894e9223242/plugin/src/main/kotlin/com/vanniktech/maven/publish/workaround/TestFixtures.kt#L26
+    @Deprecated
     public ProjectDerivedCapability(ProjectInternal project, @Nullable String featureName) {
         this.project = project;
         this.featureName = featureName;
@@ -41,19 +49,22 @@ public class ProjectDerivedCapability implements CapabilityInternal {
 
     @Override
     public String getGroup() {
-        return notNull("group", project.getGroup());
+        return project.getGroup().toString();
     }
 
     @Override
     public String getName() {
-        if (capabilityName == null) {
-            capabilityName = computeCapabilityName(project, featureName);
+        String local = this.capabilityName;
+        if (local == null) {
+            String result = computeCapabilityName(project, featureName);
+            this.capabilityName = result;
+            return result;
         }
-        return capabilityName;
+        return local;
     }
 
-    private static String computeCapabilityName(ProjectInternal project, @Nullable String featureName) {
-        String projectName = project.getOwner().getIdentity().getProjectName();
+    private static String computeCapabilityName(Project project, @Nullable String featureName) {
+        String projectName = project.getName();
         if (featureName == null) {
             return projectName;
         }
@@ -62,7 +73,7 @@ public class ProjectDerivedCapability implements CapabilityInternal {
 
     @Override
     public String getVersion() {
-        return notNull("version", project.getVersion());
+        return project.getVersion().toString();
     }
 
     @Override
@@ -87,18 +98,11 @@ public class ProjectDerivedCapability implements CapabilityInternal {
         return Objects.equal(getGroup(), that.getGroup())
             && Objects.equal(getName(), that.getName())
             && Objects.equal(getVersion(), that.getVersion());
-
-    }
-
-    private static String notNull(String id, Object o) {
-        if (o == null) {
-            throw new InvalidUserDataException(id + " must not be null");
-        }
-        return o.toString();
     }
 
     @Override
     public String getCapabilityId() {
         return getGroup() + ":" + getName();
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -25,6 +25,8 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalVariantGraphResolveStateBuilder;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.internal.Describables;
+import org.gradle.internal.component.external.model.DefaultImmutableCapability;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
@@ -92,8 +94,13 @@ public class LocalComponentGraphResolveStateFactory {
         LocalComponentGraphResolveMetadata metadata,
         ConfigurationsProvider configurations
     ) {
+        ImmutableCapabilities defaultCapabilities = ImmutableCapabilities.of(
+            DefaultImmutableCapability.defaultCapabilityForComponent(metadata.getModuleVersionId())
+        );
+
         LocalVariantGraphResolveStateFactory variantsFactory = new ConfigurationsProviderVariantFactory(
             metadata.getId(),
+            defaultCapabilities,
             configurations,
             metadataBuilder,
             model,
@@ -167,6 +174,7 @@ public class LocalComponentGraphResolveStateFactory {
     private static class ConfigurationsProviderVariantFactory implements LocalVariantGraphResolveStateFactory {
 
         private final ComponentIdentifier componentId;
+        private final ImmutableCapabilities defaultCapabilities;
         private final ConfigurationsProvider configurationsProvider;
         private final LocalVariantGraphResolveStateBuilder stateBuilder;
         private final ModelContainer<?> model;
@@ -174,12 +182,14 @@ public class LocalComponentGraphResolveStateFactory {
 
         public ConfigurationsProviderVariantFactory(
             ComponentIdentifier componentId,
+            ImmutableCapabilities defaultCapabilities,
             ConfigurationsProvider configurationsProvider,
             LocalVariantGraphResolveStateBuilder stateBuilder,
             ModelContainer<?> model,
             CalculatedValueContainerFactory calculatedValueContainerFactory
         ) {
             this.componentId = componentId;
+            this.defaultCapabilities = defaultCapabilities;
             this.configurationsProvider = configurationsProvider;
             this.stateBuilder = stateBuilder;
             this.model = model;
@@ -193,7 +203,7 @@ public class LocalComponentGraphResolveStateFactory {
                 DefaultLocalVariantGraphResolveStateBuilder.DependencyCache cache =
                     new DefaultLocalVariantGraphResolveStateBuilder.DependencyCache();
 
-                VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
+                VariantIdentityUniquenessVerifier.buildReport(configurationsProvider, defaultCapabilities).assertNoConflicts();
 
                 configurationsProvider.visitConsumable(configuration -> {
                     LocalVariantGraphResolveState variantState = stateBuilder.createConsumableVariantState(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -29,7 +29,7 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
     public AbstractComponentGraphResolveState(long instanceId, T graphMetadata) {
         this.instanceId = instanceId;
         this.graphMetadata = graphMetadata;
-        this.implicitCapability =  DefaultImmutableCapability.defaultCapabilityForComponent(graphMetadata.getModuleVersionId());
+        this.implicitCapability = DefaultImmutableCapability.defaultCapabilityForComponent(graphMetadata.getModuleVersionId());
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.resource.local.FileResourceListener;
@@ -224,8 +225,14 @@ public class LockFileReaderWriter {
             .forEach(GFileUtils::deleteQuietly);
     }
 
-    private String buildRegenerationComment() {
-        return "# To regenerate this file, run: ./gradlew " + context.projectPath("dependencies") + " --write-locks";
+    private @Nullable String buildRegenerationComment() {
+        ProjectIdentity projectId = context.getProjectIdentity();
+        if (projectId != null) {
+            org.gradle.util.Path taskPath = projectId.getBuildTreePath().child("dependencies");
+            return "# To regenerate this file, run: ./gradlew " + taskPath + " --write-locks";
+        }
+
+        return null;
     }
 
     private void writeUniqueLockfile(Path lockfilePath, Map<String, List<String>> dependencyToLockId, List<String> emptyLockIds) {
@@ -233,7 +240,10 @@ public class LockFileReaderWriter {
             Files.createDirectories(lockfilePath.getParent());
             List<String> content = new ArrayList<>(50);
             content.addAll(LOCKFILE_HEADER_LIST);
-            content.add(buildRegenerationComment());
+            String regenerationMessage = buildRegenerationComment();
+            if (regenerationMessage != null) {
+                content.add(regenerationMessage);
+            }
             for (Map.Entry<String, List<String>> entry : dependencyToLockId.entrySet()) {
                 String builder = entry.getKey() + "=" + entry.getValue().stream().sorted().collect(Collectors.joining(","));
                 content.add(builder);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -52,7 +52,10 @@ class DefaultConfigurationContainerSpec extends Specification {
     }
 
     private ObjectFactory objectFactory = TestUtil.objectFactory()
-    private DomainObjectContext domainObjectContext = Mock()
+    private DomainObjectContext domainObjectContext = Mock() {
+        getIdentityPath() >> Path.ROOT
+        getModel() >> StandaloneDomainObjectContext.ANONYMOUS
+    }
     private ListenerManager listenerManager = Mock()
     private FileCollectionFactory fileCollectionFactory = Mock()
     private BuildOperationRunner buildOperationRunner = Mock()
@@ -108,10 +111,6 @@ class DefaultConfigurationContainerSpec extends Specification {
     }
 
     def "adds and gets"() {
-        1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
-        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
-
         when:
         def compile = configurationContainer.create("compile")
 
@@ -137,10 +136,6 @@ class DefaultConfigurationContainerSpec extends Specification {
     }
 
     def "configures and finds"() {
-        1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
-        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
-
         when:
         def compile = configurationContainer.create("compile") {
             description = "I compile!"
@@ -154,9 +149,6 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "creates detached"() {
         given:
-        1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
-        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
-
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
         def dependency2 = new DefaultExternalModuleDependency("group", "name2", "version")
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.event.AnonymousListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
@@ -79,7 +80,8 @@ class DefaultConfigurationContainerSpec extends Specification {
         TestUtil.problemsService(),
         new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry()),
-        TestUtil.providerFactory()
+        TestUtil.providerFactory(),
+        new TestWorkerLeaseService()
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -42,6 +42,7 @@ import org.gradle.internal.code.UserCodeApplicationContext
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.ToBeImplemented
@@ -80,7 +81,8 @@ class DefaultConfigurationContainerTest extends Specification {
         TestUtil.problemsService(),
         new AttributeDesugaring(attributesFactory),
         new ResolveExceptionMapper(StandaloneDomainObjectContext.ANONYMOUS, new DocumentationRegistry()),
-        TestUtil.providerFactory()
+        TestUtil.providerFactory(),
+        new TestWorkerLeaseService()
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -81,6 +81,7 @@ import org.gradle.internal.event.AnonymousListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.test.fixtures.ExpectDeprecation
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
@@ -1915,7 +1916,8 @@ This method is only meant to be called on configurations which allow the (non-de
             TestUtil.problemsService(),
             new AttributeDesugaring(attributesFactory),
             new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry()),
-            TestUtil.providerFactory()
+            TestUtil.providerFactory(),
+            new TestWorkerLeaseService()
         )
 
         new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1885,16 +1885,17 @@ This method is only meant to be called on configurations which allow the (non-de
     private DefaultConfigurationFactory confFactory(String projectPath, String buildPath) {
         def build = Path.path(buildPath)
         def project = Path.path(projectPath)
-        def buildTreePath = build.append(Path.path(projectPath))
-        def identity = project.name != null ? ProjectIdentity.forSubproject(build, project) : ProjectIdentity.forRootProject(build, "foo")
+        def identity = project.name != null
+            ? ProjectIdentity.forSubproject(build, project)
+            : ProjectIdentity.forRootProject(build, "foo")
 
-        def domainObjectContext = Stub(DomainObjectContext)
-        _ * domainObjectContext.identityPath(_) >> { String p -> buildTreePath.child(p) }
-        _ * domainObjectContext.projectPath(_) >> { String p -> project.child(p) }
-        _ * domainObjectContext.buildPath >> build
-        _ * domainObjectContext.projectIdentity >> identity
-        _ * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
-        _ * domainObjectContext.equals(_) >> true // In these tests, we assume we're in the same context
+        def domainObjectContext = Stub(DomainObjectContext) {
+            getBuildPath() >> identity.buildPath
+            getIdentityPath() >> identity.buildTreePath
+            getProjectIdentity() >> identity
+            getModel() >> StandaloneDomainObjectContext.ANONYMOUS
+            equals(_) >> true // In these tests, we assume we're in the same context
+        }
 
         def publishArtifactNotationParser = new PublishArtifactNotationParserFactory(
             TestUtil.objectFactory(),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.provider.DefaultPropertyFactory
 import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.provider.PropertyHost
@@ -54,7 +55,10 @@ class DefaultDependencyLockingProviderTest extends Specification {
     DisplayName owner = Mock()
     FileResolver resolver = Mock()
     StartParameter startParameter = Mock()
-    DomainObjectContext context = Mock()
+    DomainObjectContext context = Mock() {
+        getIdentityPath() >> Path.ROOT
+        getProjectIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "root")
+    }
     DependencySubstitutionRules dependencySubstitutionRules = Mock()
     FileResourceListener listener = Mock()
     PropertyFactory propertyFactory = new DefaultPropertyFactory(Stub(PropertyHost))
@@ -64,9 +68,6 @@ class DefaultDependencyLockingProviderTest extends Specification {
     DefaultDependencyLockingProvider provider
 
     def setup() {
-        context.identityPath(_) >> { String value -> Path.path(value) }
-        context.getProjectPath() >> Path.path(':')
-        context.projectPath(_) >> { String value -> Path.path(":" + value) }
         resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
         resolver.resolve(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) >> uniqueLockFile

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -44,8 +44,7 @@ class LockFileReaderWriterTest extends Specification {
     FileResolver resolver = Mock()
     ProjectIdentity identity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":foo"))
     DomainObjectContext context = Mock() {
-        identityPath(_) >> { String value -> Path.path(value) }
-        projectPath(_) >> { String value -> Path.path(":foo:" + value) }
+        getIdentityPath() >> identity.buildTreePath
         getProjectIdentity() >> identity
         getDisplayName() >> identity.displayName
     }
@@ -323,9 +322,9 @@ empty=d
     @Issue("https://github.com/gradle/gradle/issues/37735")
     def 'writes regeneration comment for root project'() {
         given:
+        ProjectIdentity owningProject = ProjectIdentity.forRootProject(Path.ROOT, "root")
         DomainObjectContext rootContext = Mock() {
-            identityPath(_) >> { String value -> Path.path(value) }
-            projectPath(_) >> { String value -> Path.path(":" + value) }
+            getProjectIdentity() >> owningProject
             getDisplayName() >> "root project 'myProject'"
         }
         FileResolver rootResolver = Mock()

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/configurations/model/ConfigurationReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/configurations/model/ConfigurationReportModelFactory.java
@@ -31,6 +31,8 @@ import org.gradle.api.internal.artifacts.configurations.VariantIdentityUniquenes
 import org.gradle.api.internal.attributes.DefaultCompatibilityRuleChain;
 import org.gradle.api.internal.attributes.DefaultDisambiguationRuleChain;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,29 +63,30 @@ public final class ConfigurationReportModelFactory {
         ConfigurationContainerInternal configurations = (ConfigurationContainerInternal) project.getConfigurations();
         final Map<String, ReportConfiguration> convertedConfigurations = new HashMap<>(configurations.size());
 
-        VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport = VariantIdentityUniquenessVerifier.buildReport(configurations);
+        ImmutableCapabilities defaultCapabilities = ImmutableCapabilities.of(new ProjectDerivedCapability(project));
+        VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport = VariantIdentityUniquenessVerifier.buildReport(configurations, defaultCapabilities);
         configurations.stream()
             .map(ConfigurationInternal.class::cast)
-            .forEach(configuration -> getOrConvert(configuration, uniquenessReport, project, convertedConfigurations));
+            .forEach(configuration -> getOrConvert(configuration, uniquenessReport, project, convertedConfigurations, defaultCapabilities));
 
         return new ConfigurationReportModel(project.getName(),
             convertedConfigurations.values().stream().sorted(Comparator.comparing(ReportConfiguration::getName)).collect(Collectors.toList()),
             attributesWithCompatibilityRules, attributesWithDisambiguationRules);
     }
 
-    private ReportConfiguration getOrConvert(ConfigurationInternal configuration, VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport, Project project, Map<String, ReportConfiguration> convertedConfigurations) {
+    private ReportConfiguration getOrConvert(ConfigurationInternal configuration, VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport, Project project, Map<String, ReportConfiguration> convertedConfigurations, ImmutableCapabilities defaultCapabilities) {
         return computeIfAbsentExternal(convertedConfigurations, configuration.getName(), name -> {
             final List<ReportConfiguration> extendedConfigurations = new ArrayList<>(configuration.getExtendsFrom().size());
             configuration.getExtendsFrom().stream()
                 .map(ConfigurationInternal.class::cast)
-                .forEach(c -> extendedConfigurations.add(getOrConvert(c, uniquenessReport, project, convertedConfigurations)));
+                .forEach(c -> extendedConfigurations.add(getOrConvert(c, uniquenessReport, project, convertedConfigurations, defaultCapabilities)));
 
-            return convertConfiguration(configuration, uniquenessReport, project, fileResolver, extendedConfigurations);
+            return convertConfiguration(configuration, uniquenessReport, project, fileResolver, extendedConfigurations, defaultCapabilities);
         });
     }
 
-    private ReportConfiguration convertConfiguration(ConfigurationInternal configuration, VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport, Project project, FileResolver fileResolver, List<ReportConfiguration> extendedConfigurations) {
-        GradleException duplicateFailure = uniquenessReport.failureFor(configuration, false);
+    private ReportConfiguration convertConfiguration(ConfigurationInternal configuration, VariantIdentityUniquenessVerifier.VerificationReport uniquenessReport, Project project, FileResolver fileResolver, List<ReportConfiguration> extendedConfigurations, ImmutableCapabilities defaultCapabilities) {
+        GradleException duplicateFailure = uniquenessReport.failureFor(configuration, defaultCapabilities, false);
         List<? extends GradleException> lenientErrors = duplicateFailure != null ? Collections.singletonList(duplicateFailure) : Collections.emptyList();
 
         final List<ReportAttribute> attributes = configuration.getAttributes().keySet().stream()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -27,19 +27,25 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Models and controls access to an abstract set of related mutable objects.
+ * <p>
+ * A context may have an identity, meaning objects within that context are
+ * identifiable and addressable within a build tree. Or, they may be anonymous,
+ * meaning the domain has no unique identity and therefore the objects within
+ * it have no absolute identity within the build tree.
  */
 @ServiceScope(Scope.Project.class)
 public interface DomainObjectContext extends Describable {
 
     /**
-     * Creates a path from the root of the build tree to the current context + name.
+     * Return the identity of this context within a build tree. Null for
+     * contexts that have no unique identity.
      */
-    Path identityPath(String name);
+    @Nullable Path getIdentityPath();
 
     /**
-     * Creates a path from the root of the project tree to the current context + name.
+     * The identity of the build that this context belongs to.
      */
-    Path projectPath(String name);
+    Path getBuildPath();
 
     /**
      * If this context represents a project, its identity.
@@ -63,11 +69,6 @@ public interface DomainObjectContext extends Describable {
      * The container that holds the model for this context, to allow synchronized access to the model.
      */
     ModelContainer<?> getModel();
-
-    /**
-     * The path to the build that is associated with this object.
-     */
-    Path getBuildPath();
 
     /**
      * Whether the context is a script.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.service.scopes.Scope;
@@ -51,14 +50,6 @@ public interface DomainObjectContext extends Describable {
      * If this context represents a project, its identity.
      */
     @Nullable ProjectIdentity getProjectIdentity();
-
-    /**
-     * If this context represents a project, the project.
-     *
-     * NOTE: This method should be avoided if at all possible. Instead, rely on
-     * {@link #getProjectIdentity()}, or if not possible, prefer {@link #getProjectState()}.
-     */
-    @Nullable ProjectInternal getProject();
 
     /**
      * If this context represents a project, the project state.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.groovy.scripts.ScriptSource;
-import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
@@ -203,44 +202,4 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
         return false;
     }
 
-    @Override
-    public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
-        return new CalculatedModelValueImpl<>(initialValue);
-    }
-
-    private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
-        private volatile T value;
-
-        CalculatedModelValueImpl(@Nullable T initialValue) {
-            value = initialValue;
-        }
-
-        @Override
-        public T get() throws IllegalStateException {
-            T currentValue = getOrNull();
-            if (currentValue == null) {
-                throw new IllegalStateException("No value is available.");
-            }
-            return currentValue;
-        }
-
-        @Override
-        public T getOrNull() {
-            return value;
-        }
-
-        @Override
-        public void set(T newValue) {
-            value = newValue;
-        }
-
-        @Override
-        public T update(Function<T, T> updateFunction) {
-            synchronized (this) {
-                T newValue = updateFunction.apply(value);
-                value = newValue;
-                return newValue;
-            }
-        }
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -128,13 +128,8 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
     }
 
     @Override
-    public Path identityPath(String name) {
-        return Path.path(name);
-    }
-
-    @Override
-    public Path projectPath(String name) {
-        return Path.path(name);
+    public @Nullable Path getIdentityPath() {
+        return null;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.model.ModelContainer;
@@ -134,11 +133,6 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
 
     @Override
     public @Nullable ProjectIdentity getProjectIdentity() {
-        return null;
-    }
-
-    @Override
-    public @Nullable ProjectInternal getProject() {
         return null;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -21,11 +21,8 @@ import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.project.IsolatedProject;
 import org.gradle.internal.build.BuildState;
-import org.gradle.internal.model.CalculatedModelValue;
-import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
-import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -39,7 +36,6 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -286,83 +282,8 @@ class DefaultProjectState implements ProjectState, Closeable {
     }
 
     @Override
-    public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
-        return new CalculatedModelValueImpl<>(this, workerLeaseService, initialValue);
-    }
-
-    @Override
     public void close() {
         controller.close();
     }
 
-    private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
-        private final ProjectLeaseRegistry projectLeaseRegistry;
-        private final ModelContainer<?> owner;
-        private final ReentrantLock lock = new ReentrantLock();
-        private volatile @Nullable T value;
-
-        public CalculatedModelValueImpl(DefaultProjectState owner, WorkerLeaseService projectLeaseRegistry, @Nullable T initialValue) {
-            this.projectLeaseRegistry = projectLeaseRegistry;
-            this.value = initialValue;
-            this.owner = owner;
-        }
-
-        @Override
-        public T get() throws IllegalStateException {
-            T currentValue = getOrNull();
-            if (currentValue == null) {
-                throw new IllegalStateException("No calculated value is available for " + owner);
-            }
-            return currentValue;
-        }
-
-        @Override
-        public @Nullable T getOrNull() {
-            // Grab the current value, ignore updates that may be happening
-            return value;
-        }
-
-        @Override
-        public void set(T newValue) {
-            assertCanMutate();
-            value = newValue;
-        }
-
-        @Override
-        public T update(Function<T, T> updateFunction) {
-            acquireUpdateLock();
-            try {
-                T newValue = updateFunction.apply(value);
-                value = newValue;
-                return newValue;
-            } finally {
-                releaseUpdateLock();
-            }
-        }
-
-        private void acquireUpdateLock() {
-            // It's important that we do not block waiting for the lock while holding the project mutation lock.
-            // Doing so can lead to deadlocks.
-
-            assertCanMutate();
-
-            if (lock.tryLock()) {
-                // Update lock was not contended, can keep holding the project locks
-                return;
-            }
-
-            // Another thread holds the update lock, release the project locks and wait for the other thread to finish the update
-            projectLeaseRegistry.blocking(lock::lock);
-        }
-
-        private void assertCanMutate() {
-            if (!owner.hasMutableState()) {
-                throw new IllegalStateException("Current thread does not hold the state lock for " + owner);
-            }
-        }
-
-        private void releaseUpdateLock() {
-            lock.unlock();
-        }
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/DefaultCalculatedModelValue.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/DefaultCalculatedModelValue.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.model;
+
+import org.gradle.internal.resources.ProjectLeaseRegistry;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+public class DefaultCalculatedModelValue<T extends @Nullable Object> implements CalculatedModelValue<T> {
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final ProjectLeaseRegistry projectLeaseRegistry;
+    private final ModelContainer<?> owner;
+
+    private volatile T value;
+
+    public DefaultCalculatedModelValue(
+        ModelContainer<?> owner,
+        ProjectLeaseRegistry projectLeaseRegistry,
+        T initialValue
+    ) {
+        this.projectLeaseRegistry = projectLeaseRegistry;
+        this.value = initialValue;
+        this.owner = owner;
+    }
+
+    @Override
+    public T get() throws IllegalStateException {
+        T currentValue = getOrNull();
+        if (currentValue == null) {
+            throw new IllegalStateException("No calculated value is available for " + owner);
+        }
+        return currentValue;
+    }
+
+    @Override
+    public T getOrNull() {
+        // Grab the current value, ignore updates that may be happening
+        return value;
+    }
+
+    @Override
+    public void set(T newValue) {
+        assertCanMutate();
+        value = newValue;
+    }
+
+    @Override
+    public T update(Function<T, T> updateFunction) {
+        acquireUpdateLock();
+        try {
+            T newValue = updateFunction.apply(value);
+            value = newValue;
+            return newValue;
+        } finally {
+            releaseUpdateLock();
+        }
+    }
+
+    private void acquireUpdateLock() {
+        // It's important that we do not block waiting for the lock while holding the project mutation lock.
+        // Doing so can lead to deadlocks.
+        assertCanMutate();
+
+        if (lock.tryLock()) {
+            // Update lock was not contended, can keep holding the project locks
+            return;
+        }
+
+        // Another thread holds the update lock, release the project locks and wait for the other thread to finish the update
+        projectLeaseRegistry.blocking(lock::lock);
+    }
+
+    private void assertCanMutate() {
+        if (!owner.hasMutableState()) {
+            throw new IllegalStateException("Current thread does not hold the state lock for " + owner);
+        }
+    }
+
+    private void releaseUpdateLock() {
+        lock.unlock();
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The domain object context modeling a {@link org.gradle.api.Project}.
@@ -37,13 +38,8 @@ public class ProjectDomainObjectContext implements DomainObjectContext {
     }
 
     @Override
-    public Path identityPath(String name) {
-        return getProjectIdentity().getBuildTreePath().child(name);
-    }
-
-    @Override
-    public Path projectPath(String name) {
-        return getProjectIdentity().getProjectPath().child(name);
+    public @Nullable Path getIdentityPath() {
+        return projectState.getIdentity().getBuildTreePath();
     }
 
     @Override
@@ -68,7 +64,7 @@ public class ProjectDomainObjectContext implements DomainObjectContext {
 
     @Override
     public Path getBuildPath() {
-        return getProjectIdentity().getBuildPath();
+        return projectState.getIdentity().getBuildPath();
     }
 
     @Override
@@ -88,7 +84,7 @@ public class ProjectDomainObjectContext implements DomainObjectContext {
 
     @Override
     public String getDisplayName() {
-        return getProjectIdentity().getDisplayName();
+        return projectState.getIdentity().getDisplayName();
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectDomainObjectContext.java
@@ -48,11 +48,6 @@ public class ProjectDomainObjectContext implements DomainObjectContext {
     }
 
     @Override
-    public ProjectInternal getProject() {
-        return projectState.getMutableModel();
-    }
-
-    @Override
     public ProjectState getProjectState() {
         return projectState;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -40,9 +40,9 @@ class DefaultProjectDependencyTest extends Specification {
 
     def setup() {
         def project = Mock(ProjectInternal) {
+            getName() >> projectState.identity.projectName
             getGroup() >> "org.gradle"
             getVersion() >> "1.2"
-            getOwner() >> projectState
         }
         projectState.getMutableModel() >> project
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.problems.ProblemReporter
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultProjectDescriptorRegistry
 import org.gradle.internal.build.BuildState
+import org.gradle.internal.model.DefaultCalculatedModelValue
 import org.gradle.internal.operations.BuildOperationsParameters
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.service.DefaultServiceRegistry
@@ -702,7 +703,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createProject(state1, project1)
         def state2 = registry.stateFor(projectId("p2"))
         createProject(state2, project2)
-        def calculatedValue = state1.newCalculatedValue("initial")
+        def calculatedValue = new DefaultCalculatedModelValue<>(state1, workerLeaseService, "initial")
 
         when:
         calculatedValue.set("bad")
@@ -742,7 +743,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createProject(state1, project1)
         def state2 = registry.stateFor(projectId("p2"))
         createProject(state2, project2)
-        def calculatedValue = state1.newCalculatedValue("initial")
+        def calculatedValue = new DefaultCalculatedModelValue<>(state1, workerLeaseService, "initial")
 
         when:
         calculatedValue.update { throw new RuntimeException() }
@@ -782,7 +783,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def project1 = project("p1")
         def state1 = registry.stateFor(projectId("p1"))
         createProject(state1, project1)
-        def calculatedValue = state1.newCalculatedValue("initial")
+        def calculatedValue = new DefaultCalculatedModelValue<>(state1, workerLeaseService, "initial")
 
         when:
         async {
@@ -821,7 +822,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def project1 = project("p1")
         def state1 = registry.stateFor(projectId("p1"))
         createProject(state1, project1)
-        def calculatedValue = state1.newCalculatedValue("initial")
+        def calculatedValue = new DefaultCalculatedModelValue<>(state1, workerLeaseService, "initial")
 
         when:
         async {
@@ -856,7 +857,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def project2 = project("p2")
         def state2 = registry.stateFor(projectId("p2"))
         createProject(state2, project2)
-        def calculatedValue = state1.newCalculatedValue("initial")
+        def calculatedValue = new DefaultCalculatedModelValue<>(state1, workerLeaseService, "initial")
 
         when:
         async {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
@@ -38,7 +38,6 @@ import java.util.function.BiConsumer
 class BuildOperationFiringBuildWorkPreparerTest extends Specification {
     def "build operation provides execution plan when queries with all node types"() {
         def project = Stub(ProjectInternal) {
-            projectPath(_) >> { args -> Path.path(":" + args[0]) }
             getProjectIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "root")
         }
         def ti1 = TestTaskIdentities.create("t1", Task, project)


### PR DESCRIPTION
Updates to attempt to make this type more generic to better model things like build scoped state. Still more work to do. See individual commits for specific details:

- Move CalculatedModelValue out of ModelContainer. Was only used in Configuration, no need for this to be tied to DomainObjectContext specifically.
- Remove identityPath(String) and projectPath(String) in favor of exposing the raw identity path and letting consumers create paths as necessary
- Remove DomainObjectContext.getProject(). Migrate users to not require any project at all or otherwise move to getProjectState().getMutableModel()

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
