### PR TITLE
Run buildCommitDistribution without a daemon to avoid leaking it on Windows CI

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -192,6 +192,7 @@ abstract class BuildCommitDistribution @Inject internal constructor(
 
         return listOfNotNull(
             "./gradlew" + (if (OperatingSystem.current().isWindows) ".bat" else ""),
+            "--no-daemon",
             if (gradleModeCompatibility == null) "--no-configuration-cache" else null,
             // TODO:isolated https://github.com/gradle/gradle/issues/36771
             if (gradleModeCompatibility == "IP") null else "-Dorg.gradle.unsafe.isolated-projects=false",


### PR DESCRIPTION
### Context

On Windows CI, builds intermittently fail during checkout/clean with:

```
org.gradle.tooling.internal.consumer.DefaultFailure: Unable to delete directory
'C:\tcagent1\work\<hash>\testing\performance\build'
  Failed to delete some children. This might happen because a process has files open ...
  - ...\build\tmp\buildCommitDistribution\build-logic\.gradle
  - ...\build\tmp\buildCommitDistribution\.gradle
  New files were found ... a process is still writing to the target directory.
```

**Root cause.** The `buildCommitDistribution` task checks out `gradle/gradle` into
`testing/performance/build/tmp/buildCommitDistribution` and runs a nested `./gradlew`
build there to produce the baseline distribution. That nested build was started
**without `--no-daemon`**, so it left a lingering Gradle daemon. Windows agents reuse
the same TeamCity checkout directory across builds, so the leaked daemon keeps files
open under `build/tmp/buildCommitDistribution` (its `.gradle` dirs), and the *next*
build on the same agent fails to delete `testing/performance/build`.

In every observed case the failing build was immediately preceded, **on the same agent**,
by a `PerformanceTest` build (which is what runs `buildCommitDistribution`).

**Why the pre-build cleanup didn't kill it.** The `KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS`
step (`KillLeakingJavaProcesses.java`) only kills Gradle processes whose classpath is
inside the checkout directory. This daemon runs from a wrapper distribution in
`GRADLE_USER_HOME` (`…\.gradle\wrapper\dists\…`), so its classpath is outside the checkout
and it is intentionally skipped. Only `KILL_ALL_GRADLE_PROCESSES` would catch it, but that
runs only on retry / merge-queue, not as normal pre-build cleanup.

**Fix.** A one-shot clean distribution build gains nothing from a persistent daemon, so run
it with `--no-daemon`. No daemon then lingers to lock the directory.

### Example failures

Trigger chain:
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Stage_PullRequestFeedback_Trigger/115430016

Individual `Unable to delete directory` failures (each preceded on the same agent by a `PerformanceTest` build):
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_4_bucket30/115429980 (windows314)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_4_bucket23/115429973 (windows271)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_4_bucket22/115429972 (windows308)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_4_bucket5_virtual_Batch_2_1/115430040 (windows303)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket4_virtual_Batch_4_1/115430033 (windows276)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket3_virtual_Batch_1_1/115430067 (windows318)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket29/115429915 (windows385)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket25/115429911 (windows301)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket19/115429905 (windows314)
- https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket13/115455581 (windows318, separate occurrence)
