### PR TITLE
set TargetJvmVersion on pmdAuxClasspath resolvable configurations

### DIFF
--- a/platforms/jvm/code-quality/build.gradle.kts
+++ b/platforms/jvm/code-quality/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(libs.inject)
     api(libs.jspecify)
 
+    implementation(projects.jvmServices)
     implementation(projects.logging)
     implementation(projects.native)
     implementation(projects.pluginsGroovy)
@@ -68,6 +69,7 @@ dependencies {
     integTestImplementation(libs.jsoup) {
         because("We need to validate generated HTML reports")
     }
+    integTestImplementation(testFixtures(projects.resourcesHttp))
 }
 
 gradleModule {

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.pmd
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
+
+class PmdAuxClasspathAttributesIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    MavenHttpModule module
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("pmd")
+            }
+            repositories {
+                maven { url = '${mavenHttpRepo.uri}' }
+                ${mavenCentralRepositoryDefinition()}
+            }
+            dependencies {
+                pmdAux 'org:producer:1.0'
+            }
+            afterEvaluate {
+                configurations.configureEach {
+                    // use configureEach because the mainPmdAuxClasspath configuration does not exist at configuration time
+                    attributes.attribute(Attribute.of('custom.attribute.1', String), '1')
+                    attributes.attribute(Attribute.of('custom.attribute.2', String), '2')
+                }
+            }
+        """
+
+        module = mavenHttpRepo.module('org', 'producer', '1.0')
+            .withModuleMetadata()
+            .adhocVariants()
+            .variant("runtimeElements", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.jvm.version': 25,
+                'org.gradle.category': 'library',
+                'org.gradle.libraryelements': 'jar',
+                'org.gradle.usage': 'java-runtime',
+                'custom.attribute.1': '1',
+                'custom.attribute.2': '2'
+            ], { artifact('producer-1.0.jar') })
+            .variant("runtimeElementsCustom3a", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.jvm.version': 25,
+                'org.gradle.category': 'library',
+                'org.gradle.libraryelements': 'jar',
+                'org.gradle.usage': 'java-runtime',
+                'custom.attribute.1': '1',
+                'custom.attribute.2': '2',
+                'custom.attribute.3': 'a'
+            ], { artifact('producer-1.0-custom.jar') })
+            .variant("runtimeElementsCustom3b", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.jvm.version': 25,
+                'org.gradle.category': 'library',
+                'org.gradle.libraryelements': 'jar',
+                'org.gradle.usage': 'java-runtime',
+                'custom.attribute.1': '1',
+                'custom.attribute.2': '2',
+                'custom.attribute.3': 'b'
+            ], { artifact('producer-1.0-custom.jar') })
+            .publish()
+
+    }
+
+    def "pmd Aux classpath has enough attributes to disambiguate variants"() {
+        given:
+        module.pom.expectGet()
+        module.moduleMetadata.expectGet()
+
+        when:
+        succeeds 'pmdMain', 'dependencyInsight', '--configuration', 'mainPmdAuxClasspath', '--dependency', 'producer'
+
+        then:
+        // without the correct attributes, the build will fail with "Could not resolve org:producer:1.0" and "Ambiguity errors"
+        outputContains('org:producer:1.0')
+        outputContains('Variant runtimeElements:')
+        outputDoesNotContain('FAILED')
+    }
+}

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
@@ -16,17 +16,24 @@
 
 package org.gradle.api.plugins.quality.pmd
 
-import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.test.fixtures.server.http.MavenHttpModule
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.internal.jvm.Jvm
+import org.junit.jupiter.api.Assumptions
 
-import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
+class PmdAuxClasspathAttributesIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
-class PmdAuxClasspathAttributesIntegrationTest extends AbstractHttpDependencyResolutionTest {
-    MavenHttpModule module
+    def "pmd aux classpath can disambiguate variants using the configured toolchain java version"() {
+        given:
+        Jvm higherJvm = AvailableJavaHomes.getAvailableJdk {
+            it.javaMajorVersion > Jvm.current().javaVersionMajor
+        }
+        Assumptions.assumeTrue(higherJvm != null)
 
-    def setup() {
         settingsFile << """
-            rootProject.name = 'test'
+            rootProject.name = "test"
         """
 
         buildFile << """
@@ -34,70 +41,62 @@ class PmdAuxClasspathAttributesIntegrationTest extends AbstractHttpDependencyRes
                 id("java-library")
                 id("pmd")
             }
+
             repositories {
-                maven { url = '${mavenHttpRepo.uri}' }
-                ${mavenCentralRepositoryDefinition()}
+                ${mavenTestRepository()}
             }
+
             dependencies {
-                pmdAux 'org:producer:1.0'
+                pmdAux("org:producer:1.0")
             }
