### PR TITLE
Keep copy button visible while scrolling long stack traces

### DIFF
--- a/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/CodePanelRenderer.java
+++ b/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/CodePanelRenderer.java
@@ -37,9 +37,9 @@ public class CodePanelRenderer extends ReportRenderer<CodePanelRenderer.Data, Si
     @Override
     public void render(Data data, SimpleHtmlWriter htmlWriter) throws IOException {
         // Wrap in a <span>, to work around CSS problem in IE
-        htmlWriter.startElement("span").attribute("class", "code")
-            .startElement("pre").attribute("id", data.codePanelId).characters(data.text).endElement();
+        htmlWriter.startElement("span").attribute("class", "code");
         addClipboardCopyButton(htmlWriter, data.codePanelId);
+        htmlWriter.startElement("pre").attribute("id", data.codePanelId).characters(data.text).endElement();
         htmlWriter.endElement();
     }
 }

--- a/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/HtmlWriterTools.java
+++ b/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/HtmlWriterTools.java
@@ -39,11 +39,14 @@ public class HtmlWriterTools {
      * @throws IOException if an I/O error occurs
      */
     public static SimpleMarkupWriter addClipboardCopyButton(SimpleHtmlWriter writer, String copyElementId) throws IOException {
-        return writer.startElement("button")
+        return writer.startElement("div")
+            .attribute("class", "clipboard-copy-btn-container")
+            .startElement("button")
             .attribute("class", "clipboard-copy-btn")
             .attribute("aria-label", "Copy to clipboard")
             .attribute("data-copy-element-id", copyElementId)
             .characters("Copy")
+            .endElement()
             .endElement();
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
@@ -240,6 +240,8 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
                 String failureOutputId = "root-" + rootIndex + "-test-failure-" + result.getName();
                 htmlWriter.startElement("span").attribute("class", "code");
 
+                addClipboardCopyButton(htmlWriter, failureOutputId);
+
                 htmlWriter.startElement("pre").attribute("id", failureOutputId);
                 if (hasFailures) {
                     for (SerializableFailure failure : result.getFailures()) {
@@ -251,7 +253,6 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
                 }
                 htmlWriter.endElement(); // pre
 
-                addClipboardCopyButton(htmlWriter, failureOutputId);
                 htmlWriter.endElement(); // span
 
                 htmlWriter.endElement(); // div
@@ -443,16 +444,16 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
         @Override
         protected void render(PerRootInfo info, SimpleHtmlWriter htmlWriter) throws IOException {
             String outputId = "root-" + rootIndex + "-test-" + destination.name().toLowerCase(Locale.ROOT) + "-" + info.getResults().get(0).getName();
-            htmlWriter.startElement("span").attribute("class", "code")
-                .startElement("pre")
+            htmlWriter.startElement("span").attribute("class", "code");
+            addClipboardCopyButton(htmlWriter, outputId);
+            htmlWriter.startElement("pre")
                 .attribute("id", outputId);
             outputReader.useTestOutputEvents(
                 info.getOutputEntries(), destination,
                 event -> htmlWriter.characters(event.getMessage())
             );
-            htmlWriter.endElement();
-            addClipboardCopyButton(htmlWriter, outputId);
-            htmlWriter.endElement();
+            htmlWriter.endElement(); // pre
+            htmlWriter.endElement(); // span
         }
     }
 

--- a/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
+++ b/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
@@ -121,6 +121,13 @@ div.metadata td {
     color: darkred;
 }
 
+.clipboard-copy-btn-container {
+    position: sticky;
+    top: 0;
+    height: 0;
+    z-index: 1;
+}
+
 .clipboard-copy-btn {
     position: absolute;
     top: 8px;


### PR DESCRIPTION
Fixes #38531 

### Context

In the HTML test report, the "Copy" button was always statically positioned in the top right. Due to JVM stack traces being very long in the case of a failure occuring, users often had to scroll way further down. This caused the button to go out of view since it was in a fixed position, so if a user wanted to copy the stack trace they would then have to scroll all the way back up.

My approach to fix this was to make the button sticky so it will always stay within the user's viewport even when scrolling all the way down.

### Changes

First approach was to just change the styling of the button to `position: sticky`, however since it was wrapped in a span with `position: relative` that wasn't possible. Therefore I wrapped the button in a new div with zero-height and `position: sticky` and the button keeps the original layout. I also had to move it so it would render before the `<pre>` because otherwise the button would sit below the entire stack trace.

Files I changed:

- `HtmlWriterTools` - wraps the button in `div.clipboard-copy-btn-container`
- `CodePanelRenderer` / `PerRootTabRenderer` - emit the button before the `<pre>`
- `generic/style.css` - adds the `.clipboard-copy-btn-container` rule

### Testing

I did not add any unit/integration tests since this is a pure layout/css change. However I did test it by first trying it out via DevTools in my Chrome Browser. 

I then implemented the code changes and built it locally via `./gradlew install` and ran tests in my test repository with the generated binary. Below you can find a short screen recording of the result:

https://github.com/user-attachments/assets/31f65c6e-bcae-42f9-bbf6-376065ce13bc

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things