### PR TITLE
Restrict Groovy 6 test coverage to Java 17+

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -107,22 +107,31 @@ class GroovyCoverage {
     private static Set<String> groovyVersionsSupportedByJdk(JavaVersion javaVersion) {
         def allVersions = allVersions()
 
+        def supported
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_26)) {
-            return VersionCoverage.versionsAtLeast(allVersions, '4.0.29')
+            supported = VersionCoverage.versionsAtLeast(allVersions, '4.0.29')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_25)) {
-            return VersionCoverage.versionsAtLeast(allVersions, '3.0.25')
+            supported = VersionCoverage.versionsAtLeast(allVersions, '3.0.25')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {
             // Latest 3.0.x patches support Java 15+
-            return VersionCoverage.versionsAtLeast(allVersions, '3.0.0')
+            supported = VersionCoverage.versionsAtLeast(allVersions, '3.0.0')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
-            return VersionCoverage.versionsBetweenInclusive(allVersions, '2.2.2', '2.5.10')
+            supported = VersionCoverage.versionsBetweenInclusive(allVersions, '2.2.2', '2.5.10')
         } else if (javaVersion < JavaVersion.VERSION_11) {
             // 5.0.0 requires Java 11+
             // Using 4.99.99 as a placeholder because beta versions aren't properly handled by VersionCoverage
-            return VersionCoverage.versionsBelow(allVersions, "4.99.99")
+            supported = VersionCoverage.versionsBelow(allVersions, "4.99.99")
         } else {
-            return allVersions
+            supported = allVersions
         }
+
+        // 6.0.0 requires Java 17+
+        // Using 5.99.99 as a placeholder because beta versions aren't properly handled by VersionCoverage
+        if (!javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+            supported = VersionCoverage.versionsBelow(supported, "5.99.99")
+        }
+
+        return supported
     }
 
     static Map<String, Jvm> groovyVersionsSupportedByAvailableJdks(Set<String> groovyVersions) {


### PR DESCRIPTION
### Context

`GroovyCompileToolchainIntegrationTest > "can compile source and run tests using Java 11 for Groovy 6.0.0-alpha-2"` was failing on master ([example build](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsIntegMultiVersion_33_bucket4/115176523)) with a `NoCompatibleVariantsFailure`:

```
Could not resolve org.apache.groovy:groovy:6.0.0-alpha-2.
  > No matching variant ... The consumer was configured to find a library ...
    compatible with Java 11 ... but every variant declares a component compatible with Java 17
```

Groovy 6.0.0-alpha-2 (added to the test matrix in `52a7b6441e6`) requires **Java 17+**. However `GroovyCoverage.groovyVersionsSupportedByJdk` only encoded per-JDK *lower* bounds; JDKs 11–16 fell through to buckets that returned the full version set, including Groovy 6. So `GroovyCoverage.supportsJavaVersion("6.0.0-alpha-2", 11)` returned `true`, the test's `Assume` guard didn't skip, and the build hit an unresolvable variant.

### Changes

Add a Java-17 upper-bound guard to `groovyVersionsSupportedByJdk`: after the existing per-JDK logic computes the supported set, strip Groovy 6+ for any JDK not compatible with Java 17. This mirrors the existing `4.99.99` placeholder used for the "Groovy 5 requires Java 11+" guard. Fixes the reported Java 11 failure as well as the latent Java 15/16 cases (the `VERSION_15` bucket also let Groovy 6 through).

Verified against the failing build config on this branch: https://builds.gradle.org/build/115223647

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

_Note: this touches only a test fixture (`GroovyCoverage`); the behavior change is that the affected multi-version test now correctly skips the unsupported Groovy 6 / Java <17 combinations. No new tests added._
