### PR TITLE
Add public service lookup to Project, Settings, Gradle and Task

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupConfigurationCacheIntegrationTest.groovy
@@ -20,44 +20,14 @@ import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixtu
 import spock.lang.Issue
 
 /**
- * Pins the Groovy closure dispatch and configuration-cache behavior of the public {@code service(Class)}
- * lookup in the corner cases where the receiver resolution or the captured instance interacts with the
- * configuration cache. Happy-path and error-message coverage lives in the core
- * {@code PublicServiceLookupIntegrationTest}.
+ * Pins how a public {@code service(Class)} instance captured in a settings script survives the
+ * configuration cache and remains usable from a task action. Happy-path and error-message coverage
+ * lives in the core {@code PublicServiceLookupIntegrationTest}.
  */
 @Issue("https://github.com/gradle/gradle/issues/13121")
-class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+class ServiceLookupConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     def configurationCache = new ConfigurationCacheFixture(this)
-
-    def "service lookup in an owner-first task closure fails as an unsupported script reference at execution time"() {
-        given:
-        buildFile """
-            tasks.register("some") {
-                onlyIf {
-                    service(ProviderFactory)
-                    throw new IllegalStateException("UNREACHABLE")
-                }
-                doFirst {
-                }
-            }
-        """
-
-        when:
-        configurationCacheFails ":some"
-
-        then:
-        failure.assertHasFailure("Invocation of 'service' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache.") {
-            // The cause is not reported
-        }
-        outputDoesNotContain("UNREACHABLE")
-
-        configurationCache.assertStateStoredAndDiscarded {
-            hasStoreFailure = false
-            reportedOutsideBuildFailure = true
-            problem "Task `:some` of type `org.gradle.api.DefaultTask`: invocation of 'service' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache."
-        }
-    }
 
     def "a settings-scoped service captured in a settings script survives the configuration cache and is usable in a task action"() {
         given:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -96,6 +96,8 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
             gradle.rootProject {
                 tasks.register("useLayout") {
                     doLast {
+                        // Tripwire on the first line: if the action is ever entered, this prints.
+                        println("REACHED ACTION")
                         println("settings dir: " + captured.settingsDirectory.asFile.name)
                     }
                 }
@@ -106,12 +108,16 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         run ":useLayout"
 
         then:
+        outputContains("REACHED ACTION")
         outputContains("settings dir: " + testDirectory.name)
 
         when: "run with the configuration cache, the captured service is re-resolved from the task's own project registry, which cannot see the settings scope"
         configurationCacheFails ":useLayout"
 
         then:
+        // The failure happens while loading the cache entry, before the task action runs...
         failure.assertHasCause("No service of type BuildLayout available in project services.")
+        // ...so the action is never entered on the reused build.
+        outputDoesNotContain("REACHED ACTION")
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -82,7 +82,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         then:
         // The rejection happens while the task is being created, not while it runs...
         failure.assertHasCause("Could not create task ':useLayout'.")
-        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and settings plugins.")
+        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks.\nIt is available in settings scripts and settings plugins.")
         // ...so the task action is never entered.
         outputDoesNotContain("REACHED ACTION")
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -82,7 +82,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         then:
         // The rejection happens while the task is being created, not while it runs...
         failure.assertHasCause("Could not create task ':useLayout'.")
-        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and plugins.")
+        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and settings plugins.")
         // ...so the task action is never entered.
         outputDoesNotContain("REACHED ACTION")
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import spock.lang.Issue
+
+/**
+ * Pins the Groovy closure dispatch and configuration-cache behavior of the public {@code service(Class)}
+ * lookup in the corner cases where the receiver resolution or the captured instance interacts with the
+ * configuration cache. Happy-path and error-message coverage lives in the core
+ * {@code PublicServiceLookupIntegrationTest}.
+ */
+@Issue("https://github.com/gradle/gradle/issues/13121")
+class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def configurationCache = new ConfigurationCacheFixture(this)
+
+    def "service lookup in an owner-first task closure fails as an unsupported script reference at execution time"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                onlyIf {
+                    service(ProviderFactory)
+                    throw new IllegalStateException("UNREACHABLE")
+                }
+                doFirst {
+                }
+            }
+        """
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFailure("Invocation of 'service' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache.") {
+            // The cause is not reported
+        }
+        outputDoesNotContain("UNREACHABLE")
+
+        configurationCache.assertStateStoredAndDiscarded {
+            hasStoreFailure = false
+            reportedOutsideBuildFailure = true
+            problem "Task `:some` of type `org.gradle.api.DefaultTask`: invocation of 'service' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache."
+        }
+    }
+
+    def "looking up a settings-only service through a task closure resolves to the task and is rejected at configuration time"() {
+        given:
+        settingsFile << """
+            gradle.rootProject {
+                tasks.register("useLayout") {
+                    // `service` here resolves to the Task receiver, which does not expose the
+                    // settings-only BuildLayout, so this fails while the task is being configured.
+                    def captured = service(BuildLayout)
+                    doLast {
+                        println("settings dir: " + captured.settingsDirectory.asFile.name)
+                    }
+                }
+            }
+        """
+
+        when:
+        fails ":useLayout"
+
+        then:
+        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and plugins.")
+    }
+
+    def "a settings-scoped service captured in a settings script and used in a task action cannot be re-resolved under the configuration cache"() {
+        given:
+        settingsFile << """
+            // Captured at settings-script scope, where `service` resolves to the Settings receiver
+            // and BuildLayout is available. The instance is then used from a task action.
+            def captured = service(BuildLayout)
+            gradle.rootProject {
+                tasks.register("useLayout") {
+                    doLast {
+                        println("settings dir: " + captured.settingsDirectory.asFile.name)
+                    }
+                }
+            }
+        """
+
+        when: "run without the configuration cache, the captured settings-scoped service is used directly"
+        run ":useLayout"
+
+        then:
+        outputContains("settings dir: " + testDirectory.name)
+
+        when: "run with the configuration cache, the captured service is re-resolved from the task's own project registry, which cannot see the settings scope"
+        configurationCacheFails ":useLayout"
+
+        then:
+        failure.assertHasCause("No service of type BuildLayout available in project services.")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -87,7 +87,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         outputDoesNotContain("REACHED ACTION")
     }
 
-    def "a settings-scoped service captured in a settings script and used in a task action cannot be re-resolved under the configuration cache"() {
+    def "a settings-scoped service captured in a settings script survives the configuration cache and is usable in a task action"() {
         given:
         settingsFile """
             // Captured at settings-script scope, where `service` resolves to the Settings receiver
@@ -96,7 +96,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
             gradle.rootProject {
                 tasks.register("useLayout") {
                     doLast {
-                        // Tripwire on the first line: if the action is ever entered, this prints.
+                        // Tripwire on the first line: prints only if the action is actually entered.
                         println("REACHED ACTION")
                         println("settings dir: " + captured.settingsDirectory.asFile.name)
                     }
@@ -111,13 +111,20 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         outputContains("REACHED ACTION")
         outputContains("settings dir: " + testDirectory.name)
 
-        when: "run with the configuration cache, the captured service is re-resolved from the task's own project registry, which cannot see the settings scope"
-        configurationCacheFails ":useLayout"
+        when: "the configuration cache entry is stored, BuildLayout is captured by value"
+        configurationCacheRun ":useLayout"
 
         then:
-        // The failure happens while loading the cache entry, before the task action runs...
-        failure.assertHasCause("No service of type BuildLayout available in project services.")
-        // ...so the action is never entered on the reused build.
-        outputDoesNotContain("REACHED ACTION")
+        configurationCache.assertStateStored()
+        outputContains("REACHED ACTION")
+        outputContains("settings dir: " + testDirectory.name)
+
+        when: "the configuration cache entry is reused, the captured BuildLayout is restored by value"
+        configurationCacheRun ":useLayout"
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("REACHED ACTION")
+        outputContains("settings dir: " + testDirectory.name)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -68,6 +68,8 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
                     // settings-only BuildLayout, so this fails while the task is being configured.
                     def captured = service(BuildLayout)
                     doLast {
+                        // Tripwire on the first line: if the action is ever entered, this prints.
+                        println("REACHED ACTION")
                         println("settings dir: " + captured.settingsDirectory.asFile.name)
                     }
                 }
@@ -78,7 +80,11 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         fails ":useLayout"
 
         then:
+        // The rejection happens while the task is being created, not while it runs...
+        failure.assertHasCause("Could not create task ':useLayout'.")
         failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and plugins.")
+        // ...so the task action is never entered.
+        outputDoesNotContain("REACHED ACTION")
     }
 
     def "a settings-scoped service captured in a settings script and used in a task action cannot be re-resolved under the configuration cache"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -32,7 +32,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
 
     def "service lookup in an owner-first task closure fails as an unsupported script reference at execution time"() {
         given:
-        buildFile << """
+        buildFile """
             tasks.register("some") {
                 onlyIf {
                     service(ProviderFactory)
@@ -61,7 +61,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
 
     def "looking up a settings-only service through a task closure resolves to the task and is rejected at configuration time"() {
         given:
-        settingsFile << """
+        settingsFile """
             gradle.rootProject {
                 tasks.register("useLayout") {
                     // `service` here resolves to the Task receiver, which does not expose the
@@ -89,7 +89,7 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
 
     def "a settings-scoped service captured in a settings script and used in a task action cannot be re-resolved under the configuration cache"() {
         given:
-        settingsFile << """
+        settingsFile """
             // Captured at settings-script scope, where `service` resolves to the Settings receiver
             // and BuildLayout is available. The instance is then used from a task action.
             def captured = service(BuildLayout)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ServiceLookupGroovyDispatchIntegrationTest.groovy
@@ -59,34 +59,6 @@ class ServiceLookupGroovyDispatchIntegrationTest extends AbstractConfigurationCa
         }
     }
 
-    def "looking up a settings-only service through a task closure resolves to the task and is rejected at configuration time"() {
-        given:
-        settingsFile """
-            gradle.rootProject {
-                tasks.register("useLayout") {
-                    // `service` here resolves to the Task receiver, which does not expose the
-                    // settings-only BuildLayout, so this fails while the task is being configured.
-                    def captured = service(BuildLayout)
-                    doLast {
-                        // Tripwire on the first line: if the action is ever entered, this prints.
-                        println("REACHED ACTION")
-                        println("settings dir: " + captured.settingsDirectory.asFile.name)
-                    }
-                }
-            }
-        """
-
-        when:
-        fails ":useLayout"
-
-        then:
-        // The rejection happens while the task is being created, not while it runs...
-        failure.assertHasCause("Could not create task ':useLayout'.")
-        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks.\nIt is available in settings scripts and settings plugins.")
-        // ...so the task action is never entered.
-        outputDoesNotContain("REACHED ACTION")
-    }
-
     def "a settings-scoped service captured in a settings script survives the configuration cache and is usable in a task action"() {
         given:
         settingsFile """

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
@@ -109,4 +109,26 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
         }
         outputContains("settings dir name: " + testDirectory.name)
     }
+
+    def "can capture a settings-scoped service and use it from an isolated project action"() {
+        createDirs("a")
+        settingsFile """
+            include("a")
+            // Captured at settings scope and used from an isolated 'beforeProject' action,
+            // which is serialized per project. The captured BuildLayout must survive that.
+            def captured = service(BuildLayout)
+            gradle.lifecycle.beforeProject { project ->
+                println(project.path + " settings dir: " + captured.settingsDirectory.asFile.name)
+            }
+        """
+
+        when:
+        isolatedProjectsRun(":a:help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":a")
+        }
+        outputContains(":a settings dir: " + testDirectory.name)
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/13121")
+class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    def "can look up a service in a task action of the owning project"() {
+        createDirs("a")
+        settingsFile """
+            include("a")
+        """
+        file("a/thing.txt").text = "content"
+        file("a/build.gradle") << """
+            tasks.register("cleanThing") {
+                doLast {
+                    service(FileSystemOperations).delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """
+
+        when:
+        isolatedProjectsRun(":a:cleanThing")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":a")
+        }
+        !file("a/thing.txt").exists()
+    }
+
+    def "can look up a service at configuration time of the owning project"() {
+        createDirs("a")
+        settingsFile """
+            include("a")
+        """
+        file("a/build.gradle") << """
+            def dirName = service(ProjectLayout).projectDirectory.asFile.name
+            tasks.register("show") {
+                doLast {
+                    println("project dir name: " + dirName)
+                }
+            }
+        """
+
+        when:
+        isolatedProjectsRun(":a:show")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":a")
+        }
+        outputContains("project dir name: a")
+    }
+
+    def "reports a problem when a build script looks up a service on another project"() {
+        createDirs("a", "b")
+        settingsFile """
+            include("a")
+            include("b")
+        """
+        buildFile """
+            project(':a').service(ObjectFactory)
+        """
+
+        when:
+        isolatedProjectsFailsUsing(mode, "help")
+
+        then:
+        fixture.assertIsolatedProjectsProblems(mode) {
+            projectsConfigured(":", ":a", ":b")
+            problem("Build file 'build.gradle': line 2: Project ':' cannot access 'Project.service' functionality on another project ':a'")
+        }
+
+        where:
+        mode << ALL_MODES
+    }
+
+    def "can look up a service in a settings script"() {
+        settingsFile """
+            def layout = service(BuildLayout)
+            println("settings dir name: " + layout.settingsDirectory.asFile.name)
+        """
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":")
+        }
+        outputContains("settings dir name: " + testDirectory.name)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
@@ -26,7 +26,7 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
             include("a")
         """
         file("a/thing.txt").text = "content"
-        file("a/build.gradle") << """
+        buildFile("a/build.gradle", """
             tasks.register("cleanThing") {
                 doLast {
                     service(FileSystemOperations).delete {
@@ -34,7 +34,7 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
                     }
                 }
             }
-        """
+        """)
 
         when:
         isolatedProjectsRun(":a:cleanThing")
@@ -43,22 +43,22 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
         fixture.assertStateStored {
             projectsConfigured(":", ":a")
         }
+        and:
         !file("a/thing.txt").exists()
     }
 
     def "can look up a service at configuration time of the owning project"() {
-        createDirs("a")
         settingsFile """
             include("a")
         """
-        file("a/build.gradle") << """
+        buildFile("a/build.gradle", """
             def dirName = service(ProjectLayout).projectDirectory.asFile.name
             tasks.register("show") {
                 doLast {
                     println("project dir name: " + dirName)
                 }
             }
-        """
+        """)
 
         when:
         isolatedProjectsRun(":a:show")
@@ -67,6 +67,7 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
         fixture.assertStateStored {
             projectsConfigured(":", ":a")
         }
+        and:
         outputContains("project dir name: a")
     }
 
@@ -106,6 +107,7 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
         fixture.assertStateStored {
             projectsConfigured(":")
         }
+        and:
         outputContains("settings dir name: " + testDirectory.name)
     }
 
@@ -128,6 +130,7 @@ class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProje
         fixture.assertStateStored {
             projectsConfigured(":", ":a")
         }
+        and:
         outputContains(":a settings dir: " + testDirectory.name)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsServiceLookupIntegrationTest.groovy
@@ -22,7 +22,6 @@ import spock.lang.Issue
 class IsolatedProjectsServiceLookupIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
 
     def "can look up a service in a task action of the owning project"() {
-        createDirs("a")
         settingsFile """
             include("a")
         """

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -33,6 +33,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.invocation.GradleLifecycle
+import org.gradle.api.services.GradleService
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
@@ -335,7 +336,7 @@ class CrossBuildConfigurationReportingGradle(
         return delegate.getProviders()
     }
 
-    override fun <T : Any> service(serviceType: Class<T>): T {
+    override fun <T : GradleService> service(serviceType: Class<T>): T {
         onBuildMutableStateAccess("service")
         return delegate.service(serviceType)
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -335,6 +335,11 @@ class CrossBuildConfigurationReportingGradle(
         return delegate.getProviders()
     }
 
+    override fun <T : Any> service(serviceType: Class<T>): T {
+        onBuildMutableStateAccess("service")
+        return delegate.service(serviceType)
+    }
+
     override fun getPlugins(): PluginContainer {
         onBuildMutableStateAccess("getPlugins")
         return delegate.getPlugins()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -332,6 +332,9 @@ class CrossProjectConfigurationReportingGradle(
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
+    override fun <T : Any> service(serviceType: Class<T>): T =
+        delegate.service(serviceType)
+
     override fun getIncludedBuilds(): MutableCollection<IncludedBuild> =
         delegate.includedBuilds
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -36,6 +36,7 @@ import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.invocation.GradleLifecycle
+import org.gradle.api.services.GradleService
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
@@ -332,7 +333,7 @@ class CrossProjectConfigurationReportingGradle(
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
-    override fun <T : Any> service(serviceType: Class<T>): T =
+    override fun <T : GradleService> service(serviceType: Class<T>): T =
         delegate.service(serviceType)
 
     override fun getIncludedBuilds(): MutableCollection<IncludedBuild> =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -23,6 +23,7 @@ import org.gradle.api.Action
 import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.ProjectEvaluationListener
+import org.gradle.api.services.ProjectService
 import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
@@ -312,7 +313,7 @@ class ProblemReportingCrossProjectModelAccess(
             return super.getObjects()
         }
 
-        override fun <T : Any> service(serviceType: Class<T>): T {
+        override fun <T : ProjectService> service(serviceType: Class<T>): T {
             onIsolationViolation("service")
             return delegate.service(serviceType)
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -312,6 +312,11 @@ class ProblemReportingCrossProjectModelAccess(
             return super.getObjects()
         }
 
+        override fun <T : Any> service(serviceType: Class<T>): T {
+            onIsolationViolation("service")
+            return delegate.service(serviceType)
+        }
+
         override fun mkdir(path: Any): File {
             onIsolationViolation("mkdir")
             return super.mkdir(path)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ConfigurationCacheCodecs.kt
@@ -53,6 +53,7 @@ import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.serialize.BaseSerializerFactory.HASHCODE_SERIALIZER
 import org.gradle.internal.serialize.codecs.core.BooleanValueSnapshotCodec
+import org.gradle.internal.serialize.codecs.core.BuildLayoutCodec
 import org.gradle.internal.serialize.codecs.core.BuildServiceParameterCodec
 import org.gradle.internal.serialize.codecs.core.BuildServiceProviderCodec
 import org.gradle.internal.serialize.codecs.core.CalculatedValueContainerCodec
@@ -316,6 +317,9 @@ class DefaultConfigurationCacheCodecs(
             bind(NullValueSnapshotCodec)
 
             bind(GradlePropertiesCodec)
+            // Must precede ServicesCodec: BuildLayout is a @ServiceScope type that ServicesCodec
+            // would otherwise try (and fail) to re-resolve from the task's own scope on load.
+            bind(BuildLayoutCodec)
             bind(ServicesCodec)
 
             bind(ProxyCodec)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BuildLayoutCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BuildLayoutCodec.kt
@@ -18,12 +18,9 @@ package org.gradle.internal.serialize.codecs.core
 
 import org.gradle.api.file.BuildLayout
 import org.gradle.api.file.Directory
-import org.gradle.api.internal.GeneratedSubclasses
+import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.codecs.Decoding
-import org.gradle.internal.serialize.graph.codecs.Encoding
-import org.gradle.internal.serialize.graph.codecs.EncodingProducer
 import org.gradle.internal.serialize.graph.readNonNull
 
 
@@ -32,33 +29,27 @@ import org.gradle.internal.serialize.graph.readNonNull
  *
  * [BuildLayout] is a Settings-scoped service, but the data it exposes — the settings and root
  * directories — is immutable for the build. It can be captured in a settings script and used from a
- * task action, so it must survive the configuration cache. The general [org.gradle.internal.serialize.graph.codecs.ServicesCodec]
- * cannot help here: it re-resolves a service from the isolate owner's registry on load, and a task's
- * registry is Project-scoped, a sibling of the Settings scope, so the settings-scoped [BuildLayout]
- * is unreachable (and the Settings registry no longer exists at execution time). Instead, this codec
- * writes the two directories and reconstructs an immutable value on load.
+ * task action, so it must survive the configuration cache. The general
+ * [org.gradle.internal.serialize.graph.codecs.ServicesCodec] cannot help: it re-resolves a service
+ * from the isolate owner's registry on load, and a task's registry is Project-scoped, a sibling of
+ * the Settings scope, so the settings-scoped [BuildLayout] is unreachable (and the Settings registry
+ * no longer exists at execution time). Instead, this codec writes the two directories and
+ * reconstructs an immutable value on load.
  *
- * Must be bound ahead of [org.gradle.internal.serialize.graph.codecs.ServicesCodec] so that it wins
- * for this type (first matching binding is used).
+ * Must be bound ahead of [org.gradle.internal.serialize.graph.codecs.ServicesCodec], which also
+ * matches [BuildLayout] via its {@code @ServiceScope} annotation, so that this codec wins.
  */
-object BuildLayoutCodec : EncodingProducer, Decoding {
+object BuildLayoutCodec : Codec<BuildLayout> {
 
-    override fun encodingForType(type: Class<*>): Encoding? =
-        if (BuildLayout::class.java.isAssignableFrom(GeneratedSubclasses.unpack(type))) BuildLayoutEncoding else null
+    override suspend fun WriteContext.encode(value: BuildLayout) {
+        write(value.settingsDirectory)
+        write(value.rootDirectory)
+    }
 
     override suspend fun ReadContext.decode(): BuildLayout {
         val settingsDirectory = readNonNull<Directory>()
         val rootDirectory = readNonNull<Directory>()
         return SerializedBuildLayout(settingsDirectory, rootDirectory)
-    }
-}
-
-
-private object BuildLayoutEncoding : Encoding {
-    override suspend fun WriteContext.encode(value: Any) {
-        value as BuildLayout
-        write(value.settingsDirectory)
-        write(value.rootDirectory)
     }
 }
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BuildLayoutCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BuildLayoutCodec.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.codecs.core
+
+import org.gradle.api.file.BuildLayout
+import org.gradle.api.file.Directory
+import org.gradle.api.internal.GeneratedSubclasses
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.codecs.Decoding
+import org.gradle.internal.serialize.graph.codecs.Encoding
+import org.gradle.internal.serialize.graph.codecs.EncodingProducer
+import org.gradle.internal.serialize.graph.readNonNull
+
+
+/**
+ * Serializes [BuildLayout] by value.
+ *
+ * [BuildLayout] is a Settings-scoped service, but the data it exposes — the settings and root
+ * directories — is immutable for the build. It can be captured in a settings script and used from a
+ * task action, so it must survive the configuration cache. The general [org.gradle.internal.serialize.graph.codecs.ServicesCodec]
+ * cannot help here: it re-resolves a service from the isolate owner's registry on load, and a task's
+ * registry is Project-scoped, a sibling of the Settings scope, so the settings-scoped [BuildLayout]
+ * is unreachable (and the Settings registry no longer exists at execution time). Instead, this codec
+ * writes the two directories and reconstructs an immutable value on load.
+ *
+ * Must be bound ahead of [org.gradle.internal.serialize.graph.codecs.ServicesCodec] so that it wins
+ * for this type (first matching binding is used).
+ */
+object BuildLayoutCodec : EncodingProducer, Decoding {
+
+    override fun encodingForType(type: Class<*>): Encoding? =
+        if (BuildLayout::class.java.isAssignableFrom(GeneratedSubclasses.unpack(type))) BuildLayoutEncoding else null
+
+    override suspend fun ReadContext.decode(): BuildLayout {
+        val settingsDirectory = readNonNull<Directory>()
+        val rootDirectory = readNonNull<Directory>()
+        return SerializedBuildLayout(settingsDirectory, rootDirectory)
+    }
+}
+
+
+private object BuildLayoutEncoding : Encoding {
+    override suspend fun WriteContext.encode(value: Any) {
+        value as BuildLayout
+        write(value.settingsDirectory)
+        write(value.rootDirectory)
+    }
+}
+
+
+private class SerializedBuildLayout(
+    private val settingsDir: Directory,
+    private val rootDir: Directory
+) : BuildLayout {
+    override fun getSettingsDirectory(): Directory = settingsDir
+    override fun getRootDirectory(): Directory = rootDir
+}

--- a/platforms/core-configuration/isolated-action-services/src/main/kotlin/org/gradle/internal/isolate/actions/services/IsolatedActionCodecsFactory.kt
+++ b/platforms/core-configuration/isolated-action-services/src/main/kotlin/org/gradle/internal/isolate/actions/services/IsolatedActionCodecsFactory.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.internal.isolate.graph.IsolationCodecsProvider
 import org.gradle.internal.reflection.access.ObjectOpener
+import org.gradle.internal.serialize.codecs.core.BuildLayoutCodec
 import org.gradle.internal.serialize.codecs.core.DirectoryCodec
 import org.gradle.internal.serialize.codecs.core.DirectoryPropertyCodec
 import org.gradle.internal.serialize.codecs.core.FixedValueReplacingProviderCodec
@@ -85,6 +86,9 @@ class IsolatedActionCodecsFactory(
         bind(LoggerCodec)
         bind(ProxyCodec)
 
+        // Must precede ServicesCodec: BuildLayout is a @ServiceScope type that ServicesCodec
+        // would otherwise try (and fail) to re-resolve from the project scope on load.
+        bind(BuildLayoutCodec)
         bind(ServicesCodec)
 
         bind(JavaObjectSerializationCodec(javaSerializationEncodingLookup, objectOpener))

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PublicServiceLookupIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PublicServiceLookupIntegrationTest.kt
@@ -36,13 +36,12 @@ class PublicServiceLookupIntegrationTest : AbstractKotlinIntegrationTest() {
                 service<ProviderFactory>(),
                 service<FileSystemOperations>(),
                 service<ArchiveOperations>(),
-                service<ExecOperations>(),
                 service<ProjectLayout>(),
             )
             println("resolved services: " + services.size)
         """)
 
-        assertThat(build("help").output, containsString("resolved services: 6"))
+        assertThat(build("help").output, containsString("resolved services: 5"))
     }
 
     @Test
@@ -119,8 +118,8 @@ class PublicServiceLookupIntegrationTest : AbstractKotlinIntegrationTest() {
     fun `services can be looked up via the generated KClass overload`() {
         withDefaultSettings()
         withBuildScript("""
-            val execOps = service(ExecOperations::class)
-            println("kclass lookup: " + (execOps is ExecOperations))
+            val objectFactory = service(ObjectFactory::class)
+            println("kclass lookup: " + (objectFactory is ObjectFactory))
         """)
 
         assertThat(build("help").output, containsString("kclass lookup: true"))
@@ -154,35 +153,47 @@ class PublicServiceLookupIntegrationTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    fun `looking up an internal service fails and enumerates the available services`() {
+    fun `looking up an internal service does not compile`() {
+        // A type that implements none of the scope markers is rejected by the bound at compile time.
+        // The runtime message that enumerates the available services is covered by the Groovy DSL test.
         withDefaultSettings()
         withBuildScript("""
             service<org.gradle.api.internal.project.ProjectInternal>()
         """)
 
-        val failure = buildAndFail("help")
-
-        failure.assertHasDescription(
-            "org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
-                "The following services are available in project scripts and plugins: " +
-                "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
-                "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
-                "org.gradle.process.ExecOperations, org.gradle.api.file.ProjectLayout."
-        )
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Script compilation error")
+        }
     }
 
     @Test
-    fun `looking up a project-only service from a settings script fails with a helpful message`() {
+    fun `looking up a project-only service from a settings script does not compile`() {
+        // ProjectLayout is not available in the settings scope, so the SettingsService bound
+        // rejects it at compile time. The runtime message is covered by the Groovy DSL test.
         withSettings("""
             service<ProjectLayout>()
         """)
         withBuildScript("")
 
-        val failure = buildAndFail("help")
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Script compilation error")
+            assertHasErrorOutput("Service")
+        }
+    }
 
-        failure.assertHasDescription(
-            "org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. " +
-                "It is available in project scripts and plugins and tasks."
-        )
+    @Test
+    fun `looking up a settings-only service from a task does not compile`() {
+        withDefaultSettings()
+        withBuildScript("""
+            tasks.register("useLayout") {
+                // BuildLayout is only available in the settings scope, so the bound rejects this at compile time
+                service<BuildLayout>()
+            }
+        """)
+
+        buildAndFail("useLayout").apply {
+            assertHasErrorOutput("Script compilation error")
+            assertHasErrorOutput("Service")
+        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PublicServiceLookupIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PublicServiceLookupIntegrationTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import spock.lang.Issue
+
+
+@Issue("https://github.com/gradle/gradle/issues/13121")
+class PublicServiceLookupIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    fun `all documented services can be looked up in a build script`() {
+        withDefaultSettings()
+        withBuildScript("""
+            val services = listOf(
+                service<ObjectFactory>(),
+                service<ProviderFactory>(),
+                service<FileSystemOperations>(),
+                service<ArchiveOperations>(),
+                service<ExecOperations>(),
+                service<ProjectLayout>(),
+            )
+            println("resolved services: " + services.size)
+        """)
+
+        assertThat(build("help").output, containsString("resolved services: 6"))
+    }
+
+    @Test
+    fun `can delete files with FileSystemOperations looked up inside a task action`() {
+        withDefaultSettings()
+        withFile("thing.txt", "content")
+        withBuildScript("""
+            tasks.register("cleanThing") {
+                doLast {
+                    service<FileSystemOperations>().delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """)
+
+        build("cleanThing")
+
+        assertFalse(existing("thing.txt").exists())
+    }
+
+    @Test
+    fun `can capture a service at configuration time and use it in a task action`() {
+        withDefaultSettings()
+        withFile("thing.txt", "content")
+        withBuildScript("""
+            tasks.register("cleanThing") {
+                val fs = service<FileSystemOperations>()
+                doLast {
+                    fs.delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """)
+
+        build("cleanThing")
+
+        assertFalse(existing("thing.txt").exists())
+    }
+
+    @Test
+    fun `services can be looked up in a settings script`() {
+        withSettings("""
+            val layout = service<BuildLayout>()
+            println("settings dir name: " + layout.settingsDirectory.asFile.name)
+
+            val property = service<ObjectFactory>().property(String::class.java)
+            property.set("from-settings")
+            println("settings property: " + property.get())
+        """)
+        withBuildScript("")
+
+        val output = build("help").output
+
+        assertThat(output, containsString("settings dir name: " + projectRoot.name))
+        assertThat(output, containsString("settings property: from-settings"))
+    }
+
+    @Test
+    fun `services can be looked up in an init script`() {
+        withDefaultSettings()
+        withBuildScript("")
+        withFile("init.gradle.kts", """
+            val property = service<ObjectFactory>().property(String::class.java)
+            property.set("from-init")
+            println("init property: " + property.get())
+        """)
+
+        assertThat(build("help", "-I", "init.gradle.kts").output, containsString("init property: from-init"))
+    }
+
+    @Test
+    fun `services can be looked up via the generated KClass overload`() {
+        withDefaultSettings()
+        withBuildScript("""
+            val execOps = service(ExecOperations::class)
+            println("kclass lookup: " + (execOps is ExecOperations))
+        """)
+
+        assertThat(build("help").output, containsString("kclass lookup: true"))
+    }
+
+    @Test
+    fun `services can be looked up in a precompiled script plugin`() {
+        withDefaultSettings().appendText("""include("consumer")""")
+        withKotlinDslPluginIn("buildSrc")
+        withDefaultSettingsIn("buildSrc")
+        withFile("buildSrc/src/main/kotlin/my-conventions.gradle.kts", """
+            tasks.register("cleanThing") {
+                doLast {
+                    service<FileSystemOperations>().delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """)
+        withFile("consumer/thing.txt", "content")
+        withBuildScriptIn("consumer", """
+            plugins {
+                id("my-conventions")
+            }
+        """)
+        withBuildScript("")
+
+        build(":consumer:cleanThing")
+
+        assertFalse(existing("consumer/thing.txt").exists())
+    }
+
+    @Test
+    fun `looking up an internal service fails and enumerates the available services`() {
+        withDefaultSettings()
+        withBuildScript("""
+            service<org.gradle.api.internal.project.ProjectInternal>()
+        """)
+
+        val failure = buildAndFail("help")
+
+        failure.assertHasDescription(
+            "org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
+                "The following services are available in project scripts and plugins: " +
+                "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
+                "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
+                "org.gradle.process.ExecOperations, org.gradle.api.file.ProjectLayout."
+        )
+    }
+
+    @Test
+    fun `looking up a project-only service from a settings script fails with a helpful message`() {
+        withSettings("""
+            service<ProjectLayout>()
+        """)
+        withBuildScript("")
+
+        val failure = buildAndFail("help")
+
+        failure.assertHasDescription(
+            "org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. " +
+                "It is available in project scripts and plugins and tasks."
+        )
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ServiceLookupExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ServiceLookupExtensions.kt
@@ -23,6 +23,10 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.services.GradleService
+import org.gradle.api.services.ProjectService
+import org.gradle.api.services.SettingsService
+import org.gradle.api.services.TaskService
 
 
 /**
@@ -35,7 +39,7 @@ import org.gradle.api.invocation.Gradle
  * @since 9.8.0
  */
 @Incubating
-inline fun <reified T : Any> Project.service(): T =
+inline fun <reified T : ProjectService> Project.service(): T =
     service(T::class.java)
 
 
@@ -62,7 +66,7 @@ inline fun <reified T : Any> Project.service(): T =
  * @since 9.8.0
  */
 @Incubating
-inline fun <reified T : Any> Task.service(): T =
+inline fun <reified T : TaskService> Task.service(): T =
     service(T::class.java)
 
 
@@ -76,7 +80,7 @@ inline fun <reified T : Any> Task.service(): T =
  * @since 9.8.0
  */
 @Incubating
-inline fun <reified T : Any> Settings.service(): T =
+inline fun <reified T : SettingsService> Settings.service(): T =
     service(T::class.java)
 
 
@@ -90,5 +94,5 @@ inline fun <reified T : Any> Settings.service(): T =
  * @since 9.8.0
  */
 @Incubating
-inline fun <reified T : Any> Gradle.service(): T =
+inline fun <reified T : GradleService> Gradle.service(): T =
     service(T::class.java)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ServiceLookupExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ServiceLookupExtensions.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Incubating
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.Incubating
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.initialization.Settings
+import org.gradle.api.invocation.Gradle
+
+
+/**
+ * Looks up a service provided by Gradle for use in this project.
+ *
+ * @param T the type of the service to look up
+ * @return the service instance
+ * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+ * @see [Project.service]
+ * @since 9.8.0
+ */
+@Incubating
+inline fun <reified T : Any> Project.service(): T =
+    service(T::class.java)
+
+
+/**
+ * Looks up a service provided by Gradle for use in this task.
+ *
+ * The lookup can be used both at configuration time and from task actions at execution time,
+ * and is safe to use with the configuration cache:
+ *
+ * ```kotlin
+ * tasks.register("cleanThing") {
+ *     doLast {
+ *         service<FileSystemOperations>().delete {
+ *             delete("thing")
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param T the type of the service to look up
+ * @return the service instance
+ * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+ * @see [Task.service]
+ * @since 9.8.0
+ */
+@Incubating
+inline fun <reified T : Any> Task.service(): T =
+    service(T::class.java)
+
+
+/**
+ * Looks up a service provided by Gradle for use in this build.
+ *
+ * @param T the type of the service to look up
+ * @return the service instance
+ * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+ * @see [Settings.service]
+ * @since 9.8.0
+ */
+@Incubating
+inline fun <reified T : Any> Settings.service(): T =
+    service(T::class.java)
+
+
+/**
+ * Looks up a service provided by Gradle for use in init scripts and [Gradle] plugins.
+ *
+ * @param T the type of the service to look up
+ * @return the service instance
+ * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+ * @see [Gradle.service]
+ * @since 9.8.0
+ */
+@Incubating
+inline fun <reified T : Any> Gradle.service(): T =
+    service(T::class.java)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleExtensions.kt
@@ -19,6 +19,12 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.invocation.Gradle
 
 
+/**
+ * Looks up any service in the build (`Gradle`) scope service registry, including Gradle internal services.
+ *
+ * This function is not considered stable public API. For the publicly supported services,
+ * prefer [org.gradle.api.invocation.Gradle.service].
+ */
 inline fun <reified T : Any> Gradle.serviceOf(): T =
     (gradle as GradleInternal).services.get()
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
@@ -23,6 +23,12 @@ import org.gradle.api.internal.project.ProjectInternal
 import java.io.File
 
 
+/**
+ * Looks up any service in the project scope service registry, including Gradle internal services.
+ *
+ * This function is not considered stable public API. For the publicly supported services,
+ * prefer [org.gradle.api.Project.service].
+ */
 inline fun <reified T : Any> Project.serviceOf(): T =
     (this as ProjectInternal).services.get()
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/SettingsExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/SettingsExtensions.kt
@@ -18,6 +18,13 @@ package org.gradle.kotlin.dsl.support
 import org.gradle.api.initialization.Settings
 
 
+/**
+ * Looks up any service in the build (`Gradle`) scope service registry, including Gradle internal services.
+ *
+ * Note that this resolves against the `Gradle` scope, not the `Settings` scope.
+ * This function is not considered stable public API. For the publicly supported services,
+ * prefer [org.gradle.api.initialization.Settings.service].
+ */
 inline fun <reified T : Any> Settings.serviceOf(): T =
     gradle.serviceOf()
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -186,4 +186,7 @@ abstract class GradleDelegate : Gradle {
 
     override fun getProviders(): ProviderFactory =
         delegate.providers
+
+    override fun <T : Any> service(serviceType: Class<T>): T =
+        delegate.service(serviceType)
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -28,6 +28,7 @@ import org.gradle.api.initialization.IncludedBuild
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.invocation.GradleLifecycle
+import org.gradle.api.services.GradleService
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
@@ -187,6 +188,6 @@ abstract class GradleDelegate : Gradle {
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
-    override fun <T : Any> service(serviceType: Class<T>): T =
+    override fun <T : GradleService> service(serviceType: Class<T>): T =
         delegate.service(serviceType)
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
@@ -25,6 +25,7 @@ import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.ProjectState
 import org.gradle.api.Task
+import org.gradle.api.services.ProjectService
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.DependencyFactory
@@ -478,7 +479,7 @@ abstract class ProjectDelegate : Project {
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
-    override fun <T : Any> service(serviceType: Class<T>): T =
+    override fun <T : ProjectService> service(serviceType: Class<T>): T =
         delegate.service(serviceType)
 
     override fun getSubprojects(): MutableSet<Project> =

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
@@ -478,6 +478,9 @@ abstract class ProjectDelegate : Project {
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
+    override fun <T : Any> service(serviceType: Class<T>): T =
+        delegate.service(serviceType)
+
     override fun getSubprojects(): MutableSet<Project> =
         delegate.subprojects
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -28,6 +28,7 @@ import org.gradle.api.initialization.SharedModelDefaults
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.services.SettingsService
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
@@ -157,7 +158,7 @@ abstract class SettingsDelegate : Settings {
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
-    override fun <T : Any> service(serviceType: Class<T>): T =
+    override fun <T : SettingsService> service(serviceType: Class<T>): T =
         delegate.service(serviceType)
 
     override fun dependencyResolutionManagement(dependencyResolutionConfiguration: Action<in DependencyResolutionManagement>) =

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -157,6 +157,9 @@ abstract class SettingsDelegate : Settings {
     override fun getProviders(): ProviderFactory =
         delegate.providers
 
+    override fun <T : Any> service(serviceType: Class<T>): T =
+        delegate.service(serviceType)
+
     override fun dependencyResolutionManagement(dependencyResolutionConfiguration: Action<in DependencyResolutionManagement>) =
         delegate.dependencyResolutionManagement(dependencyResolutionConfiguration)
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -92,7 +92,7 @@ tasks.register("cleanReports") {
 }
 ```
 
-Use `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL. The lookup works both at configuration time and from task actions, is compatible with the Configuration Cache and Isolated Projects, and covers `ObjectFactory`, `ProviderFactory`, `FileSystemOperations`, `ArchiveOperations`, `ExecOperations`, and the scope-specific `ProjectLayout` and `BuildLayout`.
+Use `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL. It is compatible with the Configuration Cache and Isolated Projects, and covers `ObjectFactory`, `ProviderFactory`, `FileSystemOperations`, and `ArchiveOperations` in every scope, `ProjectLayout` in projects and tasks, `BuildLayout` in settings, and `ExecOperations` in task actions. In the Kotlin and Java DSLs, looking up a service that is not available in the current scope is caught at compile time.
 
 Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or later at runtime.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -81,7 +81,7 @@ Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engine
 
 #### Look up Gradle services from scripts and task actions
 
-Build, settings, and init scripts — and task actions — can now look up commonly used Gradle services directly, without declaring an `@Inject` point or going through the `objects.newInstance(...)` ceremony:
+Build, settings, and init scripts, as well as task actions, can now [look up commonly used Gradle services](userguide/service_injection.html#looking_up_services) directly, without declaring an `@Inject` point or going through the `objects.newInstance(...)` ceremony:
 
 ```kotlin
 tasks.register("cleanReports") {
@@ -96,9 +96,7 @@ Use `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL. T
 
 Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or later at runtime.
 
-If your build or plugin already declares a `service` method, property, or extension on `Project`, `Settings`, `Gradle`, or a task, the new built-in `service(...)` member may shadow it; rename yours to avoid ambiguity.
-
-See [Looking up services in scripts](userguide/service_injection.html#looking_up_services) for details.
+See the [Looking up services in scripts](userguide/service_injection.html#looking_up_services) section in the Gradle User Manual for more details.
 
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,6 +79,27 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
+#### Look up Gradle services from scripts and task actions
+
+Build, settings, and init scripts — and task actions — can now look up commonly used Gradle services directly, without declaring an `@Inject` point or going through the `objects.newInstance(...)` ceremony:
+
+```kotlin
+tasks.register("cleanReports") {
+    val fs = service<FileSystemOperations>()
+    doLast {
+        fs.delete { delete("build/reports") }
+    }
+}
+```
+
+Use `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL. The lookup works both at configuration time and from task actions, is compatible with the Configuration Cache and Isolated Projects, and covers `ObjectFactory`, `ProviderFactory`, `FileSystemOperations`, `ArchiveOperations`, `ExecOperations`, and the scope-specific `ProjectLayout` and `BuildLayout`.
+
+Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or later at runtime.
+
+If your build or plugin already declares a `service` method, property, or extension on `Project`, `Settings`, `Gradle`, or a task, the new built-in `service(...)` member may shadow it; rename yours to avoid ambiguity.
+
+See [Looking up services in scripts](userguide/service_injection.html#looking_up_services) for details.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -212,6 +212,8 @@ include::sample[dir="snippets/optimizing-builds/configuration-cache/projectAtExe
 
 Fixing ad-hoc tasks in scripts requires additional effort, making it a good opportunity to refactor them into proper task classes.
 
+TIP: Ad-hoc tasks and scripts can also obtain these services directly with the <<service_injection.adoc#looking_up_services,`service(...)` lookup>>, avoiding the extra injected type shown above.
+
 The table below lists recommended replacements for commonly used `Project` methods:
 
 [cols="a,a",options="header"]

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -167,7 +167,7 @@ The set of services you can look up depends on where the lookup happens:
 
 [%header,cols="2,1,1,1,1"]
 |===
-| Service | Build scripts & project plugins | Task actions | Settings scripts & plugins | Init scripts & `Gradle` plugins
+| Service | Project scripts & project plugins | Tasks | Settings scripts & settings plugins | Init scripts & init plugins
 
 | <<objectfactory,`ObjectFactory`>>               | ✓ | ✓ | ✓ | ✓
 | <<providerfactory,`ProviderFactory`>>           | ✓ | ✓ | ✓ | ✓
@@ -179,7 +179,7 @@ The set of services you can look up depends on where the lookup happens:
 |===
 
 In the Kotlin and Java DSLs each `service(...)` is bounded to the scopes above, so requesting a service that is not available in the current scope — or a type that is not a Gradle service at all — is a compile error.
-In the Groovy DSL, where the bound is not enforced (or when the type is supplied reflectively as a `Class`), the same request instead fails at runtime with an `InvalidUserDataException` whose message lists the services available in that scope; for a <<build_services.adoc#build_services,shared build service>> it points you to `@ServiceReference` and `gradle.sharedServices` instead.
+In the Groovy DSL, where the bound is not enforced (or when the type is supplied reflectively as a `Class`), the same request instead fails at runtime with an `InvalidUserDataException`: for a service requested outside its scope the message names the scopes where it _is_ available, and for a type that is not a Gradle service at all it lists the services available in the current scope; for a <<build_services.adoc#build_services,shared build service>> it points you to `@ServiceReference` and `gradle.sharedServices` instead.
 This check covers only _where_ a service can be looked up; it does not distinguish configuration-time from execution-time use, nor does it police cross-project access (see below).
 
 Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -197,7 +197,7 @@ NOTE: A service that is only available in the settings scope (such as `BuildLayo
 Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)`.
 The Gradle services give you path resolution, copy and sync specs, and robust deletion, and they keep your code compatible with the Configuration Cache.
 
-`ExecOperations` can be looked up only from a task action, reflecting that running external processes at configuration time is incompatible with the Configuration Cache.
+`ExecOperations` can be looked up only through a task (via `Task.service`), not from a project, settings, or init script.
 
 [[objectfactory]]
 == `ObjectFactory`
@@ -400,7 +400,7 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 The `ExecOperations` is injected into the `MyExecOperationsTask` task's constructor using the `@Inject` annotation.
 
 To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts>>.
-It can be looked up only from a task action, not at configuration time.
+To run one at configuration time instead, use `providers.exec` or a `ValueSource`, which are compatible with the Configuration Cache.
 
 [[toolingmodelbuilderregistry]]
 == `ToolingModelBuilderRegistry`

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -165,22 +165,22 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The set of services you can look up depends on where the lookup happens:
 
-[%header,cols="2,1,1,1"]
+[%header,cols="2,1,1,1,1"]
 |===
-| Service | Project scripts, plugins & task actions | Settings scripts & plugins | Init scripts & `Gradle` plugins
+| Service | Build scripts & project plugins | Task actions | Settings scripts & plugins | Init scripts & `Gradle` plugins
 
-| <<objectfactory,`ObjectFactory`>>               | ✓ | ✓ | ✓
-| <<providerfactory,`ProviderFactory`>>           | ✓ | ✓ | ✓
-| <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓ | ✓
-| <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓ | ✓
-| <<execoperations,`ExecOperations`>>             | ✓ | ✓ | ✓
-| <<sec:projectlayout,`ProjectLayout`>>           | ✓ |   |
-| <<buildlayout,`BuildLayout`>>                   |   | ✓ |
+| <<objectfactory,`ObjectFactory`>>               | ✓ | ✓ | ✓ | ✓
+| <<providerfactory,`ProviderFactory`>>           | ✓ | ✓ | ✓ | ✓
+| <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓ | ✓ | ✓
+| <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓ | ✓ | ✓
+| <<execoperations,`ExecOperations`>>             |   | ✓ |   |
+| <<sec:projectlayout,`ProjectLayout`>>           | ✓ | ✓ |   |
+| <<buildlayout,`BuildLayout`>>                   |   |   | ✓ |
 |===
 
-Looking up a type that is not available in the current scope, an internal type, or a <<build_services.adoc#build_services,shared build service>> fails with an `InvalidUserDataException`.
-The message lists the services that _are_ available in that scope.
-For a shared build service, the message points you to `@ServiceReference` and `gradle.sharedServices` instead.
+In the Kotlin and Java DSLs each `service(...)` is bounded to the scopes above, so requesting a service that is not available in the current scope — or a type that is not a Gradle service at all — is a compile error.
+In the Groovy DSL, where the bound is not enforced (or when the type is supplied reflectively as a `Class`), the same request instead fails at runtime with an `InvalidUserDataException` whose message lists the services available in that scope; for a <<build_services.adoc#build_services,shared build service>> it points you to `@ServiceReference` and `gradle.sharedServices` instead.
+This check covers only _where_ a service can be looked up; it does not distinguish configuration-time from execution-time use, nor does it police cross-project access (see below).
 
 Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.
 
@@ -198,6 +198,8 @@ Look up project-scoped services (or `ProjectLayout`) from the task instead.
 
 Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)`.
 The Gradle services give you path resolution, copy and sync specs, and robust deletion, and they keep your code compatible with the Configuration Cache.
+
+`ExecOperations` can be looked up only from a task action, reflecting that running external processes at configuration time is incompatible with the Configuration Cache.
 
 [[objectfactory]]
 == `ObjectFactory`
@@ -352,14 +354,17 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `FileSystemOperations` service is injected into the `MyFileSystemOperationsTask` task's constructor using the `@Inject` annotation.
 
-With some ceremony, it is possible to use `FileSystemOperations` in an ad-hoc task defined in a build script:
+To use `FileSystemOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
+
+It can also be obtained through an injection point created with `ObjectFactory.newInstance`.
+This is more verbose, but works for any injectable service, including those not available through `service()`:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=file-system-adhoc]"]
 include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=file-system-adhoc]"]
 ====
 
-First, you need to declare an interface with a property of type `FileSystemOperations`, here named `InjectedFsOps`, to serve as an injection point.
+First, you declare an interface with a property of type `FileSystemOperations`, here named `InjectedFsOps`, to serve as an injection point.
 Then call the method link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#newInstance(java.lang.Class,java.lang.Object%2E%2E%2E)[`ObjectFactory.newInstance`] to generate an implementation of the interface that holds an injected service.
 
 TIP: This is a good time to consider extracting the ad-hoc task into a proper class.
@@ -379,17 +384,8 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `ArchiveOperations` service is injected into the `MyArchiveOperationsTask` task's constructor using the `@Inject` annotation.
 
-With some ceremony, it is possible to use `ArchiveOperations` in an ad-hoc task defined in a build script:
-
-====
-include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=archive-op-adhoc]"]
-include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=archive-op-adhoc]"]
-====
-
-First, you need to declare an interface with a property of type `ArchiveOperations`, here named `InjectedArcOps`, to serve as an injection point.
-Then call the method link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#newInstance(java.lang.Class,java.lang.Object%2E%2E%2E)[`ObjectFactory.newInstance`] to generate an implementation of the interface that holds an injected service.
-
-TIP: This is a good time to consider extracting the ad-hoc task into a proper class.
+To use `ArchiveOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
+For a service that is not available through the lookup, use the `ObjectFactory.newInstance` injection point shown for <<filesystemoperations,`FileSystemOperations`>>.
 
 [[execoperations]]
 == `ExecOperations`
@@ -406,17 +402,9 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `ExecOperations` is injected into the `MyExecOperationsTask` task's constructor using the `@Inject` annotation.
 
-With some ceremony, it is possible to use `ExecOperations` in an ad-hoc task defined in a build script:
-
-====
-include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=exec-op-adhoc]"]
-include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=exec-op-adhoc]"]
-====
-
-First, you need to declare an interface with a property of type `ExecOperations`, here named `InjectedExecOps`, to serve as an injection point.
-Then call the method link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#newInstance(java.lang.Class,java.lang.Object%2E%2E%2E)[`ObjectFactory.newInstance`] to generate an implementation of the interface that holds an injected service.
-
-TIP: This is a good time to consider extracting the ad-hoc task into a proper class.
+To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts>>.
+It can be looked up only from a task action, not at configuration time.
+For a service that is not available through the lookup, use the `ObjectFactory.newInstance` injection point shown for <<filesystemoperations,`FileSystemOperations`>>.
 
 [[toolingmodelbuilderregistry]]
 == `ToolingModelBuilderRegistry`

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -384,6 +384,11 @@ The `ArchiveOperations` service is injected into the `MyArchiveOperationsTask` t
 
 To use `ArchiveOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
 
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=archive-op-lookup]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=archive-op-lookup]"]
+====
+
 [[execoperations]]
 == `ExecOperations`
 
@@ -401,6 +406,11 @@ The `ExecOperations` is injected into the `MyExecOperationsTask` task's construc
 
 To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts>>.
 To run one at configuration time instead, use `providers.exec` or a `ValueSource`, which are compatible with the Configuration Cache.
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=exec-op-lookup]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=exec-op-lookup]"]
+====
 
 [[toolingmodelbuilderregistry]]
 == `ToolingModelBuilderRegistry`

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -141,6 +141,59 @@ The following services are available for injection in settings plugins, extensio
 | Provides access to important locations for a Gradle build, such as the root directory and settings file. Use it from a settings plugin to resolve paths relative to the root settings directory.
 |===
 
+[[looking_up_services]]
+== Looking up services in scripts incubating-label:[]
+
+Instead of declaring an `@Inject` point, build, settings, and init scripts — and task actions — can look up a curated set of Gradle services directly with `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL.
+This avoids the ad-hoc `objects.newInstance(...)` ceremony shown in the per-service sections below, while remaining compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>.
+
+The most common use is from a task action:
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=service-lookup]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=service-lookup]"]
+====
+
+A looked-up service can also be captured at configuration time and used later from a task action; the captured instance is safe to store in the Configuration Cache:
+
+====
+include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=service-lookup-capture]"]
+include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=service-lookup-capture]"]
+====
+
+=== Services available for lookup
+
+The set of services you can look up depends on where the lookup happens:
+
+[%header,cols="2,1,1,1"]
+|===
+| Service | Project scripts, plugins & task actions | Settings scripts & plugins | Init scripts & `Gradle` plugins
+
+| <<objectfactory,`ObjectFactory`>>               | ✓ | ✓ | ✓
+| <<providerfactory,`ProviderFactory`>>           | ✓ | ✓ | ✓
+| <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓ | ✓
+| <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓ | ✓
+| <<execoperations,`ExecOperations`>>             | ✓ | ✓ | ✓
+| <<sec:projectlayout,`ProjectLayout`>>           | ✓ |   |
+| <<buildlayout,`BuildLayout`>>                   |   | ✓ |
+|===
+
+Looking up a type that is not available in the current scope, an internal type, or a <<build_services.adoc#build_services,shared build service>> fails with an `InvalidUserDataException` whose message lists the services that _are_ available in that scope; for a build service it points you to `@ServiceReference` and `gradle.sharedServices` instead.
+
+Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.
+
+=== Cross-project access and Isolated Projects
+
+`service(...)` resolves against the scope in which it is called.
+Calling it on another project — for example `project(":other").service(ObjectFactory)` — reaches across the project boundary and is reported as a problem under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, exactly like `project(":other").getObjects()`.
+Look services up from the owning project instead.
+
+NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, but it cannot be restored when that task runs from the Configuration Cache, because it is re-resolved against the task's own project scope. Look up project-scoped services (or `ProjectLayout`) from the task instead.
+
+=== When to use a lookup
+
+Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)` when you need Gradle's path resolution, copy and sync specs, or robust deletion, and you want the code to keep working with the Configuration Cache.
+
 [[objectfactory]]
 == `ObjectFactory`
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -190,9 +190,7 @@ Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperation
 Calling it on another project — for example `project(":other").service(ObjectFactory)` — reaches across the project boundary and is reported as a problem under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, exactly like `project(":other").getObjects()`.
 Look services up from the owning project instead.
 
-NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, but the captured reference cannot be restored when that task runs from the Configuration Cache.
-The reference is re-resolved against the task's own project scope, which does not expose settings-only services.
-Look up project-scoped services (or `ProjectLayout`) from the task instead.
+NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, and the captured instance is preserved when that task runs from the Configuration Cache.
 
 === When to use a lookup
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -144,7 +144,7 @@ The following services are available for injection in settings plugins, extensio
 [[looking_up_services]]
 == Looking up services in scripts incubating-label:[]
 
-Instead of declaring an `@Inject` point, build, settings, and init scripts — and task actions — can look up a curated set of Gradle services directly with `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL.
+Instead of declaring an `@Inject` point, build, settings, and init scripts, as well as task actions, can look up a curated set of Gradle services directly with `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL.
 This avoids the ad-hoc `objects.newInstance(...)` ceremony shown in the per-service sections below, while remaining compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>.
 
 The most common use is from a task action:
@@ -178,7 +178,9 @@ The set of services you can look up depends on where the lookup happens:
 | <<buildlayout,`BuildLayout`>>                   |   | ✓ |
 |===
 
-Looking up a type that is not available in the current scope, an internal type, or a <<build_services.adoc#build_services,shared build service>> fails with an `InvalidUserDataException` whose message lists the services that _are_ available in that scope; for a build service it points you to `@ServiceReference` and `gradle.sharedServices` instead.
+Looking up a type that is not available in the current scope, an internal type, or a <<build_services.adoc#build_services,shared build service>> fails with an `InvalidUserDataException`.
+The message lists the services that _are_ available in that scope.
+For a shared build service, the message points you to `@ServiceReference` and `gradle.sharedServices` instead.
 
 Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.
 
@@ -188,11 +190,14 @@ Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperation
 Calling it on another project — for example `project(":other").service(ObjectFactory)` — reaches across the project boundary and is reported as a problem under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, exactly like `project(":other").getObjects()`.
 Look services up from the owning project instead.
 
-NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, but it cannot be restored when that task runs from the Configuration Cache, because it is re-resolved against the task's own project scope. Look up project-scoped services (or `ProjectLayout`) from the task instead.
+NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, but the captured reference cannot be restored when that task runs from the Configuration Cache.
+The reference is re-resolved against the task's own project scope, which does not expose settings-only services.
+Look up project-scoped services (or `ProjectLayout`) from the task instead.
 
 === When to use a lookup
 
-Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)` when you need Gradle's path resolution, copy and sync specs, or robust deletion, and you want the code to keep working with the Configuration Cache.
+Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)`.
+The Gradle services give you path resolution, copy and sync specs, and robust deletion, and they keep your code compatible with the Configuration Cache.
 
 [[objectfactory]]
 == `ObjectFactory`

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -383,7 +383,6 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 The `ArchiveOperations` service is injected into the `MyArchiveOperationsTask` task's constructor using the `@Inject` annotation.
 
 To use `ArchiveOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
-For a service that is not available through the lookup, use the `ObjectFactory.newInstance` injection point shown for <<filesystemoperations,`FileSystemOperations`>>.
 
 [[execoperations]]
 == `ExecOperations`
@@ -402,7 +401,6 @@ The `ExecOperations` is injected into the `MyExecOperationsTask` task's construc
 
 To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts>>.
 It can be looked up only from a task action, not at configuration time.
-For a service that is not available through the lookup, use the `ObjectFactory.newInstance` injection point shown for <<filesystemoperations,`FileSystemOperations`>>.
 
 [[toolingmodelbuilderregistry]]
 == `ToolingModelBuilderRegistry`

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -641,6 +641,7 @@ Keep an eye on the number of arguments to distinguish between them.
 
 WARNING: Using the `Project.copy` method at execution time, as described here, is not compatible with the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution,configuration cache>>.
 A possible solution is to implement the task as a proper class and use link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html#copy-org.gradle.api.Action-[FileSystemOperations.copy] method instead, as described in the <<configuration_cache_debugging.adoc#config_cache:troubleshooting,configuration cache chapter>>.
+Scripts and ad-hoc tasks can also obtain `FileSystemOperations` (or `ArchiveOperations`) directly with the <<service_injection.adoc#looking_up_services,`service(...)` lookup>>.
 
 Occasionally, you want to copy files or directories as _part_ of a task.
 For example, a custom archiving task based on an unsupported archive format might want to copy files to a temporary directory before they are archived.

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/working_with_files.adoc
@@ -647,9 +647,8 @@ Occasionally, you want to copy files or directories as _part_ of a task.
 For example, a custom archiving task based on an unsupported archive format might want to copy files to a temporary directory before they are archived.
 You still want to take advantage of Gradle's copy API without introducing an extra `Copy` task.
 
-The solution is to use the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:copy(org.gradle.api.Action)[Project.copy(org.gradle.api.Action)] method.
-Configuring it with a copy spec works like the `Copy` task.
-Here's a trivial example:
+As noted in the warning above, prefer link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html#copy-org.gradle.api.Action-[`FileSystemOperations.copy`] for configuration-cache compatibility; it configures a copy spec just like the `Copy` task.
+The older link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:copy(org.gradle.api.Action)[Project.copy(org.gradle.api.Action)] method shown here works the same way but is not compatible with the configuration cache:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/copy/kotlin",files="build.gradle.kts[tags=copy-method]"]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -46,6 +46,25 @@ The previous step will help you identify potential problems by issuing deprecati
 
 The embedded Kotlin has been upgraded from 2.4.0 to link:https://github.com/JetBrains/kotlin/releases/tag/v2.4.10[Kotlin 2.4.10].
 
+[[service_method_added_to_project_settings_gradle_task]]
+==== New `service(Class)` method on `Project`, `Settings`, `Gradle`, and `Task`
+
+Gradle 9.8.0 adds an incubating `service(Class)` method to link:{javadocPath}/org/gradle/api/Project.html[`Project`], link:{javadocPath}/org/gradle/api/initialization/Settings.html[`Settings`], link:{javadocPath}/org/gradle/api/invocation/Gradle.html[`Gradle`], and link:{javadocPath}/org/gradle/api/Task.html[`Task`], along with reified `service<T>()` extensions in the Kotlin DSL.
+See <<service_injection.adoc#looking_up_services,Looking up services in scripts>> for details.
+
+If your build, plugin, or convention already exposes a member called `service` on one of these types (for example a user-defined extension, a Groovy dynamic property, or a Kotlin extension function), the new built-in member may shadow it or make calls ambiguous.
+Rename your member (for example to `myService`) to disambiguate:
+
+[source,kotlin]
+.build.gradle.kts
+----
+// Before: shadowed by the new built-in Project.service(Class)
+fun Project.service(name: String): MyService = extensions.getByName(name) as MyService
+
+// After: rename to avoid the conflict
+fun Project.myService(name: String): MyService = extensions.getByName(name) as MyService
+----
+
 [[task_logging_listeners_are_now_stored_in_the_configuration_cache]]
 ==== Task logging listeners are now stored in the Configuration Cache
 

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
@@ -371,3 +371,22 @@ abstract class CleanTempTask extends DefaultTask {
 
 tasks.register("cleanTemp", CleanTempTask) {}
 // end::clean-temp-inject[]
+
+// tag::service-lookup[]
+tasks.register('checkJavaVersion') {
+    doLast {
+        service(ExecOperations).exec {
+            commandLine 'java', '-version'
+        }
+    }
+}
+// end::service-lookup[]
+
+// tag::service-lookup-capture[]
+tasks.register('cleanReports') {
+    def fs = service(FileSystemOperations) // looked up and captured at configuration time
+    doLast {
+        fs.delete { delete('build/reports') }
+    }
+}
+// end::service-lookup-capture[]

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
@@ -201,6 +201,17 @@ abstract class MyArchiveOperationsTask extends DefaultTask {
 tasks.register("myInjectedArchiveOperationsTask", MyArchiveOperationsTask)
 // end::archive-op-inject[]
 
+// tag::archive-op-lookup[]
+tasks.register('listArchiveEntries') {
+    def archiveOperations = service(ArchiveOperations)
+    def layout = service(ProjectLayout)
+    doLast {
+        def entries = archiveOperations.zipTree(layout.projectDirectory.file("sources.jar")).files
+        println("Entries: ${entries*.name}")
+    }
+}
+// end::archive-op-lookup[]
+
 // tag::exec-op-inject[]
 abstract class MyExecOperationsTask extends DefaultTask {
     private ExecOperations execOperations
@@ -220,6 +231,17 @@ abstract class MyExecOperationsTask extends DefaultTask {
 
 tasks.register("myInjectedExecOperationsTask", MyExecOperationsTask)
 // end::exec-op-inject[]
+
+// tag::exec-op-lookup[]
+tasks.register('printGitStatus') {
+    def execOperations = service(ExecOperations)
+    doLast {
+        execOperations.exec {
+            commandLine 'git', 'status'
+        }
+    }
+}
+// end::exec-op-lookup[]
 
 // tag::tooling-model[]
 // Implements the ToolingModelBuilder interface.

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/groovy/build.gradle
@@ -201,22 +201,6 @@ abstract class MyArchiveOperationsTask extends DefaultTask {
 tasks.register("myInjectedArchiveOperationsTask", MyArchiveOperationsTask)
 // end::archive-op-inject[]
 
-// tag::archive-op-adhoc[]
-interface InjectedArcOps {
-    @Inject //@javax.inject.Inject
-    ArchiveOperations getArcOps()
-}
-
-tasks.register('myAdHocArchiveOperationsTask') {
-    def injected = project.objects.newInstance(InjectedArcOps)
-    def archiveFile = "${projectDir}/sources.jar"
-
-    doLast {
-        injected.arcOps.zipTree(archiveFile)
-    }
-}
-// end::archive-op-adhoc[]
-
 // tag::exec-op-inject[]
 abstract class MyExecOperationsTask extends DefaultTask {
     private ExecOperations execOperations
@@ -236,23 +220,6 @@ abstract class MyExecOperationsTask extends DefaultTask {
 
 tasks.register("myInjectedExecOperationsTask", MyExecOperationsTask)
 // end::exec-op-inject[]
-
-// tag::exec-op-adhoc[]
-interface InjectedExecOps {
-    @Inject //@javax.inject.Inject
-    ExecOperations getExecOps()
-}
-
-tasks.register('myAdHocExecOperationsTask') {
-    def injected = project.objects.newInstance(InjectedExecOps)
-
-    doLast {
-        injected.execOps.exec {
-            commandLine 'ls', '-la'
-        }
-    }
-}
-// end::exec-op-adhoc[]
 
 // tag::tooling-model[]
 // Implements the ToolingModelBuilder interface.

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
@@ -310,3 +310,22 @@ tasks.register("cleanTemp", CleanTempTask::class) {}
 // Also exercise the Java implementation that lives in buildSrc, so the snippets
 // integration test compiles and instantiates org.example.CleanTempTask.
 tasks.register<org.example.CleanTempTask>("cleanTempJava") {}
+
+// tag::service-lookup[]
+tasks.register("checkJavaVersion") {
+    doLast {
+        service<ExecOperations>().exec {
+            commandLine("java", "-version")
+        }
+    }
+}
+// end::service-lookup[]
+
+// tag::service-lookup-capture[]
+tasks.register("cleanReports") {
+    val fs = service<FileSystemOperations>() // looked up and captured at configuration time
+    doLast {
+        fs.delete { delete("build/reports") }
+    }
+}
+// end::service-lookup-capture[]

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
@@ -172,6 +172,17 @@ abstract class MyArchiveOperationsTask
 tasks.register("myInjectedArchiveOperationsTask", MyArchiveOperationsTask::class)
 // end::archive-op-inject[]
 
+// tag::archive-op-lookup[]
+tasks.register("listArchiveEntries") {
+    val archiveOperations = service<ArchiveOperations>()
+    val layout = service<ProjectLayout>()
+    doLast {
+        val entries = archiveOperations.zipTree(layout.projectDirectory.file("sources.jar")).files
+        println("Entries: ${entries.map { it.name }}")
+    }
+}
+// end::archive-op-lookup[]
+
 // tag::exec-op-inject[]
 abstract class MyExecOperationsTask
 @Inject constructor(private var execOperations: ExecOperations) : DefaultTask() {
@@ -186,6 +197,17 @@ abstract class MyExecOperationsTask
 
 tasks.register("myInjectedExecOperationsTask", MyExecOperationsTask::class)
 // end::exec-op-inject[]
+
+// tag::exec-op-lookup[]
+tasks.register("printGitStatus") {
+    val execOperations = service<ExecOperations>()
+    doLast {
+        execOperations.exec {
+            commandLine("git", "status")
+        }
+    }
+}
+// end::exec-op-lookup[]
 
 // tag::tooling-model[]
 // Implements the ToolingModelBuilder interface.

--- a/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/gradle-types/services/kotlin/build.gradle.kts
@@ -172,20 +172,6 @@ abstract class MyArchiveOperationsTask
 tasks.register("myInjectedArchiveOperationsTask", MyArchiveOperationsTask::class)
 // end::archive-op-inject[]
 
-// tag::archive-op-adhoc[]
-interface InjectedArcOps {
-    @get:Inject val arcOps: ArchiveOperations
-}
-
-tasks.register("myAdHocArchiveOperationsTask") {
-    val injected = project.objects.newInstance<InjectedArcOps>()
-    val archiveFile = "${project.projectDir}/sources.jar"
-    doLast {
-        injected.arcOps.zipTree(archiveFile)
-    }
-}
-// end::archive-op-adhoc[]
-
 // tag::exec-op-inject[]
 abstract class MyExecOperationsTask
 @Inject constructor(private var execOperations: ExecOperations) : DefaultTask() {
@@ -200,22 +186,6 @@ abstract class MyExecOperationsTask
 
 tasks.register("myInjectedExecOperationsTask", MyExecOperationsTask::class)
 // end::exec-op-inject[]
-
-// tag::exec-op-adhoc[]
-interface InjectedExecOps {
-    @get:Inject val execOps: ExecOperations
-}
-
-tasks.register("myAdHocExecOperationsTask") {
-    val injected = project.objects.newInstance<InjectedExecOps>()
-
-    doLast {
-        injected.execOps.exec {
-            commandLine("ls", "-la")
-        }
-    }
-}
-// end::exec-op-adhoc[]
 
 // tag::tooling-model[]
 // Implements the ToolingModelBuilder interface.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1116,14 +1116,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     /**
      * Looks up a service provided by Gradle for use in this project.
      *
-     * <p>The following services are available in project scripts and plugins:</p>
-     * <ul>
-     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
-     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
-     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
-     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link org.gradle.api.file.ProjectLayout}</li>
-     * </ul>
+     * <p>The services available for lookup are the Gradle types that implement {@link ProjectService}.</p>
      *
      * <p>Perform this lookup at configuration time. The returned instance may be captured and used later
      * from a task action, and is safe to store in the configuration cache. To look a service up from

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1125,11 +1125,13 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * <li>{@link org.gradle.api.file.ProjectLayout}</li>
      * </ul>
      *
-     * <p>The lookup can be used both at configuration time and at execution time. The returned instance
-     * may be captured in a task action and is safe to use with the configuration cache.</p>
+     * <p>Perform this lookup at configuration time. The returned instance may be captured and used later
+     * from a task action, and is safe to store in the configuration cache. To look a service up from
+     * within a task action, use {@link Task#service(Class)} instead.</p>
      *
      * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
-     * use {@link org.gradle.api.services.ServiceReference} to access those.</p>
+     * use {@link org.gradle.api.services.ServiceReference} or {@link org.gradle.api.invocation.Gradle#getSharedServices()}
+     * to access those.</p>
      *
      * @param serviceType the type of the service to look up
      * @param <T> the service type

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1113,6 +1113,35 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     ProjectLayout getLayout();
 
     /**
+     * Looks up a service provided by Gradle for use in this project.
+     *
+     * <p>The following services are available in project scripts and plugins:</p>
+     * <ul>
+     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
+     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
+     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
+     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
+     * <li>{@link org.gradle.process.ExecOperations}</li>
+     * <li>{@link org.gradle.api.file.ProjectLayout}</li>
+     * </ul>
+     *
+     * <p>The lookup can be used both at configuration time and at execution time. The returned instance
+     * may be captured in a task action and is safe to use with the configuration cache.</p>
+     *
+     * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
+     * use {@link org.gradle.api.services.ServiceReference} to access those.</p>
+     *
+     * @param serviceType the type of the service to look up
+     * @param <T> the service type
+     * @return the service instance. Never returns null.
+     * @throws InvalidUserDataException when the given type is not one of the services available in this scope
+     * @since 9.8.0
+     */
+    @Incubating
+    @HiddenInDefinition
+    <T> T service(Class<T> serviceType);
+
+    /**
      * Creates a directory and returns a file pointing to it.
      *
      * @param path The path for the directory to be created. Evaluated as per {@link #file(Object)}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -47,6 +47,7 @@ import org.gradle.api.project.IsolatedProject;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.resources.ResourceHandler;
+import org.gradle.api.services.ProjectService;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
@@ -1121,7 +1122,6 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
      * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
      * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link org.gradle.process.ExecOperations}</li>
      * <li>{@link org.gradle.api.file.ProjectLayout}</li>
      * </ul>
      *
@@ -1139,7 +1139,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      */
     @Incubating
     @HiddenInDefinition
-    <T> T service(Class<T> serviceType);
+    <T extends ProjectService> T service(Class<T> serviceType);
 
     /**
      * Creates a directory and returns a file pointing to it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -816,15 +816,7 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
     /**
      * Looks up a service provided by Gradle for use in this task.
      *
-     * <p>The following services are available:</p>
-     * <ul>
-     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
-     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
-     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
-     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link org.gradle.process.ExecOperations}</li>
-     * <li>{@link org.gradle.api.file.ProjectLayout}</li>
-     * </ul>
+     * <p>The services available for lookup are the Gradle types that implement {@link TaskService}.</p>
      *
      * <p>The lookup can be used both at configuration time and from task actions at execution time,
      * and is safe to use with the configuration cache:</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -28,6 +28,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceRegistration;
+import org.gradle.api.services.TaskService;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskDependency;
@@ -848,5 +849,5 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
      * @since 9.8.0
      */
     @Incubating
-    <T> T service(Class<T> serviceType);
+    <T extends TaskService> T service(Class<T> serviceType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -811,4 +811,42 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
      * @see org.gradle.api.services.ServiceReference
      */
     void usesService(Provider<? extends BuildService<?>> service);
+
+    /**
+     * Looks up a service provided by Gradle for use in this task.
+     *
+     * <p>The following services are available:</p>
+     * <ul>
+     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
+     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
+     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
+     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
+     * <li>{@link org.gradle.process.ExecOperations}</li>
+     * <li>{@link org.gradle.api.file.ProjectLayout}</li>
+     * </ul>
+     *
+     * <p>The lookup can be used both at configuration time and from task actions at execution time,
+     * and is safe to use with the configuration cache:</p>
+     *
+     * <pre>
+     * tasks.register("cleanThing") {
+     *     doLast {
+     *         service(FileSystemOperations).delete {
+     *             delete("thing")
+     *         }
+     *     }
+     * }
+     * </pre>
+     *
+     * <p>This method does not provide access to {@link BuildService shared build services};
+     * use {@link org.gradle.api.services.ServiceReference} to access those.</p>
+     *
+     * @param serviceType the type of the service to look up
+     * @param <T> the service type
+     * @return the service instance. Never returns null.
+     * @throws InvalidUserDataException when the given type is not one of the services available in this scope
+     * @since 9.8.0
+     */
+    @Incubating
+    <T> T service(Class<T> serviceType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ArchiveOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ArchiveOperations.java
@@ -17,6 +17,10 @@ package org.gradle.api.file;
 
 import org.gradle.api.Project;
 import org.gradle.api.resources.ReadableResource;
+import org.gradle.api.services.GradleService;
+import org.gradle.api.services.ProjectService;
+import org.gradle.api.services.SettingsService;
+import org.gradle.api.services.TaskService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -29,7 +33,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 6.6
  */
 @ServiceScope({Scope.Build.class, Scope.Project.class})
-public interface ArchiveOperations {
+public interface ArchiveOperations extends GradleService, ProjectService, SettingsService, TaskService {
 
     /**
      * Creates resource that points to a gzip compressed file at the given path.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
@@ -18,6 +18,7 @@ package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.services.SettingsService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -34,7 +35,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  */
 @Incubating
 @ServiceScope(Scope.Settings.class)
-public interface BuildLayout {
+public interface BuildLayout extends SettingsService {
     /**
      * Returns the settings directory.
      * <p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
@@ -19,6 +19,10 @@ package org.gradle.api.file;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.services.GradleService;
+import org.gradle.api.services.ProjectService;
+import org.gradle.api.services.SettingsService;
+import org.gradle.api.services.TaskService;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -32,7 +36,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 6.0
  */
 @ServiceScope({Scope.Build.class, Scope.Project.class})
-public interface FileSystemOperations {
+public interface FileSystemOperations extends GradleService, ProjectService, SettingsService, TaskService {
 
     /**
      * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given action is used

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -18,6 +18,8 @@ package org.gradle.api.file;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.services.ProjectService;
+import org.gradle.api.services.TaskService;
 import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
 import org.gradle.declarative.dsl.model.annotations.ValueFactories;
 import org.gradle.internal.service.scopes.Scope;
@@ -35,7 +37,7 @@ import java.io.File;
  * @since 4.1
  */
 @ServiceScope(Scope.Project.class)
-public interface ProjectLayout {
+public interface ProjectLayout extends ProjectService, TaskService {
     /**
      * Returns the project directory.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -29,6 +29,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.services.SettingsService;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.declarative.dsl.model.annotations.Adding;
@@ -315,7 +316,6 @@ public interface Settings extends PluginAware, ExtensionAware {
      * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
      * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
      * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link org.gradle.process.ExecOperations}</li>
      * <li>{@link BuildLayout}</li>
      * </ul>
      *
@@ -330,7 +330,7 @@ public interface Settings extends PluginAware, ExtensionAware {
      */
     @Incubating
     @HiddenInDefinition
-    <T> T service(Class<T> serviceType);
+    <T extends SettingsService> T service(Class<T> serviceType);
 
     /**
      * Returns the {@link Gradle} instance for the current build.

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -307,6 +307,32 @@ public interface Settings extends PluginAware, ExtensionAware {
     ProviderFactory getProviders();
 
     /**
+     * Looks up a service provided by Gradle for use in this build.
+     *
+     * <p>The following services are available in settings scripts and plugins:</p>
+     * <ul>
+     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
+     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
+     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
+     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
+     * <li>{@link org.gradle.process.ExecOperations}</li>
+     * <li>{@link BuildLayout}</li>
+     * </ul>
+     *
+     * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
+     * use {@link Gradle#getSharedServices()} to access those.</p>
+     *
+     * @param serviceType the type of the service to look up
+     * @param <T> the service type
+     * @return the service instance. Never returns null.
+     * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+     * @since 9.8.0
+     */
+    @Incubating
+    @HiddenInDefinition
+    <T> T service(Class<T> serviceType);
+
+    /**
      * Returns the {@link Gradle} instance for the current build.
      *
      * @return The Gradle instance. Never returns null.

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -310,14 +310,7 @@ public interface Settings extends PluginAware, ExtensionAware {
     /**
      * Looks up a service provided by Gradle for use in this build.
      *
-     * <p>The following services are available in settings scripts and plugins:</p>
-     * <ul>
-     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
-     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
-     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
-     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link BuildLayout}</li>
-     * </ul>
+     * <p>The services available for lookup are the Gradle types that implement {@link SettingsService}.</p>
      *
      * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
      * use {@link Gradle#getSharedServices()} to access those.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.api.services.GradleService;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.accesscontrol.ForExternalUse;
 import org.gradle.internal.service.scopes.Scope;
@@ -427,7 +428,6 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
      * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
      * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * <li>{@link org.gradle.process.ExecOperations}</li>
      * </ul>
      *
      * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
@@ -440,5 +440,5 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * @since 9.8.0
      */
     @Incubating
-    <T> T service(Class<T> serviceType);
+    <T extends GradleService> T service(Class<T> serviceType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -422,13 +422,7 @@ public interface Gradle extends PluginAware, ExtensionAware {
     /**
      * Looks up a service provided by Gradle for use in init scripts and {@link Gradle} plugins.
      *
-     * <p>The following services are available:</p>
-     * <ul>
-     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
-     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
-     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
-     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
-     * </ul>
+     * <p>The services available for lookup are the Gradle types that implement {@link GradleService}.</p>
      *
      * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
      * use {@link #getSharedServices()} to access those.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -417,4 +417,28 @@ public interface Gradle extends PluginAware, ExtensionAware {
      */
     @Incubating
     ProviderFactory getProviders();
+
+    /**
+     * Looks up a service provided by Gradle for use in init scripts and {@link Gradle} plugins.
+     *
+     * <p>The following services are available:</p>
+     * <ul>
+     * <li>{@link org.gradle.api.model.ObjectFactory}</li>
+     * <li>{@link org.gradle.api.provider.ProviderFactory}</li>
+     * <li>{@link org.gradle.api.file.FileSystemOperations}</li>
+     * <li>{@link org.gradle.api.file.ArchiveOperations}</li>
+     * <li>{@link org.gradle.process.ExecOperations}</li>
+     * </ul>
+     *
+     * <p>This method does not provide access to {@link org.gradle.api.services.BuildService shared build services};
+     * use {@link #getSharedServices()} to access those.</p>
+     *
+     * @param serviceType the type of the service to look up
+     * @param <T> the service type
+     * @return the service instance. Never returns null.
+     * @throws org.gradle.api.InvalidUserDataException when the given type is not one of the services available in this scope
+     * @since 9.8.0
+     */
+    @Incubating
+    <T> T service(Class<T> serviceType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -33,6 +33,10 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
+import org.gradle.api.services.GradleService;
+import org.gradle.api.services.ProjectService;
+import org.gradle.api.services.SettingsService;
+import org.gradle.api.services.TaskService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -50,7 +54,7 @@ import java.util.Set;
  * @since 4.0
  */
 @ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Project.class})
-public interface ObjectFactory {
+public interface ObjectFactory extends GradleService, ProjectService, SettingsService, TaskService {
     /**
      * Creates a simple immutable {@link Named} object of the given type and name.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -24,6 +24,10 @@ import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.file.FileContents;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.services.GradleService;
+import org.gradle.api.services.ProjectService;
+import org.gradle.api.services.SettingsService;
+import org.gradle.api.services.TaskService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.process.ExecOutput;
@@ -45,7 +49,7 @@ import java.util.function.BiFunction;
  */
 @NonExtensible
 @ServiceScope(Scope.Build.class)
-public interface ProviderFactory {
+public interface ProviderFactory extends GradleService, ProjectService, SettingsService, TaskService {
 
     /**
      * Creates a {@link Provider} whose value is calculated using the given {@link Callable}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/GradleService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/GradleService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.services;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Marks a service that can be looked up via {@link org.gradle.api.invocation.Gradle#service(Class)}.
+ * It is not meant to be implemented by user code.
+ *
+ * @since 9.8.0
+ */
+@Incubating
+public interface GradleService {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/ProjectService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/ProjectService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.services;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Marks a service that can be looked up via {@link org.gradle.api.Project#service(Class)}.
+ * It is not meant to be implemented by user code.
+ *
+ * @since 9.8.0
+ */
+@Incubating
+public interface ProjectService {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/SettingsService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/SettingsService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.services;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Marks a service that can be looked up via {@link org.gradle.api.initialization.Settings#service(Class)}.
+ * It is not meant to be implemented by user code.
+ *
+ * @since 9.8.0
+ */
+@Incubating
+public interface SettingsService {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/TaskService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/TaskService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.services;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Marks a service that can be looked up via {@link org.gradle.api.Task#service(Class)}.
+ * It is not meant to be implemented by user code.
+ *
+ * @since 9.8.0
+ */
+@Incubating
+public interface TaskService {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/process/ExecOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/ExecOperations.java
@@ -17,6 +17,7 @@
 package org.gradle.process;
 
 import org.gradle.api.Action;
+import org.gradle.api.services.TaskService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -28,7 +29,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 6.0
  */
 @ServiceScope({Scope.Build.class, Scope.Project.class})
-public interface ExecOperations {
+public interface ExecOperations extends TaskService {
 
     /**
      * Executes the specified external process.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -320,10 +320,12 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause("org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
-            "The following services are available in project scripts and project plugins: " +
-            "org.gradle.api.file.ArchiveOperations, org.gradle.api.file.FileSystemOperations, " +
-            "org.gradle.api.file.ProjectLayout, org.gradle.api.model.ObjectFactory, " +
-            "org.gradle.api.provider.ProviderFactory.")
+            "The following services are available in project scripts and project plugins:\n" +
+            " - org.gradle.api.file.ArchiveOperations\n" +
+            " - org.gradle.api.file.FileSystemOperations\n" +
+            " - org.gradle.api.model.ObjectFactory\n" +
+            " - org.gradle.api.file.ProjectLayout\n" +
+            " - org.gradle.api.provider.ProviderFactory")
     }
 
     def "a user type that implements a scope marker but is not a Gradle service is still rejected at runtime"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -270,6 +270,34 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
             "\nIt is available in project scripts, project plugins, and tasks.")
     }
 
+    def "looking up a settings-only service through a task closure resolves to the task and is rejected at configuration time"() {
+        settingsFile """
+            gradle.rootProject {
+                tasks.register("useLayout") {
+                    // `service` here resolves to the Task receiver, which does not expose the
+                    // settings-only BuildLayout, so this fails while the task is being configured.
+                    def captured = service(BuildLayout)
+                    doLast {
+                        // Tripwire on the first line: if the action is ever entered, this prints.
+                        println("REACHED ACTION")
+                        println("settings dir: " + captured.settingsDirectory.asFile.name)
+                    }
+                }
+            }
+        """
+
+        when:
+        fails(":useLayout")
+
+        then:
+        // The rejection happens while the task is being created, not while it runs...
+        failure.assertHasCause("Could not create task ':useLayout'.")
+        failure.assertHasCause("org.gradle.api.file.BuildLayout is not available in tasks." +
+            "\nIt is available in settings scripts and settings plugins.")
+        // ...so the task action is never entered.
+        outputDoesNotContain("REACHED ACTION")
+    }
+
     def "looking up an execution-only service from a build script fails with a helpful message"() {
         buildFile """
             service(ExecOperations)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -25,13 +25,12 @@ import spock.lang.Issue
 class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
     def "all documented services can be looked up in a build script"() {
-        buildFile << """
+        buildFile """
             def services = [
                 service(ObjectFactory),
                 service(ProviderFactory),
                 service(FileSystemOperations),
                 service(ArchiveOperations),
-                service(ExecOperations),
                 service(ProjectLayout),
             ]
             println("resolved services: " + services.count { it != null })
@@ -39,12 +38,12 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds("help")
-        outputContains("resolved services: 6")
+        outputContains("resolved services: 5")
     }
 
     def "can delete files with FileSystemOperations looked up inside a task action"() {
         file("thing.txt").text = "content"
-        buildFile << """
+        buildFile """
             tasks.register("cleanThing") {
                 doLast {
                     service(FileSystemOperations).delete {
@@ -65,7 +64,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         file("doomed.txt").text = "content"
         file("zip-src/entry.txt").text = "entry"
         file("zip-src").zipTo(file("stuff.zip"))
-        buildFile << """
+        buildFile """
             tasks.register("use") {
                 def captured = service($serviceType)
                 def targetFile = file("doomed.txt")
@@ -97,7 +96,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
     def "FileSystemOperations from a project script resolves paths relative to the project directory"() {
         createDirs("sub")
-        settingsFile << """
+        settingsFile """
             include("sub")
         """
         file("local.txt").text = "root"
@@ -121,7 +120,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "services can be looked up in a settings script"() {
-        settingsFile << """
+        settingsFile """
             def layout = service(BuildLayout)
             println("settings dir name: " + layout.settingsDirectory.asFile.name)
 
@@ -137,26 +136,24 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "services can be looked up in an init script"() {
-        initScriptFile << """
+        initScriptFile """
             def property = service(ObjectFactory).property(String)
             property.set("from-init")
             println("init property: " + property.get())
-            println("init exec ops: " + (service(ExecOperations) != null))
         """
 
         expect:
         args("-I", "init.gradle")
         succeeds("help")
         outputContains("init property: from-init")
-        outputContains("init exec ops: true")
     }
 
     def "each project's task resolves its own project-scoped service when registered from an allprojects block"() {
         createDirs("a")
-        settingsFile << """
+        settingsFile """
             include("a")
         """
-        buildFile << """
+        buildFile """
             allprojects { proj ->
                 tasks.register("ping") {
                     def projectPath = proj.path
@@ -177,7 +174,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "service can be looked up from a closure nested inside a task action"() {
-        buildFile << """
+        buildFile """
             tasks.register("nested") {
                 doLast {
                     def makeProperty = { service(ObjectFactory).property(String) }
@@ -196,7 +193,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "looking up a project-only service from a settings script fails with a helpful message"() {
-        settingsFile << """
+        settingsFile """
             service(ProjectLayout)
         """
 
@@ -207,8 +204,20 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. It is available in project scripts and plugins and tasks.")
     }
 
+    def "looking up an execution-only service from a build script fails with a helpful message"() {
+        buildFile """
+            service(ExecOperations)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("org.gradle.process.ExecOperations is not available in project scripts and plugins. It is available in tasks.")
+    }
+
     def "looking up an internal service fails and enumerates the available services"() {
-        buildFile << """
+        buildFile """
             service(org.gradle.api.internal.project.ProjectInternal)
         """
 
@@ -220,11 +229,25 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
             "The following services are available in project scripts and plugins: " +
             "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
             "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
-            "org.gradle.process.ExecOperations, org.gradle.api.file.ProjectLayout.")
+            "org.gradle.api.file.ProjectLayout.")
+    }
+
+    def "a user type that implements a scope marker but is not a Gradle service is still rejected at runtime"() {
+        buildFile """
+            abstract class NotAService implements org.gradle.api.services.ProjectService {}
+
+            service(NotAService)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("NotAService is not a service that is available for lookup with service().")
     }
 
     def "looking up a shared build service fails with a pointer to the build service APIs"() {
-        buildFile << """
+        buildFile """
             abstract class CounterService implements org.gradle.api.services.BuildService<org.gradle.api.services.BuildServiceParameters.None> {
             }
 
@@ -239,7 +262,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "looking up a null service type fails with a helpful message"() {
-        buildFile << """
+        buildFile """
             service(null)
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
@@ -254,6 +255,26 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("out: nested-value")
+    }
+
+    @ToBeFixedForConfigurationCache(because = "an onlyIf closure resolves owner-first, so service() resolves to the enclosing script, and a script object cannot be referenced from a Groovy closure at execution time under the configuration cache")
+    def "a service can be looked up from an onlyIf predicate"() {
+        buildFile """
+            tasks.register("check") {
+                onlyIf {
+                    service(ProviderFactory) != null
+                }
+                doLast {
+                    println("out: ran")
+                }
+            }
+        """
+
+        when:
+        succeeds("check")
+
+        then:
+        outputContains("out: ran")
     }
 
     def "looking up a project-only service from a settings script fails with a helpful message"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -151,19 +151,48 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         outputContains("init exec ops: true")
     }
 
-    def "ProjectLayout can be looked up on a task at configuration time"() {
+    def "each project's task resolves its own project-scoped service when registered from an allprojects block"() {
+        createDirs("a")
+        settingsFile << """
+            include("a")
+        """
         buildFile << """
-            tasks.register("showLayout") {
-                def dirName = service(ProjectLayout).projectDirectory.asFile.name
-                doLast {
-                    println("project dir name: " + dirName)
+            allprojects { proj ->
+                tasks.register("ping") {
+                    def projectPath = proj.path
+                    def captured = service(ProjectLayout)
+                    doLast {
+                        println("layout for " + projectPath + ": " + captured.projectDirectory.asFile.name)
+                    }
                 }
             }
         """
 
-        expect:
-        succeeds("showLayout")
-        outputContains("project dir name: " + testDirectory.name)
+        when:
+        succeeds("ping")
+
+        then:
+        outputContains("layout for :: " + testDirectory.name)
+        outputContains("layout for :a: a")
+    }
+
+    def "service can be looked up from a closure nested inside a task action"() {
+        buildFile << """
+            tasks.register("nested") {
+                doLast {
+                    def makeProperty = { service(ObjectFactory).property(String) }
+                    def p = makeProperty()
+                    p.set("nested-value")
+                    println("out: " + p.get())
+                }
+            }
+        """
+
+        when:
+        succeeds("nested")
+
+        then:
+        outputContains("out: nested-value")
     }
 
     def "looking up a project-only service from a settings script fails with a helpful message"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -152,13 +152,12 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "FileSystemOperations from a project script resolves paths relative to the project directory"() {
-        createDirs("sub")
         settingsFile """
             include("sub")
         """
         file("local.txt").text = "root"
         file("sub/local.txt").text = "sub"
-        file("sub/build.gradle") << """
+        buildFile("sub/build.gradle", """
             tasks.register("cleanLocal") {
                 doLast {
                     service(FileSystemOperations).delete {
@@ -166,7 +165,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-        """
+        """)
 
         when:
         succeeds(":sub:cleanLocal")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -41,7 +41,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         outputContains("resolved services: 5")
     }
 
-    def "can delete files with FileSystemOperations looked up inside a task action"() {
+    def "can look up and use a service inside a task action"() {
         file("thing.txt").text = "content"
         buildFile """
             tasks.register("cleanThing") {
@@ -58,6 +58,29 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         !file("thing.txt").exists()
+    }
+
+    def "a service resolves from the Gradle, Project, and Task scopes"() {
+        initScriptFile """
+            println("gradle-scope: " + (service(ObjectFactory) != null))
+        """
+        buildFile """
+            println("project-scope: " + (service(ObjectFactory) != null))
+            tasks.register("check") {
+                doLast {
+                    println("task-scope: " + (service(ObjectFactory) != null))
+                }
+            }
+        """
+
+        when:
+        args("-I", "init.gradle")
+        succeeds("check")
+
+        then:
+        outputContains("gradle-scope: true")
+        outputContains("project-scope: true")
+        outputContains("task-scope: true")
     }
 
     def "can capture #serviceType at configuration time and use it in a task action"() {
@@ -201,7 +224,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. It is available in project scripts and plugins and tasks.")
+        failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins. It is available in project scripts, project plugins, and tasks.")
     }
 
     def "looking up an execution-only service from a build script fails with a helpful message"() {
@@ -213,7 +236,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("org.gradle.process.ExecOperations is not available in project scripts and plugins. It is available in tasks.")
+        failure.assertHasCause("org.gradle.process.ExecOperations is not available in project scripts and project plugins. It is available in tasks.")
     }
 
     def "looking up an internal service fails and enumerates the available services"() {
@@ -226,7 +249,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause("org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
-            "The following services are available in project scripts and plugins: " +
+            "The following services are available in project scripts and project plugins: " +
             "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
             "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
             "org.gradle.api.file.ProjectLayout.")
@@ -258,7 +281,9 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("CounterService is a shared build service, which cannot be obtained with service().")
+        failure.assertHasCause("CounterService is a shared build service, which cannot be obtained with service(). " +
+            "Register it with gradle.sharedServices.registerIfAbsent() and access it " +
+            "via a property annotated with @ServiceReference, or via the provider returned from registration.")
     }
 
     def "looking up a null service type fails with a helpful message"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -321,9 +321,9 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
             "The following services are available in project scripts and project plugins: " +
-            "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
-            "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
-            "org.gradle.api.file.ProjectLayout.")
+            "org.gradle.api.file.ArchiveOperations, org.gradle.api.file.FileSystemOperations, " +
+            "org.gradle.api.file.ProjectLayout, org.gradle.api.model.ObjectFactory, " +
+            "org.gradle.api.provider.ProviderFactory.")
     }
 
     def "a user type that implements a scope marker but is not a Gradle service is still rejected at runtime"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -88,29 +88,63 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         file("zip-src/entry.txt").text = "entry"
         file("zip-src").zipTo(file("stuff.zip"))
         buildFile """
-            tasks.register("use") {
-                def captured = service($serviceType)
+            tasks.register("useObjectFactory") {
+                def captured = service(ObjectFactory)
+                doLast {
+                    def p = captured.property(String)
+                    p.set("captured-value")
+                    println("out: " + p.get())
+                }
+            }
+            tasks.register("useProviderFactory") {
+                def captured = service(ProviderFactory)
+                doLast {
+                    println("out: " + captured.provider { "provided-value" }.get())
+                }
+            }
+            tasks.register("useFileSystemOperations") {
+                def captured = service(FileSystemOperations)
                 def targetFile = file("doomed.txt")
                 doLast {
-                    ${action.replace("JAVA_EXE", jvmPath)}
+                    captured.delete { delete(targetFile) }
+                    println("out: exists=" + targetFile.exists())
+                }
+            }
+            tasks.register("useArchiveOperations") {
+                def captured = service(ArchiveOperations)
+                doLast {
+                    println("out: " + captured.zipTree("stuff.zip").files*.name.sort())
+                }
+            }
+            tasks.register("useExecOperations") {
+                def captured = service(ExecOperations)
+                doLast {
+                    def result = captured.exec { commandLine("${jvmPath}", "-version") }
+                    println("out: " + result.exitValue)
+                }
+            }
+            tasks.register("useProjectLayout") {
+                def captured = service(ProjectLayout)
+                doLast {
+                    println("out: " + captured.projectDirectory.asFile.name)
                 }
             }
         """
 
         when:
-        succeeds("use")
+        succeeds("use$serviceType")
 
         then:
         outputContains(expectedOutput.replace("@PROJECT_DIR_NAME@", testDirectory.name))
 
         where:
-        serviceType            | action                                                                                        | expectedOutput
-        "ObjectFactory"        | 'def p = captured.property(String); p.set("captured-value"); println("out: " + p.get())'     | "out: captured-value"
-        "ProviderFactory"      | 'println("out: " + captured.provider { "provided-value" }.get())'                            | "out: provided-value"
-        "FileSystemOperations" | 'captured.delete { delete(targetFile) }; println("out: exists=" + targetFile.exists())'      | "out: exists=false"
-        "ArchiveOperations"    | 'println("out: " + captured.zipTree("stuff.zip").files*.name.sort())'                        | "out: [entry.txt]"
-        "ExecOperations"       | 'def r = captured.exec { commandLine("JAVA_EXE", "-version") }; println("out: " + r.exitValue)' | "out: 0"
-        "ProjectLayout"        | 'println("out: " + captured.projectDirectory.asFile.name)'                                   | "out: @PROJECT_DIR_NAME@"
+        serviceType            | expectedOutput
+        "ObjectFactory"        | "out: captured-value"
+        "ProviderFactory"      | "out: provided-value"
+        "FileSystemOperations" | "out: exists=false"
+        "ArchiveOperations"    | "out: [entry.txt]"
+        "ExecOperations"       | "out: 0"
+        "ProjectLayout"        | "out: @PROJECT_DIR_NAME@"
     }
 
     private static String getJvmPath() {
@@ -142,33 +176,41 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         file("local.txt").exists()
     }
 
-    def "services can be looked up in a settings script"() {
+    def "all documented services can be looked up in a settings script"() {
         settingsFile """
-            def layout = service(BuildLayout)
-            println("settings dir name: " + layout.settingsDirectory.asFile.name)
+            def services = [
+                service(ObjectFactory),
+                service(ProviderFactory),
+                service(FileSystemOperations),
+                service(ArchiveOperations),
+                service(BuildLayout),
+            ]
+            println("resolved services: " + services.count { it != null })
 
-            def property = service(ObjectFactory).property(String)
-            property.set("from-settings")
-            println("settings property: " + property.get())
+            println("settings dir name: " + service(BuildLayout).settingsDirectory.asFile.name)
         """
 
         expect:
         succeeds("help")
+        outputContains("resolved services: 5")
         outputContains("settings dir name: " + testDirectory.name)
-        outputContains("settings property: from-settings")
     }
 
-    def "services can be looked up in an init script"() {
+    def "all documented services can be looked up in an init script"() {
         initScriptFile """
-            def property = service(ObjectFactory).property(String)
-            property.set("from-init")
-            println("init property: " + property.get())
+            def services = [
+                service(ObjectFactory),
+                service(ProviderFactory),
+                service(FileSystemOperations),
+                service(ArchiveOperations),
+            ]
+            println("resolved services: " + services.count { it != null })
         """
 
         expect:
         args("-I", "init.gradle")
         succeeds("help")
-        outputContains("init property: from-init")
+        outputContains("resolved services: 4")
     }
 
     def "each project's task resolves its own project-scoped service when registered from an allprojects block"() {
@@ -224,7 +266,8 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins. It is available in project scripts, project plugins, and tasks.")
+        failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins." +
+            "\nIt is available in project scripts, project plugins, and tasks.")
     }
 
     def "looking up an execution-only service from a build script fails with a helpful message"() {
@@ -236,7 +279,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("org.gradle.process.ExecOperations is not available in project scripts and project plugins. It is available in tasks.")
+        failure.assertHasCause("org.gradle.process.ExecOperations is not available in project scripts and project plugins.\nIt is available in tasks.")
     }
 
     def "looking up an internal service fails and enumerates the available services"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -213,22 +213,23 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         outputContains("resolved services: 4")
     }
 
-    def "each project's task resolves its own project-scoped service when registered from an allprojects block"() {
-        createDirs("a")
+    def "each project's task resolves its own project-scoped service"() {
         settingsFile """
             include("a")
         """
-        buildFile """
-            allprojects { proj ->
-                tasks.register("ping") {
-                    def projectPath = proj.path
-                    def captured = service(ProjectLayout)
-                    doLast {
-                        println("layout for " + projectPath + ": " + captured.projectDirectory.asFile.name)
-                    }
+        // Register the task in each project's own build script rather than via an allprojects block,
+        // which would cross the project boundary and be rejected under Isolated Projects.
+        def pingTask = """
+            tasks.register("ping") {
+                def projectPath = project.path
+                def captured = service(ProjectLayout)
+                doLast {
+                    println("layout for " + projectPath + ": " + captured.projectDirectory.asFile.name)
                 }
             }
         """
+        buildFile pingTask
+        buildFile("a/build.gradle", pingTask)
 
         when:
         succeeds("ping")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.jvm.Jvm
+import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
 
 @Issue("https://github.com/gradle/gradle/issues/13121")
@@ -59,24 +61,38 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
         !file("thing.txt").exists()
     }
 
-    def "can capture a service at configuration time and use it in a task action"() {
-        file("thing.txt").text = "content"
+    def "can capture #serviceType at configuration time and use it in a task action"() {
+        file("doomed.txt").text = "content"
+        file("zip-src/entry.txt").text = "entry"
+        file("zip-src").zipTo(file("stuff.zip"))
         buildFile << """
-            tasks.register("cleanThing") {
-                def fs = service(FileSystemOperations)
+            tasks.register("use") {
+                def captured = service($serviceType)
+                def targetFile = file("doomed.txt")
                 doLast {
-                    fs.delete {
-                        delete("thing.txt")
-                    }
+                    ${action.replace("JAVA_EXE", jvmPath)}
                 }
             }
         """
 
         when:
-        succeeds("cleanThing")
+        succeeds("use")
 
         then:
-        !file("thing.txt").exists()
+        outputContains(expectedOutput.replace("@PROJECT_DIR_NAME@", testDirectory.name))
+
+        where:
+        serviceType            | action                                                                                        | expectedOutput
+        "ObjectFactory"        | 'def p = captured.property(String); p.set("captured-value"); println("out: " + p.get())'     | "out: captured-value"
+        "ProviderFactory"      | 'println("out: " + captured.provider { "provided-value" }.get())'                            | "out: provided-value"
+        "FileSystemOperations" | 'captured.delete { delete(targetFile) }; println("out: exists=" + targetFile.exists())'      | "out: exists=false"
+        "ArchiveOperations"    | 'println("out: " + captured.zipTree("stuff.zip").files*.name.sort())'                        | "out: [entry.txt]"
+        "ExecOperations"       | 'def r = captured.exec { commandLine("JAVA_EXE", "-version") }; println("out: " + r.exitValue)' | "out: 0"
+        "ProjectLayout"        | 'println("out: " + captured.projectDirectory.asFile.name)'                                   | "out: @PROJECT_DIR_NAME@"
+    }
+
+    private static String getJvmPath() {
+        return TextUtil.escapeString(Jvm.current().javaExecutable.absolutePath)
     }
 
     def "FileSystemOperations from a project script resolves paths relative to the project directory"() {
@@ -121,7 +137,7 @@ class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "services can be looked up in an init script"() {
-        file("init.gradle") << """
+        initScriptFile << """
             def property = service(ObjectFactory).property(String)
             property.set("from-init")
             println("init property: " + property.get())

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PublicServiceLookupIntegrationTest.groovy
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/13121")
+class PublicServiceLookupIntegrationTest extends AbstractIntegrationSpec {
+
+    def "all documented services can be looked up in a build script"() {
+        buildFile << """
+            def services = [
+                service(ObjectFactory),
+                service(ProviderFactory),
+                service(FileSystemOperations),
+                service(ArchiveOperations),
+                service(ExecOperations),
+                service(ProjectLayout),
+            ]
+            println("resolved services: " + services.count { it != null })
+        """
+
+        expect:
+        succeeds("help")
+        outputContains("resolved services: 6")
+    }
+
+    def "can delete files with FileSystemOperations looked up inside a task action"() {
+        file("thing.txt").text = "content"
+        buildFile << """
+            tasks.register("cleanThing") {
+                doLast {
+                    service(FileSystemOperations).delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("cleanThing")
+
+        then:
+        !file("thing.txt").exists()
+    }
+
+    def "can capture a service at configuration time and use it in a task action"() {
+        file("thing.txt").text = "content"
+        buildFile << """
+            tasks.register("cleanThing") {
+                def fs = service(FileSystemOperations)
+                doLast {
+                    fs.delete {
+                        delete("thing.txt")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("cleanThing")
+
+        then:
+        !file("thing.txt").exists()
+    }
+
+    def "FileSystemOperations from a project script resolves paths relative to the project directory"() {
+        createDirs("sub")
+        settingsFile << """
+            include("sub")
+        """
+        file("local.txt").text = "root"
+        file("sub/local.txt").text = "sub"
+        file("sub/build.gradle") << """
+            tasks.register("cleanLocal") {
+                doLast {
+                    service(FileSystemOperations).delete {
+                        delete("local.txt")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds(":sub:cleanLocal")
+
+        then:
+        !file("sub/local.txt").exists()
+        file("local.txt").exists()
+    }
+
+    def "services can be looked up in a settings script"() {
+        settingsFile << """
+            def layout = service(BuildLayout)
+            println("settings dir name: " + layout.settingsDirectory.asFile.name)
+
+            def property = service(ObjectFactory).property(String)
+            property.set("from-settings")
+            println("settings property: " + property.get())
+        """
+
+        expect:
+        succeeds("help")
+        outputContains("settings dir name: " + testDirectory.name)
+        outputContains("settings property: from-settings")
+    }
+
+    def "services can be looked up in an init script"() {
+        file("init.gradle") << """
+            def property = service(ObjectFactory).property(String)
+            property.set("from-init")
+            println("init property: " + property.get())
+            println("init exec ops: " + (service(ExecOperations) != null))
+        """
+
+        expect:
+        args("-I", "init.gradle")
+        succeeds("help")
+        outputContains("init property: from-init")
+        outputContains("init exec ops: true")
+    }
+
+    def "ProjectLayout can be looked up on a task at configuration time"() {
+        buildFile << """
+            tasks.register("showLayout") {
+                def dirName = service(ProjectLayout).projectDirectory.asFile.name
+                doLast {
+                    println("project dir name: " + dirName)
+                }
+            }
+        """
+
+        expect:
+        succeeds("showLayout")
+        outputContains("project dir name: " + testDirectory.name)
+    }
+
+    def "looking up a project-only service from a settings script fails with a helpful message"() {
+        settingsFile << """
+            service(ProjectLayout)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. It is available in project scripts and plugins and tasks.")
+    }
+
+    def "looking up an internal service fails and enumerates the available services"() {
+        buildFile << """
+            service(org.gradle.api.internal.project.ProjectInternal)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("org.gradle.api.internal.project.ProjectInternal is not a service that is available for lookup with service(). " +
+            "The following services are available in project scripts and plugins: " +
+            "org.gradle.api.model.ObjectFactory, org.gradle.api.provider.ProviderFactory, " +
+            "org.gradle.api.file.FileSystemOperations, org.gradle.api.file.ArchiveOperations, " +
+            "org.gradle.process.ExecOperations, org.gradle.api.file.ProjectLayout.")
+    }
+
+    def "looking up a shared build service fails with a pointer to the build service APIs"() {
+        buildFile << """
+            abstract class CounterService implements org.gradle.api.services.BuildService<org.gradle.api.services.BuildServiceParameters.None> {
+            }
+
+            service(CounterService)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("CounterService is a shared build service, which cannot be obtained with service().")
+    }
+
+    def "looking up a null service type fails with a helpful message"() {
+        buildFile << """
+            service(null)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("The service type given to service() must not be null.")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -57,6 +57,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.services.BuildService;
+import org.gradle.api.services.TaskService;
 import org.gradle.api.services.internal.BuildServiceProvider;
 import org.gradle.api.services.internal.BuildServiceRegistryInternal;
 import org.gradle.api.specs.Spec;
@@ -693,7 +694,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     }
 
     @Override
-    public <T> T service(Class<T> serviceType) {
+    public <T extends TaskService> T service(Class<T> serviceType) {
         return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.TASK, getServices());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectOrderingUtil;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
+import org.gradle.api.internal.services.PublicServiceLookups;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.DefaultTaskDestroyables;
 import org.gradle.api.internal.tasks.DefaultTaskInputs;
@@ -689,6 +690,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Internal
     protected ServiceRegistry getServices() {
         return services;
+    }
+
+    @Override
+    public <T> T service(Class<T> serviceType) {
+        return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.TASK, getServices());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -80,6 +80,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.resources.ResourceHandler;
+import org.gradle.api.services.ProjectService;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
@@ -929,7 +930,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     public abstract ProjectLayout getLayout();
 
     @Override
-    public <T> T service(Class<T> serviceType) {
+    public <T extends ProjectService> T service(Class<T> serviceType) {
         return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.PROJECT, getServices());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -66,6 +66,7 @@ import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator;
+import org.gradle.api.internal.services.PublicServiceLookups;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.logging.Logger;
@@ -926,6 +927,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Inject
     @Override
     public abstract ProjectLayout getLayout();
+
+    @Override
+    public <T> T service(Class<T> serviceType) {
+        return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.PROJECT, getServices());
+    }
 
     @Override
     public File file(Object path) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -64,6 +64,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.resources.ResourceHandler;
+import org.gradle.api.services.ProjectService;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
@@ -650,7 +651,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public <T> T service(Class<T> serviceType) {
+    public <T extends ProjectService> T service(Class<T> serviceType) {
         if (ProjectLayout.class.equals(serviceType)) {
             // parity with getLayout()
             onMutableStateAccess("layout");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -650,6 +650,15 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public <T> T service(Class<T> serviceType) {
+        if (ProjectLayout.class.equals(serviceType)) {
+            // parity with getLayout()
+            onMutableStateAccess("layout");
+        }
+        return delegate.service(serviceType);
+    }
+
+    @Override
     public String relativePath(Object path) {
         return delegate.relativePath(path);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -75,7 +75,7 @@ public final class PublicServiceLookups {
         .put(ProviderFactory.class, ALL_ENTRY_POINTS)
         .put(FileSystemOperations.class, ALL_ENTRY_POINTS)
         .put(ArchiveOperations.class, ALL_ENTRY_POINTS)
-        .put(ExecOperations.class, ALL_ENTRY_POINTS)
+        .put(ExecOperations.class, Sets.immutableEnumSet(EntryPoint.TASK))
         .put(ProjectLayout.class, Sets.immutableEnumSet(EntryPoint.PROJECT, EntryPoint.TASK))
         .put(BuildLayout.class, Sets.immutableEnumSet(EntryPoint.SETTINGS))
         .build();
@@ -83,10 +83,31 @@ public final class PublicServiceLookups {
     private PublicServiceLookups() {
     }
 
+    /**
+     * Visible for testing: the authoritative service→scopes allowlist, so the marker/bound consistency
+     * test can assert the compile-time markers and method bounds agree with it.
+     */
+    static ImmutableMap<Class<?>, ImmutableSet<EntryPoint>> availableServices() {
+        return AVAILABLE_SERVICES;
+    }
+
+    /**
+     * Resolves a public service, enforcing the curated allowlist at runtime.
+     *
+     * <p>The marker interfaces ({@code ProjectService}, {@code TaskService}, etc.) are only a compile-time
+     * convenience, not a trust boundary: they are unsealed, so third-party code can implement one to satisfy
+     * the bound, and Groovy/reflective calls skip it entirely. This method matches {@code serviceType} by
+     * <strong>exact identity</strong> against {@link #AVAILABLE_SERVICES} (never {@code instanceof}) and only
+     * then queries the {@link ServiceRegistry}. So a caller-supplied type that merely implements a marker is
+     * rejected, and is never resolved or executed through Gradle's DI container.</p>
+     *
+     * @throws InvalidUserDataException if the type is null, not allowlisted, or not available in this scope
+     */
     public static <T> T lookup(@Nullable Class<T> serviceType, EntryPoint entryPoint, ServiceRegistry services) {
         if (serviceType == null) {
             throw new InvalidUserDataException("The service type given to service() must not be null.");
         }
+        // Identity check: a user type that only implements a marker is not a key here, so it never reaches the registry.
         Set<EntryPoint> availableIn = AVAILABLE_SERVICES.get(serviceType);
         if (availableIn == null) {
             throw new InvalidUserDataException(unknownServiceMessage(serviceType, entryPoint));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -73,7 +73,6 @@ public final class PublicServiceLookups {
 
     private static final ImmutableSet<EntryPoint> ALL_ENTRY_POINTS = Sets.immutableEnumSet(EnumSet.allOf(EntryPoint.class));
 
-    // Iteration order is meaningful: error messages enumerate the entries in this order.
     private static final ImmutableMap<Class<?>, ImmutableSet<EntryPoint>> AVAILABLE_SERVICES = ImmutableMap.<Class<?>, ImmutableSet<EntryPoint>>builder()
         .put(ObjectFactory.class, ALL_ENTRY_POINTS)
         .put(ProviderFactory.class, ALL_ENTRY_POINTS)
@@ -155,6 +154,7 @@ public final class PublicServiceLookups {
         return AVAILABLE_SERVICES.entrySet().stream()
             .filter(entry -> entry.getValue().contains(entryPoint))
             .map(entry -> entry.getKey().getName())
+            .sorted()
             .collect(Collectors.joining(", "));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.services;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -27,10 +28,12 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildService;
+import org.gradle.internal.RenderingUtils;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.process.ExecOperations;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,19 +54,19 @@ public final class PublicServiceLookups {
      * and which scope's registry backs the lookup.
      */
     public enum EntryPoint {
-        PROJECT("project scripts and plugins"),
+        PROJECT("project scripts", "project plugins"),
         TASK("tasks"),
-        SETTINGS("settings scripts and plugins"),
-        GRADLE("init scripts and Gradle plugins");
+        SETTINGS("settings scripts", "settings plugins"),
+        GRADLE("init scripts", "init plugins");
 
-        private final String displayName;
+        private final ImmutableList<String> displayNames;
 
-        EntryPoint(String displayName) {
-            this.displayName = displayName;
+        EntryPoint(String... displayNames) {
+            this.displayNames = ImmutableList.copyOf(displayNames);
         }
 
-        public String getDisplayName() {
-            return displayName;
+        public Collection<String> getDisplayNames() {
+            return displayNames;
         }
     }
 
@@ -128,14 +131,16 @@ public final class PublicServiceLookups {
         }
         return String.format(
             "%s is not a service that is available for lookup with service(). The following services are available in %s: %s.",
-            serviceType.getName(), entryPoint.getDisplayName(), servicesAvailableIn(entryPoint));
+            serviceType.getName(),
+            entryPoint.getDisplayNames().stream().collect(RenderingUtils.oxfordJoin("and")),
+            servicesAvailableIn(entryPoint));
     }
 
     private static String wrongScopeMessage(Class<?> serviceType, EntryPoint entryPoint, Set<EntryPoint> availableIn) {
         return String.format(
             "%s is not available in %s. It is available in %s.",
-            serviceType.getName(), entryPoint.getDisplayName(),
-            availableIn.stream().map(EntryPoint::getDisplayName).collect(Collectors.joining(" and ")));
+            serviceType.getName(), entryPoint.getDisplayNames().stream().collect(RenderingUtils.oxfordJoin("and")),
+            availableIn.stream().flatMap(e -> e.getDisplayNames().stream()).collect(RenderingUtils.oxfordJoin("and")));
     }
 
     private static String servicesAvailableIn(EntryPoint entryPoint) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -35,7 +35,9 @@ import org.gradle.process.ExecOperations;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -137,7 +139,7 @@ public final class PublicServiceLookups {
                 serviceType.getName());
         }
         return String.format(
-            "%s is not a service that is available for lookup with service(). The following services are available in %s: %s.",
+            "%s is not a service that is available for lookup with service(). The following services are available in %s:%s",
             serviceType.getName(),
             entryPoint.getDisplayNames().stream().collect(RenderingUtils.oxfordJoin("and")),
             servicesAvailableIn(entryPoint));
@@ -153,8 +155,9 @@ public final class PublicServiceLookups {
     private static String servicesAvailableIn(EntryPoint entryPoint) {
         return AVAILABLE_SERVICES.entrySet().stream()
             .filter(entry -> entry.getValue().contains(entryPoint))
-            .map(entry -> entry.getKey().getName())
-            .sorted()
-            .collect(Collectors.joining(", "));
+            .map(Map.Entry::getKey)
+            .sorted(Comparator.comparing(Class::getSimpleName))
+            .map(serviceType -> "\n - " + serviceType.getName())
+            .collect(Collectors.joining());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.services;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -90,6 +91,7 @@ public final class PublicServiceLookups {
      * Visible for testing: the authoritative service→scopes allowlist, so the marker/bound consistency
      * test can assert the compile-time markers and method bounds agree with it.
      */
+    @VisibleForTesting
     static ImmutableMap<Class<?>, ImmutableSet<EntryPoint>> availableServices() {
         return AVAILABLE_SERVICES;
     }
@@ -104,6 +106,12 @@ public final class PublicServiceLookups {
      * then queries the {@link ServiceRegistry}. So a caller-supplied type that merely implements a marker is
      * rejected, and is never resolved or executed through Gradle's DI container.</p>
      *
+     * @param serviceType the service type requested by user code. May be {@code null}: the typed
+     *     {@code service(Class)} entry points are reachable with {@code null} from Groovy
+     *     ({@code service(null)}), which has no compile-time null check, so a null type is treated as
+     *     invalid user input rather than an internal precondition violation.
+     * @param entryPoint the scope the lookup was made through; supplied by Gradle, never {@code null}
+     * @param services the registry backing this scope; supplied by Gradle, never {@code null}
      * @throws InvalidUserDataException if the type is null, not allowlisted, or not available in this scope
      */
     public static <T> T lookup(@Nullable Class<T> serviceType, EntryPoint entryPoint, ServiceRegistry services) {
@@ -138,7 +146,7 @@ public final class PublicServiceLookups {
 
     private static String wrongScopeMessage(Class<?> serviceType, EntryPoint entryPoint, Set<EntryPoint> availableIn) {
         return String.format(
-            "%s is not available in %s. It is available in %s.",
+            "%s is not available in %s.\nIt is available in %s.",
             serviceType.getName(), entryPoint.getDisplayNames().stream().collect(RenderingUtils.oxfordJoin("and")),
             availableIn.stream().flatMap(e -> e.getDisplayNames().stream()).collect(RenderingUtils.oxfordJoin("and")));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/PublicServiceLookups.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.services;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.ArchiveOperations;
+import org.gradle.api.file.BuildLayout;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.services.BuildService;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.process.ExecOperations;
+import org.jspecify.annotations.Nullable;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validates and performs lookups of the services that Gradle exposes to scripts and plugins
+ * via {@code Project.service(Class)}, {@code Task.service(Class)}, {@code Settings.service(Class)}
+ * and {@code Gradle.service(Class)}.
+ *
+ * <p>Only the services in the explicit allowlist below can be obtained. Validation is decided from
+ * the requested type alone; the backing {@link ServiceRegistry} is only consulted for allowed types
+ * and is never exposed to the caller.
+ */
+public final class PublicServiceLookups {
+
+    /**
+     * The API entry point a lookup was made through, determining which services are available
+     * and which scope's registry backs the lookup.
+     */
+    public enum EntryPoint {
+        PROJECT("project scripts and plugins"),
+        TASK("tasks"),
+        SETTINGS("settings scripts and plugins"),
+        GRADLE("init scripts and Gradle plugins");
+
+        private final String displayName;
+
+        EntryPoint(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+    }
+
+    private static final ImmutableSet<EntryPoint> ALL_ENTRY_POINTS = Sets.immutableEnumSet(EnumSet.allOf(EntryPoint.class));
+
+    // Iteration order is meaningful: error messages enumerate the entries in this order.
+    private static final ImmutableMap<Class<?>, ImmutableSet<EntryPoint>> AVAILABLE_SERVICES = ImmutableMap.<Class<?>, ImmutableSet<EntryPoint>>builder()
+        .put(ObjectFactory.class, ALL_ENTRY_POINTS)
+        .put(ProviderFactory.class, ALL_ENTRY_POINTS)
+        .put(FileSystemOperations.class, ALL_ENTRY_POINTS)
+        .put(ArchiveOperations.class, ALL_ENTRY_POINTS)
+        .put(ExecOperations.class, ALL_ENTRY_POINTS)
+        .put(ProjectLayout.class, Sets.immutableEnumSet(EntryPoint.PROJECT, EntryPoint.TASK))
+        .put(BuildLayout.class, Sets.immutableEnumSet(EntryPoint.SETTINGS))
+        .build();
+
+    private PublicServiceLookups() {
+    }
+
+    public static <T> T lookup(@Nullable Class<T> serviceType, EntryPoint entryPoint, ServiceRegistry services) {
+        if (serviceType == null) {
+            throw new InvalidUserDataException("The service type given to service() must not be null.");
+        }
+        Set<EntryPoint> availableIn = AVAILABLE_SERVICES.get(serviceType);
+        if (availableIn == null) {
+            throw new InvalidUserDataException(unknownServiceMessage(serviceType, entryPoint));
+        }
+        if (!availableIn.contains(entryPoint)) {
+            throw new InvalidUserDataException(wrongScopeMessage(serviceType, entryPoint, availableIn));
+        }
+        return services.get(serviceType);
+    }
+
+    private static String unknownServiceMessage(Class<?> serviceType, EntryPoint entryPoint) {
+        if (BuildService.class.isAssignableFrom(serviceType)) {
+            return String.format(
+                "%s is a shared build service, which cannot be obtained with service(). " +
+                    "Register it with gradle.sharedServices.registerIfAbsent() and access it " +
+                    "via a property annotated with @ServiceReference, or via the provider returned from registration.",
+                serviceType.getName());
+        }
+        return String.format(
+            "%s is not a service that is available for lookup with service(). The following services are available in %s: %s.",
+            serviceType.getName(), entryPoint.getDisplayName(), servicesAvailableIn(entryPoint));
+    }
+
+    private static String wrongScopeMessage(Class<?> serviceType, EntryPoint entryPoint, Set<EntryPoint> availableIn) {
+        return String.format(
+            "%s is not available in %s. It is available in %s.",
+            serviceType.getName(), entryPoint.getDisplayName(),
+            availableIn.stream().map(EntryPoint::getDisplayName).collect(Collectors.joining(" and ")));
+    }
+
+    private static String servicesAvailableIn(EntryPoint entryPoint) {
+        return AVAILABLE_SERVICES.entrySet().stream()
+            .filter(entry -> entry.getValue().contains(entryPoint))
+            .map(entry -> entry.getKey().getName())
+            .collect(Collectors.joining(", "));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/services/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/services/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Implementation of the public service lookup available to scripts and plugins,
+ * backing {@link org.gradle.api.Project#service(Class)} and its siblings on
+ * {@code Task}, {@code Settings} and {@code Gradle}.
+ */
+@NullMarked
+package org.gradle.api.internal.services;
+
+import org.jspecify.annotations.NullMarked;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.AbstractPluginAware;
+import org.gradle.api.internal.services.PublicServiceLookups;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.toolchain.management.ToolchainManagement;
@@ -316,6 +317,11 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     @Override
     public ServiceRegistry getServices() {
         return services;
+    }
+
+    @Override
+    public <T> T service(Class<T> serviceType) {
+        return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.SETTINGS, getServices());
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.project.AbstractPluginAware;
 import org.gradle.api.internal.services.PublicServiceLookups;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.services.SettingsService;
 import org.gradle.api.toolchain.management.ToolchainManagement;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
@@ -320,7 +321,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     }
 
     @Override
-    public <T> T service(Class<T> serviceType) {
+    public <T extends SettingsService> T service(Class<T> serviceType) {
         return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.SETTINGS, getServices());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -48,6 +48,7 @@ import org.gradle.api.invocation.GradleLifecycle;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.api.services.GradleService;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
@@ -328,7 +329,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     public abstract ProviderFactory getProviders();
 
     @Override
-    public <T> T service(Class<T> serviceType) {
+    public <T extends GradleService> T service(Class<T> serviceType) {
         return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.GRADLE, getServices());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -42,6 +42,7 @@ import org.gradle.api.internal.project.CrossBuildModelAccess;
 import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.services.PublicServiceLookups;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.invocation.GradleLifecycle;
 import org.gradle.api.model.ObjectFactory;
@@ -325,6 +326,11 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     @Inject
     @Override
     public abstract ProviderFactory getProviders();
+
+    @Override
+    public <T> T service(Class<T> serviceType) {
+        return PublicServiceLookups.lookup(serviceType, PublicServiceLookups.EntryPoint.GRADLE, getServices());
+    }
 
     @Override
     public ProjectEvaluationListener addProjectEvaluationListener(ProjectEvaluationListener listener) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupMarkerConsistencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupMarkerConsistencyTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.services
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.initialization.Settings
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.services.GradleService
+import org.gradle.api.services.ProjectService
+import org.gradle.api.services.SettingsService
+import org.gradle.api.services.TaskService
+import spock.lang.Specification
+
+/**
+ * Pins the two representations of "which service is available in which scope" together: the runtime
+ * allowlist in {@link PublicServiceLookups} (authoritative), the per-scope compile-time marker interfaces,
+ * and the generic bound on each {@code service(Class)} member. If any drifts from the others this fails.
+ */
+class PublicServiceLookupMarkerConsistencyTest extends Specification {
+
+    // entry point -> [host interface declaring service(Class), scope marker]
+    private static final Map<PublicServiceLookups.EntryPoint, List<Class<?>>> SCOPES = [
+        (PublicServiceLookups.EntryPoint.PROJECT) : [Project, ProjectService],
+        (PublicServiceLookups.EntryPoint.TASK)    : [Task, TaskService],
+        (PublicServiceLookups.EntryPoint.SETTINGS): [Settings, SettingsService],
+        (PublicServiceLookups.EntryPoint.GRADLE)  : [Gradle, GradleService],
+    ]
+
+    def "every allowlisted service implements the marker for each scope it is available in"() {
+        expect:
+        PublicServiceLookups.availableServices().each { serviceType, scopes ->
+            scopes.each { entryPoint ->
+                def marker = SCOPES[entryPoint][1]
+                assert marker.isAssignableFrom(serviceType):
+                    "${serviceType.name} is allowlisted for ${entryPoint} but does not implement ${marker.name}"
+            }
+        }
+    }
+
+    def "each service(Class) member is bounded by its scope marker"() {
+        expect:
+        SCOPES.each { entryPoint, hostAndMarker ->
+            def host = hostAndMarker[0]
+            def marker = hostAndMarker[1]
+            def bound = host.getMethod("service", Class).typeParameters[0].bounds[0]
+            assert bound == marker:
+                "${host.name}.service(Class) is bounded by ${bound}, expected ${marker.name}"
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
@@ -67,10 +67,10 @@ class PublicServiceLookupsTest extends Specification {
 
         where:
         serviceType   | entryPoint | message
-        ProjectLayout | SETTINGS   | "org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins. It is available in project scripts, project plugins, and tasks."
-        ProjectLayout | GRADLE     | "org.gradle.api.file.ProjectLayout is not available in init scripts and init plugins. It is available in project scripts, project plugins, and tasks."
-        BuildLayout   | PROJECT    | "org.gradle.api.file.BuildLayout is not available in project scripts and project plugins. It is available in settings scripts and settings plugins."
-        BuildLayout   | TASK       | "org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and settings plugins."
+        ProjectLayout | SETTINGS   | "org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins.\nIt is available in project scripts, project plugins, and tasks."
+        ProjectLayout | GRADLE     | "org.gradle.api.file.ProjectLayout is not available in init scripts and init plugins.\nIt is available in project scripts, project plugins, and tasks."
+        BuildLayout   | PROJECT    | "org.gradle.api.file.BuildLayout is not available in project scripts and project plugins.\nIt is available in settings scripts and settings plugins."
+        BuildLayout   | TASK       | "org.gradle.api.file.BuildLayout is not available in tasks.\nIt is available in settings scripts and settings plugins."
     }
 
     def "rejects internal or unknown type with enumeration of available services"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
@@ -67,10 +67,10 @@ class PublicServiceLookupsTest extends Specification {
 
         where:
         serviceType   | entryPoint | message
-        ProjectLayout | SETTINGS   | "org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. It is available in project scripts and plugins and tasks."
-        ProjectLayout | GRADLE     | "org.gradle.api.file.ProjectLayout is not available in init scripts and Gradle plugins. It is available in project scripts and plugins and tasks."
-        BuildLayout   | PROJECT    | "org.gradle.api.file.BuildLayout is not available in project scripts and plugins. It is available in settings scripts and plugins."
-        BuildLayout   | TASK       | "org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and plugins."
+        ProjectLayout | SETTINGS   | "org.gradle.api.file.ProjectLayout is not available in settings scripts and settings plugins. It is available in project scripts, project plugins, and tasks."
+        ProjectLayout | GRADLE     | "org.gradle.api.file.ProjectLayout is not available in init scripts and init plugins. It is available in project scripts, project plugins, and tasks."
+        BuildLayout   | PROJECT    | "org.gradle.api.file.BuildLayout is not available in project scripts and project plugins. It is available in settings scripts and settings plugins."
+        BuildLayout   | TASK       | "org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and settings plugins."
     }
 
     def "rejects internal or unknown type with enumeration of available services"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.services
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.BuildLayout
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.process.ExecOperations
+import spock.lang.Specification
+
+import static org.gradle.api.internal.services.PublicServiceLookups.EntryPoint.GRADLE
+import static org.gradle.api.internal.services.PublicServiceLookups.EntryPoint.PROJECT
+import static org.gradle.api.internal.services.PublicServiceLookups.EntryPoint.SETTINGS
+import static org.gradle.api.internal.services.PublicServiceLookups.EntryPoint.TASK
+
+class PublicServiceLookupsTest extends Specification {
+
+    def registry = Mock(ServiceRegistry)
+
+    def "resolves #serviceType.simpleName from #entryPoint"() {
+        def instance = Mock(serviceType)
+
+        when:
+        def result = PublicServiceLookups.lookup(serviceType, entryPoint, registry)
+
+        then:
+        1 * registry.get(serviceType) >> instance
+        result == instance
+
+        where:
+        [serviceType, entryPoint] << [
+            [ObjectFactory, ProviderFactory, FileSystemOperations, ArchiveOperations, ExecOperations].collectMany { type ->
+                [PROJECT, TASK, SETTINGS, GRADLE].collect { [type, it] }
+            },
+            [[ProjectLayout, PROJECT], [ProjectLayout, TASK], [BuildLayout, SETTINGS]]
+        ].collectMany { it }
+    }
+
+    def "rejects #serviceType.simpleName from #entryPoint with pointer to available scopes"() {
+        when:
+        PublicServiceLookups.lookup(serviceType, entryPoint, registry)
+
+        then:
+        0 * registry._
+        def e = thrown(InvalidUserDataException)
+        e.message == message
+
+        where:
+        serviceType   | entryPoint | message
+        ProjectLayout | SETTINGS   | "org.gradle.api.file.ProjectLayout is not available in settings scripts and plugins. It is available in project scripts and plugins and tasks."
+        ProjectLayout | GRADLE     | "org.gradle.api.file.ProjectLayout is not available in init scripts and Gradle plugins. It is available in project scripts and plugins and tasks."
+        BuildLayout   | PROJECT    | "org.gradle.api.file.BuildLayout is not available in project scripts and plugins. It is available in settings scripts and plugins."
+        BuildLayout   | TASK       | "org.gradle.api.file.BuildLayout is not available in tasks. It is available in settings scripts and plugins."
+    }
+
+    def "rejects internal or unknown type with enumeration of available services"() {
+        when:
+        PublicServiceLookups.lookup(ServiceRegistry, PROJECT, registry)
+
+        then:
+        0 * registry._
+        def e = thrown(InvalidUserDataException)
+        e.message.startsWith("org.gradle.internal.service.ServiceRegistry is not a service that is available for lookup with service().")
+        e.message.contains("org.gradle.api.model.ObjectFactory")
+        e.message.contains("org.gradle.process.ExecOperations")
+        e.message.contains("org.gradle.api.file.ProjectLayout")
+        !e.message.contains("org.gradle.api.file.BuildLayout")
+    }
+
+    def "rejects build service type with pointer to shared build services"() {
+        when:
+        PublicServiceLookups.lookup(SomeBuildService, TASK, registry)
+
+        then:
+        0 * registry._
+        def e = thrown(InvalidUserDataException)
+        e.message.contains("is a shared build service")
+        e.message.contains("@ServiceReference")
+    }
+
+    def "rejects null service type"() {
+        when:
+        PublicServiceLookups.lookup(null, PROJECT, registry)
+
+        then:
+        0 * registry._
+        def e = thrown(InvalidUserDataException)
+        e.message == "The service type given to service() must not be null."
+    }
+
+    static abstract class SomeBuildService implements BuildService<BuildServiceParameters.None> {
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/services/PublicServiceLookupsTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.process.ExecOperations
 import spock.lang.Specification
 
 import static org.gradle.api.internal.services.PublicServiceLookups.EntryPoint.GRADLE
@@ -50,7 +49,7 @@ class PublicServiceLookupsTest extends Specification {
 
         where:
         [serviceType, entryPoint] << [
-            [ObjectFactory, ProviderFactory, FileSystemOperations, ArchiveOperations, ExecOperations].collectMany { type ->
+            [ObjectFactory, ProviderFactory, FileSystemOperations, ArchiveOperations].collectMany { type ->
                 [PROJECT, TASK, SETTINGS, GRADLE].collect { [type, it] }
             },
             [[ProjectLayout, PROJECT], [ProjectLayout, TASK], [BuildLayout, SETTINGS]]
@@ -83,7 +82,6 @@ class PublicServiceLookupsTest extends Specification {
         def e = thrown(InvalidUserDataException)
         e.message.startsWith("org.gradle.internal.service.ServiceRegistry is not a service that is available for lookup with service().")
         e.message.contains("org.gradle.api.model.ObjectFactory")
-        e.message.contains("org.gradle.process.ExecOperations")
         e.message.contains("org.gradle.api.file.ProjectLayout")
         !e.message.contains("org.gradle.api.file.BuildLayout")
     }

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,11 +1,72 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.file.ArchiveOperations",
+            "member": "Class org.gradle.api.file.ArchiveOperations",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.GradleService",
+                "org.gradle.api.services.ProjectService",
+                "org.gradle.api.services.SettingsService",
+                "org.gradle.api.services.TaskService"
+            ]
+        },
+        {
+            "type": "org.gradle.api.file.FileSystemOperations",
+            "member": "Class org.gradle.api.file.FileSystemOperations",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.GradleService",
+                "org.gradle.api.services.ProjectService",
+                "org.gradle.api.services.SettingsService",
+                "org.gradle.api.services.TaskService"
+            ]
+        },
+        {
+            "type": "org.gradle.api.file.ProjectLayout",
+            "member": "Class org.gradle.api.file.ProjectLayout",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.ProjectService",
+                "org.gradle.api.services.TaskService"
+            ]
+        },
+        {
+            "type": "org.gradle.api.model.ObjectFactory",
+            "member": "Class org.gradle.api.model.ObjectFactory",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.GradleService",
+                "org.gradle.api.services.ProjectService",
+                "org.gradle.api.services.SettingsService",
+                "org.gradle.api.services.TaskService"
+            ]
+        },
+        {
+            "type": "org.gradle.api.provider.ProviderFactory",
+            "member": "Class org.gradle.api.provider.ProviderFactory",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.GradleService",
+                "org.gradle.api.services.ProjectService",
+                "org.gradle.api.services.SettingsService",
+                "org.gradle.api.services.TaskService"
+            ]
+        },
+        {
             "type": "org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate",
             "member": "Method org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate.buildscript(kotlin.jvm.functions.Function1)",
             "acceptation": "This member was missing after a refactor, it is not new",
             "changes": [
                 "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.process.ExecOperations",
+            "member": "Class org.gradle.process.ExecOperations",
+            "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",
+            "changes": [
+                "org.gradle.api.services.TaskService"
             ]
         }
     ]


### PR DESCRIPTION
<!-- Part of #13121 -->

### Context

Part of #13121 ("Reduce ceremony to use common public services in Gradle scripts") and its related issues (#14171, #21517, #22536, #34483): since Gradle 9 removed `Project.exec` (and `project.delete`, while still present, cannot be called at execution time with the configuration cache), even a simple `doLast { exec }` requires writing a plugin class or the `ObjectFactory.newInstance` injection ceremony, which is incomprehensible to newcomers.

This PR introduces the service-lookup design the team leaned towards in [the issue discussion](https://github.com/gradle/gradle/issues/13121#issuecomment-4542596503) (option 3): a `service(Class)` method on `Project`, `Settings`, `Gradle` and `Task`, plus reified `service<T>()` extensions in the Kotlin DSL.

```groovy
tasks.register("cleanThing") {
    doLast {
        service(FileSystemOperations).delete {
            delete("thing")
        }
    }
}
```

Availability per scope is expressed with **per-scope marker interfaces** — `ProjectService`, `TaskService`, `SettingsService`, `GradleService` — used as upper bounds on the corresponding `service(...)` method. As a result, looking up a service that is not available in the current scope, or a type that is not a service at all, is a **compile error in the Kotlin and Java DSLs**. An internal runtime allowlist backs the same restriction for the Groovy DSL (where the generic bound is not enforced) and for reflective `Class` lookups, failing with an `InvalidUserDataException` whose message enumerates the services available in the current scope; `BuildService` subtypes are redirected to the shared-build-service APIs.

It works in build, settings and init scripts (Groovy and Kotlin DSL) and inside task actions, and is configuration-cache safe: the `Task` entry point resolves against the owning project's registry, which is live at execution time after CC loading, and captured service instances round-trip via the existing `ServicesCodec`.

**Exposed services (v1):**

- All scopes: `ObjectFactory`, `ProviderFactory`, `FileSystemOperations`, `ArchiveOperations`
- Projects and tasks: `ProjectLayout`
- Tasks only: `ExecOperations` — resolving it outside a task action (i.e. at configuration time) is incompatible with the configuration cache, so it is restricted to the task scope
- Settings only: `BuildLayout`

The list is deliberately conservative — build-scope services still under IP-safety review (#38028) are deferred.

**Isolated Projects:** cross-project lookups (`project(":other").service(...)`) are reported as cross-project access, consistent with `getObjects()`/`getProviders()`.

### Work plan (phased commits on this PR)

- [x] Phase 1 — `service(Class)` API + allowlist validation + Groovy DSL coverage (unit + integration tests incl. configuration cache)
- [x] Phase 2 — Kotlin DSL reified `service<T>()` extensions
- [x] Phase 3 — Isolated Projects + Groovy dispatch edge-case tests
- [x] Phase 4 — User guide (service_injection.adoc) + release notes
- [x] Review feedback — per-scope marker interfaces + generic bounds for compile-time validation; `ExecOperations` restricted to tasks

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `:core:test`, `:core:forkingIntegTest`, `:core:configCacheIntegTest`, and `:kotlin-dsl:forkingIntegTest` for the new test classes.
