### PR TITLE
Update hardcoded dependencies in performance test project generation

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -44,9 +44,9 @@ abstract class FileContentGenerator {
     String generateVersionCatalog() {
         return """
         [libraries]
-        groovy = "org.codehaus.groovy:groovy:2.5.22"
-        testng = "org.testng:testng:6.4"
-        junit = "junit:junit:4.13"
+        groovy = "org.apache.groovy:groovy:4.0.32"
+        testng = "org.testng:testng:7.12.0"
+        junit = "junit:junit:4.13.2"
 
         ${config.externalApiDependencies
             .collect { "${it.key} = \"${it.value}\"" }
@@ -175,7 +175,7 @@ abstract class FileContentGenerator {
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.0</version>
+                        <version>3.15.0</version>
                         <configuration>
                             <source>1.8</source>
                             <target>1.8</target>
@@ -187,7 +187,7 @@ abstract class FileContentGenerator {
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.5.6</version>
                         <configuration>
                             <forkCount>${config.maxParallelForks}</forkCount>
                             <reuseForks>true</reuseForks>
@@ -197,7 +197,7 @@ abstract class FileContentGenerator {
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-report-plugin</artifactId>
-                        <version>2.19.1</version>
+                        <version>3.5.6</version>
                         <executions>
                             <execution>
                                 <id>test-report</id>
@@ -230,7 +230,7 @@ abstract class FileContentGenerator {
             <dependencies>
                 ${config.externalApiDependencies.values().collect { convertToPomDependency(it) }.join("")}
                 ${config.externalImplementationDependencies.values().collect { convertToPomDependency(it) }.join("")}
-                ${convertToPomDependency('junit:junit:4.13', 'test')}
+                ${convertToPomDependency('junit:junit:4.13.2', 'test')}
                 ${subProjectDependencies}
             </dependencies>
             """

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
@@ -67,7 +67,8 @@ enum JavaTestProjectGenerator {
         .withSourceFiles(50000)
         .withSubProjects(0)
         .withDaemonMemory('3g')
-        .withCompilerMemory('6g')
+        // The Groovy 4 compiler needs more heap than Groovy 2.x to compile the 50k-file monolith
+        .withCompilerMemory('12g')
         .withSystemProperties(['org.gradle.groovy.compilation.avoidance': 'true'])
         .withFeaturePreviews('GROOVY_COMPILATION_AVOIDANCE')
         .assembleChangeFile(-1)
@@ -162,17 +163,17 @@ enum JavaTestProjectGenerator {
         .withCompilerMemory('512m')
         .assembleChangeFile()
         .withExternalApiDependencies([
-            "spring": "org.springframework.boot:spring-boot:2.7.9",
-            "aws": "com.amazonaws:aws-java-sdk-bundle:1.12.680",
-            "jooq": "org.jooq:jooq:3.19.6",
-            "grpc": "io.grpc:grpc-netty:1.62.2",
-            "otel" : "io.opentelemetry:opentelemetry-sdk:1.33.0",
-            "jackson" : "com.fasterxml.jackson.core:jackson-databind:2.10.0",
-            "junit5" : "org.junit.jupiter:junit-jupiter-engine:5.10.0",
+            "spring": "org.springframework.boot:spring-boot:4.1.0",
+            "aws": "com.amazonaws:aws-java-sdk-bundle:1.12.797",
+            "jooq": "org.jooq:jooq:3.21.6",
+            "grpc": "io.grpc:grpc-netty:1.83.0",
+            "otel" : "io.opentelemetry:opentelemetry-sdk:1.64.0",
+            "jackson" : "com.fasterxml.jackson.core:jackson-databind:2.22.1",
+            "junitJupiter" : "org.junit.jupiter:junit-jupiter-engine:6.1.2",
             "kotlin": "org.jetbrains.kotlin:kotlin-stdlib:2.4.10",
-            "testcontainers": "org.testcontainers:mysql:1.15.3",
-            "vertx": "io.vertx:vertx-web:4.4.2",
-            "keycloak": "org.keycloak:keycloak-core:24.0.1"
+            "testcontainers": "org.testcontainers:mysql:1.21.4",
+            "vertx": "io.vertx:vertx-web:5.1.5",
+            "keycloak": "org.keycloak:keycloak-core:26.7.0"
         ])
         .create()),
     SMALL_JAVA_MULTI_PROJECT_NO_BUILD_SRC(new TestProjectGeneratorConfigurationBuilder('smallJavaMultiProjectNoBuildSrc')

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
@@ -88,10 +88,10 @@ class TestProjectGeneratorConfigurationBuilder {
         this.systemProperties = [:]
         this.featurePreviews = [] as String[]
         this.externalApiDependencies = [
-            commonsLang: 'commons-lang:commons-lang:2.5',
-            commonsHttpClient: 'commons-httpclient:commons-httpclient:3.0',
-            commonsCodec: 'commons-codec:commons-codec:1.2',
-            jclOverSlf4j: 'org.slf4j:jcl-over-slf4j:2.0.17',
+            commonsLang: 'org.apache.commons:commons-lang3:3.20.0',
+            commonsHttpClient: 'org.apache.httpcomponents.client5:httpclient5:5.6.2',
+            commonsCodec: 'commons-codec:commons-codec:1.22.0',
+            jclOverSlf4j: 'org.slf4j:jcl-over-slf4j:2.0.18',
         ]
     }
 
@@ -131,7 +131,7 @@ class TestProjectGeneratorConfigurationBuilder {
         config.repositories = [mavenCentralRepositoryDefinition(this.dsl)]
         config.externalApiDependencies = this.externalApiDependencies
         config.externalImplementationDependencies = [
-            reflectasm: 'com.googlecode:reflectasm:1.01',
+            reflectasm: 'com.esotericsoftware:reflectasm:1.11.9',
         ]
 
         config.subProjects = this.subProjects

--- a/testing/performance/src/templates/config-inject/build.gradle
+++ b/testing/performance/src/templates/config-inject/build.gradle
@@ -14,15 +14,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'commons-lang:commons-lang:2.5'
-    implementation "commons-httpclient:commons-httpclient:3.0"
-    implementation "commons-codec:commons-codec:1.2"
-    implementation "org.slf4j:jcl-over-slf4j:2.0.17"
-    implementation "org.codehaus:groovy:groovy-all:2.4.15"
-    implementation "commons-codec:commons-codec:1.2"
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.testng:testng:6.4'
-    runtimeOnly 'com.googlecode:reflectasm:1.01'
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
+    implementation "org.apache.httpcomponents.client5:httpclient5:5.6.2"
+    implementation "commons-codec:commons-codec:1.22.0"
+    implementation "org.slf4j:jcl-over-slf4j:2.0.18"
+    implementation "org.apache.groovy:groovy-all:4.0.32"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.testng:testng:7.12.0'
+    runtimeOnly 'com.esotericsoftware:reflectasm:1.11.9'
 
     <% if (dependencies) { dependencies.each { %>
         implementation "${it.shortNotation()}" <% } %>
@@ -39,14 +38,14 @@ test {
 <% if (groovyProject) { %>
 apply plugin: 'groovy'
 dependencies {
-    implementation 'org.codehaus:groovy:groovy-all:2.4.15'
+    implementation 'org.apache.groovy:groovy-all:4.0.32'
 }
 <% } %>
 
 <% if (scalaProject) { %>
 apply plugin: 'scala'
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.9.2'
+    implementation 'org.scala-lang:scala-library:2.13.18'
 }
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.with {

--- a/testing/performance/src/templates/kts-project-with-source/build.gradle.kts
+++ b/testing/performance/src/templates/kts-project-with-source/build.gradle.kts
@@ -29,13 +29,13 @@ repositories {
 }
 
 dependencies {
-    implementation("commons-lang:commons-lang:2.5")
-    implementation("org.apache.httpcomponents:httpclient:4.0")
-    implementation("commons-codec:commons-codec:1.2")
-    implementation("org.slf4j:jcl-over-slf4j:2.0.17")
-    implementation("org.codehaus.groovy:groovy:2.4.15")
-    testImplementation("junit:junit:4.13")
-    runtimeOnly("com.googlecode:reflectasm:1.01")
+    implementation("org.apache.commons:commons-lang3:3.20.0")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.6.2")
+    implementation("commons-codec:commons-codec:1.22.0")
+    implementation("org.slf4j:jcl-over-slf4j:2.0.18")
+    implementation("org.apache.groovy:groovy:4.0.32")
+    testImplementation("junit:junit:4.13.2")
+    runtimeOnly("com.esotericsoftware:reflectasm:1.11.9")
 }
 
 (tasks.getByName("test") as Test).apply {

--- a/testing/performance/src/templates/project-with-source/build.gradle
+++ b/testing/performance/src/templates/project-with-source/build.gradle
@@ -21,20 +21,20 @@ repositories {
 apply plugin: "io.spring.dependency-management"
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.boot:spring-boot-dependencies:1.3.5.RELEASE'
-        mavenBom 'io.spring.platform:platform-bom:2.0.5.RELEASE'
+        mavenBom 'org.springframework.boot:spring-boot-dependencies:4.1.0'
+        mavenBom 'io.spring.platform:platform-bom:2.0.8.RELEASE'
     }
 }
 <% } %>
 
 dependencies {
-    implementation 'commons-lang:commons-lang:2.5'
-    implementation "org.apache.httpcomponents:httpclient:4.0"
-    implementation "commons-codec:commons-codec:1.2"
-    implementation "org.slf4j:jcl-over-slf4j:2.0.17"
-    implementation "org.codehaus.groovy:groovy:2.4.15"
-    testImplementation 'junit:junit:4.13'
-    runtimeOnly 'com.googlecode:reflectasm:1.01'
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
+    implementation "org.apache.httpcomponents.client5:httpclient5:5.6.2"
+    implementation "commons-codec:commons-codec:1.22.0"
+    implementation "org.slf4j:jcl-over-slf4j:2.0.18"
+    implementation "org.apache.groovy:groovy:4.0.32"
+    testImplementation 'junit:junit:4.13.2'
+    runtimeOnly 'com.esotericsoftware:reflectasm:1.11.9'
 
     <% if (dependencies) { dependencies.each { %>
         implementation "${it.shortNotation()}" <% } %>
@@ -77,14 +77,14 @@ tasks.withType(Test) {
 <% if (groovyProject) { %>
 apply plugin: 'groovy'
 dependencies {
-    implementation 'org.codehaus:groovy:groovy-all:2.4.15'
+    implementation 'org.apache.groovy:groovy-all:4.0.32'
 }
 <% } %>
 
 <% if (scalaProject) { %>
 apply plugin: 'scala'
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.9.2'
+    implementation 'org.scala-lang:scala-library:2.13.18'
 }
 tasks.withType(ScalaCompile) {
     scalaCompileOptions.with {

--- a/testing/performance/src/templates/project-with-source/pom.xml
+++ b/testing/performance/src/templates/project-with-source/pom.xml
@@ -15,40 +15,40 @@
     <% } %>
     <dependencies>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.5</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.6.2</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.2</version>
+            <version>1.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.7</version>
+            <version>2.0.18</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>2.4.21</version>
+            <version>4.0.32</version>
         </dependency>
         <dependency>
-            <groupId>com.googlecode</groupId>
+            <groupId>com.esotericsoftware</groupId>
             <artifactId>reflectasm</artifactId>
-            <version>1.01</version>
+            <version>1.11.9</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     <% if (dependencies) { dependencies.each { dep -> %>
@@ -64,8 +64,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/testing/performance/src/templates/with-testng/build.gradle
+++ b/testing/performance/src/templates/with-testng/build.gradle
@@ -1,7 +1,7 @@
 ${original}
 
 dependencies {
-    testImplementation 'org.testng:testng:6.4'
+    testImplementation 'org.testng:testng:7.12.0'
 }
 
 test {

--- a/testing/performance/src/templates/with-verbose-testng/build.gradle
+++ b/testing/performance/src/templates/with-verbose-testng/build.gradle
@@ -1,7 +1,7 @@
 ${original}
 
 dependencies {
-    testImplementation 'org.testng:testng:6.4'
+    testImplementation 'org.testng:testng:7.12.0'
 }
 
 test {


### PR DESCRIPTION
## Summary

Full refresh of the dependencies hardcoded in the performance test project generators and templates, most of which dated from 2004–2019:

- **Default generated project deps** (`TestProjectGeneratorConfiguration`, version catalog in `FileContentGenerator`): migrated abandoned coordinates to their maintained successors — `commons-lang:commons-lang:2.5` → `org.apache.commons:commons-lang3:3.20.0`, `commons-httpclient:commons-httpclient:3.0` → `org.apache.httpcomponents.client5:httpclient5:5.6.2`, `com.googlecode:reflectasm:1.01` → `com.esotericsoftware:reflectasm:1.11.9`, `org.codehaus.groovy:groovy:2.5.22` → `org.apache.groovy:groovy:4.0.32` — and bumped commons-codec, jcl-over-slf4j, junit (4.13.2), testng (7.12.0).
- **Curated list** in `smallJavaMultiProjectManyExternalDependencies`: bumped all 11 entries to latest stable (spring-boot 4.1.0, aws-java-sdk-bundle 1.12.797, jooq 3.21.6, grpc-netty 1.83.0, opentelemetry-sdk 1.64.0, jackson-databind 2.22.1, junit-jupiter-engine 6.1.2, testcontainers-mysql 1.21.4, vertx-web 5.1.5, keycloak-core 26.7.0; kotlin-stdlib 2.4.10 already latest). Renamed the `junit5` catalog alias to `junitJupiter` since it now points at JUnit 6.
- **Static templates** (`project-with-source`, `kts-project-with-source`, `config-inject`, `with-testng`, `with-verbose-testng`): same canonical set, resolving the version drift between the build.gradle / pom.xml / build.gradle.kts variants of the same template; spring BOMs bumped to spring-boot-dependencies 4.1.0 / platform-bom 2.0.8.RELEASE.
- **Generated Maven POM plugins**: maven-compiler-plugin 3.8.0 → 3.15.0, surefire/surefire-report 2.19.1 → 3.5.6.

## Fixes

- Fixed malformed 4-part coordinate `org.codehaus:groovy:groovy-all:2.4.15` (in `project-with-source` and twice in `config-inject`) → `org.apache.groovy:groovy-all:4.0.32`.
- Fixed `source/target 1.5` in the `project-with-source` Maven POM, which no modern JDK accepts.
- Removed a duplicated `commons-codec` declaration in `config-inject`.

## Notes

- Groovy stays on the 4.x line (not 5.x) because generated Groovy projects are compiled by baseline Gradle versions in cross-version scenarios.
- Generated JUnit4/TestNG test sources only use APIs that exist in the new versions (`org.junit.Test`, `org.testng.Assert`).
- Deliberately not touched: pinned remote project refs in `gradle.properties`, the Bazel `rules_jvm_external` pin (needs a SHA/Bazel-version lockstep change), the vendored GoogleTest 1.7.0 resources, and AGP/KGP versions (already auto-updated via `agp-versions.properties`/`kotlin-versions.properties`).
- This will shift performance baselines for scenarios that resolve/compile against these deps; regression numbers right after merge should be read with that in mind.

## Test plan

- [x] Performance test coverage via `@bot-gradle test APT`