### PR TITLE
Include component metadata rules in ResolutionParameters

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -42,10 +42,12 @@ import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationServ
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataRulesSupplier;
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
+import org.gradle.api.internal.artifacts.dsl.ImmutableComponentMetadataRules;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler;
@@ -79,6 +81,7 @@ import org.gradle.api.internal.artifacts.repositories.DefaultUrlArtifactReposito
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInvocationFactory;
@@ -110,7 +113,6 @@ import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.problems.Problems;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.cache.Cache;
@@ -144,7 +146,6 @@ import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resource.local.FileResourceListener;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
@@ -153,7 +154,6 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
-import org.gradle.util.internal.SimpleMapInterner;
 
 import java.io.File;
 import java.util.List;
@@ -529,19 +529,16 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         @Provides({ComponentMetadataHandler.class, ComponentMetadataHandlerInternal.class})
         DefaultComponentMetadataHandler createComponentMetadataHandler(
-            Instantiator instantiator,
-            ObjectFactory objectFactory,
+            InstantiatorFactory instantiatorFactory,
             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-            SimpleMapInterner interner,
-            AttributesFactory attributesFactory,
             IsolatableFactory isolatableFactory,
-            ComponentMetadataRuleExecutor componentMetadataRuleExecutor,
-            PlatformSupport platformSupport,
-            Problems problems
+            MavenVariantAttributesFactory mavenVariantAttributesFactory
         ) {
-            DefaultComponentMetadataHandler componentMetadataHandler = instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor, platformSupport, problems);
+            InstanceGenerator instantiator = instantiatorFactory.decorateScheme().instantiator();
+
+            DefaultComponentMetadataHandler componentMetadataHandler = instantiator.newInstance(DefaultComponentMetadataHandler.class, isolatableFactory, moduleIdentifierFactory);
             if (domainObjectContext.isScript()) {
-                componentMetadataHandler.setVariantDerivationStrategy(objectFactory.newInstance(JavaEcosystemVariantDerivationStrategy.class));
+                componentMetadataHandler.setVariantDerivationStrategy(instantiator.newInstance(JavaEcosystemVariantDerivationStrategy.class, mavenVariantAttributesFactory));
             }
             return componentMetadataHandler;
         }
@@ -572,11 +569,18 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Provides
-        ComponentMetadataProcessorFactory createComponentMetadataProcessorFactory(ComponentMetadataHandlerInternal componentMetadataHandler, DependencyResolutionManagementInternal dependencyResolutionManagement, DomainObjectContext context) {
-            if (context.isScript()) {
-                return componentMetadataHandler::createComponentMetadataProcessor;
-            }
-            return componentMetadataHandler.createFactory(dependencyResolutionManagement);
+        ComponentMetadataRulesSupplier createComponentMetadataRulesSupplier(
+            ComponentMetadataHandlerInternal componentMetadataHandler,
+            DependencyResolutionManagementInternal drm,
+            DomainObjectContext context
+        ) {
+            return () -> {
+                ImmutableComponentMetadataRules rules = componentMetadataHandler.getConfiguredRules();
+                if (context.isScript() || (!rules.getRules().isEmpty() && drm.getConfiguredRulesMode().useProjectRules())) {
+                    return rules;
+                }
+                return ((ComponentMetadataHandlerInternal) drm.getComponents()).getConfiguredRules();
+            };
         }
 
         @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.capability.CapabilitySelectorSerializer;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParser;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyConstraintFactoryInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
@@ -93,6 +94,7 @@ import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.management.DefaultDependencyResolutionManagement;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -134,6 +136,7 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         registration.add(ResolverProviderFactories.class);
         registration.add(DependencyManagementManagedTypesFactory.class);
         registration.add(RuntimeShadedJarFactory.class);
+        registration.add(DefaultComponentMetadataProcessor.Factory.class);
     }
 
     @Provides
@@ -142,13 +145,17 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         UserCodeApplicationContext context,
         DependencyManagementServices dependencyManagementServices,
         ObjectFactory objects,
