### PR TITLE
Store cross-build task references as node ids in the Configuration Cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CachedBuildState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CachedBuildState.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.execution.plan.ScheduledWork
 import org.gradle.internal.build.BuildState
+import org.gradle.internal.serialize.codecs.core.RestoredWorkGraph
 import org.gradle.internal.serialize.graph.codecs.ValueObject
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal
 import org.gradle.util.Path
@@ -94,7 +94,7 @@ class BuildWithWork(
     val build: ConfigurationCacheBuild,
     rootProjectName: String,
     projects: List<CachedProjectState>,
-    val workGraph: ScheduledWork
+    val workGraph: RestoredWorkGraph
 ) : BuildWithProjects(identityPath, rootProjectName, projects)
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -73,7 +73,9 @@ import org.gradle.internal.file.FileSystemDefaultExcludesProvider
 import org.gradle.internal.flow.services.BuildFlowScope
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
+import org.gradle.internal.serialize.codecs.core.IdForNode
 import org.gradle.internal.serialize.codecs.core.IsolateContextSource
+import org.gradle.internal.serialize.codecs.core.assignNodeIds
 import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
@@ -312,7 +314,8 @@ class ConfigurationCacheState(
             }
         }
         val transformedProjectsPerBuild = collectTransformedProjectsPerBuild(scheduledWorkPerBuild)
-        val buildTreeState = StoredBuildTreeState(requiredBuildServicesPerBuild, scheduledWorkPerBuild, transformedProjectsPerBuild)
+        val idForNode = assignNodeIds(scheduledWorkPerBuild.values)
+        val buildTreeState = StoredBuildTreeState(requiredBuildServicesPerBuild, scheduledWorkPerBuild, idForNode, transformedProjectsPerBuild)
         writeCollection(builds.values) { build ->
             writeBuildState(build, buildTreeState)
         }
