### PR TITLE
Merge release into master

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -192,6 +192,7 @@ abstract class BuildCommitDistribution @Inject internal constructor(
 
         return listOfNotNull(
             "./gradlew" + (if (OperatingSystem.current().isWindows) ".bat" else ""),
+            "--no-daemon",
             if (gradleModeCompatibility == null) "--no-configuration-cache" else null,
             // TODO:isolated https://github.com/gradle/gradle/issues/36771
             if (gradleModeCompatibility == "IP") null else "-Dorg.gradle.unsafe.isolated-projects=false",

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,6 @@ gradle.internal.testdistribution.writeTraceFile=true
 develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
-# If enabled, the Build Scan is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state.
-systemProp.develocity.internal.testacceleration.enableCustomValues=true
-# If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
-systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.7.0-commit-cec51a7a96d
 # Default ReadyForRelease performance baseline

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.7.0-commit-cec51a7a96d
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.7.0-commit-a64143c1519
+defaultRfrPerformanceBaselines=9.7.0-commit-8943fa5e8c4
 systemProp.dependency.analysis.test.analysis=false
 
 # Informs BuildCommitDistribution task that the current commit can be built with CC enabled

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import spock.lang.Issue
 
 import static org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption.Value.WARN
 
@@ -99,6 +100,24 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
         cliOrigin         | cliArgument
         "long option"     | DISABLE_CLI_OPT
         "system property" | DISABLE_SYS_PROP
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "deprecated property set to false does not disable configuration cache enabled via gradle.properties"() {
+        // Characterization test: for Configuration Cache the stable property name deliberately wins over
+        // the deprecated spelling regardless of value, unchanged since Gradle 8.1. The Isolated Projects
+        // options resolve the same situation as a conjunction (explicit disable wins) since issue 38598;
+        // flipping this test is a conscious decision to migrate CC to those semantics.
+        given:
+        file('gradle.properties') << """
+            $ENABLE_GRADLE_PROP
+        """
+
+        when:
+        run 'help', "-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=false"
+
+        then:
+        fixture.assertStateStored()
     }
 
     def "can enable configuration cache using incubating and final property variants"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.isolated
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Issue
 
 class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements TasksWithInputsAndOutputs {
 
@@ -117,6 +118,77 @@ class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegratio
         then:
         outputContains("isolatedProjects.requested=true")
         outputContains("isolatedProjects.active=true")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "resolves IP from both property names (#stableValue in #stableIn, #deprecatedValue in #deprecatedIn)"() {
+        given:
+        withIpStatusTask()
+        def fileProps = []
+        def cliProps = []
+        (stableIn == "file" ? fileProps : cliProps) << "org.gradle.isolated-projects=$stableValue"
+        (deprecatedIn == "file" ? fileProps : cliProps) << "org.gradle.unsafe.isolated-projects=$deprecatedValue"
+        file("gradle.properties") << fileProps.join("\n")
+
+        when:
+        run("ipStatus", *cliProps.collect { "-D$it".toString() })
+
+        then:
+        outputContains("isolatedProjects.requested=$expected")
+        outputContains("isolatedProjects.active=$expected")
+
+        where:
+        stableIn | deprecatedIn | stableValue | deprecatedValue | expected
+        "file"   | "file"       | true        | true            | true
+        "file"   | "file"       | true        | false           | false
+        "file"   | "file"       | false       | true            | false
+        "file"   | "file"       | false       | false           | false
+        "file"   | "cli"        | true        | true            | true
+        "file"   | "cli"        | true        | false           | false
+        "file"   | "cli"        | false       | true            | false
+        "file"   | "cli"        | false       | false           | false
+        "cli"    | "file"       | true        | true            | true
+        "cli"    | "file"       | true        | false           | false
+        "cli"    | "file"       | false       | true            | false
+        "cli"    | "file"       | false       | false           | false
+        "cli"    | "cli"        | true        | true            | true
+        "cli"    | "cli"        | true        | false           | false
+        "cli"    | "cli"        | false       | true            | false
+        "cli"    | "cli"        | false       | false           | false
+    }
+
+    def "build option takes precedence over properties"() {
+        given:
+        withIpStatusTask()
+
+        when:
+        run "ipStatus", "--isolated-projects", "-Dorg.gradle.isolated-projects=false", "-Dorg.gradle.unsafe.isolated-projects=false"
+
+        then:
+        outputContains("isolatedProjects.requested=true")
+        outputContains("isolatedProjects.active=true")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38598")
+    def "explicit disable via deprecated property wins for #optionKind option"() {
+        when:
+        run "help", "-q",
+            "-Dorg.gradle.internal.operations.verbose.parameters=true",
+            "-Dorg.gradle.isolated-projects=true",
+            "-D${stableProperty}=true",
+            "-D${deprecatedProperty}=false"
+
+        then:
+        result.getOutputLineThatContains("Operational build model parameters:").contains("${outputKey}=false")
+
+        where:
+        optionKind                    | outputKey
+        "diagnostics"                 | "isolatedProjectsDiagnostics"
+        "dangerously-ignore-problems" | "isolatedProjectsDangerouslyIgnoreProblems"
+        __
+        stableProperty                                              | deprecatedProperty
+        "org.gradle.isolated-projects.diagnostics"                  | "org.gradle.unsafe.isolated-projects.diagnostics"
+        "org.gradle.isolated-projects.dangerously-ignore-problems"  | "org.gradle.unsafe.isolated-projects.dangerously-ignore-problems"
     }
 
     def "diagnostics option is accepted under both property names"() {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.PluginAware
 import org.gradle.kotlin.dsl.support.DefaultKotlinScript
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.defaultKotlinScriptHostForSettings
+import org.gradle.kotlin.dsl.support.internalError
 import org.gradle.plugin.use.PluginDependenciesSpec
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.baseClass
@@ -62,7 +63,17 @@ abstract class KotlinSettingsScriptTemplate(
         host.scriptHandler
 
     /**
-     * Configures the plugin dependencies for the project's settings.
+     * Configures the build script classpath for settings.
+     *
+     * @see [Settings.buildscript]
+     * @since 9.7.0
+     */
+    @Suppress("unused")
+    open fun buildscript(block: ScriptHandlerScope.() -> Unit): Unit =
+        internalError()
+
+    /**
+     * Configures the plugin dependencies for settings.
      *
      * @see [PluginDependenciesSpec]
      * @since 6.0

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOption.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption;
+
+import java.util.Map;
+
+/**
+ * A boolean build option with a deprecated property alias where an explicit disable
+ * through either property name wins: when both names are set, the option is enabled
+ * only if both values are true.
+ *
+ * <p>This keeps opt-outs reliable while a renamed property is deprecated: tooling that
+ * still disables a feature under the deprecated name must keep working even when the
+ * build enables the feature under the new name.
+ *
+ * <p>The downside is that this rule ignores source precedence: a disable from a
+ * lower-precedence source (e.g. a {@code gradle.properties} file) overrides an enable
+ * from a higher-precedence source (e.g. a command-line {@code -D} argument) when the
+ * two use different names. Only the command-line flags can override a disable.
+ *
+ * <p>This is a stop-gap rather than the desired end state. The proper solution is to
+ * make the deprecated name an actual alias of the main option, resolved against it
+ * within each property source, instead of after all sources have been merged.
+ * See <a href="https://github.com/gradle/gradle/issues/38598">#38598</a>.
+ *
+ * @param <T> the type of object the option value is applied to
+ */
+public abstract class DeprecatedAliasDisableWinsBooleanBuildOption<T> extends BooleanBuildOption<T> {
+
+    public DeprecatedAliasDisableWinsBooleanBuildOption(
+        String property,
+        String deprecatedProperty,
+        BooleanCommandLineOptionConfiguration... commandLineOptionConfigurations
+    ) {
+        super(property, deprecatedProperty, commandLineOptionConfigurations);
+    }
+
+    @Override
+    protected OptionValue<String> getFromProperties(Map<String, String> properties) {
+        String value = properties.get(property);
+        String deprecatedValue = properties.get(deprecatedProperty);
+        if (value != null && deprecatedValue != null
+            && BooleanOptionUtil.isTrue(value) && !BooleanOptionUtil.isTrue(deprecatedValue)) {
+            // The deprecated name carries an explicit disable that the main property would otherwise mask
+            return new OptionValue<String>(deprecatedValue, Origin.forGradleProperty(deprecatedProperty));
+        }
+        return super.getFromProperties(properties);
+    }
+}

--- a/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOptionTest.groovy
+++ b/platforms/core-runtime/build-option/src/test/groovy/org/gradle/internal/buildoption/DeprecatedAliasDisableWinsBooleanBuildOptionTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+@Issue("https://github.com/gradle/gradle/issues/38598")
+class DeprecatedAliasDisableWinsBooleanBuildOptionTest extends Specification {
+
+    private static final String PROPERTY = 'org.gradle.test'
+    private static final String DEPRECATED_PROPERTY = 'org.gradle.unsafe.test'
+
+    def testSettings = new TestSettings()
+    def testOption = new TestOption(PROPERTY, DEPRECATED_PROPERTY)
+
+    def "does not apply option when neither property is present"() {
+        when:
+        testOption.applyFromProperty([:], testSettings)
+
+        then:
+        !testSettings.applied
+        testSettings.origin == null
+    }
+
+    def "applies a single present property like the base class (#props)"() {
+        when:
+        testOption.applyFromProperty(props, testSettings)
+
+        then:
+        testSettings.applied
+        testSettings.value == expectedValue
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == expectedOrigin
+
+        where:
+        props                            | expectedValue | expectedOrigin
+        [(PROPERTY): 'true']             | true          | PROPERTY
+        [(PROPERTY): 'false']            | false         | PROPERTY
+        [(DEPRECATED_PROPERTY): 'true']  | true          | DEPRECATED_PROPERTY
+        [(DEPRECATED_PROPERTY): 'false'] | false         | DEPRECATED_PROPERTY
+    }
+
+    def "explicit disable wins when both properties are present (#stableValue, #deprecatedValue)"() {
+        when:
+        testOption.applyFromProperty([(PROPERTY): stableValue, (DEPRECATED_PROPERTY): deprecatedValue], testSettings)
+
+        then:
+        testSettings.applied
+        testSettings.value == expectedValue
+        testSettings.origin instanceof Origin.GradlePropertyOrigin
+        testSettings.origin.source == expectedOrigin
+
+        where:
+        stableValue | deprecatedValue | expectedValue | expectedOrigin
+        'true'      | 'true'          | true          | PROPERTY
+        'true'      | 'false'         | false         | DEPRECATED_PROPERTY
+        'false'     | 'true'          | false         | PROPERTY
+        'false'     | 'false'         | false         | PROPERTY
+        'true'      | 'banana'        | false         | DEPRECATED_PROPERTY
+        'banana'    | 'true'          | false         | PROPERTY
+    }
+
+    static class TestOption extends DeprecatedAliasDisableWinsBooleanBuildOption<TestSettings> {
+
+        TestOption(String property, String deprecatedProperty) {
+            super(property, deprecatedProperty)
+        }
+
+        @Override
+        void applyTo(boolean value, TestSettings settings, Origin origin) {
+            settings.applied = true
+            settings.value = value
+            settings.origin = origin
+        }
+    }
+
+    static class TestSettings {
+        boolean applied
+        boolean value
+        Origin origin
+    }
+}

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -27,6 +27,7 @@ import org.gradle.internal.buildoption.BooleanCommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.BuildOptionSet;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.DeprecatedAliasDisableWinsBooleanBuildOption;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
 import org.gradle.internal.buildoption.EnumBuildOption;
 import org.gradle.internal.buildoption.IntegerBuildOption;
@@ -679,7 +680,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects";
         public static final String LONG_OPTION = "isolated-projects";
@@ -707,7 +708,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsDiagnosticsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsDiagnosticsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects.diagnostics";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.diagnostics";
 
@@ -721,7 +722,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsDangerouslyIgnoreProblemsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsDangerouslyIgnoreProblemsOption extends DeprecatedAliasDisableWinsBooleanBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.isolated-projects.dangerously-ignore-problems";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.dangerously-ignore-problems";
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/isolated_projects.adoc
@@ -584,6 +584,7 @@ org.gradle.isolated-projects=true
 ====
 The legacy property name `org.gradle.unsafe.isolated-projects` is still accepted, but the new `org.gradle.isolated-projects` name is preferred.
 The same applies to `org.gradle.unsafe.isolated-projects.diagnostics` and `org.gradle.unsafe.isolated-projects.dangerously-ignore-problems`.
+When both the legacy and the new name of a property are set, an explicit `false` from either one disables the feature.
 ====
 
 If you have never enabled the feature in the build before, it's likely that the build is not compatible and contains Isolated Projects <<sec:constraint_violations,constraint violations>>.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -191,6 +191,9 @@ The legacy `org.gradle.unsafe.*` names are now deprecated and will be removed in
 They continue to be accepted as aliases for now and currently emit no warning.
 Update your `gradle.properties` and command-line invocations to the new names.
 
+When both the legacy and the new name of a property are set — for example, the new name in `gradle.properties` and the legacy name injected by a plugin or CI script on the command line — an explicit `false` from either one disables the feature.
+This guarantees that tooling which still opts out via a legacy property name keeps working after a build migrates to the new names.
+
 See the <<isolated_projects.adoc#sec:enable, Enabling Isolated Projects>> section in the Gradle User Manual for the recommended setup.
 
 [[deprecated_custom_collection_types_with_cc]]

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "9.7.0-20260724020627+0000",
-    "buildTime": "20260724020627+0000"
+    "version": "9.7.0-20260728023733+0000",
+    "buildTime": "20260728023733+0000"
   },
   "latestRc": {
     "version": "9.7.0-rc-1",

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -54,14 +54,6 @@
             ]
         },
         {
-            "type": "org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate",
-            "member": "Method org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate.buildscript(kotlin.jvm.functions.Function1)",
-            "acceptation": "This member was missing after a refactor, it is not new",
-            "changes": [
-                "Method added to public class"
-            ]
-        },
-        {
             "type": "org.gradle.process.ExecOperations",
             "member": "Class org.gradle.process.ExecOperations",
             "acceptation": "Marked as injectable via the incubating service(Class) lookup markers (#13121)",

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -37,6 +37,14 @@
             "changes": [
                 "Method added to public class"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate",
+            "member": "Method org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate.buildscript(kotlin.jvm.functions.Function1)",
+            "acceptation": "This member was missing after a refactor, it is not new",
+            "changes": [
+                "Method added to public class"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Automated merge of `release` into `master` following the release promotion build
([MergeReleaseIntoMaster #387](https://builds.gradle.org/buildConfiguration/Gradle_Release_Promotion_MergeReleaseIntoMaster/115610829)),
which failed with 1 unresolvable conflict.

## Conflict resolution

Release-only files were removed and restored from `origin/master` per the build's recovery instructions
(`version.txt`, `release/notes.md`, `release-notes-assets`, `accepted-public-api-changes.json`, `release-features.txt`).

One content conflict required manual resolution:

- `platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt`
  — the commit "Add missing buildscript block in Kotlin DSL settings template for the IDE" landed on both
  branches, differing only in the `@since` tag on `buildscript {}` (master `9.8.0` vs release `9.7.0`).
  Resolved to **`@since 9.7.0`**, since the API first ships in 9.7.0 from the release branch.

## Follow-up: stale accepted API change

The first merge-queue run failed
([SanityCheck #64596](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SanityCheck/115611811))
in `:architecture-test:checkBinaryCompatibility`:

```
The following regressions are declared as accepted, but didn't match any rule:
  org.gradle.kotlin.dsl.KotlinSettingsScriptTemplate - Method buildscript(kotlin.jvm.functions.Function1) - [Method added to public class]
```

The binary compatibility baseline is the most recent release/snapshot from `released-versions.json`.
The same `buildscript {}` change reached both branches, and the timing matters:

| When (UTC) | Event |
| --- | --- |
| 2026-07-23 08:14 | added on master (`02805559802`), acceptance entry recorded |
| 2026-07-24 02:06 | baseline snapshot `9.7.0-20260724020627` built — **without** the method |
| 2026-07-24 09:53 | same fix lands on release (`07c6a60c53e`) |
| 2026-07-28 02:37 | baseline snapshot `9.7.0-20260728023733` built — **with** the method |

Master needed the acceptance because its baseline predated the release-side commit. Bumping
`latestReleaseSnapshot` to the 07-28 snapshot moves the baseline past that commit, so japicmp no
longer sees the method as added and the acceptance entry is stale. Removed it.

## Verification

- `:architecture-test:checkBinaryCompatibility` — reproduced the exact CI failure locally without the
  fix (`BUILD FAILED`, same message), `BUILD SUCCESSFUL` with it
- `./gradlew sanityCheck` — BUILD SUCCESSFUL
- `./gradlew :updateReleasedVersions` for `9.7.0-20260728023733+0000`, committed separately