-            afterEvaluate {
-                configurations.configureEach {
-                    // use configureEach because the mainPmdAuxClasspath configuration does not exist at configuration time
-                    attributes.attribute(Attribute.of('custom.attribute.1', String), '1')
-                    attributes.attribute(Attribute.of('custom.attribute.2', String), '2')
+
+            tasks.named("pmdMain") {
+                javaLauncher = toolchainService.launcherFor {
+                    it.languageVersion = JavaLanguageVersion.of(${higherJvm.javaVersionMajor})
                 }
             }
+
+            ${ResolveTestFixture.configureProject("mainPmdAuxClasspath")}
         """
 
-        module = mavenHttpRepo.module('org', 'producer', '1.0')
+        mavenRepo.module('org', 'producer', '1.0')
             .withModuleMetadata()
             .adhocVariants()
-            .variant("runtimeElements", [
+            .variant("runtimeElementsLower", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.version': 25,
+                'org.gradle.jvm.version': Integer.toString(Jvm.current().javaVersionMajor),
                 'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-runtime',
-                'custom.attribute.1': '1',
-                'custom.attribute.2': '2'
-            ], { artifact('producer-1.0.jar') })
-            .variant("runtimeElementsCustom3a", [
+            ])
+            .variant("runtimeElementsHigher", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.version': 25,
+                'org.gradle.jvm.version': Integer.toString(higherJvm.javaVersionMajor),
                 'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-runtime',
-                'custom.attribute.1': '1',
-                'custom.attribute.2': '2',
-                'custom.attribute.3': 'a'
-            ], { artifact('producer-1.0-custom.jar') })
-            .variant("runtimeElementsCustom3b", [
-                'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.version': 25,
-                'org.gradle.category': 'library',
-                'org.gradle.libraryelements': 'jar',
-                'org.gradle.usage': 'java-runtime',
-                'custom.attribute.1': '1',
-                'custom.attribute.2': '2',
-                'custom.attribute.3': 'b'
-            ], { artifact('producer-1.0-custom.jar') })
+            ])
             .publish()
 
-    }
-
-    def "pmd Aux classpath has enough attributes to disambiguate variants"() {
-        given:
-        module.pom.expectGet()
-        module.moduleMetadata.expectGet()
-
         when:
-        succeeds 'pmdMain', 'dependencyInsight', '--configuration', 'mainPmdAuxClasspath', '--dependency', 'producer'
+        withInstallations(higherJvm)
+        succeeds("checkDeps")
 
         then:
-        // without the correct attributes, the build will fail with "Could not resolve org:producer:1.0" and "Ambiguity errors"
-        outputContains('org:producer:1.0')
-        outputContains('Variant runtimeElements:')
-        outputDoesNotContain('FAILED')
+        new ResolveTestFixture(testDirectory).expectGraph {
+            root(":", ":test:") {
+                module("org:producer:1.0") {
+                    variant("runtimeElementsHigher", [
+                        'org.gradle.dependency.bundling': 'external',
+                        'org.gradle.jvm.version': Integer.toString(higherJvm.javaVersionMajor),
+                        'org.gradle.category': 'library',
+                        'org.gradle.libraryelements': 'jar',
+                        'org.gradle.usage': 'java-runtime',
+                        "org.gradle.status": "release",
+                    ])
+                }
+            }
+        }
     }
+
 }

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdAuxClasspathAttributesIntegrationTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.pmd
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.internal.jvm.Jvm
+import org.junit.jupiter.api.Assumptions
+
+class PmdAuxClasspathAttributesIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
+
+    def "pmd aux classpath can disambiguate variants using the configured toolchain java version"() {
+        given:
+        Jvm higherJvm = AvailableJavaHomes.getAvailableJdk {
+            it.javaMajorVersion > Jvm.current().javaVersionMajor
+        }
+        Assumptions.assumeTrue(higherJvm != null)
+
+        settingsFile << """
+            rootProject.name = "test"
+        """
+
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("pmd")
+            }
+
+            repositories {
+                ${mavenTestRepository()}
+            }
+
+            dependencies {
+                pmdAux("org:producer:1.0")
+            }
+
+            tasks.named("pmdMain") {
+                javaLauncher = toolchainService.launcherFor {
+                    it.languageVersion = JavaLanguageVersion.of(${higherJvm.javaVersionMajor})
+                }
+            }
+
+            ${ResolveTestFixture.configureProject("mainPmdAuxClasspath")}
+        """
+
+        mavenRepo.module('org', 'producer', '1.0')
+            .withModuleMetadata()
+            .adhocVariants()
+            .variant("runtimeElementsLower", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.jvm.version': Integer.toString(Jvm.current().javaVersionMajor),
+                'org.gradle.category': 'library',
+                'org.gradle.libraryelements': 'jar',
+                'org.gradle.usage': 'java-runtime',
+            ])
+            .variant("runtimeElementsHigher", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.jvm.version': Integer.toString(higherJvm.javaVersionMajor),
+                'org.gradle.category': 'library',
+                'org.gradle.libraryelements': 'jar',
+                'org.gradle.usage': 'java-runtime',
+            ])
+            .publish()
+
+        when:
+        withInstallations(higherJvm)
+        succeeds("checkDeps")
+
+        then:
+        new ResolveTestFixture(testDirectory).expectGraph {
+            root(":", ":test:") {
+                module("org:producer:1.0") {
+                    variant("runtimeElementsHigher", [
+                        'org.gradle.dependency.bundling': 'external',
+                        'org.gradle.jvm.version': Integer.toString(higherJvm.javaVersionMajor),
+                        'org.gradle.category': 'library',
+                        'org.gradle.libraryelements': 'jar',
+                        'org.gradle.usage': 'java-runtime',
+                        "org.gradle.status": "release",
+                    ])
+                }
+            }
+        }
+    }
+
+}

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -18,7 +18,9 @@ package org.gradle.api.plugins.quality;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionMapping;
@@ -234,7 +236,10 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     protected void configureForSourceSet(final SourceSet sourceSet, final Pmd task) {
         task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
-        ConventionMapping taskMapping = task.getConventionMapping();
+    }
+
+    @Override
+    protected void configureTaskProviderForSourceSet(SourceSet sourceSet, NamedDomainObjectProvider<Pmd> taskProvider) {
         RoleBasedConfigurationContainerInternal configurations = project.getConfigurations();
 
         Configuration compileClasspath = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
@@ -245,15 +250,24 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             conf.extendsFrom(compileClasspath, pmdAdditionalAuxDepsConfiguration);
             // This is important to get transitive implementation dependencies. PMD may load referenced classes for analysis so it expects the classpath to be "closed" world.
             getJvmPluginServices().configureAsRuntimeClasspath(conf);
+            conf.attributes(attributes ->
+                attributes.attributeProvider(
+                    TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+                    taskProvider.flatMap(task -> task.getJavaLauncher().map(launcher -> launcher.getMetadata().getLanguageVersion().asInt()))));
         });
 
