### PR TITLE
Honor explicit opt-out for Isolated Projects options

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import spock.lang.Issue
 
 import static org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption.Value.WARN
 
@@ -99,6 +100,24 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
         cliOrigin         | cliArgument
         "long option"     | DISABLE_CLI_OPT
         "system property" | DISABLE_SYS_PROP
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "deprecated property set to false does not disable configuration cache enabled via gradle.properties"() {
+        // Characterization test: for Configuration Cache the stable property name deliberately wins over
+        // the deprecated spelling regardless of value, unchanged since Gradle 8.1. The Isolated Projects
+        // options resolve the same situation as a conjunction (explicit disable wins) since issue 38598;
+        // flipping this test is a conscious decision to migrate CC to those semantics.
+        given:
+        file('gradle.properties') << """
+            $ENABLE_GRADLE_PROP
+        """
+
+        when:
+        run 'help', "-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=false"
+
+        then:
+        fixture.assertStateStored()
     }
 
     def "can enable configuration cache using incubating and final property variants"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.isolated
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Issue
 
 class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements TasksWithInputsAndOutputs {
 
@@ -117,6 +118,77 @@ class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegratio
         then:
         outputContains("isolatedProjects.requested=true")
         outputContains("isolatedProjects.active=true")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "resolves IP from both property names (#stableValue in #stableIn, #deprecatedValue in #deprecatedIn)"() {
+        given:
+        withIpStatusTask()
+        def fileProps = []
+        def cliProps = []
+        (stableIn == "file" ? fileProps : cliProps) << "org.gradle.isolated-projects=$stableValue"
+        (deprecatedIn == "file" ? fileProps : cliProps) << "org.gradle.unsafe.isolated-projects=$deprecatedValue"
+        file("gradle.properties") << fileProps.join("\n")
+
+        when:
+        run("ipStatus", *cliProps.collect { "-D$it".toString() })
+
+        then:
+        outputContains("isolatedProjects.requested=$expected")
+        outputContains("isolatedProjects.active=$expected")
+
+        where:
+        stableIn | deprecatedIn | stableValue | deprecatedValue | expected
+        "file"   | "file"       | true        | true            | true
+        "file"   | "file"       | true        | false           | false
+        "file"   | "file"       | false       | true            | false
+        "file"   | "file"       | false       | false           | false
+        "file"   | "cli"        | true        | true            | true
+        "file"   | "cli"        | true        | false           | false
+        "file"   | "cli"        | false       | true            | false
+        "file"   | "cli"        | false       | false           | false
+        "cli"    | "file"       | true        | true            | true
+        "cli"    | "file"       | true        | false           | false
+        "cli"    | "file"       | false       | true            | false
+        "cli"    | "file"       | false       | false           | false
+        "cli"    | "cli"        | true        | true            | true
+        "cli"    | "cli"        | true        | false           | false
+        "cli"    | "cli"        | false       | true            | false
+        "cli"    | "cli"        | false       | false           | false
+    }
+
+    def "build option takes precedence over properties"() {
+        given:
+        withIpStatusTask()
+
+        when:
+        run "ipStatus", "--isolated-projects", "-Dorg.gradle.isolated-projects=false", "-Dorg.gradle.unsafe.isolated-projects=false"
+
+        then:
+        outputContains("isolatedProjects.requested=true")
+        outputContains("isolatedProjects.active=true")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "explicit disable via deprecated property wins for #optionKind option"() {
+        when:
+        run "help", "-q",
+            "-Dorg.gradle.internal.operations.verbose.parameters=true",
+            "-Dorg.gradle.isolated-projects=true",
+            "-D${stableProperty}=true",
+            "-D${deprecatedProperty}=false"
+
+        then:
+        result.getOutputLineThatContains("Operational build model parameters:").contains("${outputKey}=false")
+
+        where:
+        optionKind                    | outputKey
+        "diagnostics"                 | "isolatedProjectsDiagnostics"
+        "dangerously-ignore-problems" | "isolatedProjectsDangerouslyIgnoreProblems"
+        __
+        stableProperty                                              | deprecatedProperty
+        "org.gradle.isolated-projects.diagnostics"                  | "org.gradle.unsafe.isolated-projects.diagnostics"
+        "org.gradle.isolated-projects.dangerously-ignore-problems"  | "org.gradle.unsafe.isolated-projects.dangerously-ignore-problems"
     }
 
     def "diagnostics option is accepted under both property names"() {

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOption.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption;
+
+import java.util.Map;
+
+/**
+ * A boolean build option with a deprecated property alias where an explicit disable
+ * through either property name wins: when both names are set, the option is enabled
+ * only if both values are true.
+ *
+ * <p>This keeps opt-outs reliable while a renamed property is deprecated: tooling that
+ * still disables a feature under the deprecated name must keep working even when the
+ * build enables the feature under the new name.
+ *
+ * <p>The downside is that this rule ignores source precedence: a disable from a
+ * lower-precedence source (e.g. a {@code gradle.properties} file) overrides an enable
+ * from a higher-precedence source (e.g. a command-line {@code -D} argument) when the
+ * two use different names. Only the command-line flags can override a disable.
+ *
+ * <p>This is a stop-gap rather than the desired end state. The proper solution is to
+ * make the deprecated name an actual alias of the main option, resolved against it
+ * within each property source, instead of after all sources have been merged.
+ * See <a href="https://github.com/gradle/gradle/issues/38598">#38598</a>.
+ *
+ * @param <T> the type of object the option value is applied to
+ */
+public abstract class DeprecatedAliasDisableWinsBooleanBuildOption<T> extends BooleanBuildOption<T> {
+
+    public DeprecatedAliasDisableWinsBooleanBuildOption(
+        String property,
+        String deprecatedProperty,
+        BooleanCommandLineOptionConfiguration... commandLineOptionConfigurations
+    ) {
+        super(property, deprecatedProperty, commandLineOptionConfigurations);
+    }
+
+    @Override
+    protected OptionValue<String> getFromProperties(Map<String, String> properties) {
+        String value = properties.get(property);
+        String deprecatedValue = properties.get(deprecatedProperty);
+        if (value != null && deprecatedValue != null
+            && BooleanOptionUtil.isTrue(value) && !BooleanOptionUtil.isTrue(deprecatedValue)) {
+            // The deprecated name carries an explicit disable that the main property would otherwise mask
+            return new OptionValue<String>(deprecatedValue, Origin.forGradleProperty(deprecatedProperty));
+        }
+        return super.getFromProperties(properties);
+    }
+}

--- a/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOptionTest.groovy
+++ b/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOptionTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue("https://github.com/gradle/gradle/issues/38598")
+class DeprecatedAliasDisableWinsBooleanBuildOptionTest extends Specification {
+
+    private static final String PROPERTY = 'org.gradle.test'
+    private static final String DEPRECATED_PROPERTY = 'org.gradle.unsafe.test'
+
+    def testSettings = new TestSettings()
+    def testOption = new TestOption(PROPERTY, DEPRECATED_PROPERTY)
+
+    def "does not apply option when neither property is present"() {
+        when:
+        testOption.applyFromProperty([:], testSettings)
+
+        then:
+        !testSettings.applied
+        testSettings.origin == null
+    }
+
+    def "applies a single present property like the base class (#props)"() {
+        when:
+        testOption.applyFromProperty(props, testSettings)
+
+        then:
+        testSettings.applied
+        testSettings.value == expectedValue
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == expectedOrigin
+
+        where:
+        props                            | expectedValue | expectedOrigin
+        [(PROPERTY): 'true']             | true          | PROPERTY
+        [(PROPERTY): 'false']            | false         | PROPERTY
+        [(DEPRECATED_PROPERTY): 'true']  | true          | DEPRECATED_PROPERTY
+        [(DEPRECATED_PROPERTY): 'false'] | false         | DEPRECATED_PROPERTY
+    }
+
+    def "explicit disable wins when both properties are present (#stableValue, #deprecatedValue)"() {
+        when:
+        testOption.applyFromProperty([(PROPERTY): stableValue, (DEPRECATED_PROPERTY): deprecatedValue], testSettings)
+
+        then:
+        testSettings.applied
+        testSettings.value == expectedValue
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == expectedOrigin
+
+        where:
+        stableValue | deprecatedValue | expectedValue | expectedOrigin
+        'true'      | 'true'          | true          | PROPERTY
+        'true'      | 'false'         | false         | DEPRECATED_PROPERTY
+        'false'     | 'true'          | false         | PROPERTY
+        'false'     | 'false'         | false         | PROPERTY
+        'true'      | 'banana'        | false         | DEPRECATED_PROPERTY
+        'banana'    | 'true'          | false         | PROPERTY
+    }
+
+    static class TestOption extends DeprecatedAliasDisableWinsBooleanBuildOption<TestSettings> {
+
+        TestOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(boolean value, TestSettings settings, Origin origin) {
+            settings.applied = true
+            settings.value = value
+            settings.origin = origin
+        }
+    }
+
+    static class TestSettings {
+        boolean applied
+        boolean value
+        Origin origin
+    }
+}

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -27,6 +27,7 @@ import org.gradle.internal.buildoption.BooleanCommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.BuildOptionSet;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.DeprecatedAliasDisableWinsBooleanBuildOption;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
 import org.gradle.internal.buildoption.EnumBuildOption;
 import org.gradle.internal.buildoption.IntegerBuildOption;
@@ -679,7 +680,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects";
         public static final String LONG_OPTION = "isolated-projects";
@@ -707,7 +708,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsDiagnosticsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsDiagnosticsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects.diagnostics";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.diagnostics";
 
@@ -721,7 +722,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsDangerouslyIgnoreProblemsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsDangerouslyIgnoreProblemsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects.dangerously-ignore-problems";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.dangerously-ignore-problems";
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -584,6 +584,7 @@ org.gradle.isolated-projects=true
 ====
 The legacy property name `org.gradle.unsafe.isolated-projects` is still accepted, but the new `org.gradle.isolated-projects` name is preferred.
 The same applies to `org.gradle.unsafe.isolated-projects.diagnostics` and `org.gradle.unsafe.isolated-projects.dangerously-ignore-problems`.
+When both the legacy and the new name of a property are set, an explicit `false` from either one disables the feature.
 ====
 
 If you have never enabled the feature in the build before, it's likely that the build is not compatible and contains Isolated Projects <<sec:constraint_violations,constraint violations>>.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -191,6 +191,9 @@ The legacy `org.gradle.unsafe.*` names are now deprecated and will be removed in
 They continue to be accepted as aliases for now and currently emit no warning.
 Update your `gradle.properties` and command-line invocations to the new names.
 
+When both the legacy and the new name of a property are set — for example, the new name in `gradle.properties` and the legacy name injected by a plugin or CI script on the command line — an explicit `false` from either one disables the feature.
+This guarantees that tooling which still opts out via a legacy property name keeps working after a build migrates to the new names.
+
 See the <<isolated_projects.adoc#sec:enable, Enabling Isolated Projects>> section in the Gradle User Manual for the recommended setup.
 
 [[deprecated_custom_collection_types_with_cc]]


### PR DESCRIPTION
Fixes #38598

### Summary

Isolated Projects can now always be disabled through its deprecated `org.gradle.unsafe.isolated-projects=false` property, even when the build enables the feature under the stable name. A stop-gap scoped to the three Isolated Projects options; Configuration Cache alias behavior is unchanged.

### Why

Build options resolve against a single map into which all property sources (`gradle.properties`, command-line `-D`, …) have already been merged, and an alias pair resolves by name: the stable name, when present in any source, shadows the deprecated one. Tooling that still opts out under the deprecated name — the `dependency-submission` GitHub Action unconditionally passes `-Dorg.gradle.unsafe.isolated-projects=false` ([main.ts#L49](https://github.com/gradle/actions/blob/6550634d3eb14a20275549de1588a83267023d42/sources/src/actions/dependency-submission/main.ts#L49)) — therefore cannot disable the feature once a build adopts `org.gradle.isolated-projects=true` as the 9.7 docs recommend, and fails on IP problems despite an explicit opt-out. This is not an RC1 code regression: resolution has worked this way since the alias pair was introduced; 9.7 promoting the new name is what exposed it.

### What

- New `DeprecatedAliasDisableWinsBooleanBuildOption`: when both names of an alias pair are set, the effective value is their conjunction — an explicit `false` from either name wins
- `IsolatedProjectsOption`, `IsolatedProjectsDiagnosticsOption`, `IsolatedProjectsDangerouslyIgnoreProblemsOption` migrate to it; no other option touched
- Characterization test pins the unchanged Configuration Cache alias behavior
- The rule is documented in `isolated_projects.adoc` and the 9.7 upgrading guide

### Details

Consumer impact — exactly one resolution outcome changes (values parse per `BooleanOptionUtil.isTrue`, so any non-`"true"` value counts as an explicit false):

| stable name | deprecated name | before | after |
| --- | --- | --- | --- |
| `true` | `false` | IP enabled | **IP disabled** |
| any other combination | | unchanged | unchanged |

`--isolated-projects` / `--no-isolated-projects` continue to trump all properties.

Deliberate choices:

- **Conjunction, not source precedence.** The proper solution is to make the deprecated name an actual alias, resolved against the main option within each property source rather than after all sources are merged. That touches shared launcher/daemon property-merging machinery — too invasive for an RC fix. The accepted downside of the conjunction: it ignores source precedence, so a disable from a lower-precedence source beats an enable from a higher-precedence one when the two use different names. It fails safe — the rule can only ever turn the feature off.
- **Guarded override rather than "deprecated false always wins".** The override delegates to the base class except in the single case where base resolution gives the wrong value. This keeps origin attribution precise (the deprecated name is only credited when it changed the outcome) and leaves the base class's deprecated-name fallback path intact for the planned deprecation nag, which records usage there.
- **Configuration Cache options not migrated.** Their stable-name-wins behavior has stood since Gradle 8.1; changing it is out of scope for an RC fix. The new characterization test turns any accidental leakage red.
- **No mixed-usage warning in this change.** Property resolution runs in the launcher JVM and is not once-per-build; a reliable warning needs lifecycle-point detection and is deferred to a follow-up.
- **Explicit 16-row truth table over a `combined:` cross-product.** The table (name placements file/cli × values) is the specification; a what-if run against future per-source semantics showed the acceptance delta is exactly 4 cells, so migrating to the proper solution later means flipping those cells and nothing else.

Evidence: 16-iteration integration truth table plus unit truth table including origin attribution (`:build-option`, 106 tests); full `IsolatedProjectsIntegrationTest` green (35 tests); CC pin test green; `sanityCheck` green.

Review: scrutinize `DeprecatedAliasDisableWinsBooleanBuildOption.getFromProperties` (the entire behavior change, ~8 lines) and the `expected` column of the truth-table test; the three base-class swaps and doc sentences are skimmable.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
