### PR TITLE
Reattach non-abstract property owners after configuration cache restore

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -426,6 +426,15 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         return isAttachableType(metadata.getReturnType(), metadata.method::isAnnotationPresent);
     }
 
+    private static boolean hasAttachableOverridableGetter(PropertyMetadata property) {
+        for (MethodMetadata getter : property.getOverridableGetters()) {
+            if (isAttachableMethod(getter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean isAttachableType(Class<?> type, Predicate<Class<? extends Annotation>> propertyHasAnnotation) {
         // This should apply to all 'managed' types however only the ConfigurableFileCollection and Provider types and @Nested value current implement OwnerAware
         return Provider.class.isAssignableFrom(type) || isConfigurableFileCollectionType(type) || hasNestedAnnotation(propertyHasAnnotation);
@@ -1039,9 +1048,16 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 visitor.mixInConventionAware();
             }
             for (PropertyMetadata property : conventionProperties) {
-                boolean applyRole = isAttachProperty(property) && isLazyAttachPropertyIfNeeded(property) && isRoleType(property);
+                boolean attachProperty = isAttachProperty(property) && isLazyAttachPropertyIfNeeded(property);
+                boolean applyRole = attachProperty && isRoleType(property);
                 if (applyRole) {
                     visitor.instantiatesNestedObjects();
+                }
+                if (attachProperty && isReattachProperty(property) && hasAttachableOverridableGetter(property)) {
+                    // The owner is attached lazily by the overriding getter, which is not invoked when the
+                    // object is restored from the configuration cache. Reattach it on demand so the property
+                    // keeps its display name after a cached run. See https://github.com/gradle/gradle/issues/37421.
+                    visitor.attachOnDemand(property, applyRole);
                 }
             }
         }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
 import org.gradle.internal.Describables
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
+import org.gradle.internal.state.ModelObject
 import org.gradle.util.internal.ConfigureUtil
 import spock.lang.Issue
 
@@ -117,6 +118,25 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
 
         // Does not assign display name to mutable property
         mutableBean.someValue.toString() == "property(java.lang.String, undefined)"
+    }
+
+    def "reattaches owner to read only non-final Property when reading from the configuration cache"() {
+        given:
+        def bean = create(HasReadOnlyProperty, Describables.of("<display name>"))
+        // When the object is restored from the configuration cache, the value is read back through the field and
+        // the lazily-attaching getter is never invoked, so the owner is not attached at this point.
+        def field = HasReadOnlyProperty.getDeclaredField("prop")
+        field.accessible = true
+        def property = field.get(bean)
+
+        expect:
+        property.toString() == "property(java.lang.String, undefined)"
+
+        when:
+        (bean as ModelObject).attachModelProperties()
+
+        then:
+        property.toString() == "<display name> property 'someValue'"
     }
 
     def "assigns display name to read only non-final nested property that is not managed"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.api.tasks
 
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.FailsWith
 import spock.lang.Issue
 
@@ -213,7 +211,6 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("inside: output is produced by thing")
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/37421; Fails with Configuration Cache")
     def "reports failure to query non-abstract Property<T> with non-final getter"() {
         given:
         javaFile("buildSrc/src/main/java/MyTask.java", """
@@ -248,14 +245,7 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("property = task ':thing' property 'count'")
-        if (!GradleContextualExecuter.configCache) {
-            // This is the correct failure message.
-            failure.assertHasCause("Cannot query the value of task ':thing' property 'count' because it has no value available.")
-        } else {
-            // TODO(https://github.com/gradle/gradle/issues/37421): There shouldn't be any difference in behavior with CC enabled.
-            //  This assert encodes current behavior, not desired one.
-            failure.assertHasCause("Cannot query the value of this property because it has no value available.")
-        }
+        failure.assertHasCause("Cannot query the value of task ':thing' property 'count' because it has no value available.")
     }
 
     @FailsWith(reason = "non-final getters do not trigger attachOwner/attachProducer logic", value = AssertionError)


### PR DESCRIPTION
<!-- Fixes #37421 -->
Fixes #37421

### Context

A non-abstract `Property` (or `ConfigurableFileCollection`) getter that returns a backing field has its owner attached **lazily**, by the getter override that the class generator injects. That override only runs when the getter is actually invoked during configuration.

When the owning object is restored from the configuration cache, configuration is skipped, so the getter is never called and the owner is never attached. Internal access through the backing field then reports a generic error instead of naming the owning task and property:

| Execution | Error message |
| --- | --- |
| No configuration cache | `Cannot query the value of task ':thing' property 'count' because it has no value available.` |
| With configuration cache | `Cannot query the value of this property because it has no value available.` |

This is the divergence tracked by the `@ToBeImplemented` test in `TaskPropertiesIntegrationTest`.

### Changes

Abstract managed properties are already re-attached on cache read through the generated `attachModelProperties()` method — `ManagedPropertiesHandler` registers them for on-demand reattachment (extended to `ConfigurableFileCollection` in bab3822). Non-abstract *convention* properties whose owner is attached lazily through an overriding getter were never registered for this reattachment, so they lost their owner after a cached run.

`ExtensibleTypePropertyHandler` now registers such convention properties (a reattachable type with an attachable overriding getter) for on-demand reattachment, so `attachModelProperties()` restores their owner after deserialization — mirroring the existing behavior for abstract managed properties. This only affects the configuration-cache restore path; construction behavior is unchanged.

### Tests

- Updated the `@ToBeImplemented` integration test in `TaskPropertiesIntegrationTest` to assert the now-consistent message under both executers.
- Added a unit test in `AsmBackedClassGeneratorDecoratedTest` that reads the property back through the field (as happens on cache restore) and verifies `attachModelProperties()` reattaches its owner.

<sub>Prepared with AI assistance.</sub>

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew model-core:test --tests "*AsmBackedClassGeneratorDecoratedTest"`.
