### PR TITLE
Fix flaky DaemonLogCleanupActionIntegrationTest test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DaemonLogCleanupActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DaemonLogCleanupActionIntegrationTest.groovy
@@ -228,7 +228,10 @@ class DaemonLogCleanupActionIntegrationTest extends AbstractIntegrationSpec impl
     }
 
     long justUnderFourteenDays() {
-        exactlyFourteenDaysAgo() + 10000 // 10 seconds newer
+        // One hour newer than the boundary. The margin must comfortably exceed the time between
+        // stamping the file here and the cleanup computing its threshold during the build, or
+        // the file crosses the boundary while the build starts up and gets deleted.
+        exactlyFourteenDaysAgo() + TimeUnit.HOURS.toMillis(1)
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DaemonLogCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DaemonLogCleanupActionTest.groovy
@@ -187,17 +187,22 @@ class DaemonLogCleanupActionTest extends Specification {
         given:
         def versionDir = createDaemonVersionDir("8.0")
         def exactlyFourteenDaysOld = createDaemonLog(versionDir, 1234, exactlyNDaysAgo(DEFAULT_RETENTION_DAYS))
-        def justUnderFourteenDays = createDaemonLog(versionDir, 5678, exactlyNDaysAgo(DEFAULT_RETENTION_DAYS) + 1000) // 1 second newer
+        def justOverFourteenDays = createDaemonLog(versionDir, 5678, exactlyFourteenDaysOld.lastModified() - 1)
+
+        and:
+        def boundary = exactlyFourteenDaysOld.lastModified()
+        assert justOverFourteenDays.lastModified() < boundary
+        def boundaryCleanupAction = new DaemonLogCleanupAction(daemonBaseDir, deleter, { -> boundary })
 
         when:
-        def cleanedUp = cleanupAction.execute(progressMonitor)
+        def cleanedUp = boundaryCleanupAction.execute(progressMonitor)
 
         then:
         cleanedUp
         1 * progressMonitor.incrementDeleted()
         1 * progressMonitor.incrementSkipped()
-        exactlyFourteenDaysOld.assertDoesNotExist()
-        justUnderFourteenDays.assertExists()
+        exactlyFourteenDaysOld.assertExists()
+        justOverFourteenDays.assertDoesNotExist()
     }
 
     private TestFile createDaemonVersionDir(String version) {


### PR DESCRIPTION
The 'respects 14-day retention boundary' test has been flaky on CI for a while. It stamped a file 10 seconds inside the retention boundary, but the cleanup computes its threshold from the wall clock during the build. Whenever launcher startup plus the build took more than 10 seconds, common on slow agents, the file crossed the boundary and was deleted. Widen the margin to one hour, which build startup cannot plausibly consume.

The unit test's boundary case had the same race in miniature. Rewrite it to pin the cleanup's clock to the boundary file's actual modification time, so it tests the exact millisecond boundary deterministically. This also documents the strict semantics: a log modified exactly at the boundary is retained.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
