### PR TITLE
Ignore Develocity agent stack traces in smoke tests

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
@@ -101,6 +101,10 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
             .withProjectDir(projectDir)
             .withTestKitDir(SHARED_GRADLE_USER_HOME)
             .withJdkWarningChecksDisabled() // Kapt seems to be accessing JDK internals. See KT-49187
+            // These projects apply the Develocity plugin and use the remote build cache, so a Develocity outage makes
+            // the Develocity agent log connection stack traces to the build output. Those are infrastructure noise
+            // unrelated to what these smoke tests verify. See https://github.com/gradle/gradle-private/issues/5290
+            .ignoreStackTraces("Develocity agent may log stack traces when ge.gradle.org / the remote build cache is unavailable")
 
         if (JavaVersion.current().isJava9Compatible()) {
             runner.withJvmArguments(

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
@@ -80,6 +80,10 @@ abstract class AbstractGradleceptionSmokeTest extends AbstractSmokeTest {
 
         runner.ignoreDeprecationWarnings("Gradleception smoke tests don't check for deprecation warnings; TODO: we should add expected deprecations for each task being called")
         runner.withJdkWarningChecksDisabled() // The Gradle build somehow still emits these warnings
+        // The Gradle build publishes Build Scans and uses the remote build cache, so a Develocity outage makes the
+        // Develocity agent log connection stack traces to the build output. Those are infrastructure noise unrelated
+        // to what these smoke tests verify. See https://github.com/gradle/gradle-private/issues/5290
+        runner.ignoreStackTraces("Develocity agent may log stack traces when ge.gradle.org / the remote build cache is unavailable")
 
         return runner
     }


### PR DESCRIPTION
During a Develocity (`ge.gradle.org`) / remote build cache outage, several smoke tests fail with `unexpected stack trace` assertions even though nothing is wrong with the build under test. This blocked the `release` merge queue (e.g. [Pull Request Feedback (Trigger) #115369852](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_Stage_PullRequestFeedback_Trigger/115369852), triggered by the unrelated PR #38574).

### Root cause

The Gradleception smoke tests run the real Gradle build (which publishes Build Scans and uses the remote build cache), and the Android smoke tests build a project with the Develocity plugin applied. When `ge.gradle.org` / `usw2-edge.gradle.org` returns HTTP `500`, the Develocity agent logs the failures with full stack traces to standard output:

```
java.lang.RuntimeException: Loading entry from 'https://usw2-edge.gradle.org/cache/...' response status 500: Internal Server Error
	at com.gradle.enterprise.agent.c.a.b.a(SourceFile:73)
	at com.gradle.scan.plugin.internal.dep.org.apache.http.impl.client.CloseableHttpClient.execute(SourceFile:223)
	...
```

`ResultAssertion` then trips its stack-trace check:

```
java.lang.AssertionError: Standard output line 611 contains an unexpected stack trace: 	at com.gradle.enterprise.agent.c.a.b.a(SourceFile:73)
```

### Fix

Disable the stack-trace checker for these smoke tests via the existing `SmokeTestGradleRunner.ignoreStackTraces(reason)` mechanism, applied centrally in the two runner factories that already disable deprecation and JDK-warning checks:

- `AbstractGradleceptionSmokeTest.runnerFor(...)` — covers all `GradleBuild*SmokeTest`
- `AbstractAndroidProjectSmokeTest.runnerForLocation(...)` — covers `AndroidProject*SmokeTest`

The stack traces these tests trip on come from the Develocity agent's best-effort remote-cache / build-scan communication, not from the build being verified, so ignoring them is safe.

Fixes gradle/gradle-private#5290

### Reviewing this PR
- [ ] Make sure commit history and messages are clear and follow the [contribution guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
