### PR TITLE
Fix incorrect IdeaModule scopes defaults in DSL docs

### DIFF
--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -25,9 +25,9 @@
                 <td>
                     <itemizedlist>
                         <listitem><literal>COMPILE</literal> -> empty</listitem>
-                        <listitem><literal>RUNTIME</literal> -> plus <literal>project.configurations.runtimeClasspath</literal></listitem>
-                        <listitem><literal>TEST</literal> -> plus <literal>project.configurations.testCompileClasspath</literal> and <literal>project.configurations.testRuntimeClasspath</literal></listitem>
-                        <listitem><literal>PROVIDED</literal> -> plus <literal>project.configurations.compileClasspath</literal></listitem>
+                        <listitem><literal>RUNTIME</literal> -> <literal>plus += project.configurations.runtimeClasspath</literal></listitem>
+                        <listitem><literal>TEST</literal> -> <literal>plus += project.configurations.testCompileClasspath</literal> and <literal>plus += project.configurations.testRuntimeClasspath</literal></listitem>
+                        <listitem><literal>PROVIDED</literal> -> <literal>plus += project.configurations.compileClasspath</literal></listitem>
                     </itemizedlist>
                 </td>
             </tr>

--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -25,9 +25,9 @@
                 <td>
                     <itemizedlist>
                         <listitem><literal>COMPILE</literal> -> empty</listitem>
-                        <listitem><literal>RUNTIME</literal> -> <literal>plus += project.configurations.runtimeClasspath</literal></listitem>
-                        <listitem><literal>TEST</literal> -> <literal>plus += project.configurations.testCompileClasspath</literal> and <literal>plus += project.configurations.testRuntimeClasspath</literal></listitem>
-                        <listitem><literal>PROVIDED</literal> -> <literal>plus += project.configurations.compileClasspath</literal></listitem>
+                        <listitem><literal>RUNTIME</literal> -> plus <literal>project.configurations.runtimeClasspath</literal></listitem>
+                        <listitem><literal>TEST</literal> -> plus <literal>project.configurations.testCompileClasspath</literal> and <literal>project.configurations.testRuntimeClasspath</literal></listitem>
+                        <listitem><literal>PROVIDED</literal> -> plus <literal>project.configurations.compileClasspath</literal></listitem>
                     </itemizedlist>
                 </td>
             </tr>

--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -24,10 +24,10 @@
                 <td><literal>[:]</literal></td>
                 <td>
                     <itemizedlist>
-                        <listitem><literal>COMPILE</literal> -> <literal>project.configurations.compileClasspath</literal></listitem>
-                        <listitem><literal>RUNTIME</literal> -> <literal>project.configurations.runtimeClasspath - project.configurations.compileClasspath</literal></listitem>
-                        <listitem><literal>TEST</literal> -> <literal>project.configurations.testRuntimeClasspath - project.configurations.runtimeClasspath</literal></listitem>
-                        <listitem><literal>PROVIDED</literal></listitem>
+                        <listitem><literal>COMPILE</literal> -> empty</listitem>
+                        <listitem><literal>RUNTIME</literal> -> plus <literal>project.configurations.runtimeClasspath</literal></listitem>
+                        <listitem><literal>TEST</literal> -> plus <literal>project.configurations.testCompileClasspath</literal> and <literal>project.configurations.testRuntimeClasspath</literal></listitem>
+                        <listitem><literal>PROVIDED</literal> -> plus <literal>project.configurations.compileClasspath</literal></listitem>
                     </itemizedlist>
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
The idea+java plugin defaults for `IdeaModule.scopes` in the DSL docs did not match what `IdeaPlugin.setupScopes` actually configures.

Updated the documented defaults to:
- COMPILE: empty
- RUNTIME: plus `runtimeClasspath`
- TEST: plus `testCompileClasspath` and `testRuntimeClasspath`
- PROVIDED: plus `compileClasspath`

Fixes #25414

## Test plan
- [ ] Confirm the scopes list in `IdeaModule.xml` matches `IdeaPlugin.setupScopes`
- [ ] Spot-check the rendered DSL page once docs are built