### PR TITLE
Improve RFC 9457 error format and add problem details integration tests

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -446,14 +446,16 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         failure.assertHasCause("Could not resolve ${group}:${module}:${version}.")
         failure.assertHasCause("Failed to list versions for ${group}:${module}.")
         failure.assertHasCause("Unable to load Maven meta-data from ${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
     }
 
     private void assertDependencyListingUnauthorizedError(String group, String module, String version) {
         failure.assertHasCause("Could not resolve ${group}:${module}:${version}.")
         failure.assertHasCause("Failed to list versions for ${group}:${module}.")
         failure.assertHasCause("Unable to load Maven meta-data from ${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml'. Received status code 401 from server: Unauthorized")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${group}/${module}/maven-metadata.xml'.")
+        failure.assertHasCause("Received status code 401 from server: Unauthorized")
     }
 
     private void assertDependencyMetaDataReadTimeout(MavenModule module) {
@@ -466,13 +468,15 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     private void assertDependencyMetaDataInternalServerError(MavenModule module) {
         failure.assertHasCause("Could not resolve ${mavenModuleCoordinates(module)}.")
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
     }
 
     private void assertDependencyMetaDataUnauthorizedError(MavenModule module) {
         failure.assertHasCause("Could not resolve ${mavenModuleCoordinates(module)}.")
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'. Received status code 401 from server: Unauthorized")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
+        failure.assertHasCause("Received status code 401 from server: Unauthorized")
     }
 
     private void assertDependencyArtifactReadTimeout(MavenModule module) {
@@ -485,13 +489,15 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     private void assertDependencyArtifactInternalServerError(MavenModule module) {
         failure.assertHasCause("Could not download ${module.artifactFile.name} (${mavenModuleCoordinates(module)})")
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
     }
 
     private void assertDependencyArtifactUnauthorizedError(MavenModule module) {
         failure.assertHasCause("Could not download ${module.artifactFile.name} (${mavenModuleCoordinates(module)})")
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'.")
-        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'. Received status code 401 from server: Unauthorized")
+        failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'.")
+        failure.assertHasCause("Received status code 401 from server: Unauthorized")
     }
 
     private void assertDependencySkipped(MavenModule module, String repositoryName) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
@@ -315,7 +315,8 @@ dependencies {
         fails ":checkDeps"
         failure.assertHasCause("Could not resolve org.utils:api:+.")
         failure.assertHasCause("Could not resolve org.utils:api:2.1.")
-        failure.assertHasCause("Could not GET '${legacyMetadataURI('org.utils', 'api', '2.1')}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${legacyMetadataURI('org.utils', 'api', '2.1')}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         resetExpectations()
@@ -331,7 +332,8 @@ dependencies {
         then:
         fails ":checkDeps"
         failure.assertHasCause("Could not download api-2.1.jar (org.utils:api:2.1)")
-        failure.assertHasCause("Could not GET '${artifactURI('org.utils', 'api', '2.1')}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${artifactURI('org.utils', 'api', '2.1')}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -479,7 +479,8 @@ task showBroken {
         }
         failure.assertResolutionFailure(':broken')
             .assertHasCause('Could not resolve group:projectA:1.3.')
-            .assertHasCause("Could not GET '${module.ivy.uri}'. Received status code 500 from server: Internal Server Error")
+            .assertHasCause("Could not GET '${module.ivy.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()
@@ -567,7 +568,8 @@ task retrieve(type: Sync) {
         then:
         fails "retrieve"
         failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
-        failure.assertHasCause("Could not GET '${module.jar.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${module.jar.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -1252,7 +1252,8 @@ dependencies {
         fails "checkDeps"
         failure.assertHasCause("Could not resolve group:projectA:2.+")
         failure.assertHasCause("Could not list versions using Ivy pattern '${ivyHttpRepo.ivyPattern}'.")
-        failure.assertHasCause("Could not GET '${directoryList.uri}'. Received status code 500 from server")
+        failure.assertHasCause("Could not GET '${directoryList.uri}'.")
+        failure.assertHasCause("Received status code 500 from server")
 
         when:
         def projectA2 = ivyHttpRepo.module("group", "projectA", "2.2").publish()
@@ -1318,7 +1319,8 @@ dependencies {
         then:
         fails "checkDeps"
         failure.assertHasCause("Could not resolve group:projectA:latest.release")
-        failure.assertHasCause("Could not GET '${projectA.ivy.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${projectA.ivy.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()
@@ -1328,7 +1330,8 @@ dependencies {
         then:
         fails "checkDeps"
         failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
-        failure.assertHasCause("Could not GET '${projectA.jar.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${projectA.jar.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -359,10 +359,11 @@ Searched in the following locations:
         fails("verify")
         failure.assertHasCause("Could not download some-artifact-1.0-broken-sources.jar (some.group:some-artifact:1.0)")
         failure.assertHasCause("Could not get resource '${brokenSources.uri}'.")
-        failure.assertHasCause("Could not GET '${brokenSources.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${brokenSources.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
         failure.assertHasCause("Could not download some-artifact-1.0-my-javadoc.jar (some.group:some-artifact:1.0)")
         failure.assertHasCause("Could not get resource '${brokenJavadoc.uri}'.")
-        failure.assertHasCause("Could not GET '${brokenJavadoc.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${brokenJavadoc.uri}'.")
 
         when:
         fixture.clearExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -283,7 +283,8 @@ task showBroken {
         then:
         failure.assertResolutionFailure(':broken')
             .assertHasCause('Could not resolve group:projectA:1.3.')
-            .assertHasCause("Could not GET '${module.pom.uri}'. Received status code 500 from server: Internal Server Error")
+            .assertHasCause("Could not GET '${module.pom.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()
@@ -478,7 +479,8 @@ task retrieve(type: Sync) {
         then:
         fails "retrieve"
         failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
-        failure.assertHasCause("Could not GET '${module.artifact.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${module.artifact.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -193,7 +193,8 @@ task retrieve(type: Sync) {
         failure.assertHasCause('Could not resolve group:projectA:1.+.')
         failure.assertHasCause('Failed to list versions for group:projectA.')
         failure.assertHasCause("Unable to load Maven meta-data from ${metaData.uri}.")
-        failure.assertHasCause("Could not GET '${metaData.uri}'. Received status code 500 from server")
+        failure.assertHasCause("Could not GET '${metaData.uri}'.")
+        failure.assertHasCause("Received status code 500 from server")
 
         when:
         metaData.expectGetMissing()
@@ -208,7 +209,8 @@ task retrieve(type: Sync) {
         failure.assertHasCause('Could not resolve group:projectA:1.+.')
         failure.assertHasCause('Failed to list versions for group:projectA.')
         failure.assertHasCause("Could not list versions using M2 pattern '${mavenHttpRepo.uri}")
-        failure.assertHasCause("Could not GET '${moduleDir.uri}'. Received status code 500 from server")
+        failure.assertHasCause("Could not GET '${moduleDir.uri}'.")
+        failure.assertHasCause("Received status code 500 from server")
 
         when:
         server.resetExpectations()
@@ -239,7 +241,8 @@ task retrieve(type: Sync) {
 
         then:
         failure.assertHasCause("Could not resolve group:projectA:1.+.")
-        failure.assertHasCause("Could not GET '${projectA.pom.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${projectA.pom.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()
@@ -251,7 +254,8 @@ task retrieve(type: Sync) {
 
         then:
         failure.assertHasCause("Could not download projectA-1.1.jar (group:projectA:1.1)")
-        failure.assertHasCause("Could not GET '${projectA.artifact.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${projectA.artifact.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()
@@ -392,7 +396,8 @@ Searched in the following locations:
         then:
         failure.assertHasCause('Could not resolve group:projectA:1.+')
         failure.assertHasCause('Could not resolve group:projectA:1.1')
-        failure.assertHasCause("Could not GET '${repo1.uri}/group/projectA/1.1/projectA-1.1.pom'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${repo1.uri}/group/projectA/1.1/projectA-1.1.pom'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         server.resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -260,7 +260,8 @@ Searched in the following locations:
         then:
         fails("verify")
         failure.assertHasCause("Could not determine artifacts for some.group:some-artifact:1.0")
-        failure.assertHasCause("Could not HEAD '${sourceArtifact.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not HEAD '${sourceArtifact.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         fixture.clearExpectations()
@@ -290,7 +291,8 @@ Searched in the following locations:
         fails("verify")
         failure.assertHasCause("Could not download some-artifact-1.0-javadoc.jar (some.group:some-artifact:1.0)")
         failure.assertHasCause("Could not get resource '${javadocArtifact.uri}'")
-        failure.assertHasCause("Could not GET '${javadocArtifact.uri}'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${javadocArtifact.uri}'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         fixture.clearExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRfc9457RemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRfc9457RemoteResolveIntegrationTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+
+/**
+ * End-to-end integration tests that drive Gradle dependency resolution against a Maven
+ * repository which fails artifact requests with an RFC 9457 Problem Details response
+ * ({@code application/problem+json}).
+ *
+ * <p>These tests exercise the full resolution stack (not just the low-level HTTP client)
+ * and demonstrate the console output a user sees when a modern repository (e.g.
+ * Nexus 3.75+, Artifactory) rejects a request with a detailed problem body.
+ */
+class MavenRfc9457RemoteResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    def setup() {
+        settingsFile << """
+            rootProject.name = "root"
+        """
+        buildFile << """
+            repositories {
+                maven { url = "${mavenHttpRepo.uri}" }
+            }
+            configurations { compile }
+            dependencies {
+                compile 'group:projectA:1.2'
+            }
+            task retrieve(type: Sync) {
+                from configurations.compile
+                into 'libs'
+            }
+        """
+    }
+
+    def "surfaces RFC 9457 detail from artifact-quarantine 403 (detail-only overload)"() {
+        given:
+        def module = mavenHttpRepo.module('group', 'projectA', '1.2').publish()
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGetBroken(403,
+            "Artifact 'group:projectA:1.2' is quarantined pending policy review (rule: 'block-untrusted-publishers').")
+
+        then:
+        fails "retrieve"
+        failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
+        failure.assertHasCause(
+            "Could not GET '${module.artifact.uri}'. Received status code 403 from server: " +
+                "Artifact 'group:projectA:1.2' is quarantined pending policy review (rule: 'block-untrusted-publishers')."
+        )
+    }
+
+    def "surfaces RFC 9457 detail from license-policy 451 (full-payload overload)"() {
+        given:
+        def module = mavenHttpRepo.module('group', 'projectA', '1.2').publish()
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGetBroken(451, [
+            type    : "https://example.com/problems/license-violation",
+            title   : "License Policy Violation",
+            status  : 451,
+            detail  : "The artifact group:projectA:1.2 uses a GPL-3.0 license, which is not permitted by the organization's approved-licenses policy.",
+            instance: "/repository/maven-central/group/projectA/1.2/projectA-1.2.jar"
+        ])
+
+        then:
+        fails "retrieve"
+        failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
+        failure.assertHasCause(
+            "Could not GET '${module.artifact.uri}'. Received status code 451 from server: " +
+                "The artifact group:projectA:1.2 uses a GPL-3.0 license, which is not permitted by the organization's approved-licenses policy."
+        )
+    }
+
+    def "surfaces RFC 9457 detail from vulnerability-gate 403 (full-payload overload) and shows it in console output"() {
+        given:
+        def module = mavenHttpRepo.module('group', 'projectA', '1.2').publish()
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGetBroken(403, [
+            type    : "https://example.com/problems/vulnerability-blocked",
+            title   : "Vulnerability Policy Violation",
+            status  : 403,
+            detail  : "Download blocked: group:projectA:1.2 has 2 known critical CVEs (CVE-2025-11111, CVE-2025-22222). Contact security@example.com to request an exception.",
+            instance: "/repository/maven-central/group/projectA/1.2/projectA-1.2.jar"
+        ])
+
+        then:
+        fails "retrieve"
+
+        and: "the detailed RFC 9457 message reaches the user-facing console output"
+        failure.assertHasErrorOutput(
+            "Received status code 403 from server: Download blocked: group:projectA:1.2 has 2 known critical CVEs (CVE-2025-11111, CVE-2025-22222). Contact security@example.com to request an exception."
+        )
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRfc9457RemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRfc9457RemoteResolveIntegrationTest.groovy
@@ -59,8 +59,9 @@ class MavenRfc9457RemoteResolveIntegrationTest extends AbstractHttpDependencyRes
         then:
         fails "retrieve"
         failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
+        failure.assertHasCause("Could not GET '${module.artifact.uri}'.")
         failure.assertHasCause(
-            "Could not GET '${module.artifact.uri}'. Received status code 403 from server: " +
+            "Received status code 403 from server: " +
                 "Artifact 'group:projectA:1.2' is quarantined pending policy review (rule: 'block-untrusted-publishers')."
         )
     }
@@ -82,8 +83,9 @@ class MavenRfc9457RemoteResolveIntegrationTest extends AbstractHttpDependencyRes
         then:
         fails "retrieve"
         failure.assertHasCause("Could not download projectA-1.2.jar (group:projectA:1.2)")
+        failure.assertHasCause("Could not GET '${module.artifact.uri}'.")
         failure.assertHasCause(
-            "Could not GET '${module.artifact.uri}'. Received status code 451 from server: " +
+            "Received status code 451 from server: " +
                 "The artifact group:projectA:1.2 uses a GPL-3.0 license, which is not permitted by the organization's approved-licenses policy."
         )
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -819,7 +819,8 @@ task retrieve(type: Sync) {
         and:
         failure.assertHasCause('Could not resolve group:projectA:1.0-SNAPSHOT.')
         failure.assertHasCause("Unable to load Maven meta-data from ${metaData.uri}.")
-        failure.assertHasCause("Could not GET '${metaData.uri}'. Received status code 500 from server")
+        failure.assertHasCause("Could not GET '${metaData.uri}'.")
+        failure.assertHasCause("Received status code 500 from server")
 
         when:
         server.resetExpectations()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -442,7 +442,8 @@ abstract class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest e
         then:
         fails 'checkDeps'
         failure.assertHasCause("Could not resolve group:projectB:latest.release.")
-        failure.assertHasCause("Could not GET '${server.uri}/repo/group/projectB/2.2/status.txt'. Received status code 500 from server: Internal Server Error")
+        failure.assertHasCause("Could not GET '${server.uri}/repo/group/projectB/2.2/status.txt'.")
+        failure.assertHasCause("Received status code 500 from server: Internal Server Error")
 
         when:
         resetExpectations()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisablerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisablerTest.groovy
@@ -92,7 +92,7 @@ class ConnectionFailureRepositoryDisablerTest extends Specification {
     }
 
     static RuntimeException createHttpErrorStatusCodeException(int statusCode) {
-        createNestedException(new HttpErrorStatusCodeException('GET', 'test.file', statusCode, ''))
+        createNestedException(new HttpErrorStatusCodeException(statusCode, ''))
     }
 
     static RuntimeException createTimeoutException() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -80,7 +80,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
     }
 
     private static HttpErrorStatusCodeException status(int statusCode) {
-        new HttpErrorStatusCodeException("GET", "DUMMY", statusCode, "test") {
+        new HttpErrorStatusCodeException(statusCode, "test") {
             @Override
             String toString() {
                 "status $statusCode"

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
@@ -48,7 +48,7 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
             new SocketException("something went wrong"),
             new SocketTimeoutException("something went wrong"),
             new HttpHostConnectException(new IOException("something went wrong"), null, null),
-            new HttpErrorStatusCodeException("something", "something", 503, "something"),
+            new HttpErrorStatusCodeException(503, "something"),
             new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
         ]
     }
@@ -74,7 +74,7 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
                 new SocketException("something went wrong"),
                 new SocketTimeoutException("something went wrong"),
                 new HttpHostConnectException(new IOException("something went wrong"), null, null),
-                new HttpErrorStatusCodeException("something", "something", 503, "something"),
+                new HttpErrorStatusCodeException(503, "something"),
                 new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
         ]
     }
@@ -97,7 +97,7 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
         where:
         ex << [
             new RuntimeException("non network issue"),
-            new HttpErrorStatusCodeException("something", "something", 400, "something")
+            new HttpErrorStatusCodeException(400, "something")
         ]
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
@@ -41,8 +41,8 @@ class NetworkingIssueVerifierTest extends Specification {
         "ConnectionClosedException"                                 | new ConnectionClosedException("something went wrong")
         "HttpHostConnectException"                                  | new HttpHostConnectException(new IOException("something went wrong"), null, null)
         "DefaultMultiCauseException"                                | new DefaultMultiCauseException("something went wrong", new SocketTimeoutException())
-        "HttpErrorStatusCodeException with server error"            | new HttpErrorStatusCodeException("something", "something", 503, "something")
-        "HttpErrorStatusCodeException with transient client error"  | new HttpErrorStatusCodeException("something", "something", 429, "something")
+        "HttpErrorStatusCodeException with server error"            | new HttpErrorStatusCodeException(503, "something")
+        "HttpErrorStatusCodeException with transient client error"  | new HttpErrorStatusCodeException(429, "something")
         "RuntimeException with a likely network exception as cause" | new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
     }
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -160,7 +160,8 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         then:
         failure.assertHasDescription("Execution failed for task ':publishMavenPublicationToMavenRepository' (registered by plugin 'org.gradle.maven-publish').")
         failure.assertHasCause("Failed to publish publication 'maven' to repository 'maven'")
-        failure.assertHasCause("Could not PUT '${module.artifact.uri}'. Received status code 401 from server: Unauthorized")
+        failure.assertHasCause("Could not PUT '${module.artifact.uri}'.")
+        failure.assertHasCause("Received status code 401 from server: Unauthorized")
 
         where:
         authScheme << [AuthScheme.BASIC, AuthScheme.DIGEST, AuthScheme.NTLM]
@@ -178,7 +179,8 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         then:
         failure.assertHasDescription("Execution failed for task ':publishMavenPublicationToMavenRepository' (registered by plugin 'org.gradle.maven-publish').")
         failure.assertHasCause("Failed to publish publication 'maven' to repository 'maven'")
-        failure.assertHasCause("Could not PUT '${module.artifact.uri}'. Received status code 401 from server: Unauthorized")
+        failure.assertHasCause("Could not PUT '${module.artifact.uri}'.")
+        failure.assertHasCause("Received status code 401 from server: Unauthorized")
 
         where:
         authScheme << [AuthScheme.BASIC, AuthScheme.DIGEST, AuthScheme.NTLM]

--- a/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
+++ b/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
@@ -60,7 +60,8 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 403
         e.message.contains("Artifact Quarantined")
     }
@@ -78,7 +79,8 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 403
         e.message.contains("Repository policy violation: artifact contains known vulnerabilities")
     }
@@ -100,7 +102,8 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 451
         e.message.contains("The artifact com.example:my-library:1.0.0 violates the organization's license policy (GPL license not allowed)")
     }
@@ -113,7 +116,8 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 403
         e.message.contains("Forbidden")
     }
@@ -127,11 +131,12 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 500
 
-        and: "should fall back to reason phrase or empty string"
-        e.message.contains("Could not GET")
+        and: "should fall back to reason phrase or empty string on the outer wrapper"
+        outer.message.contains("Could not GET")
     }
 
     def "5xx responses without RFC9457 body still produce a server-error exception"() {
@@ -142,10 +147,11 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/broken.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 500
         e.serverError
-        e.message.contains("Could not GET")
+        outer.message.contains("Could not GET")
         e.message.contains("500")
     }
 
@@ -158,11 +164,12 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
         client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
-        HttpErrorStatusCodeException e = thrown()
+        HttpRequestException outer = thrown()
+        HttpErrorStatusCodeException e = outer.cause as HttpErrorStatusCodeException
         e.statusCode == 403
 
-        and: "should fall back to reason phrase or empty string"
-        e.message.contains("Could not GET")
+        and: "should fall back to reason phrase or empty string on the outer wrapper"
+        outer.message.contains("Could not GET")
     }
 
     /**

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -294,7 +294,8 @@ public class ApacheCommonsHttpClient implements HttpClient {
             // Close the response to avoid leaving connections open
             response.close();
 
-            throw new HttpErrorStatusCodeException(method, effectiveUri.toString(), statusCode, errorDetail);
+            HttpErrorStatusCodeException statusCause = new HttpErrorStatusCodeException(statusCode, errorDetail);
+            throw new HttpRequestException(String.format("Could not %s '%s'.", method, effectiveUri), statusCause);
         }
     }
 

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeException.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeException.java
@@ -26,9 +26,8 @@ public class HttpErrorStatusCodeException extends RuntimeException {
 
     private final int statusCode;
 
-    public HttpErrorStatusCodeException(String method, String source, int statusCode, String reason) {
-        super(String.format("Could not %s '%s'. Received status code %s from server: %s",
-            method, source, statusCode, reason));
+    public HttpErrorStatusCodeException(int statusCode, String reason) {
+        super(String.format("Received status code %s from server: %s", statusCode, reason));
         this.statusCode = statusCode;
     }
 

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
@@ -37,7 +37,8 @@ public class HttpResourceUploader implements ExternalResourceUploader {
         try (HttpClient.Response response = http.performRawPut(destination.getUri(), ImmutableMap.of(), resource)) {
             if (!response.isSuccessful()) {
                 URI effectiveUri = response.getEffectiveUri();
-                throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusCode(), response.getStatusReason());
+                HttpErrorStatusCodeException statusCause = new HttpErrorStatusCodeException(response.getStatusCode(), response.getStatusReason());
+                throw new HttpRequestException(String.format("Could not %s '%s'.", response.getMethod(), effectiveUri), statusCause);
             }
         }
     }

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
@@ -86,7 +86,8 @@ class ApacheCommonsHttpClientTest extends Specification {
         client.performGet(URI.create("http://gradle.org"), ImmutableMap.of())
 
         then:
-        thrown(HttpErrorStatusCodeException)
+        def e = thrown(HttpRequestException)
+        e.cause instanceof HttpErrorStatusCodeException
         1 * response.close()
         1 * response.entity.content.close()
     }

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeExceptionTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeExceptionTest.groovy
@@ -22,7 +22,7 @@ class HttpErrorStatusCodeExceptionTest extends Specification {
 
     def "can identify status code as 5xx error"() {
         when:
-        boolean serverError = new HttpErrorStatusCodeException('GET', 'http://localhost:8080/', statusCode, '')
+        boolean serverError = new HttpErrorStatusCodeException(statusCode, '')
 
         then:
         serverError
@@ -33,7 +33,7 @@ class HttpErrorStatusCodeExceptionTest extends Specification {
 
     def "can identify status code as non-server error"() {
         when:
-        boolean serverError = new HttpErrorStatusCodeException('GET', 'http://localhost:8080/', statusCode, '')
+        boolean serverError = new HttpErrorStatusCodeException(statusCode, '')
 
         then:
         serverError

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
@@ -38,9 +38,10 @@ class HttpResourceUploaderTest extends Specification {
         new HttpResourceUploader(client).upload(Mock(ReadableContent), name)
 
         then:
-        HttpErrorStatusCodeException exception = thrown()
+        HttpRequestException exception = thrown()
         exception.message.contains(uri.toString())
-        exception.message.contains("Received status code 500 from server")
+        exception.cause instanceof HttpErrorStatusCodeException
+        exception.cause.message.contains("Received status code 500 from server")
         1 * response.close()
     }
 

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
@@ -44,6 +44,22 @@ abstract class HttpResource extends AbstractHttpResource {
         server.expectGetBroken(getPath())
     }
 
+    /**
+     * Expects one GET request, which fails with the given status code and an
+     * RFC 9457 Problem Details body auto-built from the supplied detail message.
+     */
+    void expectGetBroken(int statusCode, String rfc9457Detail) {
+        server.expectGetBroken(getPath(), statusCode, rfc9457Detail)
+    }
+
+    /**
+     * Expects one GET request, which fails with the given status code and the
+     * supplied RFC 9457 Problem Details JSON body (as a map).
+     */
+    void expectGetBroken(int statusCode, Map<String, ?> rfc9457ProblemJson) {
+        server.expectGetBroken(getPath(), statusCode, rfc9457ProblemJson)
+    }
+
     void expectGetUnauthorized() {
         server.expectGetUnauthorized(getPath())
     }

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -18,6 +18,7 @@ package org.gradle.test.fixtures.server.http
 import com.google.common.net.UrlEscapers
 import com.google.gson.Gson
 import com.google.gson.JsonElement
+import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import groovy.xml.MarkupBuilder
 import org.gradle.internal.hash.Hashing
@@ -287,6 +288,63 @@ class HttpServer extends ServerWithExpectations implements HttpServerFixture {
      */
     void expectGetBroken(String path) {
         expect(path, false, ['GET'], broken())
+    }
+
+    /**
+     * Expects one GET request, which fails with the given status code and an
+     * <a href="https://www.rfc-editor.org/rfc/rfc9457.html">RFC 9457 Problem Details</a>
+     * response body built from the provided detail message. Reasonable defaults are
+     * supplied for the other RFC 9457 fields (type, title, status, instance).
+     */
+    void expectGetBroken(String path, int statusCode, String rfc9457Detail) {
+        Map<String, Object> problem = [
+            type    : "about:blank",
+            title   : defaultTitleForStatus(statusCode),
+            status  : statusCode,
+            detail  : rfc9457Detail,
+            instance: path
+        ]
+        expectGetBroken(path, statusCode, problem)
+    }
+
+    /**
+     * Expects one GET request, which fails with the given status code and the supplied
+     * <a href="https://www.rfc-editor.org/rfc/rfc9457.html">RFC 9457 Problem Details</a>
+     * JSON body. The map is serialized as JSON and served with
+     * {@code Content-Type: application/problem+json}.
+     */
+    void expectGetBroken(String path, int statusCode, Map<String, ?> rfc9457ProblemJson) {
+        expect(path, false, ['GET'], rfc9457Broken(statusCode, JsonOutput.toJson(rfc9457ProblemJson)))
+    }
+
+    private static String defaultTitleForStatus(int statusCode) {
+        switch (statusCode) {
+            case 400: return "Bad Request"
+            case 401: return "Unauthorized"
+            case 403: return "Forbidden"
+            case 404: return "Not Found"
+            case 409: return "Conflict"
+            case 429: return "Too Many Requests"
+            case 451: return "Unavailable For Legal Reasons"
+            case 500: return "Internal Server Error"
+            case 502: return "Bad Gateway"
+            case 503: return "Service Unavailable"
+            default: return "HTTP ${statusCode}"
+        }
+    }
+
+    private Action rfc9457Broken(int statusCode, String jsonBody) {
+        new ActionSupport("return ${statusCode} with RFC 9457 problem+json body") {
+            @Override
+            void handle(HttpRequest request, HttpResponse response) {
+                response.setStatus(statusCode)
+                response.setContentType("application/problem+json")
+                byte[] bytes = jsonBody.getBytes("UTF-8")
+                response.setContentLength(bytes.length)
+                response.outputStream.write(bytes)
+                response.outputStream.flush()
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Implement test fixtures for simulating HTTP server responses with RFC 9457 Problem Details (application/problem+json). Add integration tests to verify how Gradle surfaces error messages from modern Maven repositories that use this standard for detailed failure reporting during dependency resolution.

Also makes the detail information a separate cause, so that it renders nicely on the console:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':retrieve' (registered in build file 'build.gradle').
> Could not resolve all files for configuration ':compile'.
   > Could not download projectA-1.2.jar (group:projectA:1.2)
      > Could not get resource 'http://127.0.0.1:55707/repo/group/projectA/1.2/projectA-1.2.jar'.
         > Could not GET 'http://127.0.0.1:55707/repo/group/projectA/1.2/projectA-1.2.jar'.
            > Received status code 403 from server: Artifact 'group:projectA:1.2' is quarantined pending policy review (rule: 'block-untrusted-publishers').
```

Continues work begun in:
- https://github.com/gradle/gradle/pull/36209