-        // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile
-        // classpath of the test sourceSet contains output of the main sourceSet.
-        taskMapping.map("classpath", () -> {
-            // It is important to subtract compileClasspath and not pmdAuxClasspath here because these configurations are resolved differently (as a compile and as a
-            // runtime classpath). Compile and runtime entries for the same dependency may resolve to different files (e.g. compiled classes directory vs. jar).
-            FileCollection nonConfigurationClasspathEntries = sourceSet.getCompileClasspath().minus(compileClasspath);
-            return sourceSet.getOutput().plus(nonConfigurationClasspathEntries).plus(pmdAuxClasspath);
+        taskProvider.configure(task -> {
+            ConventionMapping taskMapping = task.getConventionMapping();
+
+            // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile
+            // classpath of the test sourceSet contains output of the main sourceSet.
+            taskMapping.map("classpath", () -> {
+                // It is important to subtract compileClasspath and not pmdAuxClasspath here because these configurations are resolved differently (as a compile and as a
+                // runtime classpath). Compile and runtime entries for the same dependency may resolve to different files (e.g. compiled classes directory vs. jar).
+                FileCollection nonConfigurationClasspathEntries = sourceSet.getCompileClasspath().minus(compileClasspath);
+                return sourceSet.getOutput().plus(nonConfigurationClasspathEntries).plus(pmdAuxClasspath);
+            });
         });
     }
+
 }

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.quality;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.file.Directory;
@@ -235,7 +236,10 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     protected void configureForSourceSet(final SourceSet sourceSet, final Pmd task) {
         task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
-        ConventionMapping taskMapping = task.getConventionMapping();
+    }
+
+    @Override
+    protected void configureTaskProviderForSourceSet(SourceSet sourceSet, NamedDomainObjectProvider<Pmd> taskProvider) {
         RoleBasedConfigurationContainerInternal configurations = project.getConfigurations();
 
         Configuration compileClasspath = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
@@ -249,16 +253,21 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             conf.attributes(attributes ->
                 attributes.attributeProvider(
                     TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
-                    task.getJavaLauncher().map(launcher -> launcher.getMetadata().getLanguageVersion().asInt())));
+                    taskProvider.flatMap(task -> task.getJavaLauncher().map(launcher -> launcher.getMetadata().getLanguageVersion().asInt()))));
         });
 
