### PR TITLE
Warn instead of failing when the daemon cannot mutate its environment

### DIFF
--- a/platforms/core-runtime/launcher/build.gradle.kts
+++ b/platforms/core-runtime/launcher/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     // Required directly by CliTextPrinter (uses Ant Main and Groovy ReleaseInfo)
     implementation(libs.ant)
     implementation(libs.groovy)
+    implementation(libs.nativePlatform)
 
     runtimeOnly(projects.gradleCliMain)
     runtimeOnly(projects.declarativeDslProvider)

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -24,7 +24,6 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
-import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 import org.gradle.util.GradleVersion
 import spock.lang.Issue
@@ -191,9 +190,11 @@ task sleep {
         assert new TestFile(logFile).permissions == "rw-------"
     }
 
-    //Java 9 and above needs --add-opens to make environment variable mutation work
-    @Requires(JdkVersionTestPreconditions.Jdk8OrEarlier)
     def "foreground daemon log honors log levels for logging"() {
+        // Both the foreground daemon and the client must request the same daemon JVM args,
+        // so the client's build runs in the foreground daemon instead of a forked daemon.
+        List<String> daemonJvmArgs = ["-ea", "-Xms256m", "-Xmx512m"]
+
         given:
         buildFile """
             tasks.register("log") {
@@ -205,13 +206,15 @@ task sleep {
         """
 
         when:
+        executer.useOnlyRequestedJvmOpts()
+        executer.withBuildJvmOpts(daemonJvmArgs)
         def daemon = executer.noExtraLogging().withArguments("--foreground").start()
 
         then:
         poll(60) { assert daemon.standardOutput.contains(DaemonMessages.PROCESS_STARTED) }
 
         when:
-        def infoBuild = executer.withArguments("-i").withTasks("log").run()
+        def infoBuild = executer.useOnlyRequestedJvmOpts().withArguments("-i", "-Dorg.gradle.jvmargs=${daemonJvmArgs.join(" ")}").withTasks("log").run()
 
         then:
         infoBuild.output.count("debug me!") == 0
@@ -225,7 +228,7 @@ task sleep {
         daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
 
         when:
-        def debugBuild = executer.withArguments("-d").withTasks("log").run()
+        def debugBuild = executer.useOnlyRequestedJvmOpts().withArguments("-d", "-Dorg.gradle.jvmargs=${daemonJvmArgs.join(" ")}").withTasks("log").run()
 
         then:
         debugBuild.output.count("debug me!") == 1

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
@@ -23,7 +23,6 @@ import org.gradle.launcher.daemon.server.api.HandleStop
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
 import org.gradle.test.preconditions.OsTestPreconditions
-import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 
 /**
@@ -57,16 +56,26 @@ class DaemonLifecycleSpec extends AbstractDaemonLifecycleSpec {
         stopped()
     }
 
-    //Java 9 and above needs --add-opens to make environment variable mutation work
-    @Requires(JdkVersionTestPreconditions.Jdk8OrEarlier)
     def "existing foreground idle daemons are used"() {
+        // Both the foreground daemon and the client must request the same daemon JVM args,
+        // so the client's build runs in the foreground daemon instead of a forked daemon.
+        List<String> daemonJvmArgs = ["-ea", "-Xms256m", "-Xmx512m"]
+
         when:
+        run {
+            executer.useOnlyRequestedJvmOpts()
+            executer.withBuildJvmOpts(daemonJvmArgs)
+        }
         startForegroundDaemon()
 
         then:
         idle()
 
         when:
+        run {
+            executer.useOnlyRequestedJvmOpts()
+            executer.withBuildJvmOpts(daemonJvmArgs)
+        }
         startBuild()
         waitForBuildToWait()
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ForegroundDaemonIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ForegroundDaemonIntegrationTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon
+
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+
+class ForegroundDaemonIntegrationTest extends DaemonIntegrationSpec {
+
+    def "build emits a warning instead of failing when the foreground daemon cannot mutate its environment to match the client"() {
+        // JVM args for the foreground daemon. We explicitly run the foreground daemon
+        // without the necessary --add-opens flags, so that the foreground daemon will
+        // not be able to mutate its environment to match the client.
+        List<String> jvmArgs = ["-ea", "-Xms256m", "-Xmx512m"]
+
+        given:
+        executer.useOnlyRequestedJvmOpts()
+        executer.withBuildJvmOpts(jvmArgs)
+        def foregroundDaemon = startAForegroundDaemon()
+
+        buildFile """
+            tasks.register("echoEnv") {
+                doLast {
+                    println "CUSTOM_VAR=" + (System.getenv("CUSTOM_VAR") ?: "<not set>")
+                }
+            }
+        """
+
+        when:
+        executer.useOnlyRequestedJvmOpts()
+        // We must execute with the same JVM args as the foreground daemon, so we run our
+        // build in that daemon instead of starting a new one.
+        executer.withArgument("-Dorg.gradle.jvmargs=${jvmArgs.join(" ")}")
+        executer.withEnvironmentVars(CUSTOM_VAR: "custom-value")
+        succeeds("echoEnv")
+
+        then:
+        // Make sure we didn't start a new daemon.
+        daemons.registry.all.size() == 1
+
+        and:
+        outputContains("Unable to set daemon's environment variables to match the client")
+        outputContains("CUSTOM_VAR=<not set>")
+
+        cleanup:
+        foregroundDaemon?.abort()
+    }
+
+}

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -16,15 +16,11 @@
 
 package org.gradle.launcher.daemon.server.scaninfo
 
-
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.launcher.daemon.client.SingleUseDaemonClient
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.JdkVersionTestPreconditions
-
 import org.gradle.util.internal.GFileUtils
 import org.junit.Rule
 
@@ -58,9 +54,11 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         executer.withArguments('help', '--continuous', '-i').run().assertTasksScheduled(':help')
     }
 
-    //Java 9 and above needs --add-opens to make environment variable mutation work
-    @Requires(JdkVersionTestPreconditions.Jdk8OrEarlier)
     def "should capture basic data when a foreground daemon runs multiple builds"() {
+        // Both the foreground daemon and the client must request the same daemon JVM args,
+        // so the client's build runs in the foreground daemon instead of a forked daemon.
+        List<String> daemonJvmArgs = ["-ea", "-Xms256m", "-Xmx512m"]
+
         given:
         buildFile << """
         ${imports()}
@@ -70,13 +68,17 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         """
 
         when:
+        executer.useOnlyRequestedJvmOpts()
+        executer.withBuildJvmOpts(daemonJvmArgs)
         def daemon = startAForegroundDaemon()
 
         List<ExecutionResult> captureResults = []
-        captureResults << executer.withTasks('capture1').run()
-        captureResults << executer.withTasks('capture2').run()
+        captureResults << executer.useOnlyRequestedJvmOpts().withArgument("-Dorg.gradle.jvmargs=${daemonJvmArgs.join(" ")}").withTasks('capture1').run()
+        captureResults << executer.useOnlyRequestedJvmOpts().withArgument("-Dorg.gradle.jvmargs=${daemonJvmArgs.join(" ")}").withTasks('capture2').run()
 
         then:
+        // Make sure we didn't start a new daemon.
+        daemons.registry.all.size() == 1
         captureResults[0].assertTaskScheduled(':capture1')
         captureResults[1].assertTaskScheduled(':capture2')
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariables.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariables.java
@@ -16,9 +16,11 @@
 package org.gradle.launcher.daemon.server.exec;
 
 import com.google.common.annotations.VisibleForTesting;
+import net.rubygrapefruit.platform.NativeException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
+import org.gradle.internal.nativeintegration.NativeIntegrationException;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.launcher.daemon.protocol.Build;
 import org.gradle.launcher.daemon.server.api.DaemonCommandExecution;
@@ -65,21 +67,37 @@ public class ApplyClientEnvironmentVariables extends BuildCommandOnly {
         // Log only the variable names and not their values. Environment variables often contain sensitive data that should not be leaked to log files.
         logger.debug("Configuring env variables: {}", build.getParameters().getEnvVariables().keySet());
 
-        EnvironmentModificationResult setEnvironmentResult = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
-        if (!setEnvironmentResult.isSuccess()) {
-            logger.warn("Warning: Unable to set daemon's environment variables to match the client because: "
-                + System.getProperty("line.separator") + "  "
-                + setEnvironmentResult
-                + System.getProperty("line.separator") + "  "
-                + "If the daemon was started with a significantly different environment from the client, and your build "
-                + System.getProperty("line.separator") + "  "
-                + "relies on environment variables, you may experience unexpected behavior.");
+        try {
+            EnvironmentModificationResult result = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
+            if (!result.isSuccess()) {
+                printWarning(result.toString());
+            }
+        } catch (NativeException | NativeIntegrationException e) {
+            // The JVM does not permit mutating the process environment. This likely means the daemon
+            // was started without the JPMS options that forked daemons get on their command line.
+            printWarning(e.getMessage());
         }
 
         try {
             execution.proceed();
         } finally {
-            processEnvironment.maybeSetEnvironment(originalEnv);
+            try {
+                processEnvironment.maybeSetEnvironment(originalEnv);
+            } catch (NativeException | NativeIntegrationException ignored) {
+                // Failures restoring the original environment are not reported. They have the same
+                // cause as failures applying the client environment, which was already warned about.
+            }
         }
     }
+
+    private void printWarning(String message) {
+        logger.warn("Warning: Unable to set daemon's environment variables to match the client because: "
+            + System.getProperty("line.separator") + "  "
+            + message
+            + System.getProperty("line.separator") + "  "
+            + "If the daemon was started with a significantly different environment from the client, and your build "
+            + System.getProperty("line.separator") + "  "
+            + "relies on environment variables, you may experience unexpected behavior.");
+    }
+
 }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariablesTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariablesTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.launcher.daemon.server.exec
 
+import net.rubygrapefruit.platform.NativeException
 import org.gradle.api.logging.Logger
+import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.nativeintegration.EnvironmentModificationResult
 import org.gradle.internal.nativeintegration.ProcessEnvironment
 import org.gradle.launcher.daemon.protocol.Build
@@ -61,4 +63,37 @@ class ApplyClientEnvironmentVariablesTest extends Specification {
         then:
         0 * logger.warn(_)
     }
+
+    def "still applies the environment when the client environment matches this process"() {
+        given:
+        def matchingBuild = Mock(Build)
+        def matchingParameters = Mock(BuildActionParameters)
+        matchingBuild.parameters >> matchingParameters
+        def matchingEnv = Jvm.getInheritableEnvironmentVariables(System.getenv())
+        matchingParameters.envVariables >> matchingEnv
+
+        when:
+        action.doBuild(execution, matchingBuild)
+
+        then: "the per-process variables the client filtered out are still scrubbed for the build"
+        1 * execution.proceed()
+        // Applied before the build and restored after it
+        (1.._) * processEnvironment.maybeSetEnvironment(_) >> EnvironmentModificationResult.SUCCESS
+        0 * logger.warn(_)
+    }
+
+    def "logs WARN instead of failing the build when mutating the environment throws"() {
+        given:
+        processEnvironment.maybeSetEnvironment(_) >> { throw new NativeException("Unable to get mutable environment variable map.") }
+
+        when:
+        action.doBuild(execution, build)
+
+        then:
+        1 * execution.proceed()
+        1 * logger.warn({ String message ->
+            message.contains("Unable to set daemon's environment variables")
+        })
+    }
+
 }


### PR DESCRIPTION
A daemon running without the JPMS --add-opens flags, such as a foreground daemon started by the launch scripts, fails the build with 'Unable to get mutable environment variable map.' when applying the client's environment variables, instead of printing the intended warning. Wrap the native calls in try/catch and warn on failure.

Also re-enable three foreground daemon tests that have been disabled since 2018 because of this. They additionally needed the foreground daemon and the client to request the same daemon JVM args, since the test executer's default JVM args differ between the two, preventing the client from reusing the foreground daemon.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
