### PR TITLE
Add note clarifying Jackson GMM in virtual platform documentation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_align_dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/how-to/dependency-management/how_to_align_dependency_versions.adoc
@@ -73,6 +73,13 @@ If no public BOM exists, you can create a **virtual platform**.
 In this case, Gradle builds the platform **dynamically** based on the modules being used.
 For this, you must define <<component_metadata_rules.adoc#component-metadata-rules,**component metadata rules**>>:
 
+[NOTE]
+====
+Some libraries, such as Jackson, now publish Gradle Module Metadata that includes version alignment information.
+This means Gradle can automatically align their module versions without any manual configuration.
+The Jackson-based virtual platform example shown below is for illustration only; the virtual platform approach remains essential for libraries that do not publish such metadata.
+====
+
 ====
 include::sample[dir="snippets/how-to/dependency-management/dependency-management/aligning-versions/kotlin",files="build.gradle.kts[tags=dependency-full-platform]"]
 include::sample[dir="snippets/how-to/dependency-management/dependency-management/aligning-versions/groovy",files="build.gradle[tags=dependency-full-platform]"]


### PR DESCRIPTION
Fixes #21583

### Context
Jackson now publishes Gradle Module Metadata (GMM) with version alignment information built in. This makes it a confusing example for the manual virtual platform approach described in the documentation, since Jackson's versions can be aligned automatically without any manual configuration.

### Change
Added a NOTE in the "Option 2: Creating a Virtual Platform" section of the dependency version alignment documentation, explaining that:
- Jackson now publishes GMM with version alignment information
- The Jackson example is illustrative, but the virtual platform approach is essential for libraries that do NOT publish such metadata

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE)
- [ ] Provide integration tests (N/A - documentation only change)
- [ ] Provide unit tests (N/A - documentation only change)
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes (N/A)