### PR TITLE
docs: clarify the public-API status of Kotlin DSL packages

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
@@ -72,10 +72,12 @@ Conversely, the `**` wildcard matches the noted package and its subpackages.
 The Kotlin DSL provides a public API on top of the Gradle API.
 The following Kotlin DSL packages are public API:
 
-* `org.gradle.kotlin.dsl`
-* `org.gradle.kotlin.dsl.plugins.dsl`
-* `org.gradle.kotlin.dsl.precompile`
+[source,text]
+----
+org.gradle.kotlin.dsl.*  (top-level classes only — excludes subpackages)
+org.gradle.kotlin.dsl.plugins.dsl.*
+org.gradle.kotlin.dsl.precompile.*
+----
 
-Subpackages of these, for example `org.gradle.kotlin.dsl.support` or `org.gradle.kotlin.dsl.provider`, are internal implementation details and must not be used from plugins or build scripts.
 
 NOTE: For more details, see <<kotlin_dsl.adoc#avoid_using_internal_kotlin_dsl_apis,Avoid Using Internal Kotlin DSL APIs>>.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
@@ -70,7 +70,12 @@ Conversely, the `**` wildcard matches the noted package and its subpackages.
 == Kotlin DSL packages
 
 The Kotlin DSL provides a public API on top of the Gradle API.
-Only the top-level `org.gradle.kotlin.dsl` package is public API.
-Its subpackages, such as `org.gradle.kotlin.dsl.support`, are internal implementation details and must not be used from plugins or build scripts.
+The following Kotlin DSL packages are public API:
+
+* `org.gradle.kotlin.dsl`
+* `org.gradle.kotlin.dsl.plugins.dsl`
+* `org.gradle.kotlin.dsl.precompile`
+
+Subpackages of these, for example `org.gradle.kotlin.dsl.support` or `org.gradle.kotlin.dsl.provider`, are internal implementation details and must not be used from plugins or build scripts.
 
 NOTE: For more details, see <<kotlin_dsl.adoc#avoid_using_internal_kotlin_dsl_apis,Avoid Using Internal Kotlin DSL APIs>>.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/public_apis.adoc
@@ -65,3 +65,12 @@ org.gradle.util.**
 
 NOTE: The `\*` wildcard matches only classes directly in the package (e.g., `org.gradle.Foo`), but **does not include subpackages** like `org.gradle.something.Foo`.
 Conversely, the `**` wildcard matches the noted package and its subpackages.
+
+[[kotlin_dsl_packages]]
+== Kotlin DSL packages
+
+The Kotlin DSL provides a public API on top of the Gradle API.
+Only the top-level `org.gradle.kotlin.dsl` package is public API.
+Its subpackages, such as `org.gradle.kotlin.dsl.support`, are internal implementation details and must not be used from plugins or build scripts.
+
+NOTE: For more details, see <<kotlin_dsl.adoc#avoid_using_internal_kotlin_dsl_apis,Avoid Using Internal Kotlin DSL APIs>>.


### PR DESCRIPTION
<!-- Fixes #38553 -->
Fixes #38553

### Context

The public-API reference did not state the boundary of the Kotlin DSL packages, which confused users (the issue references regression #38392). This adds a short "Kotlin DSL packages" subsection to `public_apis.adoc` clarifying that only the top-level `org.gradle.kotlin.dsl` package is public API and its subpackages (e.g. `org.gradle.kotlin.dsl.support`) are internal, cross-linking the existing "Avoid Using Internal Kotlin DSL APIs" note in `kotlin_dsl.adoc`.

The boundary is grounded in the codified source of truth `build-logic-commons/basics/.../PublicKotlinDslApi.kt` (public list is `org/gradle/kotlin/dsl/*` top-level, not `.support`), and `org.gradle.kotlin.dsl.support` exists as internal production source.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) (DCO).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE) — this is documentation authored by me.
- [x] Check "Allow edit from maintainers" option.
- [ ] Provide integration tests — N/A, documentation-only change.
- [ ] Provide unit tests — N/A, documentation-only change.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes — this updates the DSL Reference.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck` — not run locally (full docs build is heavy); the added `<<kotlin_dsl.adoc#avoid_using_internal_kotlin_dsl_apis,...>>` xref was verified against `FindBrokenInternalLinks` logic (target anchor exists at `kotlin_dsl.adoc:157`, same `dsl-apis/` directory).
- [ ] `./gradlew <changed-subproject>:quickTest` — N/A, docs-only.

<sub>AI disclosure: this PR was drafted with Claude Code (AI-assisted) and human-reviewed. The package boundary was grounded in `PublicKotlinDslApi.kt` and the internal `.support` source, and the cross-reference target was verified to exist.</sub>
