### PR TITLE
Add lazy evaluation overloads for `onlyIf` task skip reasons

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -82,10 +82,12 @@ Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engine
 #### Lazy `onlyIf` reasons
 [`Task.onlyIf`](dsl/org.gradle.api.Task.html#onlyIf) and [`Task.setOnlyIf`](dsl/org.gradle.api.Task.html#setOnlyIf) now accept a `Provider<String>` that reports the reason for the task being skipped.
 
-This provider is only computed when the task is actually skipped.  
-This will avoid expensive I/O such as running an external process or reading environment state, unless the reason is needed.
+This provider is only computed when the task is actually skipped.
+This avoids expensive I/O such as running an external process or reading environment state, unless the reason is needed.
 
-Using a [`ValueSource`](userguide/configuration_cache_requirements.html#config_cache:requirements:value_source) provider will keep the computation lazy even when the task is serialized in the [Configuration Cache](userguide/configuration_cache.html).
+Using a [`ValueSource`](userguide/configuration_cache_requirements.html#config_cache:requirements:value_source) provider keeps the computation lazy even when the task is serialized in the [Configuration Cache](userguide/configuration_cache.html).
+
+See the [Using a predicate](userguide/controlling_task_execution.html#sec:using_a_predicate) section in the Gradle User Manual for more details.
 
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -79,6 +79,14 @@ Gradle provides an intuitive [command-line interface](userguide/command_line_int
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 
+#### Lazy `onlyIf` reasons
+[`Task.onlyIf`](dsl/org.gradle.api.Task.html#onlyIf) and [`Task.setOnlyIf`](dsl/org.gradle.api.Task.html#setOnlyIf) now accept a `Provider<String>` that reports the reason for the task being skipped.
+
+This provider is only computed when the task is actually skipped.  
+This will avoid expensive I/O such as running an external process or reading environment state, unless the reason is needed.
+
+Using a [`ValueSource`](userguide/configuration_cache_requirements.html#config_cache:requirements:value_source) provider will keep the computation lazy even when the task is serialized in the [Configuration Cache](userguide/configuration_cache.html).
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -542,6 +542,8 @@ To integrate a new type of value source:
 The returned `Provider` can be passed to task properties or queried during the configuration phase.
 If the value is queried at configuration time, the source is automatically considered a build configuration input.
 
+TIP: A `ValueSource`-backed provider can also be passed as the reason argument to <<controlling_task_execution.adoc#sec:lazy_onlyif_reason, `Task.onlyIf`>>, deferring an expensive skip-reason computation until the task is actually skipped.
+
 NOTE: Do not implement `getParameters()` in your class—Gradle provides the implementation automatically.
 
 TIP: Your `ValueSource` implementation does not need to be thread-safe, Gradle synchronizes calls to `obtain()`.
@@ -564,6 +566,14 @@ Because `obtain()` is called on every build (see <<#sec:configuration_cache_beha
 
 You can also use standard Java/Kotlin/Groovy process APIs such as `java.lang.ProcessBuilder` inside `obtain()`.
 
+
+=== Composing a `ValueSource` with `map`
+
+A provider returned by `providers.of(...)` can be transformed with link:{javadocPath}/org/gradle/api/provider/Provider.html#map-org.gradle.api.Transformer-[`.map { ... }`] like any other provider.
+The transformer preserves the source `ValueSource`'s laziness: neither the source's `obtain()` nor the mapping transformer runs unless the resulting provider is actually queried.
+
+Under the Configuration Cache, the mapped chain is stored as a recipe.
+The source `ValueSource` is invoked only if the mapped provider is queried on a later build — for example when it is used to compute a task input, or passed as the reason to <<controlling_task_execution.adoc#sec:lazy_onlyif_reason, `Task.onlyIf`>> and the task is skipped.
 
 [[sec:configuration_cache_behavior]]
 === Configuration Cache Behavior

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -566,7 +566,6 @@ Because `obtain()` is called on every build (see <<#sec:configuration_cache_beha
 
 You can also use standard Java/Kotlin/Groovy process APIs such as `java.lang.ProcessBuilder` inside `obtain()`.
 
-
 === Composing a `ValueSource` with `map`
 
 A provider returned by `providers.of(...)` can be transformed with link:{javadocPath}/org/gradle/api/provider/Provider.html#map-org.gradle.api.Transformer-[`.map { ... }`] like any other provider.

--- a/platforms/documentation/docs/src/docs/userguide/reference/task-development/controlling_task_execution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/task-development/controlling_task_execution.adoc
@@ -322,7 +322,7 @@ include::sample[dir="snippets/reference/task-development/taskOnlyIfLazy/kotlin",
 include::sample[dir="snippets/reference/task-development/taskOnlyIfLazy/groovy",files="build.gradle[]"]
 ====
 
-Under the <<configuration_cache.adoc#config_cache,Configuration Cache>>, only a provider backed by a <<configuration_cache_requirements.adoc#config_cache:requirements:value_source, `ValueSource`>> stays fully lazy — including any `ValueSource.map { ... }` chain built on top of one.
+Under the <<configuration_cache.adoc#config_cache,Configuration Cache>>, only a provider backed by a <<configuration_cache_requirements.adoc#config_cache:requirements:value_source, `ValueSource`>> stays fully lazy, including any `ValueSource.map { ... }` chain built on top of one.
 A provider created via `providers.provider { ... }` is resolved eagerly at cache store time, so use a `ValueSource` when the reason involves I/O or external process invocation.
 
 [[sec:using_stopexecutionexception]]

--- a/platforms/documentation/docs/src/docs/userguide/reference/task-development/controlling_task_execution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/task-development/controlling_task_execution.adoc
@@ -311,6 +311,20 @@ $ ./gradlew hello -PskipHello --info
 include::{snippetsPath}/reference/task-development/taskOnlyIf/tests/taskOnlyIf-info.out[]
 ----
 
+[[sec:lazy_onlyif_reason]]
+==== Computing the skip reason lazily
+
+When the reason is expensive to compute — for example when it requires reading a file, running an external process, or consulting a network service — pass a `Provider<String>` instead of a plain string.
+The provider is queried only when the task is actually skipped, so the cost is paid only when the reason is needed:
+
+====
+include::sample[dir="snippets/reference/task-development/taskOnlyIfLazy/kotlin",files="build.gradle.kts[]"]
+include::sample[dir="snippets/reference/task-development/taskOnlyIfLazy/groovy",files="build.gradle[]"]
+====
+
+Under the <<configuration_cache.adoc#config_cache,Configuration Cache>>, only a provider backed by a <<configuration_cache_requirements.adoc#config_cache:requirements:value_source, `ValueSource`>> stays fully lazy — including any `ValueSource.map { ... }` chain built on top of one.
+A provider created via `providers.provider { ... }` is resolved eagerly at cache store time, so use a `ValueSource` when the reason involves I/O or external process invocation.
+
 [[sec:using_stopexecutionexception]]
 === 2. Using `StopExecutionException`
 

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/groovy/build.gradle
@@ -1,0 +1,23 @@
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+abstract class ExpensiveReason implements ValueSource<String, ValueSourceParameters.None> {
+    @Override
+    String obtain() {
+        return "there is no property skipHello"
+    }
+}
+
+def hello = tasks.register('hello') {
+    doLast {
+        println 'hello world'
+    }
+}
+
+hello.configure {
+    def skipProvider = providers.gradleProperty("skipHello")
+    def reason = providers.of(ExpensiveReason) {}
+    onlyIf(reason) {
+        !skipProvider.present
+    }
+}

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-only-if-lazy'

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/kotlin/build.gradle.kts
@@ -1,0 +1,21 @@
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+abstract class ExpensiveReason : ValueSource<String, ValueSourceParameters.None> {
+    override fun obtain(): String =
+        "there is no property skipHello"
+}
+
+val hello = tasks.register("hello") {
+    doLast {
+        println("hello world")
+    }
+}
+
+hello {
+    val skipProvider = providers.gradleProperty("skipHello")
+    val reason = providers.of(ExpensiveReason::class) {}
+    onlyIf(reason) {
+        !skipProvider.isPresent()
+    }
+}

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "task-only-if-lazy"

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/tests/taskOnlyIfLazy.out
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/tests/taskOnlyIfLazy.out
@@ -1,0 +1,3 @@
+> Task :hello SKIPPED
+
+BUILD SUCCESSFUL in 0s

--- a/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/tests/taskOnlyIfLazy.sample.conf
+++ b/platforms/documentation/docs/src/snippets/reference/task-development/taskOnlyIfLazy/tests/taskOnlyIfLazy.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: hello
+flags: -PskipHello
+expected-output-file: taskOnlyIfLazy.out

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -332,6 +332,33 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
     void onlyIf(String onlyIfReason, Spec<? super Task> onlyIfSpec);
 
     /**
+     * Executes the task only if the given spec is satisfied, using a lazily-evaluated reason.
+     * <p>
+     * The spec is evaluated at task execution time, not during configuration.
+     * If the spec is not satisfied, the task is skipped.
+     * <p>
+     * You may add multiple such predicates. The task is skipped if any of the predicates return false.
+     * <p>
+     * The reason {@link Provider} is only queried when the task is actually skipped, so the reason may be
+     * computed by expensive operations (such as a {@link org.gradle.api.provider.ValueSource}) without paying
+     * that cost during configuration or when the task actually runs.
+     *
+     * <h4>Configuration cache behavior</h4>
+     * Whether the reason is actually lazy under the configuration cache depends on the flavor of provider passed.
+     * A provider backed by a {@link org.gradle.api.provider.ValueSource} (via {@link org.gradle.api.provider.ProviderFactory#of})
+     * is serialized as a recipe and not obtained at store time, so the expensive computation runs only when the
+     * task is skipped. A provider created via {@link org.gradle.api.provider.ProviderFactory#provider} is eagerly
+     * resolved at configuration cache store time; prefer a {@code ValueSource} when the reason involves I/O or
+     * external process invocations.
+     *
+     * @param onlyIfReason a provider for the reason a task should run, queried lazily and only used for logging
+     * @param onlyIfSpec specifies if a task should be run
+     * @since 9.8.0
+     */
+    @Incubating
+    void onlyIf(Provider<String> onlyIfReason, Spec<? super Task> onlyIfSpec);
+
+    /**
      * <p>Execute the task only if the given closure returns true.  The closure will be evaluated at task execution
      * time, not during configuration.  The closure will be passed a single parameter, this task. If the closure returns
      * false, the task will be skipped.</p>
@@ -365,6 +392,33 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
      */
     @Incubating
     void setOnlyIf(String onlyIfReason, Spec<? super Task> onlyIfSpec);
+
+    /**
+     * Replaces existing {@code onlyIf} predicates with the given spec, using a lazily-evaluated reason.
+     * <p>
+     * The spec is evaluated at task execution time, not during configuration.
+     * If the spec is not satisfied, the task is skipped.
+     * <p>
+     * The given predicate replaces all such predicates for this task.
+     * <p>
+     * The reason {@link Provider} is only queried when the task is actually skipped, so the reason may be
+     * computed by expensive operations (such as a {@link org.gradle.api.provider.ValueSource}) without paying
+     * that cost during configuration or when the task actually runs.
+     *
+     * <h4>Configuration cache behavior</h4>
+     * Whether the reason is actually lazy under the configuration cache depends on the flavor of provider passed.
+     * A provider backed by a {@link org.gradle.api.provider.ValueSource} (via {@link org.gradle.api.provider.ProviderFactory#of})
+     * is serialized as a recipe and not obtained at store time, so the expensive computation runs only when the
+     * task is skipped. A provider created via {@link org.gradle.api.provider.ProviderFactory#provider} is eagerly
+     * resolved at configuration cache store time; prefer a {@code ValueSource} when the reason involves I/O or
+     * external process invocations.
+     *
+     * @param onlyIfReason a provider for the reason a task should run, queried lazily and only used for logging
+     * @param onlyIfSpec specifies if a task should be run
+     * @since 9.8.0
+     */
+    @Incubating
+    void setOnlyIf(Provider<String> onlyIfReason, Spec<? super Task> onlyIfSpec);
 
     /**
      * Returns the execution state of this task. This provides information about the execution of this task, such as

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskOnlyIfReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskOnlyIfReasonIntegrationTest.groovy
@@ -19,6 +19,9 @@ package org.gradle.api.internal.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import spock.lang.Issue
 
 class TaskOnlyIfReasonIntegrationTest extends AbstractIntegrationSpec {
     def 'task skipped by #condition reports "#reason"'() {
@@ -44,6 +47,153 @@ class TaskOnlyIfReasonIntegrationTest extends AbstractIntegrationSpec {
         "onlyIf(new Spec<Task>() { boolean isSatisfiedBy(Task task) { return false } })"    | "Task satisfies onlyIf spec"
         "setOnlyIf { false }"                                                               | "Task satisfies onlyIf closure"
         "setOnlyIf(new Spec<Task>() { boolean isSatisfiedBy(Task task) { return false } })" | "Task satisfies onlyIf spec"
+        "onlyIf(providers.provider { 'condition4' }) { false }"                             | "condition4"
+        "onlyIf('...') { true }\nsetOnlyIf(providers.provider { 'condition5' }) { false }"  | "condition5"
+        "onlyIf(providers.provider { 'first' }) { false }\n" +
+            "onlyIf(providers.provider { 'second' }) { false }"                             | "first"
+        "onlyIf(providers.provider { 'first' }) { true }\n" +
+            "onlyIf(providers.provider { 'second' }) { false }"                             | "second"
+        "onlyIf('first') { false }\n" +
+            "onlyIf(providers.provider { 'second' }) { false }"                             | "first"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38488")
+    def 'ValueSource-backed reason is not obtained when the task is not skipped'() {
+        def marker = file("value-source-obtained.txt")
+        buildFile("""
+            import org.gradle.api.provider.ValueSource
+            import org.gradle.api.provider.ValueSourceParameters
+
+            abstract class ExpensiveReason implements ValueSource<String, ValueSourceParameters.None> {
+                @Override
+                String obtain() {
+                    new File('${marker.absolutePath.replace('\\', '/')}').text = 'obtained'
+                    return 'never used'
+                }
+            }
+
+            tasks.register("task") {
+                onlyIf(providers.of(ExpensiveReason) {}) { true }
+                doLast {}
+            }
+        """)
+
+        when:
+        succeeds(":task")
+
+        then:
+        !marker.exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38488")
+    def 'ValueSource-backed reason is obtained when the task is skipped'() {
+        def marker = file("value-source-obtained.txt")
+        buildFile("""
+            import org.gradle.api.provider.ValueSource
+            import org.gradle.api.provider.ValueSourceParameters
+
+            abstract class ExpensiveReason implements ValueSource<String, ValueSourceParameters.None> {
+                @Override
+                String obtain() {
+                    new File('${marker.absolutePath.replace('\\', '/')}').text = 'obtained'
+                    return 'lazy reason'
+                }
+            }
+
+            tasks.register("task") {
+                onlyIf(providers.of(ExpensiveReason) {}) { false }
+            }
+        """)
+
+        when:
+        executer.withArgument("--info")
+        succeeds(":task")
+
+        then:
+        assertTaskSkippedWithMessage("lazy reason", ":task")
+        marker.exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38488")
+    def 'only failing onlyIf reason Providers are queried, in registration order (earlier=#earlierPasses, later=#laterPasses)'() {
+        def earlierMarker = file("earlier-obtained.txt")
+        def laterMarker = file("later-obtained.txt")
+        buildFile("""
+            import org.gradle.api.provider.ValueSource
+            import org.gradle.api.provider.ValueSourceParameters
+
+            abstract class MarkerReason implements ValueSource<String, Params> {
+                interface Params extends ValueSourceParameters {
+                    org.gradle.api.file.RegularFileProperty getMarker()
+                    org.gradle.api.provider.Property<String> getReason()
+                }
+                @Override
+                String obtain() {
+                    parameters.marker.get().asFile.text = 'obtained'
+                    return parameters.reason.get()
+                }
+            }
+
+            def earlier = providers.of(MarkerReason) {
+                parameters.marker.set(file('${earlierMarker.name}'))
+                parameters.reason.set('earlier')
+            }
+            def later = providers.of(MarkerReason) {
+                parameters.marker.set(file('${laterMarker.name}'))
+                parameters.reason.set('later')
+            }
+
+            tasks.register("task") {
+                onlyIf(earlier) { $earlierPasses }
+                onlyIf(later) { $laterPasses }
+                doLast {}
+            }
+        """)
+
+        when:
+        executer.withArgument("--info")
+        succeeds(":task")
+
+        then:
+        if (expectedSkipReason == null) {
+            outputDoesNotContain("Skipping task ':task'")
+        } else {
+            assertTaskSkippedWithMessage(expectedSkipReason, ":task")
+        }
+        assert earlierMarker.exists() == expectedEarlierObtained
+        assert laterMarker.exists() == expectedLaterObtained
+
+        where:
+        earlierPasses | laterPasses || expectedSkipReason | expectedEarlierObtained | expectedLaterObtained
+        true          | false       || "later"            | false                   | true
+        false         | true        || "earlier"          | true                    | false
+        true          | true        || null               | false                   | false
+        false         | false       || "earlier"          | true                    | false
+    }
+
+    /**
+     * A {@code providers.provider { ... }} reason is a {@code DefaultProvider}, which the configuration cache
+     * documents as eagerly evaluated at store time (see {@code DefaultProvider} javadoc). This test pins that
+     * behavior so a future change won't silently regress the documented contract — and so users who need true
+     * CC laziness know to reach for {@link org.gradle.api.provider.ValueSource} instead.
+     */
+    @Issue("https://github.com/gradle/gradle/issues/38488")
+    @Requires(value = TestExecutionPreconditions.NotConfigCached, reason = "documents that DefaultProvider is eagerly evaluated by the configuration cache at store time")
+    def 'closure-backed reason Provider is not queried when the task is not skipped (without configuration cache)'() {
+        def marker = file("provider-evaluated.txt")
+        buildFile("""
+            def marker = file('${marker.name}')
+            tasks.register("task") {
+                onlyIf(providers.provider { marker.text = 'evaluated'; 'never used' }) { true }
+                doLast {}
+            }
+        """)
+
+        when:
+        succeeds(":task")
+
+        then:
+        !marker.exists()
     }
 
     private void assertTaskSkippedWithMessage(

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskOnlyIfReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskOnlyIfReasonIntegrationTest.groovy
@@ -114,6 +114,58 @@ class TaskOnlyIfReasonIntegrationTest extends AbstractIntegrationSpec {
         marker.exists()
     }
 
+    /**
+     * Characterizes {@code ValueSource.map { ... }} composition: the transformer piggybacks on the source
+     * ValueSource's laziness. Under the configuration cache, {@code MappingProvider.calculateExecutionTimeValue()}
+     * detects that its source is an un-obtained {@code ValueSourceProvider} (a "changing value") and stores itself
+     * as a recipe — <em>without</em> calling the transformer. Both the underlying {@code obtain()} and the
+     * transformer run only when the mapped provider is first {@code get()}-ed, i.e., when the task is skipped.
+     */
+    @Issue("https://github.com/gradle/gradle/issues/38488")
+    def 'mapped ValueSource-backed reason: neither source nor transformer runs unless the task is skipped (taskPasses=#taskPasses)'() {
+        def obtainMarker = file("value-source-obtained.txt")
+        def mapMarker = file("map-invoked.txt")
+        buildFile("""
+            import org.gradle.api.provider.ValueSource
+            import org.gradle.api.provider.ValueSourceParameters
+
+            abstract class RawReason implements ValueSource<String, ValueSourceParameters.None> {
+                @Override
+                String obtain() {
+                    new File('${obtainMarker.absolutePath.replace('\\', '/')}').text = 'obtained'
+                    return 'raw'
+                }
+            }
+
+            def raw = providers.of(RawReason) {}
+            def mapped = raw.map { s ->
+                new File('${mapMarker.absolutePath.replace('\\', '/')}').text = 'mapped'
+                "mapped(" + s + ")"
+            }
+
+            tasks.register("task") {
+                onlyIf(mapped) { $taskPasses }
+                doLast {}
+            }
+        """)
+
+        when:
+        executer.withArgument("--info")
+        succeeds(":task")
+
+        then:
+        if (taskPasses) {
+            outputDoesNotContain("Skipping task ':task'")
+        } else {
+            assertTaskSkippedWithMessage("mapped(raw)", ":task")
+        }
+        assert obtainMarker.exists() == !taskPasses
+        assert mapMarker.exists() == !taskPasses
+
+        where:
+        taskPasses << [true, false]
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/38488")
     def 'only failing onlyIf reason Providers are queried, in registration order (earlier=#earlierPasses, later=#laterPasses)'() {
         def earlierMarker = file("earlier-obtained.txt")

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -96,12 +96,22 @@ public abstract class DefaultTask extends org.gradle.api.internal.AbstractTask i
     }
 
     @Override
+    public void onlyIf(Provider<String> onlyIfReason, Spec<? super Task> spec) {
+        super.onlyIf(onlyIfReason, spec);
+    }
+
+    @Override
     public void setOnlyIf(Spec<? super Task> spec) {
         super.setOnlyIf(spec);
     }
 
     @Override
     public void setOnlyIf(String onlyIfReason, Spec<? super Task> spec) {
+        super.setOnlyIf(onlyIfReason, spec);
+    }
+
+    @Override
+    public void setOnlyIf(Provider<String> onlyIfReason, Spec<? super Task> spec) {
         super.setOnlyIf(onlyIfReason, spec);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -364,6 +364,16 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     }
 
     @Override
+    public void onlyIf(final Provider<String> onlyIfReason, final Spec<? super Task> spec) {
+        taskMutator.mutate("Task.onlyIf(Provider, Spec)", new Runnable() {
+            @Override
+            public void run() {
+                onlyIfSpec = onlyIfSpec.and(spec, onlyIfReason);
+            }
+        });
+    }
+
+    @Override
     public void setOnlyIf(final Spec<? super Task> spec) {
         taskMutator.mutate("Task.setOnlyIf(Spec)", new Runnable() {
             @Override
@@ -376,6 +386,16 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Override
     public void setOnlyIf(String onlyIfReason, Spec<? super Task> spec) {
         taskMutator.mutate("Task.setOnlyIf(String, Spec)", new Runnable() {
+            @Override
+            public void run() {
+                onlyIfSpec = createNewOnlyIfSpec().and(spec, onlyIfReason);
+            }
+        });
+    }
+
+    @Override
+    public void setOnlyIf(final Provider<String> onlyIfReason, final Spec<? super Task> spec) {
+        taskMutator.mutate("Task.setOnlyIf(Provider, Spec)", new Runnable() {
             @Override
             public void run() {
                 onlyIfSpec = createNewOnlyIfSpec().and(spec, onlyIfReason);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DescribingAndSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DescribingAndSpec.java
@@ -21,6 +21,7 @@ import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.CompositeSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.internal.ClosureSpec;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.jspecify.annotations.Nullable;
 
@@ -59,6 +60,10 @@ public class DescribingAndSpec<T> extends CompositeSpec<T> {
 
     public DescribingAndSpec<T> and(Spec<? super T> spec, String description) {
         return new DescribingAndSpec<>(specHolder.and(new SelfDescribingSpec<>(spec, description)));
+    }
+
+    public DescribingAndSpec<T> and(Spec<? super T> spec, Provider<String> descriptionProvider) {
+        return new DescribingAndSpec<>(specHolder.and(new SelfDescribingSpec<>(spec, descriptionProvider)));
     }
 
     @SuppressWarnings("rawtypes")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SelfDescribingSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SelfDescribingSpec.java
@@ -18,20 +18,32 @@ package org.gradle.api.internal.tasks.execution;
 
 import org.gradle.api.Describable;
 import org.gradle.api.GradleException;
+import org.gradle.api.internal.provider.Providers;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
+import org.jspecify.annotations.Nullable;
 
 public class SelfDescribingSpec<T> implements Describable, Spec<T> {
-    private final String description;
     private final Spec<? super T> spec;
+    private final Provider<String> descriptionProvider;
+    @Nullable
+    private String resolvedDescription;
 
     public SelfDescribingSpec(Spec<? super T> spec, String description) {
+        this(spec, Providers.of(description));
+    }
+
+    public SelfDescribingSpec(Spec<? super T> spec, Provider<String> descriptionProvider) {
         this.spec = spec;
-        this.description = description;
+        this.descriptionProvider = descriptionProvider;
     }
 
     @Override
     public String getDisplayName() {
-        return description;
+        if (resolvedDescription == null) {
+            resolvedDescription = descriptionProvider.get();
+        }
+        return resolvedDescription;
     }
 
     @Override
@@ -45,8 +57,8 @@ public class SelfDescribingSpec<T> implements Describable, Spec<T> {
 
     @Override
     public String toString() {
-        return "SelfDescribingSpec{"
-            + "description='" + description + '\''
+        return "SelfDescribingSpec{description="
+            + (resolvedDescription != null ? "'" + resolvedDescription + "'" : "<UNEVALUATED>")
             + '}';
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SelfDescribingSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SelfDescribingSpecTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution
+
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.Provider
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link SelfDescribingSpec}.
+ */
+class SelfDescribingSpecTest extends Specification {
+    def "toString reports description as <UNEVALUATED> before getDisplayName is called"() {
+        given:
+        def spec = new SelfDescribingSpec<Object>({ true }, Providers.of("the reason"))
+
+        expect:
+        spec.toString() == "SelfDescribingSpec{description=<UNEVALUATED>}"
+    }
+
+    def "toString reports the resolved description after getDisplayName is called"() {
+        given:
+        def spec = new SelfDescribingSpec<Object>({ true }, Providers.of("the reason"))
+
+        when:
+        spec.getDisplayName()
+
+        then:
+        spec.toString() == "SelfDescribingSpec{description='the reason'}"
+    }
+
+    def "String-argument constructor eagerly considers the description evaluated for toString"() {
+        given:
+        def spec = new SelfDescribingSpec<Object>({ true }, "the reason")
+
+        when:
+        spec.getDisplayName()
+
+        then:
+        spec.toString() == "SelfDescribingSpec{description='the reason'}"
+    }
+
+    def "descriptionProvider is queried at most once across repeated getDisplayName calls"() {
+        given:
+        def provider = Mock(Provider)
+        def spec = new SelfDescribingSpec<Object>({ true }, provider)
+
+        when:
+        3.times { spec.getDisplayName() }
+
+        then:
+        1 * provider.get() >> "the reason"
+        0 * provider._
+    }
+
+    def "toString does not invoke the descriptionProvider"() {
+        given:
+        def provider = Mock(Provider)
+        def spec = new SelfDescribingSpec<Object>({ true }, provider)
+
+        when:
+        def result = spec.toString()
+
+        then:
+        result == "SelfDescribingSpec{description=<UNEVALUATED>}"
+        0 * provider._
+    }
+}


### PR DESCRIPTION
Introduces new `onlyIf` and `setOnlyIf` overloads on the `Task` interface that accept a `Provider` for the skip reason.

This defers the computation of the reason until the task is actually skipped, avoiding unnecessary work during configuration. It particularly benefits expensive reason calculations and improves configuration cache behavior when using `ValueSource`-backed providers.

<!--- The issue this PR addresses -->
Fixes #38488