### PR TITLE
Document variantOf() for classifiers in version catalogs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
@@ -145,25 +145,20 @@ include::sample[dir="snippets/reference/dependency-management/centralizing-depen
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier]"]
 ====
 
-For example, to include source JARs and Javadoc JARs for IDE integration:
+For example, if a code-analysis or documentation-generation task needs the sources JAR as an artifact input:
 
 ====
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin",files="build.gradle.kts[tags=use_classifier_sources]"]
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier_sources]"]
 ====
 
-This keeps the catalog focused on coordinates while letting each consumer choose the appropriate classifier.
-
 **Common use cases for classifiers:**
 
-* **Sources and Javadoc JARs**: Many libraries publish separate JARs containing source code (`sources` classifier) or API documentation (`javadoc` classifier). IDEs and documentation tools can consume these artifacts.
+* **Sources and Javadoc JARs**: Projects that explicitly depend on Java sources (e.g., for code analysis or documentation generation) can use the `sources` or `javadoc` classifiers.
 
-* **Test Fixtures**: Libraries that publish reusable test utilities often use a `test-fixtures` classifier.
+* **Test Fixtures**: For test fixtures specifically, prefer the dedicated `testFixtures(libs.my.lib)` API rather than declaring the `test-fixtures` classifier explicitly.
 
 * **Platform-specific artifacts**: Native libraries may publish separate artifacts for different operating systems or architectures (e.g., `linux-x86_64`, `windows-x86_64`).
-
-The `variantOf()` function creates a dependency variant based on the catalog entry but with the specified classifier applied.
-Each project can independently decide which classifier variant it needs without duplicating the base coordinates in the catalog.
 
 For artifact types (common in Android projects needing `@aar`), use the `artifact` block:
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
@@ -145,7 +145,25 @@ include::sample[dir="snippets/reference/dependency-management/centralizing-depen
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier]"]
 ====
 
+For example, to include source JARs and Javadoc JARs for IDE integration:
+
+====
+include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin",files="build.gradle.kts[tags=use_classifier_sources]"]
+include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier_sources]"]
+====
+
 This keeps the catalog focused on coordinates while letting each consumer choose the appropriate classifier.
+
+**Common use cases for classifiers:**
+
+* **Sources and Javadoc JARs**: Many libraries publish separate JARs containing source code (`sources` classifier) or API documentation (`javadoc` classifier). IDEs and documentation tools can consume these artifacts.
+
+* **Test Fixtures**: Libraries that publish reusable test utilities often use a `test-fixtures` classifier.
+
+* **Platform-specific artifacts**: Native libraries may publish separate artifacts for different operating systems or architectures (e.g., `linux-x86_64`, `windows-x86_64`).
+
+The `variantOf()` function creates a dependency variant based on the catalog entry but with the specified classifier applied.
+Each project can independently decide which classifier variant it needs without duplicating the base coordinates in the catalog.
 
 For artifact types (common in Android projects needing `@aar`), use the `artifact` block:
 
@@ -383,6 +401,9 @@ These are explicit limitations the catalog TOML format does not support:
 * `type = "aar"` or `ext = "zip"` artifact types
 * `exclude` rules
 * `capabilities` requirements
+
+**Workarounds**: For classifiers and artifact types, see <<#sec:classifiers_artifact_types_and_capabilities, Classifiers, artifact types, and capabilities>>.
+For excludes and capabilities, apply them at the dependency declaration site in your build script using the standard dependency configuration DSL.
 
 [[sec:programmatic-catalog-versions]]
 == Programming catalogs

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/centralizing-dependencies/version_catalogs.adoc
@@ -145,20 +145,20 @@ include::sample[dir="snippets/reference/dependency-management/centralizing-depen
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier]"]
 ====
 
-For example, if a code-analysis or documentation-generation task needs the sources JAR as an artifact input:
+For example, to depend on the sources or Javadoc JAR:
 
 ====
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin",files="build.gradle.kts[tags=use_classifier_sources]"]
 include::sample[dir="snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy",files="build.gradle[tags=use_classifier_sources]"]
 ====
 
-**Common use cases for classifiers:**
+*Common use cases for classifiers*:
 
-* **Sources and Javadoc JARs**: Projects that explicitly depend on Java sources (e.g., for code analysis or documentation generation) can use the `sources` or `javadoc` classifiers.
+* *Sources and Javadoc JARs*: use the `sources` or `javadoc` classifiers, for example when a code-analysis or documentation-generation task needs the artifact as an input.
 
-* **Test Fixtures**: For test fixtures specifically, prefer the dedicated `testFixtures(libs.my.lib)` API rather than declaring the `test-fixtures` classifier explicitly.
+* *Platform-specific artifacts*: native libraries may publish separate artifacts for different operating systems or architectures (for example, `linux-x86_64`, `windows-x86_64`), as shown in the primary example above.
 