-        // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile
-        // classpath of the test sourceSet contains output of the main sourceSet.
-        taskMapping.map("classpath", () -> {
-            // It is important to subtract compileClasspath and not pmdAuxClasspath here because these configurations are resolved differently (as a compile and as a
-            // runtime classpath). Compile and runtime entries for the same dependency may resolve to different files (e.g. compiled classes directory vs. jar).
-            FileCollection nonConfigurationClasspathEntries = sourceSet.getCompileClasspath().minus(compileClasspath);
-            return sourceSet.getOutput().plus(nonConfigurationClasspathEntries).plus(pmdAuxClasspath);
+        taskProvider.configure(task -> {
+            ConventionMapping taskMapping = task.getConventionMapping();
+
+            // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile
+            // classpath of the test sourceSet contains output of the main sourceSet.
+            taskMapping.map("classpath", () -> {
+                // It is important to subtract compileClasspath and not pmdAuxClasspath here because these configurations are resolved differently (as a compile and as a
+                // runtime classpath). Compile and runtime entries for the same dependency may resolve to different files (e.g. compiled classes directory vs. jar).
+                FileCollection nonConfigurationClasspathEntries = sourceSet.getCompileClasspath().minus(compileClasspath);
+                return sourceSet.getOutput().plus(nonConfigurationClasspathEntries).plus(pmdAuxClasspath);
+            });
         });
     }
+
 }

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionMapping;
@@ -245,6 +246,10 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             conf.extendsFrom(compileClasspath, pmdAdditionalAuxDepsConfiguration);
             // This is important to get transitive implementation dependencies. PMD may load referenced classes for analysis so it expects the classpath to be "closed" world.
             getJvmPluginServices().configureAsRuntimeClasspath(conf);
+            conf.attributes(attributes ->
+                attributes.attributeProvider(
+                    TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+                    task.getJavaLauncher().map(launcher -> launcher.getMetadata().getLanguageVersion().asInt())));
         });
 
         // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Callables;
 import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -35,6 +36,7 @@ import org.gradle.api.plugins.quality.CodeQualityExtension;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
 
 import javax.inject.Inject;
@@ -179,17 +181,18 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
         sourceSets.all(new Action<SourceSet>() {
             @Override
             public void execute(final SourceSet sourceSet) {
-                project.getTasks().register(sourceSet.getTaskName(getTaskBaseName(), null), getCastedTaskType(), new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        configureForSourceSet(sourceSet, (T) task);
-                    }
-                });
+                String taskName = sourceSet.getTaskName(getTaskBaseName(), null);
+                TaskProvider<?> taskProvider = project.getTasks().register(taskName, getCastedTaskType(), task -> configureForSourceSet(sourceSet, (T) task));
+                NamedDomainObjectProvider<T> castTaskProvider = Cast.uncheckedCast(taskProvider);
+                configureTaskProviderForSourceSet(sourceSet, castTaskProvider);
             }
         });
     }
 
     protected void configureForSourceSet(SourceSet sourceSet, T task) {
+    }
+
+    protected void configureTaskProviderForSourceSet(SourceSet sourceSet, NamedDomainObjectProvider<T> taskProvider) {
     }
 
     @SuppressWarnings("rawtypes")

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.java.TargetJvmEnvironment
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.tasks.SourceSet
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
@@ -311,6 +313,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
             assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
             assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+            assert getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Jvm.current().getJavaVersionMajor()
         }
     }
 }

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -21,9 +21,13 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.java.TargetJvmEnvironment
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
@@ -311,6 +315,31 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
             assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
             assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+            assert getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Jvm.current().getJavaVersionMajor()
+        }
+    }
+
+    def "task aux configurations have TargetJvmVersion set based on pmd task launcher"() {
+        given:
+        project.pluginManager.apply(JavaBasePlugin)
+        project.sourceSets {
+            main
+        }
+
+        when:
+        TaskProvider<Pmd> pmdTask = project.tasks.named("pmdMain", Pmd)
+        pmdTask.configure { task ->
+            task.javaLauncher.set(
+                task.toolchainService.launcherFor {
+                    it.languageVersion = JavaLanguageVersion.of(17)
+                }
+            )
+        }
+        pmdTask.get()
+
+        then:
+        with(project.configurations.mainPmdAuxClasspath.attributes) {
+            assert getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 17
         }
     }
 }


### PR DESCRIPTION
this will improve variant matching

in complex attribute/variant scenarios, any unspecified attributes that candidates may contain become a liability, creating ambiguous selection. I have encountered such a scenario, and have been able to verify locally that adding this attribute will fix it. It makes sense, since the task is using a java launcher, that it should specify the version of java to select for.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
