### PR TITLE
Handle Copy source type changes

### DIFF
--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.util.internal.GFileUtils;
 
 import java.io.File;
 import java.util.Objects;
@@ -46,10 +47,19 @@ public class FileCopyAction implements CopyAction {
         public void processFile(FileCopyDetailsInternal details) {
             File target = fileResolver.resolve(details.getRelativePath().getPathString());
             renameIfCaseChanged(target);
+            boolean replaced = replaceTargetIfTypeChanged(details, target);
             boolean copied = details.copyTo(target);
-            if (copied) {
+            if (copied || replaced) {
                 didWork = true;
             }
+        }
+
+        private boolean replaceTargetIfTypeChanged(FileCopyDetailsInternal details, File target) {
+            if (target.exists() && target.isDirectory() != details.isDirectory()) {
+                GFileUtils.forceDelete(target);
+                return true;
+            }
+            return false;
         }
 
         private void renameIfCaseChanged(File target) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -39,6 +39,50 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     private final static DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry()
 
+    @Issue("https://github.com/gradle/gradle/issues/38487")
+    def "replaces a destination file when the source changes to a directory"() {
+        given:
+        buildFile '''
+            tasks.register("copy", Copy) {
+                from "source"
+                into "destination"
+            }
+        '''
+        file("source/resource").text = "file content"
+        run "copy"
+
+        when:
+        file("source/resource").delete()
+        file("source/resource/child.txt").text = "directory content"
+        run "copy"
+
+        then:
+        file("destination/resource").assertIsDir()
+        file("destination/resource/child.txt").text == "directory content"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38487")
+    def "replaces a destination directory when the source changes to a file"() {
+        given:
+        buildFile '''
+            tasks.register("copy", Copy) {
+                from "source"
+                into "destination"
+            }
+        '''
+        file("source/resource/child.txt").text = "directory content"
+        run "copy"
+
+        when:
+        file("source/resource").deleteDir()
+        file("source/resource").text = "file content"
+        run "copy"
+
+        then:
+        file("destination/resource").assertIsFile()
+        file("destination/resource").text == "file content"
+    }
+
     def "copies everything by default"() {
         given:
         file("files/sub/a.txt").createFile()


### PR DESCRIPTION
Fixes #38487

### Context

A `Copy` task fails when a source path changes between a file and a directory across builds because the destination still contains the previous entry type.

This change removes the conflicting destination entry before copying the new source. It handles both file-to-directory and directory-to-file transitions.

Integration tests cover both cases.

This contribution was developed with significant AI assistance. I reviewed the resulting implementation and test coverage.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check "Allow edit from maintainers" in the pull request.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes. Not applicable; this does not change public API or documentation.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Testing

- Reproduced the original failure with Gradle 9.0.0.
- Verified file-to-directory and directory-to-file transitions with the patched distribution.
- `./gradlew :core:forkingIntegTest --tests "org.gradle.api.tasks.CopyTaskIntegrationSpec.replaces a destination*"`
- `./gradlew :core:test --tests "org.gradle.api.internal.file.copy.FileCopyActionTest"`

The targeted tests passed. `sanityCheck` was also run, but it stopped in unrelated Android and Swift performance scenario generation because those fixtures were unavailable in the test environment.