### PR TITLE
Match corner radius of media to codeblocks

### DIFF
--- a/platforms/documentation/docs/src/docs/css/base.css
+++ b/platforms/documentation/docs/src/docs/css/base.css
@@ -62,6 +62,7 @@ a strong {
 
 img {
     max-width: 100%;
+    border-radius: 4px; /* match with `code` */
 }
 
 table {


### PR DESCRIPTION
Before this change, they had no radius, with default rectangular corners.

Now both images and gifs have the same 4px corner radius as codeblocks:

Image:
<img width="549" height="217" alt="image" src="https://github.com/user-attachments/assets/ab722639-7509-4038-9ad7-c5ed555f9072" />

Gif:
<img width="369" height="166" alt="image" src="https://github.com/user-attachments/assets/54184573-ca1b-409b-b78e-22fc6cd5c4a9" />
