### PR TITLE
Rebaseline performance tests for ReadyForRelease

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.7.0-commit-cec51a7a96d
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.7.0-commit-a64143c1519
+defaultRfrPerformanceBaselines=9.7.0-commit-8943fa5e8c4
 systemProp.dependency.analysis.test.analysis=false
 
 # Informs BuildCommitDistribution task that the current commit can be built with CC enabled


### PR DESCRIPTION
We've seen tiny and consistent perf regression (1%) in cold daemon scenario. Rebaseline to unblock release.