### PR TITLE
Remove Shadow plugin develocity integration workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,10 +45,6 @@ org.jetbrains.dokka.experimental.tryK2.noWarn=true
 org.jetbrains.dokka.experimental.tryK2.nowarn=true
 org.jetbrains.dokka.internal.enableWorkaroundKT80551=true
 
-# workaround until the Shadow plugin fixes IP violation in the develocity integration area
-# https://github.com/GradleUp/shadow/issues/1835
-com.gradleup.shadow.enableDevelocityIntegration=false
-
 # Android smoke test project repository and commit
 androidSmokeTestProjectRef=https://github.com/gradle/nowinandroid.git#4a5becfc8878471c1063a10c558f87e4399d12f2
 


### PR DESCRIPTION
### Context

The fix has been included in https://github.com/GradleUp/shadow/releases/tag/9.3.0

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