-* **Platform-specific artifacts**: Native libraries may publish separate artifacts for different operating systems or architectures (e.g., `linux-x86_64`, `windows-x86_64`).
+* *Test fixtures*: prefer the dedicated `testFixtures(libs.my.lib)` API over declaring the `test-fixtures` classifier explicitly.
 
 For artifact types (common in Android projects needing `@aar`), use the `artifact` block:
 
@@ -397,7 +397,7 @@ These are explicit limitations the catalog TOML format does not support:
 * `exclude` rules
 * `capabilities` requirements
 
-**Workarounds**: For classifiers and artifact types, see <<#sec:classifiers_artifact_types_and_capabilities, Classifiers, artifact types, and capabilities>>.
+*Workarounds*: for classifiers and artifact types, see <<#sec:classifiers_artifact_types_and_capabilities, Classifiers, artifact types, and capabilities>>.
 For excludes and capabilities, apply them at the dependency declaration site in your build script using the standard dependency configuration DSL.
 
 [[sec:programmatic-catalog-versions]]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
@@ -10,10 +10,10 @@ dependencies {
 
 // tag::use_classifier_sources[]
 dependencies {
-    // Add the library's source code for IDE integration
+    // Depend on the sources JAR as an artifact
     implementation(variantOf(libs.my.lib) { classifier('sources') })
-    
-    // Add the library's Javadoc for IDE integration
+
+    // Depend on the Javadoc JAR as an artifact
     implementation(variantOf(libs.my.lib) { classifier('javadoc') })
 }
 // end::use_classifier_sources[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 // tag::use_classifier[]
 dependencies {
-    implementation(variantOf(libs.my.lib) { classifier('test-fixtures') })
+    implementation(variantOf(libs.my.lib) { classifier('linux-x86_64') })
 }
 // end::use_classifier[]
 

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/groovy/build.gradle
@@ -8,6 +8,16 @@ dependencies {
 }
 // end::use_classifier[]
 
+// tag::use_classifier_sources[]
+dependencies {
+    // Add the library's source code for IDE integration
+    implementation(variantOf(libs.my.lib) { classifier('sources') })
+    
+    // Add the library's Javadoc for IDE integration
+    implementation(variantOf(libs.my.lib) { classifier('javadoc') })
+}
+// end::use_classifier_sources[]
+
 // tag::use_artifact_type[]
 dependencies {
     implementation(libs.my.lib) {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
@@ -8,6 +8,16 @@ dependencies {
 }
 // end::use_classifier[]
 
+// tag::use_classifier_sources[]
+dependencies {
+    // Add the library's source code for IDE integration
+    implementation(variantOf(libs.my.lib) { classifier("sources") })
+    
+    // Add the library's Javadoc for IDE integration
+    implementation(variantOf(libs.my.lib) { classifier("javadoc") })
+}
+// end::use_classifier_sources[]
+
 // tag::use_artifact_type[]
 dependencies {
     implementation(libs.my.lib) {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
 
 // tag::use_classifier_sources[]
 dependencies {
-    // Add the library's source code for IDE integration
+    // Depend on the sources JAR as an artifact
     implementation(variantOf(libs.my.lib) { classifier("sources") })
-    
-    // Add the library's Javadoc for IDE integration
+
+    // Depend on the Javadoc JAR as an artifact
     implementation(variantOf(libs.my.lib) { classifier("javadoc") })
 }
 // end::use_classifier_sources[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/centralizing-dependencies/catalogs-classifiers/kotlin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 // tag::use_classifier[]
 dependencies {
-    implementation(variantOf(libs.my.lib) { classifier("test-fixtures") })
+    implementation(variantOf(libs.my.lib) { classifier("linux-x86_64") })
 }
 // end::use_classifier[]
 


### PR DESCRIPTION
Fixes #17169

### Context
Users have been requesting clearer documentation on how to specify dependency classifiers (such as sources, javadoc, test-fixtures) in version catalogs. The existing documentation mentioned that classifiers are not supported in the TOML file itself, but the workaround using `variantOf()` was not sufficiently explained with practical examples.

This PR enhances the version catalog documentation to better explain how to use `variantOf()` for specifying dependency classifiers.

## Changes
- Added detailed explanation of common classifier use cases (sources, javadoc, test-fixtures, platform-specific artifacts)
- Added example showing how to use `variantOf()` for sources and javadoc JARs
- Enhanced the limitations section to reference the workaround for classifiers and artifact types
- Improved the overall clarity of the documentation

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. *(N/A - Documentation only change)*
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic. *(N/A - Documentation only change)*
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes. *(Done - Updated User Guide)*
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.