-        CollectionCallbackActionDecorator collectionCallbackActionDecorator
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        IsolatableFactory isolatableFactory
     ) {
         return instantiator.newInstance(DefaultDependencyResolutionManagement.class,
             context,
             dependencyManagementServices,
             objects,
-            collectionCallbackActionDecorator
+            collectionCallbackActionDecorator,
+            moduleIdentifierFactory,
+            isolatableFactory
         );
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
@@ -16,86 +16,69 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
-import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.rules.SpecRuleAction;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Container for registered ComponentMetadataRules, either class based or closure / action based.
+ * Mutable builder for class-based and action-based registered ComponentMetadataRules. Rules are
+ * kept in registration order so that they are applied in that order, with adjacent class rules
+ * merged into a single wrapper.
  */
-class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
+public class ComponentMetadataRuleContainer {
+
     private final List<MetadataRuleWrapper> rules = new ArrayList<>(10);
-    private MetadataRuleWrapper lastAdded;
-    private boolean classBasedRulesOnly = true;
-    private VariantDerivationStrategy variantDerivationStrategy = NoOpDerivationStrategy.getInstance();
-    private int rulesHash = 0;
-    private Consumer<DisplayName> onAdd;
+    private @Nullable Consumer<DisplayName> onAdd;
 
     void addRule(SpecRuleAction<? super ComponentMetadataDetails> ruleAction) {
-        lastAdded = new ActionBasedMetadataRuleWrapper(ruleAction);
-        addRule();
-        classBasedRulesOnly = false;
-        rulesHash = 31 * rulesHash + ruleAction.hashCode();
-    }
-
-    private void addRule() {
-        if (onAdd != null) {
-            onAdd.accept(lastAdded.getDisplayName());
-        }
-        rules.add(lastAdded);
+        addWrapper(new ActionBasedMetadataRuleWrapper(ruleAction));
     }
 
     void addClassRule(SpecConfigurableRule ruleAction) {
-        if (lastAdded != null && lastAdded.isClassBased()) {
-            lastAdded.addClassRule(ruleAction);
+        if (rules.isEmpty()) {
+            addWrapper(new ClassBasedMetadataRuleWrapper(ruleAction));
         } else {
-            lastAdded = new ClassBasedMetadataRuleWrapper(ruleAction);
-            addRule();
+            MetadataRuleWrapper last = rules.get(rules.size() - 1);
+            if (last.isClassBased()) {
+                // Merge consecutive class rules into a single wrapper so they can be batched into one cacheable action.
+                last.addClassRule(ruleAction);
+            } else {
+                addWrapper(new ClassBasedMetadataRuleWrapper(ruleAction));
+            }
         }
-        rulesHash = 31 * rulesHash + ruleAction.getConfigurableRule().hashCode();
     }
 
-    boolean isClassBasedRulesOnly() {
-        return classBasedRulesOnly;
-    }
-
-    boolean isEmpty() {
-        return rules.isEmpty();
-    }
-
-    @Override
-    public Iterator<MetadataRuleWrapper> iterator() {
-        return rules.iterator();
-    }
-
-    Collection<SpecConfigurableRule> getOnlyClassRules() {
-        if (!isClassBasedRulesOnly() || isEmpty()) {
-            throw new IllegalStateException("This method cannot be used unless there is at least one rule and they are all class based");
+    private void addWrapper(MetadataRuleWrapper wrapper) {
+        if (onAdd != null) {
+            onAdd.accept(wrapper.getDisplayName());
         }
-        return rules.get(0).getClassRules();
-    }
-
-    public VariantDerivationStrategy getVariantDerivationStrategy() {
-        return variantDerivationStrategy;
-    }
-
-    public void setVariantDerivationStrategy(VariantDerivationStrategy variantDerivationStrategy) {
-        this.variantDerivationStrategy = variantDerivationStrategy;
-    }
-
-    public int getRulesHash() {
-        return 31 * variantDerivationStrategy.hashCode() + rulesHash;
+        rules.add(wrapper);
     }
 
     void onAddRule(Consumer<DisplayName> consumer) {
         this.onAdd = consumer;
     }
+
+    public ImmutableComponentMetadataRules asImmutable() {
+        if (rules.isEmpty()) {
+            return ImmutableComponentMetadataRules.EMPTY;
+        }
+
+        ImmutableList.Builder<ImmutableComponentMetadataRules.ImmutableRule> immutableRules = ImmutableList.builderWithExpectedSize(rules.size());
+        for (MetadataRuleWrapper wrapper : rules) {
+            if (wrapper.isClassBased()) {
+                immutableRules.add(new ImmutableComponentMetadataRules.ImmutableRule.ClassBased(ImmutableList.copyOf(wrapper.getClassRules())));
+            } else {
+                immutableRules.add(new ImmutableComponentMetadataRules.ImmutableRule.ActionBased(wrapper.getRule()));
+            }
+        }
+        return new ImmutableComponentMetadataRules(immutableRules.build());
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRulesSupplier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRulesSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.internal.artifacts.dsl;
 
-import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
-import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import java.util.function.Consumer;
-
+/**
+ * Supplies the component metadata rules to be used when resolving a configuration.
+ */
 @ServiceScope(Scope.Project.class)
-public interface ComponentMetadataHandlerInternal extends ComponentMetadataHandler {
+public interface ComponentMetadataRulesSupplier {
 
-    void setVariantDerivationStrategy(VariantDerivationStrategy strategy);
-
-    VariantDerivationStrategy getVariantDerivationStrategy();
-
-    void onAddRule(Consumer<DisplayName> consumer);
-
-    ImmutableComponentMetadataRules getConfiguredRules();
+    ImmutableComponentMetadataRules getRules();
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dsl;
 
-import com.google.common.collect.Interner;
+import com.google.common.annotations.VisibleForTesting;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
@@ -25,33 +25,20 @@ import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.artifacts.maven.PomModuleDescriptor;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.MetadataResolutionContext;
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
-import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
-import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
-import org.gradle.api.internal.attributes.AttributesFactory;
-import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
-import org.gradle.api.internal.notations.DependencyMetadataNotationParser;
-import org.gradle.api.problems.Problems;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
 import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.management.DependencyResolutionManagementInternal;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.rules.DefaultRuleActionAdapter;
 import org.gradle.internal.rules.DefaultRuleActionValidator;
 import org.gradle.internal.rules.RuleAction;
@@ -62,75 +49,42 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
+import javax.inject.Inject;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public class DefaultComponentMetadataHandler implements ComponentMetadataHandler, ComponentMetadataHandlerInternal {
     private static final String ADAPTER_NAME = ComponentMetadataHandler.class.getSimpleName();
     private static final String INVALID_SPEC_ERROR = "Could not add a component metadata rule for module '%s'.";
 
-    private final Instantiator instantiator;
-    private final ComponentMetadataRuleContainer metadataRuleContainer;
     private final RuleActionAdapter ruleActionAdapter;
     private final NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser;
-    private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
-    private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
-    private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
-    private final AttributesFactory attributesFactory;
     private final IsolatableFactory isolatableFactory;
-    private final ComponentMetadataRuleExecutor ruleExecutor;
-    private final PlatformSupport platformSupport;
 
-    DefaultComponentMetadataHandler(Instantiator instantiator,
-                                    RuleActionAdapter ruleActionAdapter,
-                                    ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                    Interner<String> stringInterner,
-                                    AttributesFactory attributesFactory,
-                                    IsolatableFactory isolatableFactory,
-                                    ComponentMetadataRuleExecutor ruleExecutor,
-                                    PlatformSupport platformSupport,
-                                    Problems problems) {
-        this.instantiator = instantiator;
+    private final ComponentMetadataRuleContainer metadataRuleContainer;
+    private VariantDerivationStrategy variantDerivationStrategy = NoOpDerivationStrategy.getInstance();
+
+    @Inject
+    public DefaultComponentMetadataHandler(
+        IsolatableFactory isolatableFactory,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory
+    ) {
+        this(createAdapter(), isolatableFactory, moduleIdentifierFactory);
+    }
+
+    @VisibleForTesting
+    DefaultComponentMetadataHandler(
+        RuleActionAdapter ruleActionAdapter,
+        IsolatableFactory isolatableFactory,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory
+    ) {
         this.ruleActionAdapter = ruleActionAdapter;
+        this.isolatableFactory = isolatableFactory;
+
         this.moduleIdentifierNotationParser = NotationParserBuilder
             .toType(ModuleIdentifier.class)
             .fromCharSequence(new ModuleIdentifierNotationConverter(moduleIdentifierFactory))
             .toComposite();
-        this.ruleExecutor = ruleExecutor;
-        this.dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, stringInterner, problems);
-        this.dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, stringInterner, problems);
-        this.componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create();
-        this.attributesFactory = attributesFactory;
-        this.isolatableFactory = isolatableFactory;
         this.metadataRuleContainer = new ComponentMetadataRuleContainer();
-        this.platformSupport = platformSupport;
-    }
-
-    public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner, AttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor ruleExecutor, PlatformSupport platformSupport, Problems problems) {
-        this(instantiator, createAdapter(), moduleIdentifierFactory, stringInterner, attributesFactory, isolatableFactory, ruleExecutor, platformSupport, problems);
-    }
-
-    private DefaultComponentMetadataHandler(Instantiator instantiator,
-                                            RuleActionAdapter ruleActionAdapter,
-                                            NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser,
-                                            NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
-                                            NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
-                                            NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser,
-                                            AttributesFactory attributesFactory,
-                                            IsolatableFactory isolatableFactory,
-                                            ComponentMetadataRuleExecutor ruleExecutor,
-                                            PlatformSupport platformSupport) {
-        this.instantiator = instantiator;
-        this.ruleActionAdapter = ruleActionAdapter;
-        this.moduleIdentifierNotationParser = moduleIdentifierNotationParser;
-        this.ruleExecutor = ruleExecutor;
-        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
-        this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
-        this.componentIdentifierNotationParser = componentIdentifierNotationParser;
-        this.attributesFactory = attributesFactory;
-        this.isolatableFactory = isolatableFactory;
-        this.metadataRuleContainer = new ComponentMetadataRuleContainer();
-        this.platformSupport = platformSupport;
     }
 
     private static RuleActionAdapter createAdapter() {
@@ -243,46 +197,23 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     }
 
     @Override
-    public ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext) {
-        return new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, ruleExecutor, platformSupport, resolutionContext);
+    public ImmutableComponentMetadataRules getConfiguredRules() {
+        return metadataRuleContainer.asImmutable();
     }
 
     @Override
     public void setVariantDerivationStrategy(VariantDerivationStrategy strategy) {
-        metadataRuleContainer.setVariantDerivationStrategy(strategy);
+        this.variantDerivationStrategy = strategy;
     }
 
     @Override
     public VariantDerivationStrategy getVariantDerivationStrategy() {
-        return metadataRuleContainer.getVariantDerivationStrategy();
+        return variantDerivationStrategy;
     }
 
     @Override
     public void onAddRule(Consumer<DisplayName> consumer) {
         metadataRuleContainer.onAddRule(consumer);
-    }
-
-    @Override
-    public ComponentMetadataProcessorFactory createFactory(DependencyResolutionManagementInternal dependencyResolutionManagement) {
-        // we need to defer the creation of the actual factory until configuration is completed
-        // Typically the state of whether to prefer project rules or not is not known when this
-        // method is called.
-        Supplier<ComponentMetadataHandlerInternal> actualHandler = () -> {
-            // determine whether to use the project local handler or the settings handler
-            boolean useRules = dependencyResolutionManagement.getConfiguredRulesMode().useProjectRules();
-            if (metadataRuleContainer.isEmpty() || !useRules) {
-                // We're creating a component metadata handler which will be applied the settings
-                // rules and the current derivation strategy
-                DefaultComponentMetadataHandler delegate = new DefaultComponentMetadataHandler(
-                    instantiator, ruleActionAdapter, moduleIdentifierNotationParser, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, isolatableFactory, ruleExecutor, platformSupport
-                );
-                dependencyResolutionManagement.applyRules(delegate);
-                delegate.setVariantDerivationStrategy(getVariantDerivationStrategy());
-                return delegate;
-            }
-            return this;
-        };
-        return resolutionContext -> actualHandler.get().createComponentMetadataProcessor(resolutionContext);
     }
 
     static class ComponentMetadataDetailsMatchingSpec implements Spec<ComponentMetadataDetails> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Transformer;
@@ -28,6 +29,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.MetadataResolutionContext;
+import org.gradle.api.internal.artifacts.dsl.ImmutableComponentMetadataRules.ImmutableRule;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.UserProvidedMetadata;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
@@ -35,7 +37,10 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstra
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesFactory;
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.problems.Problems;
 import org.gradle.internal.Actions;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRules;
@@ -55,8 +60,12 @@ import org.gradle.internal.rules.SpecRuleAction;
 import org.gradle.internal.serialize.InputStreamBackedDecoder;
 import org.gradle.internal.serialize.OutputStreamBackedEncoder;
 import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.util.internal.SimpleMapInterner;
 
+import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -73,7 +82,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         return realizeMetadata(metadata);
     };
 
-    private ModuleComponentResolveMetadata maybeForceRealisation(ModuleComponentResolveMetadata metadata) {
+    private ModuleComponentResolveMetadata maybeForceRealization(ModuleComponentResolveMetadata metadata) {
         if (FORCE_REALIZE) {
             metadata = realizeMetadata(metadata);
             metadata = forceSerialization(metadata);
@@ -105,26 +114,34 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         return metadata;
     }
 
+    private final MetadataResolutionContext metadataResolutionContext;
+    private final ImmutableComponentMetadataRules metadataRuleContainer;
+    private final VariantDerivationStrategy variantDerivationStrategy;
+
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
     private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
     private final AttributesFactory attributesFactory;
     private final ComponentMetadataRuleExecutor ruleExecutor;
-    private final MetadataResolutionContext metadataResolutionContext;
-    private final ComponentMetadataRuleContainer metadataRuleContainer;
     private final PlatformSupport platformSupport;
 
-    public DefaultComponentMetadataProcessor(ComponentMetadataRuleContainer metadataRuleContainer,
-                                             Instantiator instantiator,
-                                             NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
-                                             NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
-                                             NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser,
-                                             AttributesFactory attributesFactory,
-                                             ComponentMetadataRuleExecutor ruleExecutor,
-                                             PlatformSupport platformSupport,
-                                             MetadataResolutionContext resolutionContext) {
+    public DefaultComponentMetadataProcessor(
+        MetadataResolutionContext resolutionContext,
+        ImmutableComponentMetadataRules metadataRuleContainer,
+        VariantDerivationStrategy variantDerivationStrategy,
+        Instantiator instantiator,
+        NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
+        NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
+        NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser,
+        AttributesFactory attributesFactory,
+        ComponentMetadataRuleExecutor ruleExecutor,
+        PlatformSupport platformSupport
+    ) {
+        this.metadataResolutionContext = resolutionContext;
         this.metadataRuleContainer = metadataRuleContainer;
+        this.variantDerivationStrategy = variantDerivationStrategy;
+
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
@@ -132,44 +149,52 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         this.attributesFactory = attributesFactory;
         this.ruleExecutor = ruleExecutor;
         this.platformSupport = platformSupport;
-        this.metadataResolutionContext = resolutionContext;
     }
 
     @Override
     public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata origin) {
-        VariantDerivationStrategy curStrategy = metadataRuleContainer.getVariantDerivationStrategy();
-        ModuleComponentResolveMetadata metadata = origin.withDerivationStrategy(curStrategy);
-        ModuleComponentResolveMetadata updatedMetadata;
-        if (metadataRuleContainer.isEmpty()) {
-            updatedMetadata = maybeForceRealisation(metadata);
-        } else if (metadataRuleContainer.isClassBasedRulesOnly()) {
-            Action<ComponentMetadataContext> action = collectRulesAndCreateAction(metadataRuleContainer.getOnlyClassRules(), metadata.getModuleVersionId(), metadataResolutionContext.getInjectingInstantiator());
-            if (action instanceof InstantiatingAction) {
-                InstantiatingAction<ComponentMetadataContext> ia = (InstantiatingAction<ComponentMetadataContext>) action;
-                if (shouldCacheComponentMetadataRule(ia, metadata)) {
-                    updatedMetadata = processClassRuleWithCaching(ia, metadata, metadataResolutionContext);
-                } else {
-                    MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
-                    processClassRule(action, metadata, createDetails(mutableMetadata));
-                    updatedMetadata = maybeForceRealisation(mutableMetadata.asImmutable());
-                }
-            } else {
-                updatedMetadata = maybeForceRealisation(metadata);
-            }
-        } else {
-            MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
-            ComponentMetadataDetails details = createDetails(mutableMetadata);
-            processAllRules(metadata, details, metadata.getModuleVersionId());
-            updatedMetadata = maybeForceRealisation(mutableMetadata.asImmutable());
-        }
-
+        ModuleComponentResolveMetadata metadata = origin.withDerivationStrategy(variantDerivationStrategy);
+        ModuleComponentResolveMetadata updatedMetadata = getUpdatedMetadata(metadata);
         if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
             throw new ModuleVersionResolveException(updatedMetadata.getModuleVersionId(), () -> String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().getDisplayName(), updatedMetadata.getStatusScheme()));
         }
         return updatedMetadata;
     }
 
-    private boolean shouldCacheComponentMetadataRule(InstantiatingAction<ComponentMetadataContext> action, ModuleComponentResolveMetadata metadata) {
+    private ModuleComponentResolveMetadata getUpdatedMetadata(ModuleComponentResolveMetadata metadata) {
+        ImmutableList<ImmutableRule> rules = metadataRuleContainer.getRules();
+
+        if (rules.isEmpty()) {
+            return maybeForceRealization(metadata);
+        }
+
+        if (rules.size() == 1 && rules.get(0) instanceof ImmutableRule.ClassBased classBased) {
+            Action<ComponentMetadataContext> action = collectRulesAndCreateAction(
+                classBased.classRules(),
+                metadata.getModuleVersionId(),
+                metadataResolutionContext.getInjectingInstantiator()
+            );
+
+            if (action instanceof InstantiatingAction<ComponentMetadataContext> ia) {
+                if (shouldCacheComponentMetadataRule(ia, metadata)) {
+                    return processClassRuleWithCaching(ia, metadata, metadataResolutionContext);
+                } else {
+                    MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
+                    processClassRule(action, metadata, createDetails(mutableMetadata));
+                    return maybeForceRealization(mutableMetadata.asImmutable());
+                }
+            } else {
+                return maybeForceRealization(metadata);
+            }
+        }
+
+        MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
+        ComponentMetadataDetails details = createDetails(mutableMetadata);
+        processAllRules(metadata, details, metadata.getModuleVersionId(), rules);
+        return maybeForceRealization(mutableMetadata.asImmutable());
+    }
+
+    private static boolean shouldCacheComponentMetadataRule(InstantiatingAction<ComponentMetadataContext> action, ModuleComponentResolveMetadata metadata) {
         return action.getRules().isCacheable() && metadata.isComponentMetadataRuleCachingEnabled();
     }
 
@@ -180,32 +205,37 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
     @Override
     public ComponentMetadata processMetadata(ComponentMetadata metadata) {
         ComponentMetadata updatedMetadata;
-        if (metadataRuleContainer.isEmpty()) {
-            updatedMetadata = metadata;
-        } else {
-            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(metadata, attributesFactory);
-            processAllRules(null, details, metadata.getId());
-            updatedMetadata = details.asImmutable();
-        }
+        updatedMetadata = getUpdatedMetadata(metadata);
         if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
             throw new ModuleVersionResolveException(updatedMetadata.getId(), () -> String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().toString(), updatedMetadata.getStatusScheme()));
         }
         return updatedMetadata;
     }
 
-    @Override
-    public int getRulesHash() {
-        return metadataRuleContainer.getRulesHash();
+    private ComponentMetadata getUpdatedMetadata(ComponentMetadata metadata) {
+        ImmutableList<ImmutableRule> rules = metadataRuleContainer.getRules();
+
+        if (rules.isEmpty()) {
+            return metadata;
+        } else {
+            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(metadata, attributesFactory);
+            processAllRules(null, details, metadata.getId(), rules);
+            return details.asImmutable();
+        }
     }
 
-    private void processAllRules(ModuleComponentResolveMetadata metadata, ComponentMetadataDetails details, ModuleVersionIdentifier id) {
-        for (MetadataRuleWrapper wrapper : metadataRuleContainer) {
-            if (wrapper.isClassBased()) {
-                Collection<SpecConfigurableRule> rules = wrapper.getClassRules();
-                Action<ComponentMetadataContext> action = collectRulesAndCreateAction(rules, id, metadataResolutionContext.getInjectingInstantiator());
+    @Override
+    public int getRulesHash() {
+        return 31 * variantDerivationStrategy.hashCode() + metadataRuleContainer.getRulesHash();
+    }
+
+    private void processAllRules(ModuleComponentResolveMetadata metadata, ComponentMetadataDetails details, ModuleVersionIdentifier id, ImmutableList<ImmutableRule> rules) {
+        for (ImmutableRule rule : rules) {
+            if (rule instanceof ImmutableRule.ClassBased classBased) {
+                Action<ComponentMetadataContext> action = collectRulesAndCreateAction(classBased.classRules(), id, metadataResolutionContext.getInjectingInstantiator());
                 processClassRule(action, metadata, details);
-            } else {
-                processRule(wrapper.getRule(), metadata, details);
+            } else if (rule instanceof ImmutableRule.ActionBased actionBased) {
+                processRule(actionBased.rule(), metadata, details);
             }
         }
     }
@@ -397,4 +427,57 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
             return new UserProvidedMetadata(id, statusScheme, attributes.asImmutable());
         }
     }
+
+    @ServiceScope(Scope.Build.class)
+    public static class Factory {
+
+        private final Instantiator instantiator;
+        private final AttributesFactory attributesFactory;
+        private final ComponentMetadataRuleExecutor ruleExecutor;
+        private final PlatformSupport platformSupport;
+
+        private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
+        private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+        private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
+
+        @Inject
+        public Factory(
+            Instantiator instantiator,
+            AttributesFactory attributesFactory,
+            ComponentMetadataRuleExecutor ruleExecutor,
+            PlatformSupport platformSupport,
+            SimpleMapInterner stringInterner,
+            Problems problems
+        ) {
+            this.instantiator = instantiator;
+            this.attributesFactory = attributesFactory;
+            this.ruleExecutor = ruleExecutor;
+            this.platformSupport = platformSupport;
+
+            this.dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, stringInterner, problems);
+            this.dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, stringInterner, problems);
+            this.componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create();
+        }
+
+        public DefaultComponentMetadataProcessor create(
+            MetadataResolutionContext resolutionContext,
+            ImmutableComponentMetadataRules rules,
+            VariantDerivationStrategy variantDerivationStrategy
+        ) {
+            return new DefaultComponentMetadataProcessor(
+                resolutionContext,
+                rules,
+                variantDerivationStrategy,
+                instantiator,
+                dependencyMetadataNotationParser,
+                dependencyConstraintMetadataNotationParser,
+                componentIdentifierNotationParser,
+                attributesFactory,
+                ruleExecutor,
+                platformSupport
+            );
+        }
+
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ImmutableComponentMetadataRules.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ImmutableComponentMetadataRules.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.internal.rules.SpecRuleAction;
+
+public class ImmutableComponentMetadataRules {
+
+    public static final ImmutableComponentMetadataRules EMPTY = new ImmutableComponentMetadataRules(ImmutableList.of());
+
+    private final ImmutableList<ImmutableRule> rules;
+    private final int rulesHash;
+
+    ImmutableComponentMetadataRules(ImmutableList<ImmutableRule> rules) {
+        this.rules = rules;
+        this.rulesHash = computeRulesHash(rules);
+    }
+
+    public ImmutableList<ImmutableRule> getRules() {
+        return rules;
+    }
+
+    public int getRulesHash() {
+        return rulesHash;
+    }
+
+    private static int computeRulesHash(ImmutableList<ImmutableRule> rules) {
+        int hash = 0;
+        for (ImmutableRule rule : rules) {
+            if (rule instanceof ImmutableRule.ClassBased classBased) {
+                for (SpecConfigurableRule classRule : classBased.classRules()) {
+                    hash = 31 * hash + classRule.getConfigurableRule().hashCode();
+                }
+            } else if (rule instanceof ImmutableRule.ActionBased actionBased) {
+                hash = 31 * hash + actionBased.rule().hashCode();
+            }
+        }
+        return hash;
+    }
+
+    public sealed interface ImmutableRule {
+        record ClassBased(ImmutableList<SpecConfigurableRule> classRules) implements ImmutableRule {}
+        record ActionBased(SpecRuleAction<? super ComponentMetadataDetails> rule) implements ImmutableRule {}
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.action.ConfigurableRule;
 
-class SpecConfigurableRule {
+public class SpecConfigurableRule {
 
     private final ConfigurableRule<ComponentMetadataContext> configurableRule;
     private final Spec<ModuleVersionIdentifier> spec;
@@ -39,4 +39,5 @@ class SpecConfigurableRule {
     public Spec<ModuleVersionIdentifier> getSpec() {
         return spec;
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.ImmutableList;
@@ -36,6 +35,8 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataRulesSupplier;
 import org.gradle.api.internal.artifacts.dsl.ImmutableModuleReplacements;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.AdhocRootComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.ProjectRootComponentProvider;
@@ -64,6 +65,7 @@ import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -83,9 +85,12 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final AttributeSchemaServices attributeSchemaServices;
     private final LocalVariantGraphResolveStateBuilder variantStateBuilder;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+    private final ComponentMetadataHandlerInternal componentMetadataHandler;
+    private final ComponentMetadataRulesSupplier componentMetadataRulesSupplier;
     private final boolean useEnhancedOrdering;
     private final RootComponentProvider rootComponentProvider;
 
+    @Inject
     public DefaultConfigurationResolver(
         RepositoriesSupplier repositoriesSupplier,
         ShortCircuitingResolutionExecutor resolutionExecutor,
@@ -94,6 +99,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         AttributeSchemaServices attributeSchemaServices,
         LocalVariantGraphResolveStateBuilder variantStateBuilder,
         CalculatedValueContainerFactory calculatedValueContainerFactory,
+        ComponentMetadataHandlerInternal componentMetadataHandler,
+        ComponentMetadataRulesSupplier componentMetadataRulesSupplier,
         FeatureFlags featureFlags,
         RootComponentProvider rootComponentProvider
     ) {
@@ -104,6 +111,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.attributeSchemaServices = attributeSchemaServices;
         this.variantStateBuilder = variantStateBuilder;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
+        this.componentMetadataHandler = componentMetadataHandler;
+        this.componentMetadataRulesSupplier = componentMetadataRulesSupplier;
         this.useEnhancedOrdering = featureFlags.isEnabled(FeaturePreviews.Feature.ENHANCED_GRAPH_ORDERING);
         this.rootComponentProvider = rootComponentProvider;
     }
@@ -178,7 +187,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             resolutionStrategy.isFailingOnDynamicVersions(),
             resolutionStrategy.isFailingOnChangingVersions(),
             failureResolutions,
-            resolutionStrategy.getCachePolicy().asImmutable()
+            resolutionStrategy.getCachePolicy().asImmutable(),
+            componentMetadataRulesSupplier.getRules(),
+            componentMetadataHandler.getVariantDerivationStrategy()
         );
     }
 
@@ -323,6 +334,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
         private final ImmutableAttributesSchemaFactory attributesSchemaFactory;
         private final LocalComponentGraphResolveStateFactory localResolveStateFactory;
+        private final ComponentMetadataHandlerInternal componentMetadataHandler;
+        private final ComponentMetadataRulesSupplier componentMetadataRulesSupplier;
         private final FeatureFlags featureFlags;
 
         public Factory(
@@ -337,6 +350,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
             ImmutableAttributesSchemaFactory attributesSchemaFactory,
             LocalComponentGraphResolveStateFactory localResolveStateFactory,
+            ComponentMetadataHandlerInternal componentMetadataHandler,
+            ComponentMetadataRulesSupplier componentMetadataRulesSupplier,
             FeatureFlags featureFlags
         ) {
             this.moduleIdentity = moduleIdentity;
@@ -350,6 +365,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             this.moduleIdentifierFactory = moduleIdentifierFactory;
             this.attributesSchemaFactory = attributesSchemaFactory;
             this.localResolveStateFactory = localResolveStateFactory;
+            this.componentMetadataHandler = componentMetadataHandler;
+            this.componentMetadataRulesSupplier = componentMetadataRulesSupplier;
             this.featureFlags = featureFlags;
         }
 
@@ -369,6 +386,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                 attributeSchemaServices,
                 variantStateBuilder,
                 calculatedValueContainerFactory,
+                componentMetadataHandler,
+                componentMetadataRulesSupplier,
                 featureFlags,
                 rootComponentProvider
             );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.DomainObjectContext;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.DefaultResolverResults;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -142,7 +141,6 @@ public class ResolutionExecutor {
     private final ResolutionFailureHandler resolutionFailureHandler;
     private final VariantArtifactSetCache variantArtifactSetCache;
     private final VariantTransformRegistry transformRegistry;
-    private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
     private final AttributeDesugaring attributeDesugaring;
     private final NamedObjectInstantiator namedObjectInstantiator;
 
@@ -175,7 +173,6 @@ public class ResolutionExecutor {
         ResolutionFailureHandler resolutionFailureHandler,
         VariantArtifactSetCache variantArtifactSetCache,
         VariantTransformRegistry transformRegistry,
-        ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
         AttributeDesugaring attributeDesugaring,
         NamedObjectInstantiator namedObjectInstantiator
     ) {
@@ -206,7 +203,6 @@ public class ResolutionExecutor {
         this.resolutionFailureHandler = resolutionFailureHandler;
         this.variantArtifactSetCache = variantArtifactSetCache;
         this.transformRegistry = transformRegistry;
-        this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
         this.attributeDesugaring = attributeDesugaring;
         this.namedObjectInstantiator = namedObjectInstantiator;
     }
@@ -456,7 +452,8 @@ public class ResolutionExecutor {
         // state to `createResolvers` that is specific to this resolution.
         resolvers.add(externalResolverFactory.createResolvers(
             repositories,
-            componentMetadataProcessorFactory,
+            params.getComponentMetadataRules(),
+            params.getVariantDerivationStrategy(),
             legacyParams.getComponentSelectionRules(),
             params.isDependencyVerificationEnabled(),
             params.getCacheExpirationControl(),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionParameters.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionParameters.java
@@ -21,9 +21,11 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.LegacyResolutionParameters;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
+import org.gradle.api.internal.artifacts.dsl.ImmutableComponentMetadataRules;
 import org.gradle.api.internal.artifacts.dsl.ImmutableModuleReplacements;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.Conflict;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
@@ -63,6 +65,8 @@ public class ResolutionParameters {
     private final boolean failingOnChangingVersions;
     private final FailureResolutions failureResolutions;
     private final CacheExpirationControl cacheExpirationControl;
+    private final ImmutableComponentMetadataRules componentMetadataRules;
+    private final VariantDerivationStrategy variantDerivationStrategy;
 
     public ResolutionParameters(
         ResolutionHost resolutionHost,
@@ -81,7 +85,9 @@ public class ResolutionParameters {
         boolean failingOnDynamicVersions,
         boolean failingOnChangingVersions,
         FailureResolutions failureResolutions,
-        CacheExpirationControl cacheExpirationControl
+        CacheExpirationControl cacheExpirationControl,
+        ImmutableComponentMetadataRules componentMetadataRules,
+        VariantDerivationStrategy variantDerivationStrategy
     ) {
         this.resolutionHost = resolutionHost;
         this.rootComponent = rootComponent;
@@ -100,6 +106,8 @@ public class ResolutionParameters {
         this.failingOnChangingVersions = failingOnChangingVersions;
         this.failureResolutions = failureResolutions;
         this.cacheExpirationControl = cacheExpirationControl;
+        this.componentMetadataRules = componentMetadataRules;
+        this.variantDerivationStrategy = variantDerivationStrategy;
     }
 
     /**
@@ -267,6 +275,20 @@ public class ResolutionParameters {
      */
     public boolean isFailingOnChangingVersions() {
         return failingOnChangingVersions;
+    }
+
+    /**
+     * The component metadata rules that may modify the metadata of software components resolved from external repositories.
+     */
+    public ImmutableComponentMetadataRules getComponentMetadataRules() {
+        return componentMetadataRules;
+    }
+
+    /**
+     * Get the strategy used to synthesize variants for components which do not natively expose variants.
+     */
+    public VariantDerivationStrategy getVariantDerivationStrategy() {
+        return variantDerivationStrategy;
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ExternalModuleComponentResolverFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ExternalModuleComponentResolverFactory.java
@@ -24,6 +24,8 @@ import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.MetadataResolutionContext;
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.dsl.ImmutableComponentMetadataRules;
 import org.gradle.api.internal.artifacts.ivyservice.CacheExpirationControl;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -46,6 +48,7 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.component.external.model.ExternalModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveStateFactory;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -87,6 +90,7 @@ public class ExternalModuleComponentResolverFactory {
     private final AttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
+    private final DefaultComponentMetadataProcessor.Factory componentMetadataProcessorFactory;
 
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final ChangingValueDependencyResolutionListener listener;
@@ -106,7 +110,8 @@ public class ExternalModuleComponentResolverFactory {
         CalculatedValueFactory calculatedValueFactory,
         AttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
-        ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor
+        ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
+        DefaultComponentMetadataProcessor.Factory componentMetadataProcessorFactory
     ) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
@@ -122,6 +127,7 @@ public class ExternalModuleComponentResolverFactory {
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
         this.componentMetadataSupplierRuleExecutor = componentMetadataSupplierRuleExecutor;
+        this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
     }
 
     /**
@@ -129,7 +135,8 @@ public class ExternalModuleComponentResolverFactory {
      */
     public ComponentResolvers createResolvers(
         Collection<? extends ResolutionAwareRepository> repositories,
-        ComponentMetadataProcessorFactory metadataProcessor,
+        ImmutableComponentMetadataRules rules,
+        VariantDerivationStrategy variantDerivationStrategy,
         ComponentSelectionRulesInternal componentSelectionRules,
         boolean dependencyVerificationEnabled,
         CacheExpirationControl cacheExpirationControl,
@@ -138,6 +145,9 @@ public class ExternalModuleComponentResolverFactory {
         if (repositories.isEmpty()) {
             return new NoRepositoriesResolver();
         }
+
+        ComponentMetadataProcessorFactory metadataProcessor = context ->
+            componentMetadataProcessorFactory.create(context, rules, variantDerivationStrategy);
 
         UserResolverChain moduleResolver = new UserResolverChain(versionComparator, componentSelectionRules, versionParser, consumerSchema, attributesFactory, attributeSchemaServices, metadataProcessor, componentMetadataSupplierRuleExecutor, calculatedValueFactory, cacheExpirationControl);
         ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionComparator, moduleIdentifierFactory, versionParser, consumerSchema, attributesFactory, attributeSchemaServices, metadataProcessor, componentMetadataSupplierRuleExecutor, calculatedValueFactory, cacheExpirationControl);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -24,11 +24,12 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ComponentResult;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.component.Component;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.RepositoriesSupplier;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataRulesSupplier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ErrorHandlingArtifactResolver;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ExternalModuleComponentResolverFactory;
@@ -69,10 +70,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
+
     private final ResolutionStrategyFactory resolutionStrategyFactory;
     private final RepositoriesSupplier repositoriesSupplier;
     private final ExternalModuleComponentResolverFactory externalResolverFactory;
-    private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
+    private final ComponentMetadataRulesSupplier componentMetadataRulesSupplier;
+    private final ComponentMetadataHandlerInternal componentMetadataHandler;
     private final ComponentTypeRegistry componentTypeRegistry;
 
     private final Set<ComponentIdentifier> componentIds = new LinkedHashSet<>();
@@ -83,13 +86,15 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
         ResolutionStrategyFactory resolutionStrategyFactory,
         RepositoriesSupplier repositoriesSupplier,
         ExternalModuleComponentResolverFactory externalResolverFactory,
-        ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
+        ComponentMetadataRulesSupplier componentMetadataRulesSupplier,
+        ComponentMetadataHandlerInternal componentMetadataHandler,
         ComponentTypeRegistry componentTypeRegistry
     ) {
         this.resolutionStrategyFactory = resolutionStrategyFactory;
         this.repositoriesSupplier = repositoriesSupplier;
         this.externalResolverFactory = externalResolverFactory;
-        this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
+        this.componentMetadataRulesSupplier = componentMetadataRulesSupplier;
+        this.componentMetadataHandler = componentMetadataHandler;
         this.componentTypeRegistry = componentTypeRegistry;
     }
 
@@ -152,7 +157,8 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
 
         ComponentResolvers componentResolvers = externalResolverFactory.createResolvers(
             filteredRepositories,
-            componentMetadataProcessorFactory,
+            componentMetadataRulesSupplier.getRules(),
+            componentMetadataHandler.getVariantDerivationStrategy(),
             resolutionStrategy.getComponentSelection(),
             resolutionStrategy.isDependencyVerificationEnabled(),
             resolutionStrategy.getCachePolicy().asImmutable(),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryFactory.java
@@ -16,19 +16,22 @@
 package org.gradle.api.internal.artifacts.query;
 
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.RepositoriesSupplier;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataRulesSupplier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ExternalModuleComponentResolverFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 
 import javax.inject.Inject;
 
 public class DefaultArtifactResolutionQueryFactory implements ArtifactResolutionQueryFactory {
+
     private final ResolutionStrategyFactory resolutionStrategyFactory;
     private final RepositoriesSupplier repositoriesSupplier;
     private final ExternalModuleComponentResolverFactory ivyFactory;
-    private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
+    private final ComponentMetadataRulesSupplier componentMetadataRulesSupplier;
+    private final ComponentMetadataHandlerInternal componentMetadataHandler;
     private final ComponentTypeRegistry componentTypeRegistry;
 
     @Inject
@@ -36,18 +39,28 @@ public class DefaultArtifactResolutionQueryFactory implements ArtifactResolution
         ResolutionStrategyFactory resolutionStrategyFactory,
         RepositoriesSupplier repositoriesSupplier,
         ExternalModuleComponentResolverFactory ivyFactory,
-        ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
+        ComponentMetadataRulesSupplier componentMetadataRulesSupplier,
+        ComponentMetadataHandlerInternal componentMetadataHandler,
         ComponentTypeRegistry componentTypeRegistry
     ) {
         this.resolutionStrategyFactory = resolutionStrategyFactory;
         this.repositoriesSupplier = repositoriesSupplier;
         this.ivyFactory = ivyFactory;
-        this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
+        this.componentMetadataRulesSupplier = componentMetadataRulesSupplier;
+        this.componentMetadataHandler = componentMetadataHandler;
         this.componentTypeRegistry = componentTypeRegistry;
     }
 
     @Override
     public ArtifactResolutionQuery createArtifactResolutionQuery() {
-        return new DefaultArtifactResolutionQuery(resolutionStrategyFactory, repositoriesSupplier, ivyFactory, componentMetadataProcessorFactory, componentTypeRegistry);
+        return new DefaultArtifactResolutionQuery(
+            resolutionStrategyFactory,
+            repositoriesSupplier,
+            ivyFactory,
+            componentMetadataRulesSupplier,
+            componentMetadataHandler,
+            componentTypeRegistry
+        );
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
@@ -19,7 +19,6 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
-import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
@@ -29,9 +28,8 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 
 import static org.gradle.api.internal.notations.ModuleNotationValidation.validate;
 
-public class ComponentIdentifierParserFactory implements Factory<NotationParser<Object, ComponentIdentifier>> {
+public class ComponentIdentifierParserFactory {
 
-    @Override
     public NotationParser<Object, ComponentIdentifier> create() {
         return NotationParserBuilder.toType(ComponentIdentifier.class)
             .fromCharSequence(new StringNotationConverter())
@@ -70,4 +68,5 @@ public class ComponentIdentifierParserFactory implements Factory<NotationParser<
             );
         }
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -16,14 +16,10 @@
 package org.gradle.internal.management;
 
 import com.google.common.collect.ImmutableList;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.ActionConfiguration;
 import org.gradle.api.Describable;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.NamedDomainObjectList;
-import org.gradle.api.artifacts.ComponentMetadataDetails;
-import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
@@ -35,7 +31,9 @@ import org.gradle.api.initialization.resolve.RulesMode;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
@@ -45,22 +43,21 @@ import org.gradle.api.provider.Property;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.code.UserCodeApplicationContext;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.lazy.Lazy;
 import org.jspecify.annotations.NullMarked;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.List;
 
 @NullMarked
 public class DefaultDependencyResolutionManagement implements DependencyResolutionManagementInternal {
     private static final DisplayName UNKNOWN_CODE = Describables.of("unknown code");
     private static final Logger LOGGER = Logging.getLogger(DependencyResolutionManagement.class);
-    private final List<Action<? super ComponentMetadataHandler>> componentMetadataRulesActions = new ArrayList<>();
 
     private final Lazy<DependencyResolutionServices> dependencyResolutionServices;
     private final UserCodeApplicationContext context;
-    private final ComponentMetadataHandler registar = new ComponentMetadataRulesRegistar();
+    private final ComponentMetadataHandlerInternal components;
     private final Property<RepositoriesMode> repositoryMode;
     private final Property<RulesMode> rulesMode;
     private final Property<String> librariesExtensionName;
@@ -74,7 +71,9 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         UserCodeApplicationContext context,
         DependencyManagementServices dependencyManagementServices,
         ObjectFactory objects,
-        CollectionCallbackActionDecorator collectionCallbackActionDecorator
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        IsolatableFactory isolatableFactory
     ) {
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
@@ -83,6 +82,8 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
         this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, context, dependencyResolutionServices);
+        this.components = objects.newInstance(DefaultComponentMetadataHandler.class, isolatableFactory, moduleIdentifierFactory);
+        this.components.onAddRule(name -> assertMutable());
     }
 
     @Override
@@ -93,12 +94,12 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     @Override
     public void components(Action<? super ComponentMetadataHandler> registration) {
         assertMutable();
-        componentMetadataRulesActions.add(registration);
+        registration.execute(components);
     }
 
     @Override
     public ComponentMetadataHandler getComponents() {
-        return registar;
+        return components;
     }
 
     @Override
@@ -218,74 +219,4 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         }
     }
 
-    @Override
-    public void applyRules(ComponentMetadataHandler target) {
-        for (Action<? super ComponentMetadataHandler> rule : componentMetadataRulesActions) {
-            rule.execute(target);
-        }
-    }
-
-    private class ComponentMetadataRulesRegistar implements ComponentMetadataHandler {
-        @Override
-        public ComponentMetadataHandler all(Action<? super ComponentMetadataDetails> rule) {
-            components(h -> h.all(rule));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler all(Closure<?> rule) {
-            components(h -> h.all(rule));
-            return this;
-        }
-
-        @Override
-        @Deprecated
-        public ComponentMetadataHandler all(Object ruleSource) {
-            components(h -> h.all(ruleSource));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler all(Class<? extends ComponentMetadataRule> rule) {
-            components(h -> h.all(rule));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler all(Class<? extends ComponentMetadataRule> rule, Action<? super ActionConfiguration> configureAction) {
-            components(h -> h.all(rule, configureAction));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler withModule(Object id, Action<? super ComponentMetadataDetails> rule) {
-            components(h -> h.withModule(id, rule));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler withModule(Object id, Closure<?> rule) {
-            components(h -> h.withModule(id, rule));
-            return this;
-        }
-
-        @Override
-        @Deprecated
-        public ComponentMetadataHandler withModule(Object id, Object ruleSource) {
-            components(h -> h.withModule(id, ruleSource));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler withModule(Object id, Class<? extends ComponentMetadataRule> rule) {
-            components(h -> h.withModule(id, rule));
-            return this;
-        }
-
-        @Override
-        public ComponentMetadataHandler withModule(Object id, Class<? extends ComponentMetadataRule> rule, Action<? super ActionConfiguration> configureAction) {
-            components(h -> h.withModule(id, rule, configureAction));
-            return this;
-        }
-    }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CachedCodePathComponentMetadataProcessorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CachedCodePathComponentMetadataProcessorTest.groovy
@@ -89,7 +89,7 @@ class CachedCodePathComponentMetadataProcessorTest extends Specification {
         )
 
         when: "a processor runs on this metadata through the caching code path"
-        def processor = processorWithCacheThatNeverHits()
+        def processor = processorWithCacheThatNeverHits(metadataRuleContainer.asImmutable())
         def result = processor.processMetadata(metadata.asImmutable())
 
         then: "the result should have the variant added by the rule"
@@ -107,7 +107,7 @@ class CachedCodePathComponentMetadataProcessorTest extends Specification {
         "ivy"        | 2
     }
 
-    private DefaultComponentMetadataProcessor processorWithCacheThatNeverHits() {
+    private DefaultComponentMetadataProcessor processorWithCacheThatNeverHits(ImmutableComponentMetadataRules container) {
         CacheBuilder cacheBuilder
         cacheBuilder = Mock(CacheBuilder) {
             withInitialLockMode(_ as FileLockManager.LockMode) >> { cacheBuilder }
@@ -140,8 +140,16 @@ class CachedCodePathComponentMetadataProcessorTest extends Specification {
         def executorWithCache = new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, Mock(Serializer))
 
         new DefaultComponentMetadataProcessor(
-            metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser,
-            AttributeTestUtil.attributesFactory(), executorWithCache, DependencyManagementTestUtil.platformSupport(), context
+            context,
+            container,
+            NoOpDerivationStrategy.instance,
+            instantiator,
+            dependencyMetadataNotationParser,
+            dependencyConstraintMetadataNotationParser,
+            componentIdentifierNotationParser,
+            AttributeTestUtil.attributesFactory(),
+            executorWithCache,
+            DependencyManagementTestUtil.platformSupport()
         )
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainerTest.groovy
@@ -26,10 +26,9 @@ class ComponentMetadataRuleContainerTest extends Specification {
     @Subject
     def container = new ComponentMetadataRuleContainer()
 
-    def 'is empty and class based by default'() {
+    def 'is empty by default'() {
         expect:
-        container.isEmpty()
-        container.isClassBasedRulesOnly()
+        container.asImmutable().rules.isEmpty()
     }
 
     def 'records added rules in order'() {
@@ -42,15 +41,12 @@ class ComponentMetadataRuleContainerTest extends Specification {
         container.addClassRule(rule2)
 
         then:
-        !container.isEmpty()
-        !container.isClassBasedRulesOnly()
-        def iterator = container.iterator()
-        def ruleWrapper = iterator.next()
-        !ruleWrapper.isClassBased()
-        ruleWrapper.rule == rule1
-        def ruleWrapper2 = iterator.next()
-        ruleWrapper2.isClassBased()
-        ruleWrapper2.classRules.contains(rule2)
+        def rules = container.asImmutable().rules
+        rules.size() == 2
+        rules[0] instanceof ImmutableComponentMetadataRules.ImmutableRule.ActionBased
+        rules[0].rule() == rule1
+        rules[1] instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        rules[1].classRules().contains(rule2)
     }
 
     def 'records subsequent class based rule in a single wrapper'() {
@@ -63,12 +59,10 @@ class ComponentMetadataRuleContainerTest extends Specification {
         container.addClassRule(rule2)
 
         then:
-        !container.isEmpty()
-        container.isClassBasedRulesOnly()
-        def iterator = container.iterator()
-        def ruleWrapper = iterator.next()
-        ruleWrapper.isClassBased()
-        ruleWrapper.classRules.containsAll([rule1, rule2])
+        def rules = container.asImmutable().rules
+        rules.size() == 1
+        rules[0] instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        rules[0].classRules().containsAll([rule1, rule2])
     }
 
     private SpecConfigurableRule configurableRule() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -28,12 +28,12 @@ import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.MetadataResolutionContext
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
-import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer
 import org.gradle.api.specs.Specs
 import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.action.ConfigurableRule
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy
 import org.gradle.internal.component.external.model.ivy.DefaultMutableIvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor
@@ -53,22 +53,21 @@ import javax.xml.namespace.QName
 
 class DefaultComponentMetadataHandlerTest extends Specification {
     private static final String GROUP = "group"
-    final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-
-    // For testing ModuleMetadataProcessor capabilities
     private static final String MODULE = "module"
 
-    // For testing ComponentMetadataHandler capabilities
+    final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     def executor = new ComponentMetadataRuleExecutor(Stub(GlobalScopedCacheBuilderFactory), Stub(DefaultInMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), Stub(BuildCommencedTimeProvider), Stub(Serializer))
-    def stringInterner = SimpleMapInterner.notThreadSafe()
-    def handler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.isolatableFactory(), executor, DependencyManagementTestUtil.platformSupport(), TestUtil.problemsService())
+
+    def handler = new DefaultComponentMetadataHandler(SnapshotTestUtil.isolatableFactory(), moduleIdentifierFactory)
+
     RuleActionAdapter adapter = Mock(RuleActionAdapter)
-    def mockedHandler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), adapter, moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.isolatableFactory(), executor, DependencyManagementTestUtil.platformSupport(), TestUtil.problemsService())
+    def mockedHandler = new DefaultComponentMetadataHandler(adapter, SnapshotTestUtil.isolatableFactory(), moduleIdentifierFactory)
+
     def ruleAction = Stub(RuleAction)
     def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
+
     MetadataResolutionContext context = Mock()
-    ModuleSourcesSerializer moduleSourcesSerializer = new ModuleSourcesSerializer([:])
 
     def 'setup'() {
         TestComponentMetadataRule.instanceCount = 0
@@ -87,10 +86,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         1 * adapter.createFromAction(action) >> ruleAction
 
         and:
-        !mockedHandler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = mockedHandler.metadataRuleContainer.iterator().next()
-        ruleWrapper.rule.action == (ruleAction)
-        ruleWrapper.rule.spec == Specs.satisfyAll()
+        !mockedHandler.configuredRules.rules.isEmpty()
+        def ruleWrapper = mockedHandler.configuredRules.rules.first()
+        ruleWrapper.rule().action == (ruleAction)
+        ruleWrapper.rule().spec == Specs.satisfyAll()
     }
 
     def "add closure rule that applies to all components"() {
@@ -103,11 +102,11 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         1 * adapter.createFromClosure(ComponentMetadataDetails, closure) >> ruleAction
 
         and:
-        !mockedHandler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = mockedHandler.metadataRuleContainer.iterator().next()
-        !ruleWrapper.classBased
-        ruleWrapper.rule.action == (ruleAction)
-        ruleWrapper.rule.spec == Specs.satisfyAll()
+        !mockedHandler.configuredRules.rules.isEmpty()
+        def ruleWrapper = mockedHandler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ActionBased
+        ruleWrapper.rule().action == (ruleAction)
+        ruleWrapper.rule().spec == Specs.satisfyAll()
     }
 
     def "add class rule that applies to all components"() {
@@ -115,10 +114,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all(TestComponentMetadataRule)
 
         then:
-        !handler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = handler.metadataRuleContainer.iterator().next()
-        ruleWrapper.classBased
-        def classRule = ruleWrapper.classRules.iterator().next()
+        !handler.configuredRules.rules.isEmpty()
+        def ruleWrapper = handler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        def classRule = ruleWrapper.classRules().iterator().next()
         classRule.configurableRule instanceof ConfigurableRule
         classRule.spec == Specs.satisfyAll()
         TestComponentMetadataRule.instanceCount == 0
@@ -132,10 +131,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         } as Action<ActionConfiguration>)
 
         then:
-        !handler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = handler.metadataRuleContainer.iterator().next()
-        ruleWrapper.classBased
-        def classRule = ruleWrapper.classRules.iterator().next()
+        !handler.configuredRules.rules.isEmpty()
+        def ruleWrapper = handler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        def classRule = ruleWrapper.classRules().iterator().next()
         classRule.configurableRule instanceof ConfigurableRule
         classRule.spec == Specs.satisfyAll()
         TestComponentMetadataRule.instanceCount == 0
@@ -155,11 +154,11 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         1 * adapter.createFromAction(action) >> ruleAction
 
         and:
-        !mockedHandler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = mockedHandler.metadataRuleContainer.iterator().next()
-        !ruleWrapper.classBased
-        ruleWrapper.rule.action == (ruleAction)
-        ruleWrapper.rule.spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
+        !mockedHandler.configuredRules.rules.isEmpty()
+        def ruleWrapper = mockedHandler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ActionBased
+        ruleWrapper.rule().action == (ruleAction)
+        ruleWrapper.rule().spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
     }
 
     def "add closure rule that applies to module"() {
@@ -173,11 +172,11 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         1 * adapter.createFromClosure(ComponentMetadataDetails, closure) >> ruleAction
 
         and:
-        !mockedHandler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = mockedHandler.metadataRuleContainer.iterator().next()
-        !ruleWrapper.classBased
-        ruleWrapper.rule.action == (ruleAction)
-        ruleWrapper.rule.spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
+        !mockedHandler.configuredRules.rules.isEmpty()
+        def ruleWrapper = mockedHandler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ActionBased
+        ruleWrapper.rule().action == (ruleAction)
+        ruleWrapper.rule().spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
     }
 
     def "add class rule that applies to module"() {
@@ -187,10 +186,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.withModule(notation, TestComponentMetadataRule)
 
         then:
-        !handler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = handler.metadataRuleContainer.iterator().next()
-        ruleWrapper.classBased
-        def classRule = ruleWrapper.classRules.iterator().next()
+        !handler.configuredRules.rules.isEmpty()
+        def ruleWrapper = handler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        def classRule = ruleWrapper.classRules().iterator().next()
         classRule.configurableRule instanceof ConfigurableRule
         classRule.spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
         TestComponentMetadataRule.instanceCount == 0
@@ -206,10 +205,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         } as Action<ActionConfiguration>)
 
         then:
-        !handler.metadataRuleContainer.isEmpty()
-        def ruleWrapper = handler.metadataRuleContainer.iterator().next()
-        ruleWrapper.classBased
-        def classRule = ruleWrapper.classRules.iterator().next()
+        !handler.configuredRules.rules.isEmpty()
+        def ruleWrapper = handler.configuredRules.rules.first()
+        ruleWrapper instanceof ImmutableComponentMetadataRules.ImmutableRule.ClassBased
+        def classRule = ruleWrapper.classRules().iterator().next()
         classRule.configurableRule instanceof ConfigurableRule
         classRule.spec.target == DefaultModuleIdentifier.newId(GROUP, MODULE)
         TestComponentMetadataRule.instanceCount == 0
@@ -249,7 +248,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { throw failure }
 
         and:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         InvalidUserCodeException e = thrown()
@@ -267,7 +266,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { ComponentMetadataDetails cmd, IvyModuleDescriptor imd -> closuresCalled << 3 }
 
         and:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         closuresCalled.sort() == [1, 2, 3]
@@ -281,7 +280,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         noExceptionThrown()
@@ -311,7 +310,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         noExceptionThrown()
@@ -342,7 +341,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         noExceptionThrown()
@@ -358,7 +357,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         !invoked
@@ -407,7 +406,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         }
 
         when:
-        handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
+        newProcessor(handler, context).processMetadata(metadata.asImmutable())
 
         then:
         noExceptionThrown()
@@ -492,4 +491,23 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         metadata.statusScheme = ["integration", "release"]
         return metadata
     }
+
+    def newProcessor(
+        ComponentMetadataHandlerInternal handler,
+        MetadataResolutionContext resolutionContext
+    ) {
+        new DefaultComponentMetadataProcessor.Factory(
+            TestUtil.instantiatorFactory().decorateLenient(),
+            AttributeTestUtil.attributesFactory(),
+            executor,
+            DependencyManagementTestUtil.platformSupport(),
+            SimpleMapInterner.notThreadSafe(),
+            TestUtil.problemsService()
+        ).create(
+            resolutionContext,
+            handler.getConfiguredRules(),
+            NoOpDerivationStrategy.getInstance()
+        )
+    }
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy
 import org.gradle.internal.component.external.model.ivy.DefaultMutableIvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -93,7 +94,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "does nothing when no rules registered"() {
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
+        def processor = newProcessor(ImmutableComponentMetadataRules.EMPTY)
         def metadata = ivyMetadata().asImmutable()
 
         expect:
@@ -105,7 +106,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         context.injectingInstantiator >> instantiator
         String notation = "${GROUP}:${MODULE}"
         addRuleForModule(notation)
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
+        def processor = newProcessor(metadataRuleContainer.asImmutable())
 
 
         when:
@@ -121,7 +122,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         String notation = "${GROUP}:${MODULE}"
         addRuleForModuleWithParams(notation, "foo", 42L)
 
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
+        def processor = newProcessor(metadataRuleContainer.asImmutable())
 
         when:
         processor.processMetadata(ivyMetadata().asImmutable())
@@ -132,7 +133,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "processing fails when status is not present in status scheme"() {
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
+        def processor = newProcessor(ImmutableComponentMetadataRules.EMPTY)
         def metadata = ivyMetadata()
         metadata.status = "green"
         metadata.statusScheme = ["alpha", "beta"]
@@ -156,8 +157,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
                 addRuleForModule(notation)
             }
         }
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
-
+        def processor = newProcessor(metadataRuleContainer.asImmutable())
 
         when:
         processor.processMetadata(ivyMetadata().asImmutable())
@@ -170,6 +170,10 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         where:
         rules << [rule1, rule2, "classRule1", "classRule2"].permutations()
 
+    }
+
+    private DefaultComponentMetadataProcessor newProcessor(ImmutableComponentMetadataRules container) {
+        new DefaultComponentMetadataProcessor(context, container, NoOpDerivationStrategy.getInstance(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport())
     }
 
     private SpecConfigurableRule addRuleForModule(String notation) {
@@ -197,4 +201,5 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         metadata.statusScheme = ["integration", "release"]
         return metadata
     }
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ExternalModuleComponentResolverFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ExternalModuleComponentResolverFactoryTest.groovy
@@ -20,10 +20,11 @@ import com.google.common.collect.Lists
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataProcessor
+import org.gradle.api.internal.artifacts.dsl.ImmutableComponentMetadataRules
 import org.gradle.api.internal.artifacts.ivyservice.CacheExpirationControl
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
@@ -44,6 +45,7 @@ import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema
 import org.gradle.api.internal.properties.GradleProperties
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
@@ -101,13 +103,14 @@ class ExternalModuleComponentResolverFactoryTest extends Specification {
             Stub(CalculatedValueContainerFactory),
             AttributeTestUtil.attributesFactory(),
             AttributeTestUtil.services(),
-            Stub(ComponentMetadataSupplierRuleExecutor)
+            Stub(ComponentMetadataSupplierRuleExecutor),
+            Stub(DefaultComponentMetadataProcessor.Factory)
         )
     }
 
     def "returns an empty resolver when no repositories are configured"() {
         when:
-        def resolver = newFactory().createResolvers(Collections.emptyList(), Stub(ComponentMetadataProcessorFactory), Stub(ComponentSelectionRulesInternal), false, Mock(CacheExpirationControl), ImmutableAttributesSchema.EMPTY)
+        def resolver = newFactory().createResolvers(Collections.emptyList(), ImmutableComponentMetadataRules.EMPTY, NoOpDerivationStrategy.instance, Stub(ComponentSelectionRulesInternal), false, Mock(CacheExpirationControl), ImmutableAttributesSchema.EMPTY)
 
         then:
         resolver instanceof NoRepositoriesResolver
@@ -123,7 +126,7 @@ class ExternalModuleComponentResolverFactoryTest extends Specification {
         def componentSelectionRules = Stub(ComponentSelectionRulesInternal)
 
         when:
-        def resolver = newFactory().createResolvers(repositories, Stub(ComponentMetadataProcessorFactory), componentSelectionRules, false, Mock(CacheExpirationControl), ImmutableAttributesSchema.EMPTY)
+        def resolver = newFactory().createResolvers(repositories, ImmutableComponentMetadataRules.EMPTY, NoOpDerivationStrategy.instance, componentSelectionRules, false, Mock(CacheExpirationControl), ImmutableAttributesSchema.EMPTY)
 
         then:
         assert resolver instanceof UserResolverChain

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -22,9 +22,10 @@ import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.UnresolvedComponentResult
 import org.gradle.api.component.Artifact
 import org.gradle.api.component.Component
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataRulesSupplier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ExternalModuleComponentResolverFactory
 import org.gradle.api.internal.component.ComponentTypeRegistration
@@ -40,9 +41,11 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class DefaultArtifactResolutionQueryTest extends Specification {
+
     def resolutionStrategyFactory = Stub(ResolutionStrategyFactory)
     def externalResolverFactory = Mock(ExternalModuleComponentResolverFactory)
-    def componentMetadataProcessorFactory = Mock(ComponentMetadataProcessorFactory)
+    def componentMetadataRulesSupplier = Stub(ComponentMetadataRulesSupplier)
+    def componentMetadataHandler = Stub(ComponentMetadataHandlerInternal)
     def componentTypeRegistry = Mock(ComponentTypeRegistry)
     def artifactResolver = Mock(ArtifactResolver)
     def repositoryChain = Mock(ComponentResolvers)
@@ -123,7 +126,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     }
 
     private def withArtifactResolutionInteractions(int numberOfComponentsToResolve = 1) {
-        1 * externalResolverFactory.createResolvers(_, _, _, _, _, _) >> repositoryChain
+        1 * externalResolverFactory.createResolvers(_, _, _, _, _, _, _) >> repositoryChain
         1 * repositoryChain.artifactResolver >> artifactResolver
         1 * repositoryChain.componentResolver >> componentMetaDataResolver
         numberOfComponentsToResolve * componentMetaDataResolver.resolve(_, _, _) >> { ComponentIdentifier componentId, ComponentOverrideMetadata requestMetaData, BuildableComponentResolveResult resolveResult ->
@@ -135,7 +138,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     }
 
     private DefaultArtifactResolutionQuery createArtifactResolutionQuery(ComponentTypeRegistry componentTypeRegistry) {
-        new DefaultArtifactResolutionQuery(resolutionStrategyFactory, { [] }, externalResolverFactory, componentMetadataProcessorFactory, componentTypeRegistry)
+        new DefaultArtifactResolutionQuery(resolutionStrategyFactory, { [] }, externalResolverFactory, componentMetadataRulesSupplier, componentMetadataHandler, componentTypeRegistry)
     }
 
     private ComponentTypeRegistry createTestComponentTypeRegistry() {
@@ -169,4 +172,5 @@ class DefaultArtifactResolutionQueryTest extends Specification {
 
     private static interface UnknownArtifact extends Artifact {
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/management/DependencyResolutionManagementInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/management/DependencyResolutionManagementInternal.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.management;
 
-import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.initialization.resolve.RepositoriesMode;
@@ -32,8 +31,6 @@ import java.util.List;
 public interface DependencyResolutionManagementInternal extends DependencyResolutionManagement, FinalizableValue {
 
     void configureProject(ProjectInternal project);
-
-    void applyRules(ComponentMetadataHandler target);
 
     RepositoriesModeInternal getConfiguredRepositoriesMode();
 


### PR DESCRIPTION
Component metadata rules and the variant derivation strategy are now captured as an immutable snapshot and passed through ResolutionParameters, rather than being pulled out of a service as hidden inputs to resolution.

- Settings-scoped rules are now passed as immutable data. Previously DependencyResolutionManagementInternal.applyRules mutated a project-scoped handler passed into a settings-scoped service, rather than that service exposing its own immutable settings-scoped rules.
- Remove the ComponentMetadataHandlerInternal.createFactory indirection through delegate handlers. The logic for choosing between a project's and the settings' rules is now stated plainly in one place.
- Wire component metadata rules and the variant derivation strategy explicitly through ResolutionParameters instead of embedding them in a service where they acted as hidden inputs to resolution.
- Split DefaultComponentMetadataHandler into a rule DSL builder and a separate processor factory. The DSL element can now be created in the settings scope without dragging in services it doesn't need.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
