### PR TITLE
Generalize project locking

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ModelContainer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ModelContainer.java
@@ -20,7 +20,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Encapsulates some mutable model, and provides synchronized access to the model.
@@ -34,10 +33,9 @@ public interface ModelContainer<T> {
     <S extends @Nullable Object> S fromMutableState(Function<? super T, ? extends S> factory);
 
     /**
-     * Runs the given supplier, while synchronizing on the project.
-     * The mutable state of the project can be used by the calculation, if a reference to it has been retrieved earlier.
+     * {@link #fromMutableState(Function)} but allows the function to be run even if the model is in an invalid state.
      */
-    <S extends @Nullable Object> S runWithModelLock(Supplier<S> action);
+    <S extends @Nullable Object> S fromMutableStateEvenAfterFailure(Function<? super T, ? extends S> function);
 
     /**
      * DO NOT USE THIS METHOD. It is here to provide some specific backwards compatibility.

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ObjectGuard.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/ObjectGuard.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.model;
+
+import org.gradle.internal.work.Synchronizer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Provides a thread-safe way to initialize and access a value.
+ */
+@NullMarked
+public class ObjectGuard<T> {
+
+    private volatile @Nullable T value;
+    private final Synchronizer synchronizer;
+
+    public ObjectGuard(Synchronizer synchronizer) {
+        this.synchronizer = synchronizer;
+    }
+
+    /**
+     * Set the value of the object.
+     *
+     * @throws IllegalStateException if the object has already been initialized.
+     */
+    public void initialize(T value) {
+        synchronizer.withLock(() -> {
+            if (this.value != null) {
+                throw new IllegalStateException("Object has already been initialized.");
+            }
+            this.value = value;
+        });
+    }
+
+    /**
+     * Returns true if the object has been initialized and not yet destroyed.
+     */
+    public boolean hasValue() {
+        return value != null;
+    }
+
+    /**
+     * Returns the value of the object without acquiring a lock.
+     * <p>
+     * This method should be avoided.
+     */
+    public T unsafeGet() {
+        T local = value;
+        if (local == null) {
+            throw new IllegalStateException("Object has not been initialized.");
+        }
+        return local;
+    }
+
+    /**
+     * Executes the given function with the value of the object while holding
+     * the lock and returns the result.
+     */
+    public <V extends @Nullable Object> V fromValue(Function<? super T, V> function) {
+        return synchronizer.withLock(() -> function.apply(unsafeGet()));
+    }
+
+    /**
+     * Executes the given action with the value of the object while holding
+     * the lock.
+     */
+    public void runWithValue(Consumer<? super T> consumer) {
+        synchronizer.withLock(() -> consumer.accept(unsafeGet()));
+    }
+
+    /**
+     * If initialized, executes the given action with the value of the object
+     * while holding the lock and then uninitializes the object.
+     */
+    public void destroy(Consumer<? super T> consumer) {
+        synchronizer.withLock(() -> {
+            T local = value;
+            if (local != null) {
+                try {
+                    consumer.accept(local);
+                } finally {
+                    this.value = null;
+                }
+            }
+        });
+    }
+
+}

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultSynchronizer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultSynchronizer.java
@@ -16,9 +16,10 @@
 
 package org.gradle.internal.work;
 
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
 
 class DefaultSynchronizer implements Synchronizer {
     private final WorkerLeaseService workerLeaseService;
@@ -39,10 +40,10 @@ class DefaultSynchronizer implements Synchronizer {
     }
 
     @Override
-    public <T extends @Nullable Object> T withLock(Factory<T> action) {
+    public <T extends @Nullable Object> T withLock(Supplier<T> action) {
         Thread previous = takeOwnership();
         try {
-            return action.create();
+            return action.get();
         } finally {
             releaseOwnership(previous);
         }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/Synchronizer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/Synchronizer.java
@@ -16,10 +16,14 @@
 
 package org.gradle.internal.work;
 
-import org.gradle.internal.Factory;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.function.Supplier;
+
+@NullMarked
 public interface Synchronizer {
+
     /**
      * Runs the given action while holding the associated resource lock, blocking until the lock can be acquired.
      *
@@ -32,5 +36,6 @@ public interface Synchronizer {
      *
      * Fails if the current thread is already holding the resource lock. May release project locks prior to blocking, as per {@link WorkerLeaseService#blocking(Runnable)}.
      */
-    <T extends @Nullable Object> T withLock(Factory<T> action);
+    <T extends @Nullable Object> T withLock(Supplier<T> action);
+
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WaitBuildOperationFiringSynchronizer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WaitBuildOperationFiringSynchronizer.java
@@ -17,13 +17,13 @@
 package org.gradle.internal.work;
 
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.Factory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class WaitBuildOperationFiringSynchronizer implements Synchronizer {
 
@@ -43,13 +43,10 @@ public class WaitBuildOperationFiringSynchronizer implements Synchronizer {
         final BuildOperationContext buildOperationContext = startWaitingOperation();
 
         try {
-            delegate.withLock(new Runnable() {
-                @Override
-                public void run() {
-                    successfulWait.set(true);
-                    buildOperationContext.setResult(null);
-                    action.run();
-                }
+            delegate.withLock(() -> {
+                successfulWait.set(true);
+                buildOperationContext.setResult(null);
+                action.run();
             });
         } finally {
             if (!successfulWait.get()) {
@@ -59,18 +56,15 @@ public class WaitBuildOperationFiringSynchronizer implements Synchronizer {
     }
 
     @Override
-    public <T extends @Nullable Object> T withLock(final Factory<T> action) {
+    public <T extends @Nullable Object> T withLock(final Supplier<T> action) {
         final AtomicBoolean successfulWait = new AtomicBoolean(false);
         final BuildOperationContext buildOperationContext = startWaitingOperation();
 
         try {
-            return delegate.withLock(new Factory<T>() {
-                @Override
-                public T create() {
-                    successfulWait.set(true);
-                    buildOperationContext.setResult(null);
-                    return action.create();
-                }
+            return delegate.withLock(() -> {
+                successfulWait.set(true);
+                buildOperationContext.setResult(null);
+                return action.get();
             });
         } finally {
             if (!successfulWait.get()) {
@@ -86,4 +80,5 @@ public class WaitBuildOperationFiringSynchronizer implements Synchronizer {
                 .displayName("Synchronizer wait: " + targetDescription.getDisplayName())
         );
     }
+
 }

--- a/platforms/core-runtime/launcher/build.gradle.kts
+++ b/platforms/core-runtime/launcher/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     api(projects.daemonServices)
 
     api(libs.guava)
+    api(libs.inject)
     api(libs.jspecify)
 
     implementation(projects.buildProcessServices)

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/DefaultBuildTreeActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/DefaultBuildTreeActionExecutor.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.launcher.exec;
 
 import org.gradle.internal.UncheckedException;
@@ -50,6 +49,8 @@ import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import org.gradle.internal.work.ProjectParallelExecutionController;
 
 public class DefaultBuildTreeActionExecutor implements BuildTreeActionExecutor {
 
@@ -61,17 +62,20 @@ public class DefaultBuildTreeActionExecutor implements BuildTreeActionExecutor {
     private final ValueSnapshotter valueSnapshotter;
     private final InternalOptions options;
     private final WorkerLeaseService workerLeaseService;
+    private final ProjectParallelExecutionController projectParallelExecutionController;
     private final BuildOperationRunner buildOperationRunner;
     private final LoggingBuildOperationProgressBroadcaster loggingBuildOperationProgressBroadcaster;
     private final BuildOperationNotificationValve buildOperationNotificationValve;
     private final RootBuildOperationRef rootBuildOperationRef;
 
+    @Inject
     public DefaultBuildTreeActionExecutor(
         BuildModelParametersFactory modelParametersFactory,
         BuildLayoutValidator buildLayoutValidator,
         ValueSnapshotter valueSnapshotter,
         InternalOptions options,
         WorkerLeaseService workerLeaseService,
+        ProjectParallelExecutionController projectParallelExecutionController,
         BuildOperationRunner buildOperationRunner,
         LoggingBuildOperationProgressBroadcaster loggingBuildOperationProgressBroadcaster,
         BuildOperationNotificationValve buildOperationNotificationValve,
@@ -82,6 +86,7 @@ public class DefaultBuildTreeActionExecutor implements BuildTreeActionExecutor {
         this.valueSnapshotter = valueSnapshotter;
         this.options = options;
         this.workerLeaseService = workerLeaseService;
+        this.projectParallelExecutionController = projectParallelExecutionController;
         this.buildOperationRunner = buildOperationRunner;
         this.loggingBuildOperationProgressBroadcaster = loggingBuildOperationProgressBroadcaster;
         this.buildOperationNotificationValve = buildOperationNotificationValve;
@@ -127,9 +132,12 @@ public class DefaultBuildTreeActionExecutor implements BuildTreeActionExecutor {
             BuildActionModelRequirements actionRequirements = buildActionModelRequirementsFor(action);
             BuildModelParameters buildModelParameters = buildModelParametersFactory.parametersForRootBuildTree(actionRequirements, options);
             BuildInvocationScopeId buildInvocationScopeId = new BuildInvocationScopeId(UniqueId.generate());
+            projectParallelExecutionController.startProjectExecution(buildModelParameters.isParallelProjectExecution());
             try (BuildTreeState buildTree = new BuildTreeState(buildSessionServices, actionRequirements, buildModelParameters, buildInvocationScopeId)) {
                 // assign instead of return to allow combining build failures with cleanup failures below
                 result = buildTree.getServices().get(RootBuildLifecycleBuildActionExecutor.class).execute(action);
+            } finally {
+                projectParallelExecutionController.finishProjectExecution();
             }
         } catch (Throwable t) {
             // If cleanup has failed, combine the cleanup failure with other failures that may be packed in the result

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -34,7 +34,6 @@ import org.gradle.internal.jvm.SupportedJavaVersions;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.internal.work.ProjectParallelExecutionController;
 import org.gradle.problems.buildtree.ProblemStream;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.VersionNumber;
@@ -46,7 +45,6 @@ import org.gradle.util.internal.VersionNumber;
 public class RootBuildLifecycleBuildActionExecutor {
 
     private final BuildModelParameters buildModelParameters;
-    private final ProjectParallelExecutionController projectParallelExecutionController;
     private final BuildTreeLifecycleListener lifecycleListener;
     private final ProblemsInternal problemsService;
     private final BuildOperationProgressEventEmitter eventEmitter;
@@ -58,7 +56,6 @@ public class RootBuildLifecycleBuildActionExecutor {
 
     public RootBuildLifecycleBuildActionExecutor(
         BuildModelParameters buildModelParameters,
-        ProjectParallelExecutionController projectParallelExecutionController,
         BuildTreeLifecycleListener lifecycleListener,
         ProblemsInternal problemsService,
         BuildOperationProgressEventEmitter eventEmitter,
@@ -67,7 +64,6 @@ public class RootBuildLifecycleBuildActionExecutor {
         BuildActionRunner buildActionRunner
     ) {
         this.buildModelParameters = buildModelParameters;
-        this.projectParallelExecutionController = projectParallelExecutionController;
         this.lifecycleListener = lifecycleListener;
         this.problemsService = problemsService;
         this.eventEmitter = eventEmitter;
@@ -87,23 +83,18 @@ public class RootBuildLifecycleBuildActionExecutor {
         }
         executed = true;
 
-        projectParallelExecutionController.startProjectExecution(buildModelParameters.isParallelProjectExecution());
+        lifecycleListener.afterStart();
+        StartParameterInternal startParameter = action.getStartParameter();
         try {
-            lifecycleListener.afterStart();
-            StartParameterInternal startParameter = action.getStartParameter();
-            try {
-                initDeprecationLogging(startParameter);
-                maybeNagOnDeprecatedJavaRuntimeVersion();
-                maybeNagOnImplicitParallelModelBuildingOptIn(startParameter);
-                RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(startParameter, null));
-                return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));
-            } finally {
-                // Since continuous builds reuse the same StartParameter for multiple build trees.
-                startParameter.clearMutationListener();
-                lifecycleListener.beforeStop();
-            }
+            initDeprecationLogging(startParameter);
+            maybeNagOnDeprecatedJavaRuntimeVersion();
+            maybeNagOnImplicitParallelModelBuildingOptIn(startParameter);
+            RootBuildState rootBuild = buildStateRegistry.createRootBuild(BuildDefinition.fromStartParameter(startParameter, null));
+            return rootBuild.run(buildController -> buildActionRunner.run(action, buildController));
         } finally {
-            projectParallelExecutionController.finishProjectExecution();
+            // Since continuous builds reuse the same StartParameter for multiple build trees.
+            startParameter.clearMutationListener();
+            lifecycleListener.beforeStop();
         }
     }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -67,7 +67,6 @@ import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.FileChangeListeners;
-import org.gradle.internal.work.ProjectParallelExecutionController;
 import org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner;
 import org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner;
 import org.gradle.launcher.exec.DefaultBuildTreeActionExecutor;
@@ -191,7 +190,6 @@ public class LauncherServices extends AbstractGradleModuleServices {
         @Provides
         RootBuildLifecycleBuildActionExecutor createActionExecutor(
             BuildModelParameters buildModelParameters,
-            ProjectParallelExecutionController projectParallelExecutionController,
             List<BuildActionRunner> buildActionRunners,
             StyledTextOutputFactory styledTextOutputFactory,
             BuildStateRegistry buildStateRegistry,
@@ -218,7 +216,6 @@ public class LauncherServices extends AbstractGradleModuleServices {
         ) {
             return new RootBuildLifecycleBuildActionExecutor(
                 buildModelParameters,
-                projectParallelExecutionController,
                 listenerManager.getBroadcaster(BuildTreeLifecycleListener.class),
                 problemsService,
                 eventEmitter,

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.buildtree.BuildTreeLifecycleListener
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
-import org.gradle.internal.work.ProjectParallelExecutionController
 import org.gradle.problems.buildtree.ProblemStream
 import spock.lang.Specification
 
@@ -49,7 +48,6 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
 
         def executor = new RootBuildLifecycleBuildActionExecutor(
             Stub(BuildModelParameters),
-            Stub(ProjectParallelExecutionController),
             listener,
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),
@@ -74,7 +72,6 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
         given:
         def executor = new RootBuildLifecycleBuildActionExecutor(
             Stub(BuildModelParameters),
-            Stub(ProjectParallelExecutionController),
             Stub(BuildTreeLifecycleListener),
             Stub(ProblemsInternal),
             Stub(BuildOperationProgressEventEmitter),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -22,7 +22,6 @@ import org.gradle.util.Path;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Domain object context implementation intended for identifying contexts that wrap no mutable state.
@@ -56,13 +55,13 @@ public abstract class StandaloneDomainObjectContext implements DomainObjectConte
     }
 
     @Override
-    public <S> S runWithModelLock(Supplier<S> action) {
-        return action.get();
+    public <S> S fromMutableState(Function<? super Object, ? extends S> factory) {
+        return factory.apply(MODEL);
     }
 
     @Override
-    public <S> S fromMutableState(Function<? super Object, ? extends S> factory) {
-        return factory.apply(MODEL);
+    public <S> S fromMutableStateEvenAfterFailure(Function<? super Object, ? extends S> function) {
+        return function.apply(MODEL);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -25,6 +25,7 @@ import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.work.Synchronizer;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.util.internal.CollectionUtils;
 import org.jspecify.annotations.Nullable;
@@ -47,14 +48,12 @@ class DefaultProjectState implements ProjectState, Closeable {
     private final ProjectIdentity identity;
     private final IProjectFactory projectFactory;
     private final ProjectLifecycleController controller;
-    private final WorkerLeaseService workerLeaseService;
     private final ProjectStateLookup projectStateLookup;
 
-    private final ResourceLock allProjectsLock;
     private final ResourceLock projectLock;
     private final ResourceLock taskLock;
 
-    private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
+    private final ProjectLockSynchronizer synchronizer;
 
     DefaultProjectState(
         BuildState owner,
@@ -69,12 +68,14 @@ class DefaultProjectState implements ProjectState, Closeable {
         this.descriptor = descriptor;
         this.identity = descriptor.getIdentity();
         this.projectFactory = projectFactory;
-        this.controller = new ProjectLifecycleController(getDisplayName(), stateTransitionControllerFactory, this::withProjectLock, buildServices);
-        this.workerLeaseService = workerLeaseService;
         this.projectStateLookup = projectStateLookup;
-        this.allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
+
         this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identity.getBuildTreePath());
         this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identity.getBuildTreePath());
+
+        ResourceLock allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
+        this.synchronizer = new ProjectLockSynchronizer(workerLeaseService, projectLock, allProjectsLock);
+        this.controller = new ProjectLifecycleController(getDisplayName(), stateTransitionControllerFactory, synchronizer, buildServices);
     }
 
     @Override
@@ -172,12 +173,12 @@ class DefaultProjectState implements ProjectState, Closeable {
 
     @Override
     public ProjectInternal getMutableModel() {
-        return controller.getMutableModel();
+        return controller.getModel().unsafeGet();
     }
 
     @Override
     public ProjectInternal getMutableModelEvenAfterFailure() {
-        return controller.getMutableModelEvenAfterFailure();
+        return controller.getModelEvenAfterFailure().unsafeGet();
     }
 
     @Override
@@ -201,7 +202,11 @@ class DefaultProjectState implements ProjectState, Closeable {
 
     @Override
     public void ensureTasksDiscovered() {
-        controller.ensureTasksDiscovered();
+        controller.ensureSelfConfigured();
+        applyToMutableState(project -> {
+            project.getTasks().discoverTasks();
+            project.bindAllModelRules();
+        });
     }
 
     // endregion
@@ -218,72 +223,103 @@ class DefaultProjectState implements ProjectState, Closeable {
 
     @Override
     public void applyToMutableState(Consumer<? super ProjectInternal> action) {
-        fromMutableState(p -> {
-            action.accept(p);
-            return null;
-        });
+        controller.getModel().runWithValue(action);
     }
 
     @Override
     public <S extends @Nullable Object> S fromMutableState(Function<? super ProjectInternal, ? extends S> function) {
-        return runWithModelLock(() -> function.apply(getMutableModel()));
-    }
-
-    private void withProjectLock(Runnable action) {
-        runWithModelLock(() -> {
-            action.run();
-            return null;
-        });
+        return controller.getModel().fromValue(function);
     }
 
     @Override
-    public <S extends @Nullable Object> S runWithModelLock(Supplier<S> action) {
-        Thread currentThread = Thread.currentThread();
-        if (canDoAnythingToThisProject.contains(currentThread)) {
-            // Current thread is allowed to access anything at any time, so run the action
-            return action.get();
-        }
-
-        Collection<? extends ResourceLock> currentLocks = workerLeaseService.getCurrentProjectLocks();
-        if (currentLocks.contains(projectLock) || currentLocks.contains(allProjectsLock)) {
-            // if we already hold the project lock for this project
-            if (currentLocks.size() == 1) {
-                // the lock for this project is the only lock we hold, can run the action
-                return action.get();
-            } else {
-                throw new IllegalStateException("Current thread holds more than one project lock. It should hold only one project lock at any given time.");
-            }
-        } else {
-            return workerLeaseService.withReplacedLocks(currentLocks, projectLock, action::get);
-        }
+    public <S extends @Nullable Object> S fromMutableStateEvenAfterFailure(Function<? super ProjectInternal, ? extends S> function) {
+        return controller.getModelEvenAfterFailure().fromValue(function);
     }
 
     @Override
     public <S> S forceAccessToMutableState(Function<? super ProjectInternal, ? extends S> factory) {
-        Thread currentThread = Thread.currentThread();
-        boolean added = canDoAnythingToThisProject.add(currentThread);
-        try {
-            return factory.apply(getMutableModel());
-        } finally {
-            if (added) {
-                canDoAnythingToThisProject.remove(currentThread);
-            }
-        }
+        return synchronizer.withForcedAccess(() -> controller.getModel().fromValue(factory));
     }
 
     @Override
     public boolean hasMutableState() {
-        Thread currentThread = Thread.currentThread();
-        if (canDoAnythingToThisProject.contains(currentThread)) {
-            return true;
-        }
-        Collection<? extends ResourceLock> locks = workerLeaseService.getCurrentProjectLocks();
-        return locks.contains(projectLock) || locks.contains(allProjectsLock);
+        return synchronizer.hasLock();
     }
 
     @Override
     public void close() {
         controller.close();
+    }
+
+    private static class ProjectLockSynchronizer implements Synchronizer {
+
+        private final WorkerLeaseService workerLeaseService;
+        private final ResourceLock projectLock;
+        private final ResourceLock allProjectsLock;
+
+        private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
+
+        public ProjectLockSynchronizer(
+            WorkerLeaseService workerLeaseService,
+            ResourceLock projectLock,
+            ResourceLock allProjectsLock
+        ) {
+            this.workerLeaseService = workerLeaseService;
+            this.projectLock = projectLock;
+            this.allProjectsLock = allProjectsLock;
+        }
+
+        @Override
+        public void withLock(Runnable action) {
+            withLock(() -> {
+                action.run();
+                return null;
+            });
+        }
+
+        @Override
+        public <T extends @Nullable Object> T withLock(Supplier<T> action) {
+            Thread currentThread = Thread.currentThread();
+            if (canDoAnythingToThisProject.contains(currentThread)) {
+                // Current thread is allowed to access anything at any time, so run the action
+                return action.get();
+            }
+
+            Collection<? extends ResourceLock> currentLocks = workerLeaseService.getCurrentProjectLocks();
+            if (currentLocks.contains(projectLock) || currentLocks.contains(allProjectsLock)) {
+                // if we already hold the project lock for this project
+                if (currentLocks.size() == 1) {
+                    // the lock for this project is the only lock we hold, can run the action
+                    return action.get();
+                } else {
+                    throw new IllegalStateException("Current thread holds more than one project lock. It should hold only one project lock at any given time.");
+                }
+            } else {
+                return workerLeaseService.withReplacedLocks(currentLocks, projectLock, action::get);
+            }
+        }
+
+        public <T> T withForcedAccess(Supplier<T> action) {
+            Thread currentThread = Thread.currentThread();
+            boolean added = canDoAnythingToThisProject.add(currentThread);
+            try {
+                return action.get();
+            } finally {
+                if (added) {
+                    canDoAnythingToThisProject.remove(currentThread);
+                }
+            }
+        }
+
+        public boolean hasLock() {
+            Thread currentThread = Thread.currentThread();
+            if (canDoAnythingToThisProject.contains(currentThread)) {
+                return true;
+            }
+            Collection<? extends ResourceLock> locks = workerLeaseService.getCurrentProjectLocks();
+            return locks.contains(projectLock) || locks.contains(allProjectsLock);
+        }
+
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.logging.LoggingManagerFactory;
+import org.gradle.internal.model.ObjectGuard;
 import org.gradle.internal.model.StateTransitionController;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
@@ -29,7 +30,7 @@ import org.gradle.internal.service.scopes.ProjectScopeServices;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.jspecify.annotations.Nullable;
+import org.gradle.internal.work.Synchronizer;
 
 import java.io.Closeable;
 
@@ -38,26 +39,23 @@ import java.io.Closeable;
  */
 @ServiceScope(Scope.Project.class)
 public class ProjectLifecycleController implements Closeable {
+
     private final ServiceRegistry buildServices;
     private final StateTransitionController<State> controller;
-    private final ProjectLockGuard lockGuard;
-    @Nullable
-    private ProjectInternal project;
-    @Nullable
-    private CloseableServiceRegistry projectScopeServices;
+    private final ObjectGuard<ProjectInternal> model;
 
     private enum State implements StateTransitionController.State {
         NotCreated, Created, Configured
     }
 
-    public ProjectLifecycleController(DisplayName displayName, StateTransitionControllerFactory factory, ProjectLockGuard lockGuard, ServiceRegistry buildServices) {
+    public ProjectLifecycleController(DisplayName displayName, StateTransitionControllerFactory factory, Synchronizer projectLockSynchronizer, ServiceRegistry buildServices) {
         this.buildServices = buildServices;
-        this.lockGuard = lockGuard;
-        controller = factory.newController(displayName, State.NotCreated);
+        this.model = new ObjectGuard<>(projectLockSynchronizer);
+        this.controller = factory.newController(displayName, State.NotCreated);
     }
 
     public boolean isCreated() {
-        return project != null;
+        return controller.hasSeenStateIgnoringFailures(State.Created) && model.hasValue();
     }
 
     public void assertConfigured() {
@@ -75,52 +73,32 @@ public class ProjectLifecycleController implements Closeable {
         controller.transition(State.NotCreated, State.Created, () -> {
             ServiceRegistryFactory serviceRegistryFactory = domainObject -> {
                 LoggingManagerFactory loggingManagerFactory = buildServices.get(LoggingManagerFactory.class);
-                projectScopeServices = ProjectScopeServices.create(buildServices, (ProjectInternal) domainObject, loggingManagerFactory);
-                return projectScopeServices;
+                return ProjectScopeServices.create(buildServices, (ProjectInternal) domainObject, loggingManagerFactory);
             };
-            project = projectFactory.createProject(build, descriptor, owner, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
+            ProjectInternal project = projectFactory.createProject(build, descriptor, owner, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
+            model.initialize(project);
         });
     }
 
-    public ProjectInternal getMutableModel() {
+    public ObjectGuard<ProjectInternal> getModel() {
         controller.assertHasSeenState(State.Created);
-        return project;
+        return model;
     }
 
-    public ProjectInternal getMutableModelEvenAfterFailure() {
+    public ObjectGuard<ProjectInternal> getModelEvenAfterFailure() {
         controller.assertHasSeenStateIgnoringFailures(State.Created);
-        return project;
+        return model;
     }
 
     public void ensureSelfConfigured() {
-        controller.maybeTransitionIfNotCurrentlyTransitioning(State.Created, State.Configured, () -> lockGuard.withProjectLock(() -> project.evaluateUnchecked()));
-    }
-
-    public void ensureTasksDiscovered() {
-        ensureSelfConfigured();
-        lockGuard.withProjectLock(() -> {
-            project.getTasks().discoverTasks();
-            project.bindAllModelRules();
-        });
+        controller.maybeTransitionIfNotCurrentlyTransitioning(State.Created, State.Configured, () -> model.runWithValue(ProjectInternal::evaluateUnchecked));
     }
 
     @Override
     public void close() {
-        if (project != null) {
-            try {
-                projectScopeServices.close();
-            } finally {
-                project = null;
-                projectScopeServices = null;
-            }
-        }
+        model.destroy(project -> {
+            ((CloseableServiceRegistry) project.getServices()).close();
+        });
     }
 
-    /**
-     * Runs an action while holding the owning project's state lock.
-     */
-    @FunctionalInterface
-    public interface ProjectLockGuard {
-        void withProjectLock(Runnable action);
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
@@ -287,7 +287,7 @@ public class DefaultToolingModelBuilderRegistry implements ToolingModelBuilderRe
 
         @Override
         public Object build(Object parameter) {
-            return target.runWithModelLock(() -> delegate.build(parameter));
+            return target.fromMutableStateEvenAfterFailure(project -> delegate.build(parameter));
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -64,6 +64,8 @@ import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import java.util.function.Function
+
 class DefaultGradleSpec extends Specification {
     ListenerManager listenerManager = Spy(TestListenerManager)
 
@@ -506,7 +508,7 @@ class DefaultGradleSpec extends Specification {
         _ * state.name >> name
         _ * state.mutableModel >> project
         _ * state.applyToMutableState(_) >> { java.util.function.Consumer c -> c.accept(project) }
-        _ * state.runWithModelLock(_) >> { java.util.function.Supplier s -> s.get() }
+        _ * state.fromMutableState(_) >> { Function<?, ?> func -> func.apply(project) }
         return state
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.UnknownModelException
 import spock.lang.Specification
 
+import java.util.function.Function
 import java.util.function.Supplier
 
 class DefaultToolingModelBuilderRegistryTest extends Specification {
@@ -95,7 +96,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
         and:
         1 * buildOperationRunner.call(_) >> { CallableBuildOperation operation -> operation.call(Stub(BuildOperationContext)) }
-        1 * projectState.runWithModelLock(_) >> { Supplier supplier -> supplier.get() }
+        1 * projectState.fromMutableState(_) >> { Function<?, ?> func -> func.apply(project) }
         1 * application.reapply(_) >> { Supplier supplier -> supplier.get() }
         1 * builder2.buildAll("model", project) >> "result"
         0 * _
@@ -188,7 +189,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
         and:
         1 * buildOperationRunner.call(_) >> { CallableBuildOperation operation -> operation.call(Stub(BuildOperationContext)) }
-        1 * projectState.runWithModelLock (_) >> { Supplier supplier -> supplier.get() }
+        1 * projectState.fromMutableState(_) >> { Function<?, ?> func -> func.apply(project) }
         1 * builder.buildAll("model", "param", project) >> "result"
         0 * _
     }

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -26,6 +26,7 @@ import org.jspecify.annotations.NullMarked
 import org.jspecify.annotations.Nullable
 
 import java.util.function.BooleanSupplier
+import java.util.function.Supplier
 
 @NullMarked
 class TestWorkerLeaseService implements WorkerLeaseService {
@@ -111,8 +112,8 @@ class TestWorkerLeaseService implements WorkerLeaseService {
             }
 
             @Override
-            <T> T withLock(Factory<T> action) {
-                return action.create()
+            <T> T withLock(Supplier<T> action) {
+                return action.get()
             }
         }
     }


### PR DESCRIPTION
Instead of a mostly custom implementation, move custom locking logic to a Syncronizer, then wrap the mutable Project model in a ObjectGuard, which applies the synchronizer to it. Now, safe access to the project can be done through the guard.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
