### PR TITLE
Deprecate legacy lock file format

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -93,6 +93,25 @@ Additionally, the transitional system property `org.gradle.tooling.parallel.igno
 Once `org.gradle.parallel` and `org.gradle.tooling.parallel` are independent, the flag is redundant, so Gradle 10 simply ignores it.
 No action is required in Gradle 9.x; if you set it explicitly, you can remove it when upgrading to Gradle 10.
 
+[[legacy_dependency_lock_format]]
+==== Deprecation of the legacy dependency lock file format
+
+Before Gradle 6.4, <<dependency_locking.adoc#locking-versions,dependency locking>> stored lock state in a separate file per locked configuration, located in the `gradle/dependency-locks` directory under that configuration's project directory.
+Since Gradle 6.4, lock state has been stored in a single `gradle.lockfile` per project, but Gradle has continued to read lock state stored in the legacy format.
+
+Loading lock state from legacy lock files is now deprecated.
+Starting in Gradle 10, Gradle will no longer read legacy lock files.
+
+To migrate to the new format, regenerate the lock state of affected projects by running:
+
+[source,bash]
+----
+./gradlew dependencies --write-locks
+----
+
+When writing the new lock file, Gradle automatically deletes the legacy lock files whose state was migrated.
+See <<dependency_locking.adoc#sec:migrate-single-lockfile,Migrating your legacy lockfile>> for details.
+
 [[changes_9.7.0]]
 == Upgrading from 9.6.0 and earlier
 

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
@@ -28,7 +28,7 @@ class EclipseDependencyLockingIntegrationTest extends AbstractEclipseIntegration
         mvnRepo.module("groupOne", "artifactTwo", "1.1").publish()
         def repoJar = mvnRepo.module("groupOne", "artifactTwo", "2.0").publish().artifactFile
 
-        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactTwo:1.1'
+        file('gradle.lockfile') << 'groupOne:artifactTwo:1.1=compileClasspath'
 
         //when
         expectTaskDeprecations("eclipse", "eclipseClasspath", "eclipseJdt", "eclipseProject")
@@ -65,7 +65,7 @@ class EclipseDependencyLockingIntegrationTest extends AbstractEclipseIntegration
         def artifactOne = mvnRepo.module("groupOne", "artifactOne", "1.1").publish().artifactFile
         def artifactTwo = mvnRepo.module("groupOne", "artifactTwo", "2.0").publish().artifactFile
 
-        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactOne:1.1'
+        file('gradle.lockfile') << 'groupOne:artifactOne:1.1=compileClasspath'
 
         //when
         expectTaskDeprecations("eclipse", "eclipseClasspath", "eclipseJdt", "eclipseProject")

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
@@ -29,7 +29,7 @@ class IdeaDependencyLockingIntegrationTest extends AbstractIdeIntegrationTest {
         mvnRepo.module("groupOne", "artifactTwo", "1.1").publish()
         mvnRepo.module("groupOne", "artifactTwo", "2.0").publish()
 
-        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactTwo:1.1'
+        file('gradle.lockfile') << 'groupOne:artifactTwo:1.1=compileClasspath'
 
         //when
         expectTaskDeprecations("idea", "ideaModule", "ideaProject", "ideaWorkspace")
@@ -66,7 +66,7 @@ class IdeaDependencyLockingIntegrationTest extends AbstractIdeIntegrationTest {
         mvnRepo.module("groupOne", "artifactOne", "1.1").publish()
         mvnRepo.module("groupOne", "artifactTwo", "2.0").publish()
 
-        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactOne:1.1'
+        file('gradle.lockfile') << 'groupOne:artifactOne:1.1=compileClasspath'
 
         //when
         expectTaskDeprecations("idea", "ideaModule", "ideaProject", "ideaWorkspace")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
@@ -70,6 +70,9 @@ abstract class AbstractLockingIntegrationTest extends AbstractDependencyResoluti
         def constraintVersion = lockMode() == LockMode.LENIENT ? "1.0" : "{strictly 1.0}"
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:
@@ -187,7 +190,7 @@ dependencies {
             dependencyLocking {
                 lockAllConfigurations()
             }
-            
+
             repositories {
                 maven {
                     url = "${mavenRepo.uri}"
@@ -196,11 +199,11 @@ dependencies {
             configurations {
                 conf
             }
-            
+
             dependencies {
                 conf 'org:bar:1.+'
             }
-            
+
             task copyDeps(type: Copy) {
                 from configurations.conf
                 into "\$buildDir/output"
@@ -536,6 +539,9 @@ dependencies {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
@@ -576,6 +582,9 @@ dependencies {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies', '--update-locks', 'org:f*'
 
         then:
@@ -616,6 +625,9 @@ dependencies {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
@@ -661,6 +673,9 @@ dependencies {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
@@ -828,6 +843,9 @@ dependencies {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
@@ -49,6 +49,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'checkDeps'
 
         then:
@@ -90,6 +93,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'checkDeps'
 
         then:
@@ -130,6 +136,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'checkDeps'
 
         then:
@@ -170,6 +179,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'checkDeps'
 
         then:
@@ -202,6 +214,9 @@ configurations {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'checkDeps'
 
         then:
@@ -243,11 +258,14 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         run 'dependencies'
 
         then:
-        outputContains """lockedConf
-+--- org:foo:1.+ FAILED
+        outputContains 'lockedConf'
+        outputContains """+--- org:foo:1.+ FAILED
 +--- org:foo:1.1 FAILED
 \\--- org:foo:{strictly 1.0} FAILED"""
 
@@ -287,11 +305,14 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         run 'dependencies'
 
         then:
-        outputContains """lockedConf
-+--- org:foo:[1.0, 1.1] FAILED
+        outputContains 'lockedConf'
+        outputContains """+--- org:foo:[1.0, 1.1] FAILED
 +--- org:foo:1.1 FAILED
 +--- org:foo:{strictly 1.0} FAILED
 \\--- org:bar:1.0 FAILED
@@ -328,6 +349,10 @@ dependencies {
 """
 
         lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'], unique)
+
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
 
         expect:
         succeeds 'checkDeps'
@@ -366,6 +391,10 @@ dependencies {
 """
 
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
+
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
 
         expect:
         succeeds 'checkDeps'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
@@ -56,6 +56,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:
@@ -104,6 +107,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:
@@ -152,6 +158,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:
@@ -198,6 +207,9 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:
@@ -238,6 +250,9 @@ configurations {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'checkDeps'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -26,7 +26,7 @@ class LockingInteractionsIntegrationTest extends AbstractHttpDependencyResolutio
         settingsFile << "rootProject.name = 'locking-interactions'"
     }
 
-    def 'locking constraints do not bring back excluded modules'() {
+    def 'locking constraints do not bring back excluded modules (unique: #unique)'() {
         def foo = mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0').dependsOn(foo).publish()
 
@@ -52,15 +52,20 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies'
 
         then:
         outputContains('org:bar')
         outputDoesNotContain('foo')
 
+        where:
+        unique << [true, false]
     }
 
     def 'does not lock dependencies missing a version'() {
@@ -93,7 +98,7 @@ dependencies {
         lockfileFixture.verifyLockfile('lockedConf', [])
     }
 
-    def "can lock when using latest.#level"() {
+    def "can lock when using latest.#level (unique: #unique)"() {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0-SNAPSHOT').withNonUniqueSnapshots().publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
@@ -122,18 +127,23 @@ dependencies {
         if (level == 'integration') {
             version += '-SNAPSHOT'
         }
-        lockfileFixture.createLockfile('lockedConf', ["org:bar:$version".toString()], false)
+        lockfileFixture.createLockfile('lockedConf', ["org:bar:$version".toString()], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencies'
 
         then:
         outputContains("org:bar:latest.${level} -> $resolvedVersion")
 
         where:
-        level         | resolvedVersion
-        'release'     | '1.0'
-        'integration' | '1.0-SNAPSHOT'
+        level         | resolvedVersion | unique
+        'release'     | '1.0'           | true
+        'release'     | '1.0'           | false
+        'integration' | '1.0-SNAPSHOT'  | true
+        'integration' | '1.0-SNAPSHOT'  | false
     }
 
     def "can write lock when using #version"() {
@@ -340,12 +350,12 @@ task copyFiles(type: Copy) {
 
     }
 
-    def "fails when a force overwrites a locked version"() {
+    def "fails when a force overwrites a locked version (unique: #unique)"() {
         given:
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], unique)
 
         buildFile << """
 dependencyLocking {
@@ -379,18 +389,24 @@ task resolve {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'resolve'
 
         then:
         failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+
+        where:
+        unique << [true, false]
     }
 
-    def "fails when a substitute overwrites a locked version"() {
+    def "fails when a substitute overwrites a locked version (unique: #unique)"() {
         given:
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], unique)
 
         buildFile << """
 dependencyLocking {
@@ -424,18 +440,24 @@ task resolve {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'resolve'
 
         then:
         failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+
+        where:
+        unique << [true, false]
     }
 
-    def "fails when a useTarget overwrites a locked version"() {
+    def "fails when a useTarget overwrites a locked version (unique: #unique)"() {
         given:
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], unique)
 
         buildFile << """
 dependencyLocking {
@@ -471,15 +493,21 @@ task resolve {
 """
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'resolve'
 
         then:
         failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+
+        where:
+        unique << [true, false]
     }
 
-    def "ignores the lock entry that matches a composite"() {
+    def "ignores the lock entry that matches a composite (unique: #unique)"() {
         given:
-        lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'], unique)
 
         file("composite/settings.gradle") << """
 rootProject.name = 'composite'
@@ -517,18 +545,25 @@ task resolve {
     }
 }
 """
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
+
         expect:
         succeeds 'resolve', '--include-build', 'composite'
+
+        where:
+        unique << [true, false]
     }
 
-    def "avoids HTTP requests for dynamic version when lock exists"() {
+    def "avoids HTTP requests for dynamic version when lock exists (unique: #unique)"() {
         def foo10 = mavenHttpRepo.module('org', 'foo', '1.0').publish()
         mavenHttpRepo.module('org', 'foo', '1.1').publish()
         mavenHttpRepo.module('org', 'foo', '2.0').publish()
         def bar10 = mavenHttpRepo.module('org', 'bar', '1.0').dependsOn('org', 'foo', '[1.0,2.0)').publish()
         def bar21 = mavenHttpRepo.module('org', 'bar', '2.1').dependsOn('org', 'foo', '[1.0,2.0)').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:2.1', 'org:foo:1.0'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:2.1', 'org:foo:1.0'], unique)
 
         buildFile << """
 plugins {
@@ -560,9 +595,15 @@ dependencies {
         foo10.pom.expectGet()
         bar21.rootMetaData.expectGet()
         bar21.pom.expectGet()
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
 
         then:
         succeeds 'dependencies'
+
+        where:
+        unique << [true, false]
     }
 
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class MixedDependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
 
@@ -26,7 +27,7 @@ class MixedDependencyLockingIntegrationTest extends AbstractDependencyResolution
         settingsFile << "rootProject.name = 'mixedDepLock'"
     }
 
-    def 'can resolve locked and unlocked configurations'() {
+    def 'can resolve locked and unlocked configurations (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
@@ -51,9 +52,12 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique && GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
@@ -67,9 +71,11 @@ dependencies {
         outputContains('org:foo:1.1')
         outputDoesNotContain('constraint')
 
+        where:
+        unique << [true, false]
     }
 
-    def 'ignores the lockfile of a parent configuration when resolving an unlocked child configuration'() {
+    def 'ignores the lockfile of a parent configuration when resolving an unlocked child configuration (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
@@ -93,7 +99,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
@@ -101,9 +107,12 @@ dependencies {
         then:
         outputContains('org:foo:1.1')
         outputDoesNotContain('constraint')
+
+        where:
+        unique << [true, false]
     }
 
-    def 'applies the lock file to inherited dependencies'() {
+    def 'applies the lock file to inherited dependencies (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
@@ -128,14 +137,20 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique && GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
         outputContains('org:foo:1.0')
         outputContains('Dependency version enforced by Dependency Locking')
+
+        where:
+        unique << [true, false]
     }
 
     def 'writes lock file entries for inherited dependencies'() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyResolutionTest {
 
@@ -29,7 +30,7 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
         """
     }
 
-    def 'does not apply lock defined in a dependent project'() {
+    def 'does not apply lock defined in a dependent project (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
@@ -61,9 +62,12 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
             }
         """
 
-        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique && GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
 
         then:
@@ -74,9 +78,12 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
 
         then:
         outputContains('org:foo:1.1')
+
+        where:
+        unique << [true, false]
     }
 
-    def 'does apply lock to transitive dependencies from dependent project'() {
+    def 'does apply lock to transitive dependencies from dependent project (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
@@ -108,9 +115,12 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
             }
         """
 
-        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], unique)
 
         when:
+        if (!unique && GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
 
         then:
@@ -121,6 +131,9 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
 
         then:
         outputContains('org:foo:1.1')
+
+        where:
+        unique << [true, false]
     }
 
     def 'creates a lock file including transitive dependencies of dependent project'() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -55,6 +55,9 @@ buildscript {
         lockfileFixture.createBuildscriptLockfile('classpath', ['org.foo:foo-plugin:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'buildEnvironment'
 
         then:
@@ -159,6 +162,9 @@ task resolve {
         lockfileFixture.createBuildscriptLockfile('classpath', ['org.foo:foo-plugin:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'resolve'
 
         then:
@@ -234,6 +240,9 @@ plugins {
         lockfileFixture.createBuildscriptLockfile('classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         succeeds 'buildEnvironment'
 
         then:
@@ -303,6 +312,9 @@ buildscript {
         lockfileFixture.createBuildscriptLockfile('classpath', ['org.foo:foo-plugin:1.0'], unique)
 
         when:
+        if (!unique) {
+            executer.expectDocumentedDeprecationWarning("Storing dependency lock state using the legacy format has been deprecated. This is scheduled to be removed in Gradle 10. Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format. Run `./gradlew dependencies --write-locks` to update your build to the new format. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#legacy_dependency_lock_format")
+        }
         fails 'buildEnvironment'
 
         then:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -48,6 +48,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.resource.local.FileResourceListener;
 import org.jspecify.annotations.Nullable;
 
@@ -82,9 +83,6 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         this.context = context;
         this.dependencySubstitutionRules = dependencySubstitutionRules;
         this.writeLocks = startParameter.isWriteDependencyLocks();
-        if (writeLocks) {
-            LOGGER.debug("Write locks is enabled");
-        }
         List<String> lockedDependenciesToUpdate = startParameter.getLockedDependenciesToUpdate();
         partialUpdate = !lockedDependenciesToUpdate.isEmpty();
         updateLockEntryFilter = LockEntryFilterFactory.forParameter(lockedDependenciesToUpdate, "Update lock", true);
@@ -148,7 +146,15 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private List<String> findLockedModules(String lockId) {
         List<String> result = allLockState.get(lockId);
         if (result == null) {
-            result = lockFileReaderWriter.readLockFile(lockId);
+            result = lockFileReaderWriter.readLegacyLockFile(lockId);
+            if (result != null) {
+                DeprecationLogger.deprecateAction("Storing dependency lock state using the legacy format")
+                    .withContext("Since Gradle 6.4, dependency lock state is stored in a single file per project. Your build still stores lock state in a legacy format.")
+                    .withAdvice("Run `./gradlew dependencies --write-locks` to update your build to the new format.")
+                    .willBeRemovedInGradle10()
+                    .withUpgradeGuideSection(9, "legacy_dependency_lock_format")
+                    .nagUser();
+            }
         }
         return result;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -78,8 +78,12 @@ public class LockFileReaderWriter {
         LOGGER.debug("Lockfiles root: {}", lockFilesRoot);
     }
 
+    /**
+     * Read a lock file for a given lock ID from its legacy location,
+     * returning null if there is no legacy lock file for the given lock ID.
+     */
     @Nullable
-    public List<String> readLockFile(String lockId) {
+    public List<String> readLegacyLockFile(String lockId) {
         checkValidRoot();
 
         Path lockFile = lockFilesRoot.resolve(decorate(lockId) + FILE_SUFFIX);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -97,7 +97,7 @@ empty=
 
     def 'can load lockfile as strict constraints (Unique: #unique)'() {
         given:
-        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
+        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], true)
 
         when:
         def result = provider.loadLockState('conf', owner)
@@ -107,12 +107,6 @@ empty=
         result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.3'), newId(DefaultModuleIdentifier.newId('org', 'foo'), '1.0')] as Set
 
         1 * listener.fileObserved(_)
-        if (!unique) {
-            1 * listener.fileObserved(_)
-        }
-
-        where:
-        unique << [true, false]
     }
 
     def 'can load lockfile as prefer constraints in update mode (Unique: #unique)'() {
@@ -121,7 +115,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:foo']
         provider = newProvider()
-        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
+        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], true)
 
         when:
         def result = provider.loadLockState('conf', owner)
@@ -129,9 +123,6 @@ empty=
         then:
         !result.mustValidateLockState()
         result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.3')] as Set
-
-        where:
-        unique << [true, false]
     }
 
     def 'can filter lock entries using module update patterns (Unique: #unique)'() {
@@ -140,7 +131,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:*']
         provider = newProvider()
-        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
+        writeLockFile(['org:bar:1.3', 'org:foo:1.0'], true)
 
         when:
         def result = provider.loadLockState('conf', owner)
@@ -148,9 +139,6 @@ empty=
         then:
         !result.mustValidateLockState()
         result.getLockedDependencies() == [] as Set
-
-        where:
-        unique << [true, false]
     }
 
     def 'can filter lock entries using group update patterns (Unique: #unique)'() {
@@ -159,7 +147,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org.*:foo']
         provider = newProvider()
-        writeLockFile(['org.bar:foo:1.3', 'com:foo:1.0'], unique)
+        writeLockFile(['org.bar:foo:1.3', 'com:foo:1.0'], true)
 
         when:
         def result = provider.loadLockState('conf', owner)
@@ -167,9 +155,6 @@ empty=
         then:
         !result.mustValidateLockState()
         result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('com', 'foo'), '1.0')] as Set
-
-        where:
-        unique << [true, false]
     }
 
     def 'can filter lock entries impacted by dependency substitutions (Unique: #unique)'() {
@@ -183,21 +168,18 @@ empty=
             }
         }
         provider = newProvider()
-        writeLockFile(['org:bar:1.1', 'org:foo:1.1'], unique)
+        writeLockFile(['org:bar:1.1', 'org:foo:1.1'], true)
 
         when:
         def result = provider.loadLockState('conf', owner)
 
         then:
         result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.1')] as Set
-
-        where:
-        unique << [true, false]
     }
 
     def 'fails with invalid content in lock file (Unique: #unique)'() {
         given:
-        writeLockFile(["invalid"], unique)
+        writeLockFile(["invalid"], true)
 
         when:
         provider.loadLockState('conf', owner)
@@ -207,16 +189,13 @@ empty=
         1 * owner.getDisplayName() >> "owner"
         ex.message == 'Invalid lock state for owner'
         ex.cause.message == 'The module notation does not respect the lock file format of \'group:name:version\' - received \'invalid\''
-
-        where:
-        unique << [true, false]
     }
 
     private ModuleComponentIdentifier module(String org, String name, String version) {
         return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(org, name), version)
     }
 
-    def 'fails with missing lockfile in strict mode (Unique: #unique)'() {
+    def 'fails with missing lockfile in strict mode'() {
         given:
         provider.getLockMode().set(LockMode.STRICT)
 
@@ -229,9 +208,6 @@ empty=
         ex.message == 'Locking strict mode: Owner is locked but does not have lock state.'
         ex.resolutions == ["To create the lock state, run a task that performs dependency resolution and add '--write-locks' to the command line.",
                             "For more information on generating lock state, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#generating_and_updating_dependency_locks in the Gradle documentation."]
-
-        where:
-        unique << [true, false]
     }
 
     def 'fails with invalid ignored dependencies notation #notation'() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -131,7 +131,7 @@ line1
 line2"""
 
         when:
-        def result = lockFileReaderWriter.readLockFile('conf')
+        def result = lockFileReaderWriter.readLegacyLockFile('conf')
 
         then:
         result == ['line1', 'line2']
@@ -234,7 +234,7 @@ line1
 line2"""
 
         when:
-        def result = lockFileReaderWriter.readLockFile('conf')
+        def result = lockFileReaderWriter.readLegacyLockFile('conf')
 
         then:
         result == ['line1', 'line2']
@@ -300,7 +300,7 @@ empty=d
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context, lockFile, listener)
 
         when:
-        lockFileReaderWriter.readLockFile('foo')
+        lockFileReaderWriter.readLegacyLockFile('foo')
 
         then:
         def ex = thrown(IllegalStateException)


### PR DESCRIPTION
Prior to Gradle 6.4, each configuration wrote their own lock state to their own file. Starting in 6.4, we began writing a unified lockfile for each project, with all lock state for all configurations in that project. However, we continued reading these legacy lock files. Starting in Gradle 10, we will no longer maintain the machinery to read lock files in this legacy format.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
