### PR TITLE
Always suggest --export-keys in DV report when key-servers are disabled

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRenderer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRenderer.java
@@ -57,7 +57,6 @@ class HtmlDependencyVerificationReportRenderer implements DependencyVerification
     private final List<String> writeFlags;
     private final File htmlReportOutputDirectory;
     private final boolean useKeyServers;
-    private boolean hasMissingKeys = false;
 
     HtmlDependencyVerificationReportRenderer(DocumentationRegistry documentationRegistry, File verificationFile, List<String> writeFlags, File htmlReportOutputDirectory, boolean useKeyServers) {
         this.documentationRegistry = documentationRegistry;
@@ -193,7 +192,7 @@ class HtmlDependencyVerificationReportRenderer implements DependencyVerification
             .append("            It is recommended that you edit the ").append(verificationFileLink()).append(" manually. ")
             .append("            However, if you are confident that those are false positives, Gradle can help you by generating the missing verification metadata.");
 
-            if (!useKeyServers && hasMissingKeys) {
+            if (!useKeyServers) {
                 contents.append("            In this case, you can ask Gradle to export all keys it used for verification of this build to the keyring with the following command-line:</p>")
                         .append("            <pre>./gradlew --write-verification-metadata ").append(verificationOptions()).append(" --export-keys help</pre>");
             } else {
@@ -417,7 +416,6 @@ class HtmlDependencyVerificationReportRenderer implements DependencyVerification
                             reason = warning("Key " + keyInfo + " couldn't be found in local key file so verification couldn't be performed. Enable key resolution with --export-keys." + otherTrustedKeysNote);
                         }
                         reportItem(reason, "missing-key", "warning");
-                        hasMissingKeys = true;
                         break;
                 }
             });

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRendererTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRendererTest.groovy
@@ -163,15 +163,15 @@ class HtmlDependencyVerificationReportRendererTest extends Specification {
 
         where:
         failure                                                                 | stickyTipMessage
-        checksumFailure()                                                       | './gradlew --write-verification-metadata pgp,sha512 help'
-        missingChecksums()                                                      | './gradlew --write-verification-metadata pgp,sha512 help'
-        deletedArtifact()                                                       | './gradlew --write-verification-metadata pgp,sha512 help'
-        missingSignature()                                                      | './gradlew --write-verification-metadata pgp,sha512 help'
-        onlyIgnoredKeys()                                                       | './gradlew --write-verification-metadata pgp,sha512 help'
+        checksumFailure()                                                       | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        missingChecksums()                                                      | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        deletedArtifact()                                                       | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        missingSignature()                                                      | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        onlyIgnoredKeys()                                                       | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
         signatureFailure()                                                      | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
-        signatureFailure("Maven", ['abcd': signatureError(FAILED)])             | './gradlew --write-verification-metadata pgp,sha512 help'
-        signatureFailure("Maven", ['abcd': signatureError(IGNORED_KEY)])        | './gradlew --write-verification-metadata pgp,sha512 help'
-        signatureFailure("Maven", ['abcd': signatureError(PASSED_NOT_TRUSTED)]) | './gradlew --write-verification-metadata pgp,sha512 help'
+        signatureFailure("Maven", ['abcd': signatureError(FAILED)])             | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        signatureFailure("Maven", ['abcd': signatureError(IGNORED_KEY)])        | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
+        signatureFailure("Maven", ['abcd': signatureError(PASSED_NOT_TRUSTED)]) | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
         signatureFailure("Maven", ['abcd': signatureError(MISSING_KEY)])        | './gradlew --write-verification-metadata pgp,sha512 --export-keys help'
     }
 


### PR DESCRIPTION
Fixes #26202

## Context

When key-servers are disabled via `<key-servers enabled="false"/>` in `verification-metadata.xml`, the HTML dependency verification report previously only suggested the `--export-keys` flag when the specific failure was a missing PGP key. For all other failure types (checksum mismatches, missing checksums, deleted artifacts, etc.), the suggested command omitted `--export-keys`.

This is misleading because without key-servers enabled and without `--export-keys`, PGP verification cannot resolve keys at all, making the suggested command ineffective for anyone who has disabled key-servers.

## Changes

- **`HtmlDependencyVerificationReportRenderer.java`**: Changed the condition in `registerStickyTip()` from `!useKeyServers && hasMissingKeys` to just `!useKeyServers`. The `--export-keys` flag is now always included in the suggested command whenever key-servers are disabled, regardless of the specific verification failure type.
- Removed the now-unused `hasMissingKeys` field (was only read in the condition we changed).
- **`HtmlDependencyVerificationReportRendererTest.groovy`**: Updated test expectations for all `noKeyServerRenderer` cases to expect `--export-keys` in the suggested command.

## Testing

The existing unit tests in `HtmlDependencyVerificationReportRendererTest.groovy` have been updated to verify the new behavior. The data-driven tests cover all failure types (checksum, missing checksums, deleted artifact, missing signature, ignored keys, signature failures) both with and without key-servers.

## Contributor Checklist

- [x] Review [Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff)
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE)
