### PR TITLE
Re-attach owners for un-managed properties on CC restore

### DIFF
--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     testImplementation(projects.resources)
     testImplementation(testFixtures(projects.coreApi))
     testImplementation(testFixtures(projects.languageGroovy))
+    testImplementation(testFixtures(projects.logging))
     testImplementation(testFixtures(projects.modelReflect))
 
     integTestImplementation(projects.platformBase)

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -1060,9 +1060,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 }
                 if (deferOwnerAttach && isReattachProperty(property) && hasAttachableOverridableGetter(property)) {
                     // Register non-managed lazy properties for on-demand (re-)attachment to their owners.
-                    // The owner is normally attached by the overriding getter, which is not invoked when the object
-                    // is restored from the configuration cache, so the property would otherwise lose its owner.
-                    // See https://github.com/gradle/gradle/issues/37421.
+                    // The owner is normally attached by the overriding getter. CC deserialization writes straight to the
+                    // backing field without invoking it, so the property would never receive an owner.
+                    // See ModelObject#attachModelProperties().
                     visitor.attachOnDemand(property, applyRole);
                 }
             }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -426,6 +426,20 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         return isAttachableType(metadata.getReturnType(), metadata.method::isAnnotationPresent);
     }
 
+    /**
+     * Does any getter that we override actually attach the owner? This mirrors the per-getter condition used when
+     * generating the getters, so that we only register a property for re-attachment if some generated getter would
+     * have attached it in the first place.
+     */
+    private static boolean hasAttachableOverridableGetter(PropertyMetadata property) {
+        for (MethodMetadata getter : property.getOverridableGetters()) {
+            if (isAttachableMethod(getter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean isAttachableType(Class<?> type, Predicate<Class<? extends Annotation>> propertyHasAnnotation) {
         // This should apply to all 'managed' types however only the ConfigurableFileCollection and Provider types and @Nested value current implement OwnerAware
         return Provider.class.isAssignableFrom(type) || isConfigurableFileCollectionType(type) || hasNestedAnnotation(propertyHasAnnotation);
@@ -1039,9 +1053,17 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 visitor.mixInConventionAware();
             }
             for (PropertyMetadata property : conventionProperties) {
-                boolean applyRole = isAttachProperty(property) && isLazyAttachPropertyIfNeeded(property) && isRoleType(property);
+                boolean deferOwnerAttach = isAttachProperty(property) && isLazyAttachPropertyIfNeeded(property);
+                boolean applyRole = deferOwnerAttach && isRoleType(property);
                 if (applyRole) {
                     visitor.instantiatesNestedObjects();
+                }
+                if (deferOwnerAttach && isReattachProperty(property) && hasAttachableOverridableGetter(property)) {
+                    // Register non-managed lazy properties for on-demand (re-)attachment to their owners.
+                    // The owner is normally attached by the overriding getter, which is not invoked when the object
+                    // is restored from the configuration cache, so the property would otherwise lose its owner.
+                    // See https://github.com/gradle/gradle/issues/37421.
+                    visitor.attachOnDemand(property, applyRole);
                 }
             }
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -512,6 +512,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private static final String RETURN_VOID_FROM_OBJECT_MODEL_OBJECT = getMethodDescriptor(VOID_TYPE, OBJECT_TYPE, MODEL_OBJECT_TYPE);
         private static final String RETURN_VOID_FROM_DEFAULT_PROPERTY_SERVICE_LOOKUP_STRING = getMethodDescriptor(VOID_TYPE, DEFAULT_PROPERTY_TYPE, SERVICE_LOOKUP_TYPE, STRING_TYPE);
         private static final String RETURN_VOID_FROM_MODEL_OBJECT_DISPLAY_NAME = getMethodDescriptor(VOID_TYPE, MODEL_OBJECT_TYPE, DISPLAY_NAME_TYPE);
+        private static final String RETURN_VOID_FROM_EXCEPTION_MODEL_OBJECT_STRING = getMethodDescriptor(VOID_TYPE, EXCEPTION_TYPE, MODEL_OBJECT_TYPE, STRING_TYPE);
         private static final String RETURN_OBJECT_FROM_TYPE = getMethodDescriptor(OBJECT_TYPE, JAVA_LANG_REFLECT_TYPE);
         private static final String RETURN_OBJECT_FROM_OBJECT_MODEL_OBJECT_STRING = getMethodDescriptor(OBJECT_TYPE, OBJECT_TYPE, MODEL_OBJECT_TYPE, STRING_TYPE);
         private static final String RETURN_OBJECT_FROM_MODEL_OBJECT_STRING_CLASS = getMethodDescriptor(OBJECT_TYPE, MODEL_OBJECT_TYPE, STRING_TYPE, CLASS_TYPE);
@@ -1244,14 +1245,19 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             /**
              * Same as {@link #attachProperty(AttachedProperty)}, but tolerates a getter that fails.
              *
-             * <p>The getter is invoked only to obtain the property so its owner can be re-attached, so a failure
+             * <p>The getter is invoked only to obtain the property so its owner can be re-attached, so an exception
              * here is not reported: the property is simply left without an owner. A later direct call to the
              * getter still fails as usual.</p>
              */
             protected void attachPropertyIfPossible(AttachedProperty attached) {
                 // GENERATE
                 //     <type> value;
-                //     try { value = get<prop>(); } catch (Exception ignored) { <skip this property> }
+                //     try {
+                //         value = get<prop>();
+                //     } catch (Exception e) {
+                //         ManagedObjectFactory.ignoreAttachOwnerFailure(e, this, <property-name>);
+                //         <skip this property>
+                //     }
                 //     ManagedObjectFactory.attachOwner(value, this, <property-name>);
                 Label tryStart = new Label();
                 Label tryEnd = new Label();
@@ -1266,8 +1272,10 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 _POP();
                 _GOTO(done);
                 visitLabel(handler);
-                // Discard the ignored exception
-                _POP();
+                // The caught exception is on the stack, so pass it to the helper that reports it
+                _ALOAD(0);
+                _LDC(attached.property.getName());
+                _INVOKESTATIC(MANAGED_OBJECT_FACTORY_TYPE, "ignoreAttachOwnerFailure", RETURN_VOID_FROM_EXCEPTION_MODEL_OBJECT_STRING);
                 visitLabel(done);
             }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -435,6 +435,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private final static Type GENERATED_SUBCLASS_TYPE = getType(GeneratedSubclass.class);
         private final static Type MODEL_OBJECT_TYPE = getType(ModelObject.class);
         private final static Type OWNER_AWARE_TYPE = getType(OwnerAware.class);
+        private final static Type EXCEPTION_TYPE = getType(Exception.class);
         private final static Type CONVENTION_AWARE_TYPE = getType(IConventionAware.class);
         private final static Type CONVENTION_AWARE_HELPER_TYPE = getType(ConventionAwareHelper.class);
         private final static Type DYNAMIC_OBJECT_AWARE_TYPE = getType(DynamicObjectAware.class);
@@ -1240,6 +1241,32 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 super(methodVisitor);
             }
 
+            /**
+             * Same as {@link #attachProperty(AttachedProperty)}, but tolerates a getter that fails.
+             *
+             * Unlike managed properties, whose getters are generated and simply return a field, non-managed
+             * properties have hand-written getters that may fail when invoked outside the usual lifecycle.
+             * Such a property is simply left without an owner.</p
+             */
+            protected void attachPropertyIfPossible(AttachedProperty attached) {
+                // GENERATE try { <attach property> } catch (Exception ignored) { }
+                Label tryStart = new Label();
+                Label tryEnd = new Label();
+                Label handler = new Label();
+                Label done = new Label();
+                visitTryCatchBlock(tryStart, tryEnd, handler, EXCEPTION_TYPE.getInternalName());
+                visitLabel(tryStart);
+                attachProperty(attached);
+                // Discard the value left on the stack by the attach, so that both branches below leave the stack empty
+                _POP();
+                visitLabel(tryEnd);
+                _GOTO(done);
+                visitLabel(handler);
+                // Discard the ignored exception
+                _POP();
+                visitLabel(done);
+            }
+
             protected void attachProperty(AttachedProperty attached) {
                 // ManagedObjectFactory.attachOwner(get<prop>(), this, <property-name>))
                 PropertyMetadata property = attached.property;
@@ -1396,7 +1423,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 _ALOAD(0);
                 _INVOKEVIRTUAL(generatedType, INIT_ATTACH_METHOD, RETURN_VOID);
                 for (AttachedProperty attached : propertiesToAttachOnDemand) {
-                    attachProperty(attached);
+                    attachPropertyIfPossible(attached);
                 }
                 _RETURN();
             }});

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -1244,22 +1244,26 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             /**
              * Same as {@link #attachProperty(AttachedProperty)}, but tolerates a getter that fails.
              *
-             * Unlike managed properties, whose getters are generated and simply return a field, non-managed
-             * properties have hand-written getters that may fail when invoked outside the usual lifecycle.
-             * Such a property is simply left without an owner.
+             * <p>The getter is invoked only to obtain the property so its owner can be re-attached, so a failure
+             * here is not reported: the property is simply left without an owner. A later direct call to the
+             * getter still fails as usual.</p>
              */
             protected void attachPropertyIfPossible(AttachedProperty attached) {
-                // GENERATE try { <attach property> } catch (Exception ignored) { }
+                // GENERATE
+                //     <type> value;
+                //     try { value = get<prop>(); } catch (Exception ignored) { <skip this property> }
+                //     ManagedObjectFactory.attachOwner(value, this, <property-name>);
                 Label tryStart = new Label();
                 Label tryEnd = new Label();
                 Label handler = new Label();
                 Label done = new Label();
                 visitTryCatchBlock(tryStart, tryEnd, handler, EXCEPTION_TYPE.getInternalName());
                 visitLabel(tryStart);
-                attachProperty(attached);
+                invokeGetter(attached.property);
+                visitLabel(tryEnd);
+                attachOwnerToValueOnStack(attached);
                 // Discard the value left on the stack by the attach, so that both branches below leave the stack empty
                 _POP();
-                visitLabel(tryEnd);
                 _GOTO(done);
                 visitLabel(handler);
                 // Discard the ignored exception
@@ -1269,16 +1273,28 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             protected void attachProperty(AttachedProperty attached) {
                 // ManagedObjectFactory.attachOwner(get<prop>(), this, <property-name>))
-                PropertyMetadata property = attached.property;
-                boolean applyRole = attached.applyRole;
+                invokeGetter(attached.property);
+                attachOwnerToValueOnStack(attached);
+            }
+
+            private void invokeGetter(PropertyMetadata property) {
+                // GENERATE get<prop>()
                 MethodMetadata getter = property.getMainGetter();
                 _ALOAD(0);
                 _INVOKEVIRTUAL(generatedType, getter.getName(), getMethodDescriptor(getType(getter.getReturnType())));
+            }
+
+            /**
+             * Attaches the owner to the property value on the top of the stack, and applies the property's role
+             * if it has one. Leaves a single value on the stack.
+             */
+            private void attachOwnerToValueOnStack(AttachedProperty attached) {
+                boolean applyRole = attached.applyRole;
                 if (applyRole) {
                     _DUP();
                 }
                 _ALOAD(0);
-                _LDC(property.getName());
+                _LDC(attached.property.getName());
                 _INVOKESTATIC(MANAGED_OBJECT_FACTORY_TYPE, "attachOwner", RETURN_OBJECT_FROM_OBJECT_MODEL_OBJECT_STRING);
                 if (applyRole) {
                     applyRole();

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -1246,7 +1246,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
              *
              * Unlike managed properties, whose getters are generated and simply return a field, non-managed
              * properties have hand-written getters that may fail when invoked outside the usual lifecycle.
-             * Such a property is simply left without an owner.</p
+             * Such a property is simply left without an owner.
              */
             protected void attachPropertyIfPossible(AttachedProperty attached) {
                 // GENERATE try { <attach property> } catch (Exception ignored) { }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
@@ -28,11 +28,15 @@ import org.gradle.internal.state.ModelObject;
 import org.gradle.internal.state.OwnerAware;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A helper used by generated classes to create managed instances.
  */
 public class ManagedObjectFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagedObjectFactory.class);
+
     private final ServiceLookup serviceLookup;
     private final InstanceGenerator instantiator;
     private final PropertyRoleAnnotationHandler roleHandler;
@@ -52,6 +56,16 @@ public class ManagedObjectFactory {
     }
 
     // Called from generated code
+    @SuppressWarnings("unused")
+    public static void ignoreAttachOwnerFailure(Exception failure, ModelObject owner, String propertyName) {
+        // Name the property the same way a successful attach would have, since this message exists to diagnose
+        // exactly the properties that are missing that name.
+        LOGGER.debug("Could not attach owner to {} because its getter failed, leaving the property without an owner.",
+            displayNameFor(owner, propertyName), failure);
+    }
+
+    // Called from generated code
+    @SuppressWarnings("unused")
     public void applyRole(Object value, ModelObject owner) {
         roleHandler.applyRoleTo(owner, value);
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -151,15 +151,14 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         def bean = create(type, Describables.of("<display name>"))
 
         // Read the backing field directly, without going through the attaching getter. This mirrors how
-        // the configuration cache restores the property - straight into the field - so the owner-attach that
-        // normally happens in the generated getter override never runs, leaving the property without an owner.
+        // deserialization restores the property - straight into the field
         def field = type.getDeclaredField(fieldName)
         field.accessible = true
 
         expect: "the property restored into the field has no owner yet"
         field.get(bean).toString() == ownerlessDisplayName
 
-        when: "the model properties are re-attached, as the configuration cache does after deserialization"
+        when: "the model properties are re-attached, as happens after deserialization"
         (bean as ModelObject).attachModelProperties()
 
         then: "the owner (and thus the display name) is restored, observed via the field rather than the getter"
@@ -178,7 +177,7 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         def field = HasFailingAndWorkingPropertyGetters.getDeclaredField("working")
         field.accessible = true
 
-        when: "model properties are re-attached, as the configuration cache does after deserialization"
+        when: "model properties are re-attached, as happens after deserialization"
         (bean as ModelObject).attachModelProperties()
 
         then: "the failure is ignored and the remaining properties are still attached"

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
 import org.gradle.internal.state.ModelObject
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.ConfigureUtil
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 import java.lang.annotation.Annotation
@@ -217,29 +216,6 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         then: "the failure surfaces - only the getter invocation is meant to be tolerated"
         thrown(IllegalStateException)
         attempts.size() == 1
-    }
-
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/37421")
-    def "attaches owner to a non-managed read only Property whose main getter is final and only overload is not attachable"() {
-        given:
-        def bean = create(HasFinalPropertyGetterAndBooleanOverload, Describables.of("<display name>"))
-        def field = HasFinalPropertyGetterAndBooleanOverload.getDeclaredField("prop")
-        field.accessible = true
-
-        expect: "the property has no owner"
-        // FIXME The property should have an owner, whether read through the field or through the getter:
-        // field.get(bean).toString() == "<display name> property 'someValue'"
-        // bean.getSomeValue().toString() == "<display name> property 'someValue'"
-        field.get(bean).toString() == "property(java.lang.Boolean, undefined)"
-        bean.getSomeValue().toString() == "property(java.lang.Boolean, undefined)"
-
-        when: "model properties are re-attached"
-        (bean as ModelObject).attachModelProperties()
-
-        then: "the property still has no owner"
-        // FIXME The property should have an owner here too:
-        // field.get(bean).toString() == "<display name> property 'someValue'"
-        field.get(bean).toString() == "property(java.lang.Boolean, undefined)"
     }
 
     def "can attach nested extensions to object"() {
@@ -854,25 +830,6 @@ class HasReadOnlyProperty {
 interface HasRoleAnnotatedManagedProperty {
     @Producer
     Property<String> getSomeValue()
-}
-
-class HasFinalPropertyGetterAndBooleanOverload {
-    private final Property<Boolean> prop
-
-    // Final, so it cannot be overridden to attach the owner, even though this is the getter
-    // that exposes the Property, and would need an owner.
-    final Property<Boolean> getSomeValue() {
-        return prop
-    }
-
-    // Non-final, so this is the only getter that could be overridden, but its boolean return type is not attachable.
-    boolean isSomeValue() {
-        return prop.getOrElse(false)
-    }
-
-    HasFinalPropertyGetterAndBooleanOverload(ObjectFactory objectFactory) {
-        prop = objectFactory.property(Boolean)
-    }
 }
 
 class HasFailingAndWorkingPropertyGetters {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -29,10 +29,16 @@ import org.gradle.internal.BiAction
 import org.gradle.internal.Describables
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
 import org.gradle.internal.state.ModelObject
+import org.gradle.util.TestUtil
 import org.gradle.util.internal.ConfigureUtil
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
+import java.lang.annotation.Annotation
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
 import java.util.function.BiFunction
 
 import static AsmBackedClassGeneratorTest.Bean
@@ -183,6 +189,34 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         then: "the failure is ignored and the remaining properties are still attached"
         noExceptionThrown()
         field.get(bean).toString() == "<display name> property 'working'"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37421")
+    def "attempting to reattach the owner propagates a role handler exception"() {
+        given: "a role handler that fails"
+        def attempts = []
+        def roleHandler = new PropertyRoleAnnotationHandler() {
+            Set<Class<? extends Annotation>> getAnnotationTypes() { [Producer] as Set }
+            void applyRoleTo(ModelObject owner, Object target) {
+                attempts << target
+                throw new IllegalStateException("cannot apply the role")
+            }
+        }
+        def generator = AsmBackedClassGenerator.decorateAndInject([], roleHandler, [], new TestCrossBuildInMemoryCacheFactory(), 0)
+        def bean = create(generator, HasRoleAnnotatedManagedProperty)
+
+        // Write the value straight into the backing field, as deserialization does, so that the getter returns
+        // it instead of creating it - and therefore does not apply the role itself.
+        def field = bean.getClass().getDeclaredField("__someValue__")
+        field.accessible = true
+        field.set(bean, TestUtil.objectFactory().property(String))
+
+        when: "model properties are re-attached, as happens after deserialization"
+        (bean as ModelObject).attachModelProperties()
+
+        then: "the failure surfaces - only the getter invocation is meant to be tolerated"
+        thrown(IllegalStateException)
+        attempts.size() == 1
     }
 
     @ToBeImplemented("https://github.com/gradle/gradle/issues/37421")
@@ -811,6 +845,15 @@ class HasReadOnlyProperty {
     HasReadOnlyProperty(ObjectFactory objectFactory) {
         prop = objectFactory.property(String)
     }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Producer {}
+
+interface HasRoleAnnotatedManagedProperty {
+    @Producer
+    Property<String> getSomeValue()
 }
 
 class HasFinalPropertyGetterAndBooleanOverload {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Action
 import org.gradle.api.NonExtensible
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
@@ -28,9 +29,12 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
 import org.gradle.internal.Describables
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.state.ModelObject
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.ConfigureUtil
+import org.junit.Rule
 import spock.lang.Issue
 
 import java.lang.annotation.Annotation
@@ -49,6 +53,11 @@ import static org.gradle.internal.instantiation.generator.AsmBackedClassGenerato
 
 class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
     ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], Stub(PropertyRoleAnnotationHandler), [], new TestCrossBuildInMemoryCacheFactory(), 0)
+
+    final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+
+    @Rule
+    final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
 
     def "mixes in toString() implementation for class"() {
         given:
@@ -188,6 +197,12 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         then: "the failure is ignored and the remaining properties are still attached"
         noExceptionThrown()
         field.get(bean).toString() == "<display name> property 'working'"
+
+        and: "the ignored failure is logged at debug level, naming the property so that a missing owner can still be diagnosed"
+        def events = outputEventListener.events.findAll { it.message.startsWith("Could not attach owner to <display name> property 'failing'") }
+        events.size() == 1
+        events[0].logLevel == LogLevel.DEBUG
+        events[0].throwable.message == "The value of this property has been discarded during serialization."
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37421")

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.base.Function
 import org.gradle.api.Action
 import org.gradle.api.NonExtensible
 import org.gradle.api.internal.IConventionAware
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
@@ -27,7 +28,9 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
 import org.gradle.internal.Describables
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
+import org.gradle.internal.state.ModelObject
 import org.gradle.util.internal.ConfigureUtil
+import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 import java.util.function.BiFunction
@@ -140,6 +143,70 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         expect:
         bean.prop.toString() == "property 'prop'"
         beanWithDisplayName.prop.toString() == "<display-name> property 'prop'"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37421")
+    def "re-attaches owner to non-managed read only #description when model properties are re-attached"() {
+        given:
+        def bean = create(type, Describables.of("<display name>"))
+
+        // Read the backing field directly, without going through the attaching getter. This mirrors how
+        // the configuration cache restores the property - straight into the field - so the owner-attach that
+        // normally happens in the generated getter override never runs, leaving the property without an owner.
+        def field = type.getDeclaredField(fieldName)
+        field.accessible = true
+
+        expect: "the property restored into the field has no owner yet"
+        field.get(bean).toString() == ownerlessDisplayName
+
+        when: "the model properties are re-attached, as the configuration cache does after deserialization"
+        (bean as ModelObject).attachModelProperties()
+
+        then: "the owner (and thus the display name) is restored, observed via the field rather than the getter"
+        field.get(bean).toString() == "<display name> property 'someValue'"
+
+        where:
+        description                  | type                       | fieldName | ownerlessDisplayName
+        "Property"                   | HasReadOnlyProperty        | "prop"    | "property(java.lang.String, undefined)"
+        "ConfigurableFileCollection" | HasReadOnlyFileCollection  | "files"   | "file collection"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37421")
+    def "attempting to reattach the owner to a non-managed properties ignores getter exception"() {
+        given:
+        def bean = create(HasFailingAndWorkingPropertyGetters, Describables.of("<display name>"))
+        def field = HasFailingAndWorkingPropertyGetters.getDeclaredField("working")
+        field.accessible = true
+
+        when: "model properties are re-attached, as the configuration cache does after deserialization"
+        (bean as ModelObject).attachModelProperties()
+
+        then: "the failure is ignored and the remaining properties are still attached"
+        noExceptionThrown()
+        field.get(bean).toString() == "<display name> property 'working'"
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/37421")
+    def "attaches owner to a non-managed read only Property whose main getter is final and only overload is not attachable"() {
+        given:
+        def bean = create(HasFinalPropertyGetterAndBooleanOverload, Describables.of("<display name>"))
+        def field = HasFinalPropertyGetterAndBooleanOverload.getDeclaredField("prop")
+        field.accessible = true
+
+        expect: "the property has no owner"
+        // FIXME The property should have an owner, whether read through the field or through the getter:
+        // field.get(bean).toString() == "<display name> property 'someValue'"
+        // bean.getSomeValue().toString() == "<display name> property 'someValue'"
+        field.get(bean).toString() == "property(java.lang.Boolean, undefined)"
+        bean.getSomeValue().toString() == "property(java.lang.Boolean, undefined)"
+
+        when: "model properties are re-attached"
+        (bean as ModelObject).attachModelProperties()
+
+        then: "the property still has no owner"
+        // FIXME The property should have an owner here too:
+        // field.get(bean).toString() == "<display name> property 'someValue'"
+        field.get(bean).toString() == "property(java.lang.Boolean, undefined)"
     }
 
     def "can attach nested extensions to object"() {
@@ -744,6 +811,54 @@ class HasReadOnlyProperty {
 
     HasReadOnlyProperty(ObjectFactory objectFactory) {
         prop = objectFactory.property(String)
+    }
+}
+
+class HasFinalPropertyGetterAndBooleanOverload {
+    private final Property<Boolean> prop
+
+    // Final, so it cannot be overridden to attach the owner, even though this is the getter
+    // that exposes the Property, and would need an owner.
+    final Property<Boolean> getSomeValue() {
+        return prop
+    }
+
+    // Non-final, so this is the only getter that could be overridden, but its boolean return type is not attachable.
+    boolean isSomeValue() {
+        return prop.getOrElse(false)
+    }
+
+    HasFinalPropertyGetterAndBooleanOverload(ObjectFactory objectFactory) {
+        prop = objectFactory.property(Boolean)
+    }
+}
+
+class HasFailingAndWorkingPropertyGetters {
+    private final Property<String> working
+
+    // Mirrors GenerateModuleMetadata.getPublication(), whose value is discarded during serialization.
+    Property<String> getFailing() {
+        throw new IllegalStateException("The value of this property has been discarded during serialization.")
+    }
+
+    Property<String> getWorking() {
+        return working
+    }
+
+    HasFailingAndWorkingPropertyGetters(ObjectFactory objectFactory) {
+        working = objectFactory.property(String)
+    }
+}
+
+class HasReadOnlyFileCollection {
+    private final ConfigurableFileCollection files
+
+    ConfigurableFileCollection getSomeValue() {
+        return files
+    }
+
+    HasReadOnlyFileCollection(ObjectFactory objectFactory) {
+        files = objectFactory.fileCollection()
     }
 }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.internal.ToBeImplemented
 import spock.lang.FailsWith
 import spock.lang.Issue
 
@@ -247,6 +248,53 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("property = task ':thing' property 'count'")
         failure.assertHasCause("Cannot query the value of task ':thing' property 'count' because it has no value available.")
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/37421")
+    def "reports failure to query non-abstract Property<T> with final getter and boolean overload"() {
+        given:
+        javaFile("buildSrc/src/main/java/MyTask.java", """
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Internal;
+            import org.gradle.api.tasks.TaskAction;
+
+            public abstract class MyTask extends DefaultTask {
+                private final Property<Boolean> flag = getProject().getObjects().property(Boolean.class);
+
+                @Internal
+                public final Property<Boolean> getFlag() {
+                    return flag;
+                }
+
+                @Internal
+                public boolean isFlag() {
+                    return flag.getOrElse(false);
+                }
+
+                @TaskAction
+                void go() {
+                    System.out.println("flag = " + flag.get());
+                }
+            }
+        """)
+
+        buildFile """
+            tasks.register("thing", MyTask) {
+                println("property = " + getFlag())
+            }
+        """
+
+        when:
+        fails("thing")
+
+        then:
+        // FIXME The owner is never attached, in a cached run and in a plain one alike, so neither the printed
+        //  property nor the failure can name the task or the property. These should be the asserts:
+        // outputContains("property = task ':thing' property 'flag'")
+        // failure.assertHasCause("Cannot query the value of task ':thing' property 'flag' because it has no value available.")
+        outputContains("property = property(java.lang.Boolean, undefined)")
+        failure.assertHasCause("Cannot query the value of this property because it has no value available.")
     }
 
     @FailsWith(reason = "non-final getters do not trigger attachOwner/attachProducer logic", value = AssertionError)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.api.tasks
 
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.FailsWith
 import spock.lang.Issue
 
@@ -213,7 +211,7 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("inside: output is produced by thing")
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/37421; Fails with Configuration Cache")
+    @Issue("https://github.com/gradle/gradle/issues/37421")
     def "reports failure to query non-abstract Property<T> with non-final getter"() {
         given:
         javaFile("buildSrc/src/main/java/MyTask.java", """
@@ -248,14 +246,7 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("property = task ':thing' property 'count'")
-        if (!GradleContextualExecuter.configCache) {
-            // This is the correct failure message.
-            failure.assertHasCause("Cannot query the value of task ':thing' property 'count' because it has no value available.")
-        } else {
-            // TODO(https://github.com/gradle/gradle/issues/37421): There shouldn't be any difference in behavior with CC enabled.
-            //  This assert encodes current behavior, not desired one.
-            failure.assertHasCause("Cannot query the value of this property because it has no value available.")
-        }
+        failure.assertHasCause("Cannot query the value of task ':thing' property 'count' because it has no value available.")
     }
 
     @FailsWith(reason = "non-final getters do not trigger attachOwner/attachProducer logic", value = AssertionError)


### PR DESCRIPTION
Non-abstract Property and ConfigurableFileCollection getters (a.k.a. unmanaged properties) used to only attach their owner lazily in the generated getter override, which never ran when the owner was restored from the configuration cache. This PR ensures owner attachment happens for properties whose getters are never invoked (they are accessed  via direct access to the underlying property).  

Co-authored-by: Develop-KIM <kimdonghwan913@gmail.com> 
Co-authored-by: rchaves@gradle.com

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes:  #37421
Supersedes: #38615

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