@@ -524,7 +527,7 @@ class ConfigurationCacheState(
             if (scheduledWork.scheduledNodes.isNotEmpty()) {
                 writeBoolean(true)
                 withDebugFrame({ "Work Graph" }) {
-                    writeWorkGraphOf(gradle, scheduledWork)
+                    writeWorkGraphOf(gradle, scheduledWork, buildTreeState.idForNode)
                 }
             } else {
                 writeBoolean(false)
@@ -568,17 +571,17 @@ class ConfigurationCacheState(
     }
 
     private
-    fun WriteContext.writeWorkGraphOf(gradle: GradleInternal, scheduledWork: ScheduledWork) {
+    fun WriteContext.writeWorkGraphOf(gradle: GradleInternal, scheduledWork: ScheduledWork, idForNode: IdForNode) {
         workNodeCodec(gradle).run {
-            writeWork(scheduledWork)
+            writeWork(scheduledWork, idForNode)
         }
     }
 
     private
-    fun ReadContext.readWorkGraph(gradle: GradleInternal) =
+    fun ReadContext.readWorkGraph(gradle: GradleInternal): ScheduledWork =
         workNodeCodec(gradle).run {
             readWork()
-        }
+        }.work
 
     private
     suspend fun WriteContext.writeFlowScopeOf(gradle: GradleInternal) {
@@ -1017,6 +1020,7 @@ internal
 class StoredBuildTreeState(
     val requiredBuildServicesPerBuild: Map<BuildIdentifier, List<BuildServiceProvider<*, *>>>,
     private val scheduledWorkPerBuild: Map<BuildIdentifier, ScheduledWork>,
+    val idForNode: IdForNode,
     val transformedProjectsPerBuild: Map<BuildIdentifier, Set<Path>>
 ) {
     fun getTransformedProjectsOfBuild(build: BuildState): Set<Path> =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -76,6 +76,7 @@ import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
 import org.gradle.internal.serialize.codecs.core.IdForNode
 import org.gradle.internal.serialize.codecs.core.IsolateContextSource
+import org.gradle.internal.serialize.codecs.core.RestoredTaskReference
 import org.gradle.internal.serialize.codecs.core.RestoredWorkGraph
 import org.gradle.internal.serialize.codecs.core.assignNodeIds
 import org.gradle.internal.serialize.graph.MutableReadContext
@@ -268,21 +269,34 @@ class ConfigurationCacheState(
     private
     fun bindRestoredTaskReferences(builds: List<CachedBuildState>) {
         val buildsWithWork = builds.filterIsInstance<BuildWithWork>()
-        // Node ids form a single dense, contiguous id space spanning the whole build tree, so each build's
-        // nodes can be scattered into one flat array indexed by global node id, giving O(1) target lookups.
-        val globalNodesById = arrayOfNulls<Node>(buildsWithWork.sumOf { it.workGraph.buildNodesById.size })
-        for (build in buildsWithWork) {
-            val workGraph = build.workGraph
-            workGraph.buildNodesById.copyInto(globalNodesById, destinationOffset = workGraph.baseNodeId)
-        }
         for (build in buildsWithWork) {
             for (reference in build.workGraph.taskReferences) {
-                val targetNode = requireNotNull(globalNodesById[reference.targetNodeId]) {
-                    "No node with id ${reference.targetNodeId} was restored for ${reference.node}"
-                }
-                reference.node.bindTarget(targetNode as TaskNode)
+                reference.node.bindTarget(targetNodeOf(buildsWithWork, reference) as TaskNode)
             }
         }
+    }
+
+    /**
+     * Finds the restored node targeted by the given reference.
+     *
+     * Node ids form a single dense, contiguous id space spanning the whole build tree, and builds are
+     * stored in ascending [RestoredWorkGraph.baseNodeId] order, so the graph owning an id is found by
+     * walking the builds in order.
+     */
+    private
+    fun targetNodeOf(buildsWithWork: List<BuildWithWork>, reference: RestoredTaskReference): Node {
+        val nodeId = reference.targetNodeId
+        for (build in buildsWithWork) {
+            val workGraph = build.workGraph
+            val buildNodeId = nodeId - workGraph.baseNodeId
+            require(buildNodeId >= 0) {
+                "Builds are not stored in ascending base node id order, cannot find the node with id $nodeId targeted by ${reference.node}."
+            }
+            if (buildNodeId < workGraph.nodeCount) {
+                return workGraph.nodeForId(nodeId)
+            }
+        }
+        error("No node with id $nodeId was restored for ${reference.node}.")
     }
 
     private
@@ -342,9 +356,12 @@ class ConfigurationCacheState(
             }
         }
         val transformedProjectsPerBuild = collectTransformedProjectsPerBuild(scheduledWorkPerBuild)
-        val idForNode = assignNodeIds(scheduledWorkPerBuild.values)
+        val buildsToStore = builds.values.toList()
+        // Assign node ids in the order the builds are stored, so that the stored builds are always in
+        // ascending base node id order.
+        val idForNode = assignNodeIds(buildsToStore.map { scheduledWorkPerBuild.getValue(it.build.buildIdentifier) })
         val buildTreeState = StoredBuildTreeState(requiredBuildServicesPerBuild, scheduledWorkPerBuild, idForNode, transformedProjectsPerBuild)
-        writeCollection(builds.values) { build ->
+        writeCollection(buildsToStore) { build ->
             writeBuildState(build, buildTreeState)
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.cache.Cleanup
@@ -39,6 +40,7 @@ import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.caching.configuration.BuildCache
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.ScheduledWork
+import org.gradle.execution.plan.TaskNode
 import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.BuildStructureOperationProject
 import org.gradle.initialization.ProjectsIdentifiedProgressDetails
@@ -75,6 +77,7 @@ import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
 import org.gradle.internal.serialize.codecs.core.IdForNode
 import org.gradle.internal.serialize.codecs.core.IsolateContextSource
+import org.gradle.internal.serialize.codecs.core.RestoredWorkGraph
 import org.gradle.internal.serialize.codecs.core.assignNodeIds
 import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.ReadContext
@@ -205,6 +208,7 @@ class ConfigurationCacheState(
                 identifyBuild(build)
             }
         }
+        bindRestoredTaskReferences(builds)
         return originBuildInvocationId to calculateRootTaskGraph(builds, graph, graphBuilder)
     }
 
@@ -257,6 +261,28 @@ class ConfigurationCacheState(
         }
     }
 
+    /**
+     * Binds each restored reference to a task in another build to its restored target node.
+     * This can only be done once all builds in the tree have been loaded, as a reference may
+     * point into the work graph of a build that is loaded after the referencing build.
+     */
+    private
+    fun bindRestoredTaskReferences(builds: List<CachedBuildState>) {
+        val buildsWithWork = builds.filterIsInstance<BuildWithWork>()
+        val allNodesById = Int2ObjectOpenHashMap<Node>(buildsWithWork.sumOf { it.workGraph.nodesById.size })
+        for (build in buildsWithWork) {
+            allNodesById.putAll(build.workGraph.nodesById)
+        }
+        for (build in buildsWithWork) {
+            for (reference in build.workGraph.taskReferences) {
+                val targetNode = requireNotNull(allNodesById[reference.targetNodeId]) {
+                    "No node with id ${reference.targetNodeId} was restored for ${reference.node}"
+                }
+                reference.node.bindTarget(targetNode as TaskNode)
+            }
+        }
+    }
+
     private
     fun calculateRootTaskGraph(builds: List<CachedBuildState>, graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): BuildTreeWorkGraph.FinalizedGraph {
         return graph.scheduleWork { builder ->
@@ -266,7 +292,7 @@ class ConfigurationCacheState(
             for (build in builds) {
                 if (build is BuildWithWork) {
                     builder.withWorkGraph(build.build.state) {
-                        it.setScheduledWork(build.workGraph)
+                        it.setScheduledWork(build.workGraph.scheduledWork)
                     }
                 }
             }
@@ -578,10 +604,10 @@ class ConfigurationCacheState(
     }
 
     private
-    fun ReadContext.readWorkGraph(gradle: GradleInternal): ScheduledWork =
+    fun ReadContext.readWorkGraph(gradle: GradleInternal): RestoredWorkGraph =
         workNodeCodec(gradle).run {
             readWork()
-        }.work
+        }
 
     private
     suspend fun WriteContext.writeFlowScopeOf(gradle: GradleInternal) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -300,8 +300,10 @@ class ConfigurationCacheState(
     suspend fun WriteContext.writeBuildsInTree(buildEventListeners: List<RegisteredBuildServiceProvider<*, *>>) {
         val requiredBuildServicesPerBuild = buildEventListeners.groupBy { it.buildIdentifier }
         val builds = mutableMapOf<BuildState, BuildToStore>()
+        val scheduledWorkPerBuild = mutableMapOf<BuildIdentifier, ScheduledWork>()
         host.visitBuilds { state ->
             val gradle = state.mutableModel
+            scheduledWorkPerBuild[state.buildIdentifier] = gradle.taskGraph.collectScheduledWork()
             val hasScheduledWork = gradle.taskGraph.hasScheduledWork()
             builds[state] = BuildToStore(state, hasScheduledWork, hasChildren = gradle.isRootBuild)
             if (hasScheduledWork && state is StandAloneNestedBuild) {
@@ -309,17 +311,18 @@ class ConfigurationCacheState(
                 builds[state.owner] = builds.getValue(state.owner).hasChildren()
             }
         }
-        val buildTreeState = StoredBuildTreeState(requiredBuildServicesPerBuild, collectTransformedProjectsPerBuild(builds))
+        val transformedProjectsPerBuild = collectTransformedProjectsPerBuild(scheduledWorkPerBuild)
+        val buildTreeState = StoredBuildTreeState(requiredBuildServicesPerBuild, scheduledWorkPerBuild, transformedProjectsPerBuild)
         writeCollection(builds.values) { build ->
             writeBuildState(build, buildTreeState)
         }
     }
 
     private
-    fun collectTransformedProjectsPerBuild(builds: MutableMap<BuildState, BuildToStore>): Map<BuildIdentifier, Set<Path>> {
+    fun collectTransformedProjectsPerBuild(scheduledWorkPerBuild: Map<BuildIdentifier, ScheduledWork>): Map<BuildIdentifier, Set<Path>> {
         val result = mutableMapOf<BuildIdentifier, MutableSet<Path>>()
-        builds.keys.forEach { buildState ->
-            buildState.mutableModel.taskGraph.collectScheduledWork().scheduledNodes
+        scheduledWorkPerBuild.values.forEach { scheduledWork ->
+            scheduledWork.scheduledNodes
                 .asSequence()
                 .filterIsInstance<TransformStepNode>()
                 .forEach { node ->
@@ -504,7 +507,7 @@ class ConfigurationCacheState(
         val gradle = buildState.mutableModel
         if (buildState.isProjectsCreated) {
             writeBoolean(true)
-            val scheduledWork = gradle.taskGraph.collectScheduledWork()
+            val scheduledWork = buildTreeState.getScheduledWorkOfBuild(buildState)
             withDebugFrame({ "Gradle" }) {
                 writeGradleState(gradle)
                 val transformInputProjects = buildTreeState.getTransformedProjectsOfBuild(buildState)
@@ -1013,10 +1016,15 @@ class ConfigurationCacheState(
 internal
 class StoredBuildTreeState(
     val requiredBuildServicesPerBuild: Map<BuildIdentifier, List<BuildServiceProvider<*, *>>>,
+    private val scheduledWorkPerBuild: Map<BuildIdentifier, ScheduledWork>,
     val transformedProjectsPerBuild: Map<BuildIdentifier, Set<Path>>
 ) {
     fun getTransformedProjectsOfBuild(build: BuildState): Set<Path> =
         transformedProjectsPerBuild[build.buildIdentifier].orEmpty()
+
+    fun getScheduledWorkOfBuild(build: BuildState): ScheduledWork =
+        scheduledWorkPerBuild[build.buildIdentifier]
+            ?: error("No scheduled work snapshot for build '${build.identityPath}'")
 }
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.cache.Cleanup
@@ -269,13 +268,16 @@ class ConfigurationCacheState(
     private
     fun bindRestoredTaskReferences(builds: List<CachedBuildState>) {
         val buildsWithWork = builds.filterIsInstance<BuildWithWork>()
-        val allNodesById = Int2ObjectOpenHashMap<Node>(buildsWithWork.sumOf { it.workGraph.nodesById.size })
+        // Node ids form a single dense, contiguous id space spanning the whole build tree, so each build's
+        // nodes can be scattered into one flat array indexed by global node id, giving O(1) target lookups.
+        val globalNodesById = arrayOfNulls<Node>(buildsWithWork.sumOf { it.workGraph.buildNodesById.size })
         for (build in buildsWithWork) {
-            allNodesById.putAll(build.workGraph.nodesById)
+            val workGraph = build.workGraph
+            workGraph.buildNodesById.copyInto(globalNodesById, destinationOffset = workGraph.baseNodeId)
         }
         for (build in buildsWithWork) {
             for (reference in build.workGraph.taskReferences) {
-                val targetNode = requireNotNull(allNodesById[reference.targetNodeId]) {
+                val targetNode = requireNotNull(globalNodesById[reference.targetNodeId]) {
                     "No node with id ${reference.targetNodeId} was restored for ${reference.node}"
                 }
                 reference.node.bindTarget(targetNode as TaskNode)

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
 
     api(libs.kotlinStdlib)
     api(libs.slf4jApi)
-    api(libs.fastutil)
 
     implementation(projects.baseServicesGroovy)
     implementation(projects.beanSerializationServices)
@@ -62,6 +61,7 @@ dependencies {
 
     implementation(libs.asm)
     implementation(libs.commonsLang)
+    implementation(libs.fastutil)
     implementation(libs.groovy)
     implementation(libs.guava)
 

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     api(libs.kotlinStdlib)
     api(libs.slf4jApi)
+    api(libs.fastutil)
 
     implementation(projects.baseServicesGroovy)
     implementation(projects.beanSerializationServices)
@@ -61,7 +62,6 @@ dependencies {
 
     implementation(libs.asm)
     implementation(libs.commonsLang)
-    implementation(libs.fastutil)
     implementation(libs.groovy)
     implementation(libs.guava)
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskInAnotherBuildCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskInAnotherBuildCodec.kt
@@ -39,7 +39,7 @@ class TaskInAnotherBuildCodec(
     override suspend fun ReadContext.decode(): TaskInAnotherBuild {
         val taskPath = readString()
         val targetBuild = readNonNull<BuildIdentifier>()
-        return TaskInAnotherBuild.lazy(
+        return TaskInAnotherBuild.restored(
             taskPath,
             targetBuild,
             includedTaskGraph

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -18,8 +18,6 @@ package org.gradle.internal.serialize.codecs.core
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap
@@ -86,7 +84,10 @@ interface IsolateContextSource {
  */
 class RestoredWorkGraph(
     val scheduledWork: ScheduledWork,
-    val nodesById: Int2ObjectMap<Node>,
+    /** The global node id of this graph's first node in the build-tree-wide id space. */
+    val baseNodeId: Int,
+    /** This build's nodes, indexed by build node id (`globalNodeId - baseNodeId`). */
+    val buildNodesById: Array<Node>,
     val taskReferences: List<RestoredTaskReference>
 )
 
@@ -115,18 +116,27 @@ fun assignNodeIds(workGraphs: Iterable<ScheduledWork>): IdForNode {
             if (node is LocalTaskNode) {
                 // The prepareNode is not included as a scheduled node but is a dependency of
                 // scheduled task nodes. Also assign an ID for it here.
-                ids[node.prepareNode] = ids.size
+                ids.put(node.prepareNode, ids.size)
             }
         }
     }
     return { node ->
-        ids.getInt(node).also { id ->
-            require(id >= 0) {
+        ids.getInt(node).also { globalNodeId ->
+            require(globalNodeId >= 0) {
                 "Node id missing for node $node"
             }
         }
     }
 }
+
+
+/**
+ * The number of node ids assigned to a single build's work graph by [assignNodeIds]: one per scheduled node,
+ * plus one for each [LocalTaskNode]'s prepare node.
+ */
+private
+fun buildNodeCountOf(nodes: List<Node>): Int =
+    nodes.size + nodes.count { it is LocalTaskNode }
 
 
 class WorkNodeCodec(
@@ -155,7 +165,9 @@ class WorkNodeCodec(
     fun WriteContext.doWrite(work: ScheduledWork, idForNode: IdForNode) {
         val nodes = work.scheduledNodes
         val scheduledEntryNodeIds = entryNodeIdsOf(nodes, work.entryNodes, idForNode)
-        writeSmallInt(nodes.size)
+        val baseNodeId = idForNode(nodes.first())
+        writeSmallInt(baseNodeId)
+        writeSmallInt(buildNodeCountOf(nodes))
         val actionNodeSuccessors = writeNodes(nodes, idForNode)
         writeEntryNodes(scheduledEntryNodeIds)
         writeEdgesAndGroupMembership(nodes, actionNodeSuccessors, idForNode)
@@ -163,13 +175,10 @@ class WorkNodeCodec(
 
     private
     fun ReadContext.doRead(): RestoredWorkGraph {
-        val nodeCount = readSmallInt()
-        val nodesById = readNodes(nodeCount)
-        val nodeForId: NodeForId = { id ->
-            requireNotNull(nodesById[id]) {
-                "No node with id $id was restored"
-            }
-        }
+        val baseNodeId = readSmallInt()
+        val buildNodeCount = readSmallInt()
+        val buildNodesById = readNodes(baseNodeId, buildNodeCount)
+        val nodeForId: NodeForId = { globalNodeId -> buildNodesById[globalNodeId - baseNodeId] }
         val entryNodes = readEntryNodes(nodeForId)
         val taskReferences = mutableListOf<RestoredTaskReference>()
         val nodes = readEdgesAndGroupMembership(nodeForId, taskReferences)
@@ -178,7 +187,7 @@ class WorkNodeCodec(
             assert(it.scheduledNodes === nodes)
             assert(it.entryNodes === entryNodes)
         }
-        return RestoredWorkGraph(work, nodesById, taskReferences)
+        return RestoredWorkGraph(work, baseNodeId, buildNodesById, taskReferences)
     }
 
     private
@@ -263,14 +272,20 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readNodes(nodeIdCount: Int): Int2ObjectMap<Node> {
-        val nodesById = Int2ObjectOpenHashMap<Node>(nodeIdCount)
+    fun ReadContext.readNodes(baseNodeId: Int, buildNodeCount: Int): Array<Node> {
+        // Node ids of a work graph form a dense, contiguous range, so build into a temporary null-filled
+        // buffer (batches arrive out of order) and then validate every slot was filled exactly once.
+        val buildNodesById = arrayOfNulls<Node>(buildNodeCount)
         readNodeBatchesInParallel().forEach { batch ->
-            batch.forEach { (node, id) ->
-                nodesById.put(id, node)
+            batch.forEach { (node, globalNodeId) ->
+                buildNodesById[globalNodeId - baseNodeId] = node
             }
         }
-        return nodesById
+        return Array(buildNodeCount) { buildNodeId ->
+            requireNotNull(buildNodesById[buildNodeId]) {
+                "No node with id ${baseNodeId + buildNodeId} was restored"
+            }
+        }
     }
 
     private

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -18,6 +18,8 @@ package org.gradle.internal.serialize.codecs.core
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap
@@ -64,17 +66,53 @@ import org.gradle.internal.serialize.graph.writeCollection
 import org.gradle.util.Path
 import java.util.concurrent.atomic.AtomicReference
 
-private
 typealias NodeForId = (Int) -> Node
 
 
-private
 typealias IdForNode = (Node) -> Int
 
 
 interface IsolateContextSource {
     fun readContextFor(baseContext: ReadContext, path: Path): CloseableReadContext
     fun writeContextFor(baseContext: WriteContext, path: Path): CloseableWriteContext
+}
+
+
+/**
+ * The work graph restored from a build's state, along with each restored node indexed by its node id.
+ */
+class RestoredWorkGraph(
+    val work: ScheduledWork,
+    val nodesById: Int2ObjectMap<Node>
+)
+
+
+/**
+ * Assigns an ID to every node of the given work graphs, in a single id space spanning all graphs.
+ */
+fun assignNodeIds(workGraphs: Iterable<ScheduledWork>): IdForNode {
+    val ids = Object2IntOpenHashMap<Node>().apply {
+        defaultReturnValue(-1)
+    }
+    for (workGraph in workGraphs) {
+        for (node in workGraph.scheduledNodes) {
+            require(ids.put(node, ids.size) == -1) {
+                "$node is scheduled in more than one work graph"
+            }
+            if (node is LocalTaskNode) {
+                // The prepareNode is not included as a scheduled node but is a dependency of
+                // scheduled task nodes. Also assign an ID for it here.
+                ids[node.prepareNode] = ids.size
+            }
+        }
+    }
+    return { node ->
+        ids.getInt(node).also { id ->
+            require(id >= 0) {
+                "Node id missing for node $node"
+            }
+        }
+    }
 }
 
 
@@ -88,53 +126,45 @@ class WorkNodeCodec(
     private val parallelLoad: Boolean
 ) {
 
-    fun WriteContext.writeWork(work: ScheduledWork) {
+    fun WriteContext.writeWork(work: ScheduledWork, idForNode: IdForNode) {
         // Share bean instances across all nodes (except tasks, which have their own isolate)
         withGradleIsolate(owner, internalTypesCodec) {
-            doWrite(work)
+            doWrite(work, idForNode)
         }
     }
 
-    fun ReadContext.readWork(): ScheduledWork =
+    fun ReadContext.readWork(): RestoredWorkGraph =
         withGradleIsolate(owner, internalTypesCodec) {
             doRead()
         }
 
     private
-    fun WriteContext.doWrite(work: ScheduledWork) {
+    fun WriteContext.doWrite(work: ScheduledWork, idForNode: IdForNode) {
         val nodes = work.scheduledNodes
-        val entryNodes = work.entryNodes
-        val nodeCount = nodes.size
-        val scheduledNodeIds = Object2IntOpenHashMap<Node>(nodeCount).apply {
-            defaultReturnValue(-1)
-        }
-
-        val scheduledEntryNodeIds = assignNodeIds(scheduledNodeIds, nodes, entryNodes)
-        val idForNode: IdForNode = { node ->
-            scheduledNodeIds.getInt(node).also { nodeId ->
-                require(nodeId >= 0) {
-                    "Node id missing for node $node"
-                }
-            }
-        }
-
-        writeSmallInt(scheduledNodeIds.size)
+        val scheduledEntryNodeIds = entryNodeIdsOf(nodes, work.entryNodes, idForNode)
+        writeSmallInt(nodes.size)
         val actionNodeSuccessors = writeNodes(nodes, idForNode)
         writeEntryNodes(scheduledEntryNodeIds)
         writeEdgesAndGroupMembership(nodes, actionNodeSuccessors, idForNode)
     }
 
     private
-    fun ReadContext.doRead(): ScheduledWork {
-        val nodeIdCount = readSmallInt()
-        val nodeForId = readNodes(nodeIdCount)
+    fun ReadContext.doRead(): RestoredWorkGraph {
+        val nodeCount = readSmallInt()
+        val nodesById = readNodes(nodeCount)
+        val nodeForId: NodeForId = { id ->
+            requireNotNull(nodesById[id]) {
+                "No node with id $id was restored"
+            }
+        }
         val entryNodes = readEntryNodes(nodeForId)
         val nodes = readEdgesAndGroupMembership(nodeForId)
-        return ScheduledWork(nodes, entryNodes).also {
+        val work = ScheduledWork(nodes, entryNodes).also {
             // ensure no unnecessary copying happens (for performance)
             assert(it.scheduledNodes === nodes)
             assert(it.entryNodes === entryNodes)
         }
+        return RestoredWorkGraph(work, nodesById)
     }
 
     private
@@ -176,10 +206,10 @@ class WorkNodeCodec(
         }.build()
 
     private
-    fun assignNodeIds(
-        scheduledNodeIds: Object2IntOpenHashMap<Node>,
+    fun entryNodeIdsOf(
         nodes: List<Node>,
-        entryNodes: ImmutableSet<Node>
+        entryNodes: ImmutableSet<Node>,
+        idForNode: IdForNode
     ): List<Int> {
         // Not all entry nodes are always scheduled.
         // In particular, it happens when the entry node is a task of the included plugin build that runs as part of building the plugin.
@@ -187,13 +217,8 @@ class WorkNodeCodec(
         // Not restoring them as entry points doesn't affect the resulting execution plan.
         val scheduledEntryNodeIds = mutableListOf<Int>()
         nodes.forEach { node ->
-            val nodeId = scheduledNodeIds.size
-            scheduledNodeIds[node] = nodeId
             if (node in entryNodes) {
-                scheduledEntryNodeIds.add(nodeId)
-            }
-            if (node is LocalTaskNode) {
-                scheduledNodeIds[node.prepareNode] = scheduledNodeIds.size
+                scheduledEntryNodeIds.add(idForNode(node))
             }
         }
         return scheduledEntryNodeIds
@@ -215,14 +240,14 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readNodes(nodeIdCount: Int): NodeForId {
-        val nodesById = flatten(
-            readNodeBatchesInParallel().iterator(),
-            Array<Node?>(nodeIdCount) { null }
-        ) { (node, id) ->
-            this[id] = node
+    fun ReadContext.readNodes(nodeIdCount: Int): Int2ObjectMap<Node> {
+        val nodesById = Int2ObjectOpenHashMap<Node>(nodeIdCount)
+        readNodeBatchesInParallel().forEach { batch ->
+            batch.forEach { (node, id) ->
+                nodesById.put(id, node)
+            }
         }
-        return { id: Int -> nodesById[id]!! }
+        return nodesById
     }
 
     private

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -37,6 +37,7 @@ import org.gradle.execution.plan.OrdinalGroup
 import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.PostExecutionNodeAwareActionNode
 import org.gradle.execution.plan.ScheduledWork
+import org.gradle.execution.plan.TaskInAnotherBuild
 import org.gradle.execution.plan.TaskNode
 import org.gradle.internal.cc.base.exceptions.ConfigurationCacheException
 import org.gradle.internal.cc.base.serialize.withGradleIsolate
@@ -79,11 +80,23 @@ interface IsolateContextSource {
 
 
 /**
- * The work graph restored from a build's state, along with each restored node indexed by its node id.
+ * The work graph restored from a build's state, each restored node indexed by its node id and
+ * the restored references to task nodes in other builds, which are not yet to be bound to their
+ * target nodes.
  */
 class RestoredWorkGraph(
-    val work: ScheduledWork,
-    val nodesById: Int2ObjectMap<Node>
+    val scheduledWork: ScheduledWork,
+    val nodesById: Int2ObjectMap<Node>,
+    val taskReferences: List<RestoredTaskReference>
+)
+
+
+/**
+ * A restored [TaskInAnotherBuild] node, together with the id of its target node in another build's work graph.
+ */
+class RestoredTaskReference(
+    val node: TaskInAnotherBuild.Restored,
+    val targetNodeId: Int
 )
 
 
@@ -158,13 +171,14 @@ class WorkNodeCodec(
             }
         }
         val entryNodes = readEntryNodes(nodeForId)
-        val nodes = readEdgesAndGroupMembership(nodeForId)
+        val taskReferences = mutableListOf<RestoredTaskReference>()
+        val nodes = readEdgesAndGroupMembership(nodeForId, taskReferences)
         val work = ScheduledWork(nodes, entryNodes).also {
             // ensure no unnecessary copying happens (for performance)
             assert(it.scheduledNodes === nodes)
             assert(it.entryNodes === entryNodes)
         }
-        return RestoredWorkGraph(work, nodesById)
+        return RestoredWorkGraph(work, nodesById, taskReferences)
     }
 
     private
@@ -193,15 +207,24 @@ class WorkNodeCodec(
             writeSmallInt(idForNode(node))
             writeSuccessorReferencesOf(node, actionNodeSuccessors, idForNode)
             writeNodeGroup(node.group, idForNode)
+            if (node is TaskInAnotherBuild) {
+                // A stored reference always has a scheduled target. A reference whose target task has
+                // already executed is also complete, so the reference is never part of the stored work graph.
+                writeSmallInt(idForNode(node.targetNode))
+            }
         }
     }
 
     private
-    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId): List<Node> =
+    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId, taskReferences: MutableList<RestoredTaskReference>): List<Node> =
         buildCollection({ ImmutableList.builderWithExpectedSize<Node>(it) }) {
             val node = nodeForId(readSmallInt())
             readSuccessorReferencesOf(node, nodeForId)
             node.group = readNodeGroup(nodeForId)
+            if (node is TaskInAnotherBuild) {
+                val targetNodeId = readSmallInt()
+                taskReferences.add(RestoredTaskReference(node as TaskInAnotherBuild.Restored, targetNodeId))
+            }
             add(node)
         }.build()
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -78,7 +78,7 @@ interface IsolateContextSource {
 
 
 /**
- * The work graph restored from a build's state, each restored node indexed by its node id and
+ * The work graph restored from a build's state, the ids of the nodes it owns, and
  * the restored references to task nodes in other builds, which are not yet to be bound to their
  * target nodes.
  */
@@ -86,8 +86,10 @@ class RestoredWorkGraph(
     val scheduledWork: ScheduledWork,
     /** The global node id of this graph's first node in the build-tree-wide id space. */
     val baseNodeId: Int,
-    /** This build's nodes, indexed by build node id (`globalNodeId - baseNodeId`). */
-    val buildNodesById: Array<Node>,
+    /** The number of node ids owned by this graph. */
+    val nodeCount: Int,
+    /** Returns the node with the given global node id, which must be one of the ids owned by this graph. */
+    val nodeForId: NodeForId,
     val taskReferences: List<RestoredTaskReference>
 )
 
@@ -177,17 +179,16 @@ class WorkNodeCodec(
     fun ReadContext.doRead(): RestoredWorkGraph {
         val baseNodeId = readSmallInt()
         val buildNodeCount = readSmallInt()
-        val buildNodesById = readNodes(baseNodeId, buildNodeCount)
-        val nodeForId: NodeForId = { globalNodeId -> buildNodesById[globalNodeId - baseNodeId] }
-        val entryNodes = readEntryNodes(nodeForId)
+        val nodesForId = readNodes(baseNodeId, buildNodeCount)
+        val entryNodes = readEntryNodes(nodesForId)
         val taskReferences = mutableListOf<RestoredTaskReference>()
-        val nodes = readEdgesAndGroupMembership(nodeForId, taskReferences)
+        val nodes = readEdgesAndGroupMembership(nodesForId, taskReferences)
         val work = ScheduledWork(nodes, entryNodes).also {
             // ensure no unnecessary copying happens (for performance)
             assert(it.scheduledNodes === nodes)
             assert(it.entryNodes === entryNodes)
         }
-        return RestoredWorkGraph(work, baseNodeId, buildNodesById, taskReferences)
+        return RestoredWorkGraph(work, baseNodeId, buildNodeCount, nodesForId, taskReferences)
     }
 
     private
@@ -272,20 +273,17 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readNodes(baseNodeId: Int, buildNodeCount: Int): Array<Node> {
-        // Node ids of a work graph form a dense, contiguous range, so build into a temporary null-filled
-        // buffer (batches arrive out of order) and then validate every slot was filled exactly once.
-        val buildNodesById = arrayOfNulls<Node>(buildNodeCount)
+    fun ReadContext.readNodes(baseNodeId: Int, buildNodeCount: Int): NodeForId {
+        // Node ids of a work graph form a dense, contiguous range, so fill a null-initialized array
+        // indexed by build node id (batches arrive out of order).
+        val nullableNodesById = arrayOfNulls<Node>(buildNodeCount)
         readNodeBatchesInParallel().forEach { batch ->
             batch.forEach { (node, globalNodeId) ->
-                buildNodesById[globalNodeId - baseNodeId] = node
+                nullableNodesById[globalNodeId - baseNodeId] = node
             }
         }
-        return Array(buildNodeCount) { buildNodeId ->
-            requireNotNull(buildNodesById[buildNodeId]) {
-                "No node with id ${baseNodeId + buildNodeId} was restored"
-            }
-        }
+        val buildNodesById: Array<Node> = nullableNodesById.requireNoNulls()
+        return { globalNodeId -> buildNodesById[globalNodeId - baseNodeId] }
     }
 
     private

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -209,6 +209,150 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractIntegrati
         order << ['lib', 'util'].permutations()
     }
 
+    def "multiple builds can depend on the same task of another included build"() {
+        given:
+        settingsFile("""
+            includeBuild("a")
+            includeBuild("b")
+            includeBuild("shared")
+        """)
+
+        buildFile("""
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation("com.example:a:1.0")
+                implementation("com.example:b:1.0")
+            }
+        """)
+
+        file("src/main/java/Root.java") << "public class Root {}"
+
+        ["a", "b"].each { name ->
+            createDir(name) {
+                file("settings.gradle") << "rootProject.name = '$name'"
+                file('build.gradle') << """
+                    plugins {
+                        id("java-library")
+                    }
+                    group = "com.example"
+                    version = "1.0"
+                    dependencies {
+                        api("com.example:shared:1.0")
+                    }
+                """
+                file("src/main/java/${name.toUpperCase()}.java") << "public class ${name.toUpperCase()} {}"
+            }
+        }
+
+        createDir("shared") {
+            file("settings.gradle") << "rootProject.name = 'shared'"
+            file("build.gradle") << """
+                plugins {
+                    id("java-library")
+                }
+                group = "com.example"
+                version = "1.0"
+            """
+            file("src/main/java/Shared.java") << "public class Shared {}"
+        }
+
+        when:
+        succeeds("compileJava")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        file("shared/src/main/java/Shared.java").text = "public class Shared { public static final int CHANGED = 1; }"
+
+        and:
+        succeeds("compileJava")
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        result.assertTaskExecuted(":shared:compileJava")
+        result.assertTaskOrder(":shared:compileJava", ":a:compileJava", ":compileJava")
+        result.assertTaskOrder(":shared:compileJava", ":b:compileJava", ":compileJava")
+    }
+
+    def "can depend on task of included plugin build that already ran at configuration time"() {
+        given:
+        createDir("build-logic") {
+            file("settings.gradle") << "rootProject.name = 'build-logic'"
+            file("build.gradle") << """
+                plugins {
+                    id("java-gradle-plugin")
+                }
+                gradlePlugin {
+                    plugins {
+                        p {
+                            id = "test.plugin"
+                            implementationClass = "test.PluginImpl"
+                        }
+                    }
+                }
+                tasks.register("notInvolvedInBuildLogic") {
+                    doLast {
+                        println("notInvolvedInBuildLogic ran")
+                    }
+                }
+            """
+            file("src/main/java/test/PluginImpl.java") << """
+                package test;
+
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+
+                public class PluginImpl implements Plugin<Project> {
+                    public void apply(Project project) { }
+                }
+            """
+        }
+
+        settingsFile("""
+            includeBuild("build-logic")
+        """)
+
+        buildFile("""
+            plugins {
+                id("test.plugin")
+            }
+            def buildLogic = gradle.includedBuild("build-logic")
+            tasks.register("consume") {
+                // Ran at configuration time already, in order to build the plugin
+                dependsOn(buildLogic.task(":jar"))
+                // Not part of the build logic. Only scheduled in the main work graph, so the
+                // build-logic build stores a work graph that does not contain the jar task
+                dependsOn(buildLogic.task(":notInvolvedInBuildLogic"))
+                doLast {
+                    println("consume ran")
+                }
+            }
+        """)
+
+        when:
+        succeeds("consume")
+
+        then:
+        configurationCache.assertStateStored()
+        result.assertTaskExecuted(":build-logic:jar")
+        result.assertTaskExecuted(":build-logic:notInvolvedInBuildLogic")
+        result.assertTaskExecuted(":consume")
+
+        when:
+        succeeds("consume")
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        result.assertTasksExecuted(":build-logic:notInvolvedInBuildLogic", ":consume")
+    }
+
     private static withDevelocityPlugin(TestFile settingsDir) {
         ApplyDevelocityPluginFixture.applyDevelocityPlugin(
             settingsDir.file('settings.gradle')

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -167,8 +167,8 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
         }
 
         @Override
-        public void scheduleTasks(Collection<TaskIdentifier.TaskBasedTaskIdentifier> tasksToBuild) {
-            for (TaskIdentifier.TaskBasedTaskIdentifier identifier : tasksToBuild) {
+        public void scheduleTasks(Collection<TaskIdentifier> tasksToBuild) {
+            for (TaskIdentifier identifier : tasksToBuild) {
                 // This check should live lower down, and should have some kind of synchronization around it, as other threads may be
                 // running tasks at the same time
                 if (identifier.getTask().getState().getExecuted()) {

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.composite.internal
 
 import org.gradle.api.artifacts.component.BuildIdentifier
+import org.gradle.api.internal.TaskInternal
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.BuildWorkGraphController
@@ -34,8 +35,11 @@ abstract class AbstractIncludedBuildTaskGraphTest extends ConcurrentSpec {
         return build
     }
 
-    static TaskIdentifier taskIdentifier(BuildIdentifier id, String taskPath) {
-        return TaskIdentifier.of(id, taskPath)
+    TaskIdentifier taskIdentifier(BuildIdentifier id, String taskPath) {
+        def task = Stub(TaskInternal) {
+            getPath() >> taskPath
+        }
+        return new TaskIdentifier(id, task)
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/BuildLogicBuildQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/BuildLogicBuildQueue.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 @ServiceScope(Scope.BuildTree.class)
 public interface BuildLogicBuildQueue {
 
-    <T> T build(BuildState requester, List<TaskIdentifier.TaskBasedTaskIdentifier> tasks, Supplier<T> continuationUnderLock);
+    <T> T build(BuildState requester, List<TaskIdentifier> tasks, Supplier<T> continuationUnderLock);
 
     <T> T buildBuildSrc(StandAloneNestedBuild buildSrcBuild, Function<BuildTreeLifecycleController, T> continuationUnderLock);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuildQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuildQueue.java
@@ -63,12 +63,12 @@ public class DefaultBuildLogicBuildQueue implements BuildLogicBuildQueue {
     }
 
     @Override
-    public <T> T build(BuildState requester, List<TaskIdentifier.TaskBasedTaskIdentifier> tasks, Supplier<T> continuationUnderLock) {
+    public <T> T build(BuildState requester, List<TaskIdentifier> tasks, Supplier<T> continuationUnderLock) {
         if (tasks.isEmpty()) {
             // no resources to be protected
             return continuationUnderLock.get();
         }
-        List<TaskIdentifier.TaskBasedTaskIdentifier> remaining = removeExecuted(tasks);
+        List<TaskIdentifier> remaining = removeExecuted(tasks);
         if (remaining.isEmpty()) {
             // all tasks already executed
             return continuationUnderLock.get();
@@ -85,7 +85,7 @@ public class DefaultBuildLogicBuildQueue implements BuildLogicBuildQueue {
         return withBuildLogicQueueLock(() -> buildSrcBuild.run(continuationUnderLock));
     }
 
-    private <T> T doBuild(List<TaskIdentifier.TaskBasedTaskIdentifier> tasks, Supplier<T> continuationUnderLock) {
+    private <T> T doBuild(List<TaskIdentifier> tasks, Supplier<T> continuationUnderLock) {
         buildTreeWorkGraphController.withNewWorkGraph(graph -> {
             graph
                 .scheduleWork(builder -> builder.scheduleTasks(tasks))
@@ -134,7 +134,7 @@ public class DefaultBuildLogicBuildQueue implements BuildLogicBuildQueue {
         );
     }
 
-    private static List<TaskIdentifier.TaskBasedTaskIdentifier> removeExecuted(List<TaskIdentifier.TaskBasedTaskIdentifier> tasks) {
+    private static List<TaskIdentifier> removeExecuted(List<TaskIdentifier> tasks) {
         return tasks.stream()
             .filter(identifier -> !identifier.getTask().getState().getExecuted())
             .collect(Collectors.toList());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
@@ -82,14 +82,14 @@ public class DefaultBuildLogicBuilder implements BuildLogicBuilder {
         });
     }
 
-    private List<TaskIdentifier.TaskBasedTaskIdentifier> taskIdentifiersForBuildDependenciesOf(Configuration classpath) {
-        List<TaskIdentifier.TaskBasedTaskIdentifier> tasksToBuild = new ArrayList<>();
+    private List<TaskIdentifier> taskIdentifiersForBuildDependenciesOf(Configuration classpath) {
+        List<TaskIdentifier> tasksToBuild = new ArrayList<>();
         for (Task task : getDependenciesForInternalUse(classpath)) {
             BuildState targetBuild = owningBuildOf(task);
             if (targetBuild == currentBuild) {
                 throw new InvalidUserDataException("Script classpath dependencies must reside in a separate build from the script itself.");
             }
-            tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task));
+            tasksToBuild.add(new TaskIdentifier(targetBuild.getBuildIdentifier(), (TaskInternal) task));
         }
         return tasksToBuild;
     }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
@@ -19,45 +19,26 @@ package org.gradle.composite.internal;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 
-public interface TaskIdentifier {
-    BuildIdentifier getBuildIdentifier();
+public class TaskIdentifier {
 
-    String getTaskPath();
+    private final BuildIdentifier buildIdentifier;
+    private final TaskInternal task;
 
-    interface TaskBasedTaskIdentifier extends TaskIdentifier {
-        TaskInternal getTask();
+    public TaskIdentifier(BuildIdentifier buildIdentifier, TaskInternal task) {
+        this.buildIdentifier = buildIdentifier;
+        this.task = task;
     }
 
-    static TaskBasedTaskIdentifier of(BuildIdentifier buildIdentifier, TaskInternal task) {
-        return new TaskBasedTaskIdentifier() {
-            @Override
-            public BuildIdentifier getBuildIdentifier() {
-                return buildIdentifier;
-            }
-
-            @Override
-            public TaskInternal getTask() {
-                return task;
-            }
-
-            @Override
-            public String getTaskPath() {
-                return task.getPath();
-            }
-        };
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
     }
 
-    static TaskIdentifier of(BuildIdentifier buildIdentifier, String taskPath) {
-        return new TaskIdentifier() {
-            @Override
-            public BuildIdentifier getBuildIdentifier() {
-                return buildIdentifier;
-            }
-
-            @Override
-            public String getTaskPath() {
-                return taskPath;
-            }
-        };
+    public TaskInternal getTask() {
+        return task;
     }
+
+    public String getTaskPath() {
+        return task.getPath();
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -39,7 +39,7 @@ public abstract class TaskInAnotherBuild extends TaskNode implements SelfExecuti
         BuildTreeWorkGraphController taskGraph
     ) {
         BuildIdentifier targetBuild = buildIdentifierOf(task);
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task);
+        TaskIdentifier taskIdentifier = new TaskIdentifier(targetBuild, task);
         IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild) {
             @Override
@@ -50,30 +50,66 @@ public abstract class TaskInAnotherBuild extends TaskNode implements SelfExecuti
     }
 
     /**
-     * Creates a lazy reference to a task in another build.
+     * Creates a reference to a task in another build, restored from the configuration cache.
      *
-     * The task will be located on-demand to allow for cycles between builds stored to
-     * the configuration cache.
+     * The reference must be {@link Restored#bindTarget bound} to its restored target node once all
+     * builds in the tree have been loaded. The target task is located on-demand, once the work graph
+     * is being scheduled, to allow for cycles between builds stored to the configuration cache.
      *
      * @param taskPath the path to the task relative to its build
      * @param targetBuild the build containing the task
      * @param taskGraph the task graph where the task should be located
-     * @return a lazy reference to the given task.
      */
-    public static TaskInAnotherBuild lazy(
+    public static Restored restored(
         String taskPath,
         BuildIdentifier targetBuild,
         BuildTreeWorkGraphController taskGraph
     ) {
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, taskPath);
         Path taskIdentityPath = Path.path(targetBuild.getBuildPath()).append(Path.path(taskPath));
-        Lazy<IncludedBuildTaskResource> target = Lazy.unsafe().of(() -> taskGraph.locateTask(taskIdentifier));
-        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild) {
-            @Override
-            protected IncludedBuildTaskResource getTarget() {
-                return target.get();
+        return new Restored(taskIdentityPath, taskPath, targetBuild, taskGraph);
+    }
+
+    /**
+     * A reference restored from the configuration cache.
+     */
+    public static class Restored extends TaskInAnotherBuild {
+
+        private final BuildTreeWorkGraphController taskGraph;
+        private final Lazy<IncludedBuildTaskResource> target;
+
+        private @Nullable TaskNode targetNode;
+
+        private Restored(
+            Path taskIdentityPath,
+            String taskPath,
+            BuildIdentifier targetBuild,
+            BuildTreeWorkGraphController taskGraph
+        ) {
+            super(taskIdentityPath, taskPath, targetBuild);
+            this.taskGraph = taskGraph;
+
+            this.target = Lazy.unsafe().of(this::locateTarget);
+        }
+
+        /**
+         * Binds this reference to its restored target node.
+         */
+        public void bindTarget(TaskNode targetNode) {
+            this.targetNode = targetNode;
+        }
+
+        private IncludedBuildTaskResource locateTarget() {
+            if (targetNode == null) {
+                throw new IllegalStateException("No target node has been bound for " + this);
             }
-        };
+            return taskGraph.locateTask(new TaskIdentifier(getTargetBuild(), targetNode.getTask()));
+        }
+
+        @Override
+        protected IncludedBuildTaskResource getTarget() {
+            return target.get();
+        }
+
     }
 
     private IncludedBuildTaskResource.State taskState = IncludedBuildTaskResource.State.Scheduled;

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
@@ -31,7 +31,6 @@ import org.gradle.execution.plan.TaskNode;
 import org.gradle.execution.plan.TaskNodeFactory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.work.WorkerLeaseService;
-import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,9 +74,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
     @Override
     public ExportedTaskNode locateTask(TaskIdentifier taskIdentifier) {
         DefaultExportedTaskNode node = doLocate(taskIdentifier);
-        if (taskIdentifier instanceof TaskIdentifier.TaskBasedTaskIdentifier) {
-            node.maybeBindTask(((TaskIdentifier.TaskBasedTaskIdentifier) taskIdentifier).getTask());
-        }
+        node.maybeBindTask(taskIdentifier.getTask());
         return node;
     }
 
@@ -102,16 +99,6 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
 
     private DefaultExportedTaskNode doLocate(TaskIdentifier taskIdentifier) {
         return nodesByPath.computeIfAbsent(taskIdentifier.getTaskPath(), DefaultExportedTaskNode::new);
-    }
-
-    @Nullable
-    private TaskInternal findTaskNode(String taskPath) {
-        for (Task task : taskNodeFactory.getTasks()) {
-            if (task.getPath().equals(taskPath)) {
-                return (TaskInternal) task;
-            }
-        }
-        return null;
     }
 
     private class DefaultBuildWorkGraph implements BuildWorkGraph {
@@ -267,11 +254,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
         public TaskNode getTaskNode() {
             synchronized (lock) {
                 if (taskNode == null) {
-                    TaskInternal task = findTaskNode(taskPath);
-                    if (task == null) {
-                        throw new IllegalStateException("Task '" + taskPath + "' was never scheduled for execution.");
-                    }
-                    taskNode = taskNodeFactory.getOrCreateNode(task);
+                    throw new IllegalStateException("No task has been bound for task node '" + taskPath + "'.");
                 }
                 return taskNode;
             }
@@ -285,14 +268,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
         @Override
         public IncludedBuildTaskResource.State getTaskState() {
             synchronized (lock) {
-                if (taskNode == null) {
-                    TaskInternal task = findTaskNode(taskPath);
-                    if (task == null) {
-                        // Assume not scheduled yet
-                        return IncludedBuildTaskResource.State.NotScheduled;
-                    }
-                    taskNode = taskNodeFactory.getOrCreateNode(task);
-                }
+                TaskNode taskNode = getTaskNode();
                 if (taskNode.isExecuted() && taskNode.isSuccessful()) {
                     return IncludedBuildTaskResource.State.Success;
                 } else if (taskNode.isExecuted()) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkGraph.java
@@ -59,7 +59,7 @@ public interface BuildTreeWorkGraph {
         /**
          * Adds the given tasks and their dependencies to the work graph.
          */
-        void scheduleTasks(Collection<TaskIdentifier.TaskBasedTaskIdentifier> tasksToBuild);
+        void scheduleTasks(Collection<TaskIdentifier> tasksToBuild);
 
         /**
          * Adds add task filter to the given build.


### PR DESCRIPTION
Groundwork for eventually replacing the per-build work-graph coordination
(`TaskInAnotherBuild`, `ExportedTaskNode`) with work graphs that span the build tree. 

Node IDs are now assigned from a single ID space spanning all builds in the tree, and a
`TaskInAnotherBuild` reference is stored as the node id of its target instead of
`(taskPath, buildIdentifier)`. These node IDs are assigned up-front and written to the CC at store time. During load, we bind tasks to restored `TaskInAnotherBuild` directly using the global node ID rather than looking up the tasks in the target build's work graph.

It seems a stored `TaskInAnotherBuild` always references a real `TaskNode`. The `TaskInAnotherBuild` is excluded from the execution plan if the target node in the other build has already executed. This means we can always be sure the target task is present in the restored CC work graph when binding a task to a restored `TaskInAnotherBuild`. This allowed us to remove the previous path-based task lookup entirely.

This change makes it so CC no longer cares which build a task is from. This opens the door to the scheduler creating unified work graphs for a single build tree rather than segregating what would be a single work graph into several build-scoped work graphs.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
