### PR TITLE
Fix JavaApplicationInitSoakTest on Java 8 CI

### DIFF
--- a/testing/soak/src/integTest/groovy/org/gradle/buildinit/JavaApplicationInitSoakTest.groovy
+++ b/testing/soak/src/integTest/groovy/org/gradle/buildinit/JavaApplicationInitSoakTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.buildinit
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 
 class JavaApplicationInitSoakTest extends AbstractIntegrationSpec {
 
@@ -32,6 +33,7 @@ class JavaApplicationInitSoakTest extends AbstractIntegrationSpec {
 
         and:
         executer.withToolchainDownloadEnabled()
+        executer.withArguments("-Porg.gradle.java.installations.paths=" + AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(","))
         succeeds('run')
 
         then:


### PR DESCRIPTION
## Summary

Forward CI JDK installation paths to the inner `gradle run` in `JavaApplicationInitSoakTest`, so JDK 21 is resolved locally instead of via Foojay auto-provisioning from a Java 8 test JVM.

Fixes the failing `Gradle_Release8x_Check_Soak_9_0` build (`JavaApplicationInitSoakTest.toolchain auto-provisioning works`).
