### PR TITLE
Avoid ignoring source and documentation directories named build

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
@@ -101,7 +101,9 @@ build/
     def "generated .gitignore preserves source and documentation directories named build"() {
         given:
         run('init', '--project-name', 'someApp', '--overwrite')
-        assertGitSucceeds('init')
+        def emptyGitTemplate = targetDir.file('empty-git-template').createDir()
+        assertGitSucceeds('-c', "init.templateDir=${emptyGitTemplate.absolutePath}", 'init')
+        assertGitSucceeds('config', 'core.excludesFile', targetDir.file('empty-global-excludes').createFile().absolutePath)
 
         def ignoredPaths = [
             'build/output.txt',

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
@@ -97,4 +97,41 @@ build/
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
+
+    def "generated .gitignore preserves source and documentation directories named build"() {
+        given:
+        run('init', '--project-name', 'someApp', '--overwrite')
+        assertGitSucceeds('init')
+
+        def ignoredPaths = [
+            'build/output.txt',
+            'module/build/output.txt',
+            'nested/module/build/output.txt',
+            'build/src/build/output.txt'
+        ]
+        def visiblePaths = [
+            'src/build/source.txt',
+            'src/main/resources/build/fixture.txt',
+            'module/src/test/resources/build/fixture.txt',
+            'docs/build/page.md',
+            'docs/guide/assets/build/page.md',
+            'module/docs/reference/build/page.md',
+            'mybuild/output.txt'
+        ]
+        (ignoredPaths + visiblePaths).each { targetDir.file(it).createFile() }
+
+        expect:
+        ignoredPaths.every { gitExitValue('check-ignore', '--no-index', it) == 0 }
+        visiblePaths.every { gitExitValue('check-ignore', '--no-index', it) == 1 }
+    }
+
+    private void assertGitSucceeds(String... arguments) {
+        assert gitExitValue(arguments) == 0
+    }
+
+    private int gitExitValue(String... arguments) {
+        def process = ['git', *arguments].execute(null, targetDir)
+        process.consumeProcessOutput()
+        return process.waitFor()
+    }
 }

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
@@ -85,8 +85,10 @@ existingIgnores
 # Ignore Gradle project-specific cache directory
 .gradle
 
-# Ignore Gradle build output directory
-build
+# Ignore Gradle build output directories, except when used as part of source or documentation paths
+build/
+!**/docs/**/build/
+!**/src/**/build/
 
 # Ignore Kotlin plugin data
 .kotlin

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -40,7 +40,7 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     private static final List<String> GRADLE_CACHE_IGNORE_BLOCK = Arrays.asList(".gradle");
     private static final List<String> BUILD_OUTPUT_IGNORE_BLOCK = Arrays.asList("build/", "!**/docs/**/build/", "!**/src/**/build/");
     private static final List<String> KOTLIN_PLUGIN_IGNORE_BLOCK = Arrays.asList(".kotlin");
-    private static final Pattern BUILD_PATH_COMPONENT = Pattern.compile("(^|/)build(/|$)");
+    private static final Pattern BUILD_PATH_COMPONENT = Pattern.compile("(^|/)build(/|$)", Pattern.CASE_INSENSITIVE);
 
     @Override
     public void generate(InitSettings settings, BuildContentGenerationContext buildContentGenerationContext) {

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -30,24 +30,29 @@ import java.util.List;
 import java.util.Spliterator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
 
 public class GitIgnoreGenerator implements BuildContentGenerator {
+    private static final List<String> GRADLE_CACHE_IGNORE_BLOCK = Arrays.asList(".gradle");
+    private static final List<String> BUILD_OUTPUT_IGNORE_BLOCK = Arrays.asList("build/", "!**/docs/**/build/", "!**/src/**/build/");
+    private static final List<String> KOTLIN_PLUGIN_IGNORE_BLOCK = Arrays.asList(".kotlin");
+    private static final Pattern BUILD_PATH_COMPONENT = Pattern.compile("(^|/)build(/|$)");
 
     @Override
     public void generate(InitSettings settings, BuildContentGenerationContext buildContentGenerationContext) {
         File file = settings.getTarget().file(".gitignore").getAsFile();
-        List<List<String>> gitignoresToAppend = getGitignoresToAppend(file);
-        if (!gitignoresToAppend.isEmpty()) {
+        List<List<String>> gitignoreBlocksToAppend = getGitignoreBlocksToAppend(file);
+        if (!gitignoreBlocksToAppend.isEmpty()) {
             boolean shouldAppendNewLine = file.exists();
             try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(file.toPath(), UTF_8, CREATE, APPEND))) {
                 if (shouldAppendNewLine) {
                     writer.println();
                 }
-                Spliterator<List<String>> it = gitignoresToAppend.spliterator();
+                Spliterator<List<String>> it = gitignoreBlocksToAppend.spliterator();
                 if (it.tryAdvance(e -> withComment(e).forEach(writer::println))) {
                     StreamSupport.stream(it, false).forEach(e -> withSeparator(withComment(e)).forEach(writer::println));
                 }
@@ -58,19 +63,22 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     }
 
     @SuppressWarnings("DefaultCharset") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
-    private static List<List<String>> getGitignoresToAppend(File gitignoreFile) {
+    private static List<List<String>> getGitignoreBlocksToAppend(File gitignoreFile) {
         // .gradle - project cache directory, see https://docs.gradle.org/current/userguide/directory_layout.html#dir:project_root
         //  build  - build output directory, except when used as part of source or documentation paths
         // .kotlin - Kotlin Gradle Plugin caches/metadata
         List<List<String>> result = new ArrayList<>(Arrays.asList(
-            Arrays.asList(".gradle"),
-            Arrays.asList("build/", "!**/docs/**/build/", "!**/src/**/build/"),
-            Arrays.asList(".kotlin")
+            GRADLE_CACHE_IGNORE_BLOCK,
+            BUILD_OUTPUT_IGNORE_BLOCK,
+            KOTLIN_PLUGIN_IGNORE_BLOCK
         ));
         if (gitignoreFile.exists()) {
             try (BufferedReader reader = new BufferedReader(new FileReader(gitignoreFile))){
                 List<String> existingLines = reader.lines().collect(Collectors.toList());
-                result.removeIf(entry -> containsSequence(existingLines, entry));
+                result.removeIf(entry -> containsExactSequence(existingLines, entry));
+                if (containsBuildRule(existingLines)) {
+                    result.remove(BUILD_OUTPUT_IGNORE_BLOCK);
+                }
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
@@ -78,13 +86,21 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
         return result;
     }
 
-    private static boolean containsSequence(List<String> lines, List<String> sequence) {
+    private static boolean containsExactSequence(List<String> lines, List<String> sequence) {
         for (int i = 0; i <= lines.size() - sequence.size(); i++) {
             if (lines.subList(i, i + sequence.size()).equals(sequence)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean containsBuildRule(List<String> lines) {
+        return lines.stream()
+            .map(String::trim)
+            .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+            .map(line -> line.startsWith("!") ? line.substring(1) : line)
+            .anyMatch(line -> BUILD_PATH_COMPONENT.matcher(line).find());
     }
 
     private static List<String> withComment(List<String> entry) {

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.buildinit.plugins.internal;
 
-import com.google.common.collect.Sets;
 import org.gradle.internal.UncheckedException;
 
 import java.io.BufferedReader;
@@ -28,7 +27,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.Spliterator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -42,14 +40,14 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     @Override
     public void generate(InitSettings settings, BuildContentGenerationContext buildContentGenerationContext) {
         File file = settings.getTarget().file(".gitignore").getAsFile();
-        Set<String> gitignoresToAppend = getGitignoresToAppend(file);
+        List<List<String>> gitignoresToAppend = getGitignoresToAppend(file);
         if (!gitignoresToAppend.isEmpty()) {
             boolean shouldAppendNewLine = file.exists();
             try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(file.toPath(), UTF_8, CREATE, APPEND))) {
                 if (shouldAppendNewLine) {
                     writer.println();
                 }
-                Spliterator<String> it = gitignoresToAppend.spliterator();
+                Spliterator<List<String>> it = gitignoresToAppend.spliterator();
                 if (it.tryAdvance(e -> withComment(e).forEach(writer::println))) {
                     StreamSupport.stream(it, false).forEach(e -> withSeparator(withComment(e)).forEach(writer::println));
                 }
@@ -60,14 +58,19 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     }
 
     @SuppressWarnings("DefaultCharset") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
-    private static Set<String> getGitignoresToAppend(File gitignoreFile) {
+    private static List<List<String>> getGitignoresToAppend(File gitignoreFile) {
         // .gradle - project cache directory, see https://docs.gradle.org/current/userguide/directory_layout.html#dir:project_root
-        //  build  - build output directory
+        //  build  - build output directory, except when used as part of source or documentation paths
         // .kotlin - Kotlin Gradle Plugin caches/metadata
-        Set<String> result = Sets.newLinkedHashSet(Arrays.asList(".gradle", "build", ".kotlin"));
+        List<List<String>> result = new ArrayList<>(Arrays.asList(
+            Arrays.asList(".gradle"),
+            Arrays.asList("build/", "!**/docs/**/build/", "!**/src/**/build/"),
+            Arrays.asList(".kotlin")
+        ));
         if (gitignoreFile.exists()) {
             try (BufferedReader reader = new BufferedReader(new FileReader(gitignoreFile))){
-                result.removeAll(reader.lines().filter(it -> result.contains(it)).collect(Collectors.toSet()));
+                List<String> existingLines = reader.lines().collect(Collectors.toList());
+                result.removeIf(entry -> containsSequence(existingLines, entry));
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
@@ -75,16 +78,26 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
         return result;
     }
 
-    private static List<String> withComment(String entry) {
+    private static boolean containsSequence(List<String> lines, List<String> sequence) {
+        for (int i = 0; i <= lines.size() - sequence.size(); i++) {
+            if (lines.subList(i, i + sequence.size()).equals(sequence)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> withComment(List<String> entry) {
         List<String> result = new ArrayList<>();
-        if (entry.startsWith(".gradle")) {
+        String firstEntry = entry.get(0);
+        if (firstEntry.startsWith(".gradle")) {
             result.add("# Ignore Gradle project-specific cache directory");
-        } else if (entry.startsWith("build")) {
-            result.add("# Ignore Gradle build output directory");
-        } else if (entry.startsWith(".kotlin")) {
+        } else if (firstEntry.startsWith("build")) {
+            result.add("# Ignore Gradle build output directories, except when used as part of source or documentation paths");
+        } else if (firstEntry.startsWith(".kotlin")) {
             result.add("# Ignore Kotlin plugin data");
         }
-        result.add(entry);
+        result.addAll(entry);
 
         return result;
     }

--- a/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -82,7 +82,37 @@ ${getGeneratedGitignoreContent()}""")
 ${getGeneratedGitignoreContent(entry)}""")
 
         where:
-        entry << ['.gradle', '.kotlin', 'build']
+        entry << ['.gradle', '.kotlin']
+    }
+
+    def "avoids adding duplicated build ignore block when .gitignore file already exists"() {
+        setup:
+        def generator = new GitIgnoreGenerator()
+        gitignoreFile << '''build/
+!**/docs/**/build/
+!**/src/**/build/'''
+
+        when:
+        generator.generate(settings, null)
+
+        then:
+        gitignoreFile.text == toPlatformLineSeparators("""build/
+!**/docs/**/build/
+!**/src/**/build/
+${getGeneratedGitignoreContent('build')}""")
+    }
+
+    def "adds complete build ignore block when only legacy build entry exists"() {
+        setup:
+        def generator = new GitIgnoreGenerator()
+        gitignoreFile << 'build'
+
+        when:
+        generator.generate(settings, null)
+
+        then:
+        gitignoreFile.text == toPlatformLineSeparators("""build
+${getGeneratedGitignoreContent()}""")
     }
 
     private static String getGeneratedGitignoreContent(String excludingEntry = null) {
@@ -98,8 +128,10 @@ ${getGeneratedGitignoreContent(entry)}""")
             if (builder.length() > 0) {
                 builder << '\n'
             }
-            builder << '''# Ignore Gradle build output directory
-build
+            builder << '''# Ignore Gradle build output directories, except when used as part of source or documentation paths
+build/
+!**/docs/**/build/
+!**/src/**/build/
 '''
         }
 

--- a/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -37,9 +37,9 @@ class GitIgnoreGeneratorTest extends Specification {
     def setup() {
         Directory target = Mock()
         RegularFile ignoreFile = Mock()
-        1 * settings.target >> target
-        1 * target.file('.gitignore') >> ignoreFile
-        1 * ignoreFile.asFile >> gitignoreFile
+        settings.target >> target
+        target.file('.gitignore') >> ignoreFile
+        ignoreFile.asFile >> gitignoreFile
     }
 
     def "generates .gitignore file"() {
@@ -102,17 +102,41 @@ ${getGeneratedGitignoreContent(entry)}""")
 ${getGeneratedGitignoreContent('build')}""")
     }
 
-    def "adds complete build ignore block when only legacy build entry exists"() {
+    def "does not change existing build ignore rules [#existingRules]"() {
         setup:
         def generator = new GitIgnoreGenerator()
-        gitignoreFile << 'build'
+        gitignoreFile << existingRules
 
         when:
         generator.generate(settings, null)
 
         then:
-        gitignoreFile.text == toPlatformLineSeparators("""build
-${getGeneratedGitignoreContent()}""")
+        gitignoreFile.text == toPlatformLineSeparators("""$existingRules
+${getGeneratedGitignoreContent('build')}""")
+
+        where:
+        existingRules << [
+            'build',
+            'build/',
+            '''build
+!vendor/build/''',
+            '''build
+src/generated/build/''',
+            'src/generated/build/'
+        ]
+    }
+
+    def "does not append entries when generated twice"() {
+        setup:
+        def generator = new GitIgnoreGenerator()
+
+        when:
+        generator.generate(settings, null)
+        def contentAfterFirstGeneration = gitignoreFile.text
+        generator.generate(settings, null)
+
+        then:
+        gitignoreFile.text == contentAfterFirstGeneration
     }
 
     private static String getGeneratedGitignoreContent(String excludingEntry = null) {

--- a/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -118,6 +118,7 @@ ${getGeneratedGitignoreContent('build')}""")
         existingRules << [
             'build',
             'build/',
+            'Build/',
             '''build
 !vendor/build/''',
             '''build


### PR DESCRIPTION
Fixes #18737

### Context

`gradle init` currently generates a bare `build` pattern. Git treats it as matching any file or directory named `build`, so source packages and resources such as `src/main/java/com/example/build/` are ignored as well.

This change follows the root `.gitignore` approach discussed in the issue. Newly generated files use:

```gitignore
build/
!**/docs/**/build/
!**/src/**/build/
```

This keeps root and subproject build output ignored while allowing directories named `build` under source and documentation paths. The parent-directory limitation of Git ignore rules still applies, so a path below an already ignored outer `build/` remains ignored.

Merging into an existing `.gitignore` is deliberately conservative. If the file already contains any rule with a literal `build` path component, including unignore rules or case variants, the generator leaves all build-related rules untouched. This avoids changing the ordering semantics of user-owned rules. As a tradeoff, existing projects with a build rule are not automatically migrated when `init` is rerun.

### Testing

Passed locally:

- `./gradlew :build-init:test --tests org.gradle.buildinit.plugins.internal.GitIgnoreGeneratorTest`
- `./gradlew :build-init:embeddedIntegTest --tests org.gradle.buildinit.plugins.BasicTypeInitIntegrationTest`
- `./gradlew :build-init:checkstyleMain :build-init:codenarcTest :build-init:codenarcIntegTest`

The integration test initializes a real Git repository and uses `git check-ignore --no-index` to verify root and nested build output, source and documentation paths, ignored parent-directory behavior, and non-matching names such as `mybuild`. It also isolates the test from user Git templates and global excludes.

I also ran `./gradlew :build-init:quickTest`. It completed 357 tests with one unrelated failure in `BuildInitSpecsIntegrationTest > gives decent error message when triggered with unknown init-type after loading project specs`: `JavaToolchainFixture.groovy:76` throws an NPE while reading toolchain installations. The focused unit and integration tests above pass.

### AI assistance disclosure

I used Codex extensively to help analyze the issue, implement and review the change, and design the tests. I reviewed the complete diff, validated the Git behavior, and ran the checks listed above.

### Contributor Checklist

- [x] Reviewed the contribution guidelines.
- [x] All commits are signed off under the Developer Certificate of Origin.
- [x] The contributed code can be distributed under the Apache License 2.0.
- [x] Allow edits from maintainers.
- [x] Added integration tests to verify the user-visible behavior.
- [x] Added unit tests for generation, merging, and idempotency.
- [x] No user guide, DSL reference, or Javadoc update is needed because this changes generated ignore defaults without changing public API.
- [ ] `./gradlew sanityCheck`
- [ ] `./gradlew :build-init:quickTest` (one unrelated local failure described above)

### Reviewing cheatsheet

Before merging the PR, comments starting with

- ❌ ❓ **must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things