### PR TITLE
Remove stale Test Distribution diagnostic properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,6 @@ gradle.internal.testdistribution.writeTraceFile=true
 develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
-# If enabled, the build scans is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state.
-systemProp.develocity.internal.testacceleration.enableCustomValues=true
-# If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
-systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default performance baseline
 defaultPerformanceBaselines=8.14-commit-1f37b1042350
 #-----------------------------------------till here^


### PR DESCRIPTION
Backport of #38641 to the `release8x` line.