### PR TITLE
Remove stale Test Distribution diagnostic properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,6 @@ gradle.internal.testdistribution.writeTraceFile=true
 develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
-# If enabled, the Build Scan is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state.
-systemProp.develocity.internal.testacceleration.enableCustomValues=true
-# If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
-systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.7.0-commit-cec51a7a96d
 # Default ReadyForRelease performance baseline


### PR DESCRIPTION
Removes two stale Test Distribution diagnostic properties from `gradle.properties`:

- `develocity.internal.testdistribution.logWorkerReadyMessage`
- `develocity.internal.testacceleration.enableCustomValues`

Both were added in a7e7e71 (~18 months ago) to diagnose remote test executors being enqueued in the wrong state. The investigation is complete, and the WorkerReadyMessage logging is now just noise in every build.