### PR TITLE
Fix configuration cache with continuous builds for Kotlin DSL

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
+import spock.lang.Issue
+
+class ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest extends AbstractContinuousIntegrationTest {
+
+    def setup() {
+        executer.beforeExecute {
+            withArgument(AbstractConfigurationCacheIntegrationTest.ENABLE_CLI_OPT)
+        }
+    }
+
+    @Issue(['https://github.com/gradle/gradle/issues/34013', 'https://github.com/gradle/gradle/issues/38482'])
+    def "can re-store configuration cache in continuous build when Kotlin scripts are reused"() {
+        given:
+        def configFile = file("config.txt")
+        def inputFile = file("input.txt")
+        configFile.text = ""
+        inputFile.text = "original"
+
+        // Settings-script Spec (same pattern as develocity.buildScan.publishing.onlyIf { ... })
+        settingsKotlinFile << """
+            val settingsSpec: Spec<Task> = Spec { true }
+            gradle.beforeProject {
+                tasks.configureEach {
+                    onlyIf(settingsSpec)
+                }
+            }
+        """
+
+        // Configuration-time file read invalidates CC without changing the script source,
+        // so compiled Kotlin scripts are reused from the classloading cache.
+        buildKotlinFile << """
+            if (layout.projectDirectory.file("config.txt").asFile.readText().isNotEmpty()) {
+                println("loaded config.txt")
+            }
+            tasks.register("demoTask") {
+                val input = layout.projectDirectory.file("input.txt")
+                inputs.files(input)
+                doLast {
+                    println("value: " + input.asFile.readText())
+                }
+            }
+        """
+
+        when:
+        succeeds("demoTask")
+
+        then:
+        outputContains("value: original")
+        postBuildOutputContains("Configuration cache entry stored.")
+
+        when:
+        update(configFile, "changed-config")
+        update(inputFile, "changed-input")
+
+        then:
+        buildTriggeredAndSucceeded()
+        outputContains("loaded config.txt")
+        outputContains("value: changed-input")
+        postBuildOutputContains("Configuration cache entry stored.")
+        outputDoesNotContain("cannot be encoded")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
 
 class ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest extends AbstractContinuousIntegrationTest {
@@ -77,5 +79,77 @@ class ConfigurationCacheContinuousBuildKotlinScriptReuseIntegrationTest extends 
         outputContains("value: changed-input")
         postBuildOutputContains("Configuration cache entry stored.")
         outputDoesNotContain("cannot be encoded")
+    }
+
+    /**
+     * Reinstates {@code ConfigurationCacheKotlinScriptReuseIntegrationTest} (#32039 / #32205)
+     * with reuse driven by continuous reconfigure instead of sibling projects with identical scripts.
+     * Keeps the version catalog and early {@code buildscript.classLoader} access that induce a
+     * non-strict ClassLoaderScope parent.
+     */
+    @Requires(value = TestExecutionPreconditions.NotEmbeddedExecutor, reason = 'non-strict ClassLoader scope')
+    @Issue('https://github.com/gradle/gradle/issues/32039')
+    def "compiled Kotlin script with non-strict ClassLoaderScope parent can be reused across continuous reconfigure with version catalog"() {
+        given: 'a version catalog'
+        file('gradle/libs.versions.toml').text = '''
+            [versions]
+            # Deleting this line used to avoid #32039
+            test = "1"
+
+            [libraries]
+        '''.stripIndent()
+
+        and: 'settings that induce non-strict ClassLoaderScope'
+        settingsFile '''
+            gradle.rootProject {
+                // induces non-strict ClassLoaderScope in the hierarchy
+                // since this callback runs too early
+                buildscript.classLoader
+            }
+        '''
+
+        and: 'a Kotlin project script reused when only non-script inputs change'
+        def configFile = file('config.txt')
+        def inputFile = file('input.txt')
+        configFile.text = ''
+        inputFile.text = 'original'
+
+        // config.txt is read at configuration time (invalidates CC without changing script source).
+        // input.txt is a task input so continuous build keeps watching the FS.
+        kotlinFile 'build.gradle.kts', '''
+            if (layout.projectDirectory.file("config.txt").asFile.readText().isNotEmpty()) {
+                println("loaded config.txt")
+            }
+            tasks.register("ok") {
+                val input = layout.projectDirectory.file("input.txt")
+                inputs.files(input)
+                doLast {
+                    println("value: " + input.asFile.readText())
+                }
+            }
+        '''
+
+        and:
+        executer.withEagerClassLoaderCreationCheckDisabled()
+
+        when:
+        succeeds 'ok'
+
+        then:
+        outputContains 'value: original'
+        postBuildOutputContains 'Configuration cache entry stored.'
+
+        when: 'invalidate configuration cache without changing the script source'
+        update(configFile, 'changed-config')
+        update(inputFile, 'changed-input')
+
+        then:
+        buildTriggeredAndSucceeded()
+        outputContains 'loaded config.txt'
+        outputContains 'value: changed-input'
+        postBuildOutputContains 'Configuration cache entry stored.'
+        // Must not reintroduce #32039 (non-strict scope + catalog) or #34013 (CC encode failure)
+        outputDoesNotContain 'cannot be encoded'
+        outputDoesNotContain 'Unexpected delegating class loader'
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
@@ -33,10 +33,12 @@ class KotlinScriptClassloadingCache @Inject constructor(
 ) {
 
     private
-    val cache: CrossBuildInMemoryCache<ProgramId, CompiledScript> = cacheFactory.newCache { reused -> reused.onReuse() }
+    val cache: CrossBuildInMemoryCache<ProgramId, CompiledScript> = cacheFactory.newCache()
 
+    // Notify classloader scope listeners on every hit (including continuous rebuilds in the same session).
+    // See https://github.com/gradle/gradle/issues/34013 and https://github.com/gradle/gradle/issues/38482
     fun get(key: ProgramId): CompiledScript? =
-        cache.getIfPresent(key)
+        cache.getIfPresent(key)?.also { it.onReuse() }
 
     fun put(key: ProgramId, loadedScriptClass: CompiledScript) {
         cache.put(key, loadedScriptClass)


### PR DESCRIPTION
Fixes #34013
Fixes #38482

### Context

Continuous builds re-run multiple build trees in one build session. After #32205, Kotlin DSL only called `CompiledScript.onReuse()` when a script was reused across sessions. That left configuration cache without known script classloaders on the next continuous reconfigure, so storing CC failed with `Class '…' cannot be encoded`.

Groovy already calls `onReuse()` on every script cache hit. This does the same for Kotlin.

I used AI tools while investigating the issue and drafting this change; I reviewed and verified the fix and the regression test.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. *(not needed for this path)*
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. *(internal bugfix)*
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: targeted `:configuration-cache:forkingIntegTest` for the new test.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things