### PR TITLE
Re-enable cross-version flaky quarantine and un-flag stable kotlin-dsl cross-version tests

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -53,7 +53,7 @@ class FlakyTestQuarantineProject(
         model.stages
             .filter { it.stageName <= StageName.READY_FOR_RELEASE }
             .flatMap { it.functionalTests }
-            .filter { it.os == os && !it.testType.crossVersionTests }
+            .filter { it.os == os }
             .forEach {
                 buildType(FlakyTestQuarantine(model, stage, it))
             }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -20,7 +20,6 @@ import groovy.transform.CompileStatic
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.test.fixtures.Flaky
 import org.gradle.util.GradleVersion
 import org.hamcrest.Matcher
 
@@ -31,9 +30,9 @@ import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.Assert.assertTrue
+import static org.junit.Assume.assumeFalse
 
 @TargetGradleVersion(">=5.4")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     def "can fetch buildSrc classpath in face of compilation errors"() {
@@ -431,6 +430,14 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
     }
 
     def "sourcePath includes Gradle sources"() {
+
+        given:
+        // Gradle distribution sources are resolved from the published `gradle-<version>-src.zip`,
+        // which only exists for released versions. When the build providing the model is an
+        // unreleased snapshot (e.g. the version under development in the "old TAPI -> Gradle
+        // current" cross-version direction), those sources cannot be resolved, so the source
+        // path legitimately omits them. Skip the assertion in that case. See gradle-private#3414.
+        assumeFalse("Gradle distribution sources are not published for snapshot builds", targetDist.version.snapshot)
 
         expect:
         assertSourcePathIncludesGradleSourcesGiven("", "")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinInitScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinInitScriptModelCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.test.fixtures.Flaky
 
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
@@ -26,7 +25,6 @@ import static org.hamcrest.MatcherAssert.assertThat
 @TargetGradleVersion(">=5.4")
 class KotlinInitScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
-    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3708')
     def "initscript classpath does not include buildSrc"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
 
@@ -100,7 +99,6 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
 
     @TargetGradleVersion(">=5.4 <7.5")
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath includes buildSrc source roots"() {
 
         given:
@@ -117,7 +115,6 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
 
     @TargetGradleVersion(">=5.4 <7.5")
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath includes buildSrc project dependencies source roots"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
@@ -20,14 +20,12 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.test.fixtures.Flaky
 
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.MatcherAssert.assertThat
 
 @TargetGradleVersion(">=5.4")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     @LeaksFileHandles("Kotlin Compiler Daemon working directory")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.gradle.util.GradleVersion
@@ -26,7 +25,6 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.gradle.util.GradleVersion
@@ -26,7 +25,6 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "can fetch model for a given set of scripts"() {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
@@ -30,7 +29,6 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "single request models equal multi requests models"() {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,14 +17,12 @@
 package org.gradle.kotlin.dsl.tooling.builders.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.8")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r71
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
@@ -26,7 +25,6 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 @TargetGradleVersion(">=7.1")
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "kotlin-dsl project with pre-compiled script plugins should import without errors"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r75/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r75/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.tooling.builders.r75
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import static org.hamcrest.MatcherAssert.assertThat
@@ -45,7 +44,6 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
     }
 
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath does not include buildSrc project dependencies source roots"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,10 +18,8 @@ package org.gradle.kotlin.dsl.tooling.builders.r88
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import org.gradle.test.fixtures.Flaky
 
 @TargetGradleVersion(">=8.8")
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3714")
 class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     def "settings script has type-safe accessors on the classpath"() {


### PR DESCRIPTION
## Why

gradle/gradle#35335 removed **all** cross-version tests from `FlakyTestQuarantine` with the over-broad filter `!it.testType.crossVersionTests`. That is `true` for QUICK, PLATFORM, and QuickFeedbackCrossVersion coverage as well, so those were dropped from quarantine as collateral damage — not just the `AllVersionsCrossVersion` coverage that motivated the removal.

Re-enabling the quarantine for `AllVersionsCrossVersion` surfaced two further findings:
- One "flaky" failure was actually **deterministic** — `KotlinBuildScriptModelCrossVersionSpec."sourcePath includes Gradle sources"` fails in the "old TAPI → current Gradle" direction because the snapshot build under development has no published `gradle-<version>-src.zip` to resolve.
- The `kotlin-dsl-tooling-builders` cross-version specs are otherwise **stable** — across full quarantine runs the only real failure was the one above; the rest passed against every version.

## What

1. **Restore the flaky quarantine for all cross-version coverage** — relax the filter back to `it.os == os`, so QUICK/PLATFORM/QuickFeedbackCrossVersion/AllVersionsCrossVersion are quarantined again. The quarantine mechanism stays enabled for every cross-version test type.

2. **Fix the deterministic sources assertion** — guard `"sourcePath includes Gradle sources"` with `assumeFalse(targetDist.version.snapshot)`, so it is skipped only when the model provider is an unreleased snapshot (whose sources can't be resolved) and still runs/asserts for every released provider.

3. **Un-flag the stable `kotlin-dsl-tooling-builders` cross-version specs** — remove `@Flaky` from the 11 classes so they run in the normal cross-version builds again. They haven't run for a long time so now we can check if they're still flaky - if they're, we can do further actions - they're anyway in ReadyForRelease stage and won't blocker user feedback.

## Context

Addresses gradle-private#4895. 
