### PR TITLE
[DO NOT MERGE] gradle-bot failure-summary probe (v2)

### DIFF
--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/BotFailureSummaryProbeTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/BotFailureSummaryProbeTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal
+
+import spock.lang.Specification
+
+/**
+ * Intentional failure used to verify the gradle-bot Build Scan failure summary (v2:
+ * actionable summaries). DO NOT MERGE. The condition below fails with a multi-line
+ * "Condition not satisfied" message so the summary's test-name resolution and log
+ * rendering can be exercised.
+ */
+class BotFailureSummaryProbeTest extends Specification {
+    def "intentional failure to exercise gradle-bot failure summary"() {
+        given:
+        def expected = "gradle-bot renders an actionable failure summary"
+        def actual = "gradle-bot probe intentional failure"
+
+        expect:
+        actual == expected
+    }
+}


### PR DESCRIPTION
**Do not merge / do not review.**

Temporary probe PR with a single intentional Spock condition failure in
`base-services`, used to verify the updated gradle-bot Build Scan failure
summary (v2: *actionable* summaries — resolved test name, pre-existing/new
badge, relevant-log rendering, deep links, and feedback footer).

The bot is running the freshly patched image
`gradle-bot:20260717-020901-522cceb` (commit `522cceb`, branch
`failure-summary-v2`). Will be closed and the branch deleted once verified.

Triggering: \`@bot-gradle test qfl\`