### PR TITLE
Add Groovy 5 Gradleception

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -311,6 +311,7 @@ data class CIBuildModel(
                 specificBuilds =
                     listOf(
                         SpecificBuild.GradleceptionWithMaxJdk,
+                        SpecificBuild.GradleceptionWithGroovy5,
                     ),
                 functionalTests =
                     listOf(
@@ -639,6 +640,13 @@ enum class SpecificBuild {
             stage: Stage,
             flakyTestStrategy: FlakyTestStrategy,
         ): OsAwareBaseGradleBuildType = Gradleception(model, stage, JvmCategory.MAX_VERSION, "MaxJDK")
+    },
+    GradleceptionWithGroovy5 {
+        override fun create(
+            model: CIBuildModel,
+            stage: Stage,
+            flakyTestStrategy: FlakyTestStrategy,
+        ): OsAwareBaseGradleBuildType = Gradleception(model, stage, BuildToolBuildJvm, "Default", bundleGroovyMajor = 5)
     },
     CheckLinks {
         override fun create(

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -29,7 +29,6 @@ import gradlebuild.basics.BuildParams.BUILD_RC_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_TIMESTAMP
 import gradlebuild.basics.BuildParams.BUILD_VCS_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_VERSION_QUALIFIER
-import gradlebuild.basics.BuildParams.BUNDLE_GROOVY_MAJOR
 import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
@@ -142,7 +141,6 @@ object BuildParams {
     const val RUN_IDE_IN_HEADLESS_MODE = "runIdeInHeadlessMode"
     const val STUDIO_HOME = "studioHome"
     const val IDEA_HOME = "ideaHome"
-    const val BUNDLE_GROOVY_MAJOR = "bundleGroovyMajor"
     const val DEBUG_DAEMON = "debugDaemon"
     const val DEBUG_LAUNCHER = "debugLauncher"
 
@@ -463,12 +461,6 @@ val Project.isPromotionBuild: Boolean
             taskNames.any { it.contains("updateReleasedVersions") }
     }
 
-
-/**
- * Override the version of Groovy bundled by Gradle. Must be greater than or equal to the major version of Groovy used by Gradle.
- */
-val Project.bundleGroovyMajor: Int
-    get() = systemProperty(BUNDLE_GROOVY_MAJOR).orNull?.toInt() ?: 4
 
 val Project.daemonDebuggingIsEnabled: Boolean
     get() = propertyFromAnySource(DEBUG_DAEMON).isPresent

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -29,6 +29,7 @@ import gradlebuild.basics.BuildParams.BUILD_RC_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_TIMESTAMP
 import gradlebuild.basics.BuildParams.BUILD_VCS_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_VERSION_QUALIFIER
+import gradlebuild.basics.BuildParams.BUNDLE_GROOVY_MAJOR
 import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
@@ -141,6 +142,7 @@ object BuildParams {
     const val RUN_IDE_IN_HEADLESS_MODE = "runIdeInHeadlessMode"
     const val STUDIO_HOME = "studioHome"
     const val IDEA_HOME = "ideaHome"
+    const val BUNDLE_GROOVY_MAJOR = "bundleGroovyMajor"
     const val DEBUG_DAEMON = "debugDaemon"
     const val DEBUG_LAUNCHER = "debugLauncher"
 
@@ -460,6 +462,22 @@ val Project.isPromotionBuild: Boolean
         return taskNames.contains("promotionBuild") ||
             taskNames.any { it.contains("updateReleasedVersions") }
     }
+
+
+/**
+ * Override the version of Groovy bundled by Gradle. Must be greater than or equal to the major version of Groovy used by Gradle.
+ */
+val Project.bundleGroovyMajor: Int
+    get() = systemProperty(BUNDLE_GROOVY_MAJOR).orNull?.toInt() ?: 4
+
+
+/**
+ * The lowest JVM version the bundled Groovy can run on. Groovy 4 runs on Java 8, Groovy 5 needs Java 11.
+ *
+ * This is the JVM `groovyc` itself has to run on, which is not the same as the bytecode it emits.
+ */
+val Project.bundleGroovyMinimumJvm: Int
+    get() = if (bundleGroovyMajor >= 5) 11 else 8
 
 
 val Project.daemonDebuggingIsEnabled: Boolean

--- a/build-logic-settings/version-catalogs/src/main/kotlin/gradlebuild.version-catalogs.settings.gradle.kts
+++ b/build-logic-settings/version-catalogs/src/main/kotlin/gradlebuild.version-catalogs.settings.gradle.kts
@@ -16,6 +16,28 @@ import java.util.Properties
  * limitations under the License.
  */
 
+/**
+ * The Groovy major version bundled by Gradle, overridable via `-DbundleGroovyMajor` for
+ * Gradleception coverage builds.
+ *
+ * Default should match the Groovy version declared in `gradle/dependency-management/shared-versions.properties`.
+ */
+val bundleGroovyMajor = providers.systemProperty("bundleGroovyMajor").map(String::toInt).getOrElse(4)
+
+/**
+ * Version-catalog aliases that must change together when bundling a non-default Groovy major.
+ * CodeNarc is intentionally excluded: it has no Groovy 5 build, and its analysis runtime is
+ * independent of the Groovy version bundled into the distribution.
+ */
+val groovyMajorOverrides: Map<String, String> = when (bundleGroovyMajor) {
+    4 -> emptyMap()
+    5 -> mapOf(
+        "groovy" to "5.0.7!!",
+        "spock" to "2.4-groovy-5.0!!",
+    )
+    else -> error("Unsupported bundled Groovy major version: $bundleGroovyMajor")
+}
+
 dependencyResolutionManagement {
     val root = if (rootProject.name.startsWith("build-logic")) {
         layout.rootDirectory.dir("..")
@@ -25,12 +47,14 @@ dependencyResolutionManagement {
     val basePath = root.dir("gradle").dir("dependency-management")
     versionCatalogs {
         create("libs") {
+            applyGroovyMajorOverrides()
             from(files(basePath.file("distribution.versions.toml")))
         }
         create("providedLibs") {
             from(files(basePath.file("provided.versions.toml")))
         }
         create("testLibs") {
+            applyGroovyMajorOverrides()
             from(files(basePath.file("test.versions.toml")))
         }
         create("buildLibs") {
@@ -44,5 +68,21 @@ dependencyResolutionManagement {
                 version(key.toString(), value.toString())
             }
         }
+    }
+}
+
+/**
+ * Applies [groovyMajorOverrides] to a catalog that feeds the Gradle distribution.
+ *
+ * Deliberately not applied to `buildLibs`: build-logic runs on the bootstrap Gradle and
+ * compiles against `localGroovy()`, and its CodeNarc has no Groovy 5 build, so swapping only
+ * its Groovy and Spock would leave it on an inconsistent mix.
+ *
+ * Must be called before `from()`, because `version()` is first-wins and the imported TOML is
+ * parsed once the catalog is built.
+ */
+fun VersionCatalogBuilder.applyGroovyMajorOverrides() {
+    groovyMajorOverrides.forEach { (alias, version) ->
+        version(alias, version)
     }
 }

--- a/build-logic-settings/version-catalogs/src/main/kotlin/gradlebuild.version-catalogs.settings.gradle.kts
+++ b/build-logic-settings/version-catalogs/src/main/kotlin/gradlebuild.version-catalogs.settings.gradle.kts
@@ -22,29 +22,28 @@ import java.util.Properties
  *
  * Default should match the Groovy version declared in `gradle/dependency-management/shared-versions.properties`.
  */
-val bundleGroovyMajor = providers.systemProperty("bundleGroovyMajor").map(String::toInt).getOrElse(4)
+val defaultGroovyMajor = 4
+val bundleGroovyMajor = providers.systemProperty("bundleGroovyMajor").map(String::toInt).getOrElse(defaultGroovyMajor)
 
-/**
- * Version-catalog aliases that must change together when bundling a non-default Groovy major.
- * CodeNarc is intentionally excluded: it has no Groovy 5 build, and its analysis runtime is
- * independent of the Groovy version bundled into the distribution.
- */
-val groovyMajorOverrides: Map<String, String> = when (bundleGroovyMajor) {
-    4 -> emptyMap()
-    5 -> mapOf(
-        "groovy" to "5.0.7!!",
-        "spock" to "2.4-groovy-5.0!!",
-    )
-    else -> error("Unsupported bundled Groovy major version: $bundleGroovyMajor")
-}
-
-dependencyResolutionManagement {
+val basePath = run {
     val root = if (rootProject.name.startsWith("build-logic")) {
         layout.rootDirectory.dir("..")
     } else {
         layout.rootDirectory
     }
-    val basePath = root.dir("gradle").dir("dependency-management")
+    root.dir("gradle").dir("dependency-management")
+}
+
+/**
+ * Version-catalog aliases that must change together when bundling a non-default Groovy major,
+ * loaded from `groovy-versions.properties` (keyed as `groovy<major>.<alias>`).
+ *
+ * CodeNarc is intentionally excluded: it has no Groovy 5 build, and its analysis runtime is
+ * independent of the Groovy version bundled into the distribution.
+ */
+val groovyMajorOverrides: Map<String, String> = loadGroovyMajorOverrides()
+
+dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             applyGroovyMajorOverrides()
@@ -69,6 +68,28 @@ dependencyResolutionManagement {
             }
         }
     }
+}
+
+/**
+ * Loads the [groovyMajorOverrides] for [bundleGroovyMajor] from `groovy-versions.properties`,
+ * selecting entries keyed `groovy<major>.<alias>`. The default major needs no overrides, as its
+ * versions already come from the imported TOML catalogs.
+ */
+fun loadGroovyMajorOverrides(): Map<String, String> {
+    if (bundleGroovyMajor == defaultGroovyMajor) {
+        return emptyMap()
+    }
+    val prefix = "groovy$bundleGroovyMajor."
+    val groovyVersions = basePath.file("groovy-versions.properties").asFile.inputStream().use {
+        Properties().apply { load(it) }
+    }
+    val overrides = groovyVersions.entries
+        .filter { (key, _) -> key.toString().startsWith(prefix) }
+        .associate { (key, value) -> key.toString().removePrefix(prefix) to value.toString() }
+    require(overrides.isNotEmpty()) {
+        "Unsupported bundled Groovy major version: $bundleGroovyMajor"
+    }
+    return overrides
 }
 
 /**

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
@@ -18,6 +18,7 @@ import com.google.gson.Gson
 import com.google.gson.Strictness
 import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonReader
+import gradlebuild.basics.bundleGroovyMajor
 import gradlebuild.basics.repoRoot
 
 applyAutomaticUpgradeOfCapabilities()
@@ -81,6 +82,10 @@ dependencies {
             "org.gradle.profiler:gradle-profiler",
             setOf("gradle-tooling-api")
         )
+
+        if (bundleGroovyMajor >= 5) {
+            all<GroovyTargetJvmVersionRule>()
+        }
     }
 }
 
@@ -261,6 +266,30 @@ inline
 fun <reified T : ComponentMetadataRule> ComponentMetadataHandler.applyRule(module: String, vararg modulesToRemove: Any) {
     withModule<T>(module) {
         params(*modulesToRemove)
+    }
+}
+
+
+/**
+ * Lowers the JVM version Groovy publishes so that Java 8 consumers can resolve it.
+ *
+ * Groovy 5 is built for Java 11, but Gradle's client and worker code targets Java 8, so
+ * nothing in Groovy 5 matches their compile classpath. This is only safe because it applies
+ * to the `-DbundleGroovyMajor=5` coverage build, which runs on Java 17+, and because no
+ * distribution module has `src/main/groovy` - so no Java 8 module ever forks `groovyc` onto
+ * a JDK 8 launcher. The Java 8 jars it produces link against classes that cannot load on
+ * Java 8.
+ */
+abstract class GroovyTargetJvmVersionRule : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) {
+        if (context.details.id.group != "org.apache.groovy") {
+            return
+        }
+        context.details.allVariants {
+            attributes {
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            }
+        }
     }
 }
 

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/JvmCompilation.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/JvmCompilation.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.jvm
 
+import gradlebuild.basics.bundleGroovyMinimumJvm
 import org.gradle.api.Project
 import org.gradle.api.plugins.GroovyBasePlugin
 import org.gradle.api.provider.Property
@@ -106,6 +107,10 @@ abstract class JvmCompilation {
 
     @JvmName("associateGroovy")
     fun Project.associate(groovyCompile: TaskProvider<GroovyCompile>) {
+        // Groovy 5 needs at least Java 11 to run, so we can't target anything older when it's bundled.
+        // With `-DbundleGroovyMajor=5`, Java 8 compilations are bumped to Java 11, and the classes
+        // they produce won't run on Java 8.
+        val groovyJvmVersion = targetJvmVersion.map { maxOf(it, bundleGroovyMinimumJvm) }
         if(!(OperatingSystem.current().isWindows && System.getProperty("os.arch") == "aarch64")) {
             groovyCompile.configure {
                 val javaToolchains = project.the<JavaToolchainService>()
@@ -113,7 +118,7 @@ abstract class JvmCompilation {
                 // JDK we are targeting in order to see the correct standard lib classes
                 // during compilation
                 javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = targetJvmVersion.map { JavaLanguageVersion.of(it) }
+                    languageVersion = groovyJvmVersion.map { JavaLanguageVersion.of(it) }
                 }
             }
         }
@@ -121,7 +126,7 @@ abstract class JvmCompilation {
         // Need to use afterEvaluate since source/target Compatibility are not lazy
         afterEvaluate {
             groovyCompile.configure {
-                val version = targetJvmVersion.get().toString()
+                val version = groovyJvmVersion.get().toString()
                 sourceCompatibility = version
                 targetCompatibility = version
             }

--- a/gradle/dependency-management/distribution.versions.toml
+++ b/gradle/dependency-management/distribution.versions.toml
@@ -78,7 +78,7 @@ googleHttpClientApacheV2 = { group = "com.google.http-client", name = "google-ht
 googleHttpClientGson = { group = "com.google.http-client", name = "google-http-client-gson", version.ref = "googleHttpClient" }
 googleOauthClient = { group = "com.google.oauth-client", name = "google-oauth-client", version.ref = "googleOauthClient" }
 gradleFileEvents = { group = "org.gradle.fileevents", name = "gradle-fileevents", version.ref = "gradleFileEvents" }
-groovy = { group = "org.apache.groovy", name = "groovy", version.ref = "groovy" } # Assuming Groovy 3 group
+groovy = { group = "org.apache.groovy", name = "groovy", version.ref = "groovy" }
 groovyAnt = { group = "org.apache.groovy", name = "groovy-ant", version.ref = "groovy" }
 groovyAstbuilder = { group = "org.apache.groovy", name = "groovy-astbuilder", version.ref = "groovy" }
 groovyDateUtil = { group = "org.apache.groovy", name = "groovy-dateutil", version.ref = "groovy" }

--- a/gradle/dependency-management/groovy-versions.properties
+++ b/gradle/dependency-management/groovy-versions.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Version-catalog aliases applied when bundling a non-default Groovy major via
+# `-DbundleGroovyMajor`, consumed by
+# `build-logic-settings/version-catalogs/src/main/kotlin/gradlebuild.version-catalogs.settings.gradle.kts`.
+# Keyed as `groovy<major>.<alias>`.
+groovy5.groovy=5.0.7!!
+groovy5.spock=2.4-groovy-5.0!!

--- a/platforms/core-runtime/classpath/src/main/java/org/gradle/internal/classpath/CallInterceptingMetaClass.java
+++ b/platforms/core-runtime/classpath/src/main/java/org/gradle/internal/classpath/CallInterceptingMetaClass.java
@@ -521,6 +521,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
         private final Class<?> owner;
         private final String consumerClass;
         private final CallInterceptor callInterceptor;
+        private final boolean isVararg;
 
         public InterceptedMetaMethod(
             @Nullable MetaMethod original,
@@ -532,14 +533,21 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
             boolean isVararg,
             InstrumentedGroovyCallsTracker callsTracker
         ) {
+            // Groovy 5 made ParameterTypes.nativeParamTypes and isVargsMethod private, so both
+            // have to go through the constructor and an override rather than field assignment.
+            super(nativeParameterTypes);
             this.original = original;
             this.name = name;
             this.owner = owner;
             this.consumerClass = consumerClass;
             this.callInterceptor = callInterceptor;
             this.callsTracker = callsTracker;
-            this.nativeParamTypes = nativeParameterTypes;
-            this.isVargsMethod = isVararg;
+            this.isVararg = isVararg;
+        }
+
+        @Override
+        public boolean isVargsMethod() {
+            return isVararg;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -1564,7 +1564,10 @@ public class GradleResolveVisitor extends ResolveVisitor {
         super.visitCatchStatement(cs);
     }
 
+    // Groovy 5 deprecates getVariableType() in favour of getValueVariable(), which Groovy 4 does
+    // not have. Suppress until the minimum bundled Groovy is 5.
     @Override
+    @SuppressWarnings("deprecation")
     public void visitForLoop(ForStatement forLoop) {
         resolveOrFail(forLoop.getVariableType(), forLoop);
         super.visitForLoop(forLoop);


### PR DESCRIPTION
Fixes #33290

This is currently failing due to Java 8 modules that still depend on Groovy, which can't use Groovy 5 due its Java 11 requirement.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
