### PR TITLE
Give the smoke-test distribution a content-derived version

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -4,10 +4,22 @@ import common.FlakyTestStrategy
 import common.JvmCategory
 import common.Os
 import common.buildScanTagParam
+import common.buildToolGradleParameters
+import common.functionalTestParameters
 import common.getBuildScanCustomValueParam
+import common.gradleWrapper
 import common.toCapitalized
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import model.CIBuildModel
 import model.Stage
+
+/*
+ * The values below must stay in sync with Gradleception: using the same fixed timestamp and the same
+ * `gradleception-` qualifier prefix means an identical source tree yields an identical version string in
+ * both build types, so they share build cache entries instead of each populating its own namespace.
+ */
+private const val DOGFOOD_TIMESTAMP = "19800101010101+0000"
+private const val DOGFOOD_INSTALL_DIR = "dogfood-for-hash"
 
 class SmokeTests(
     model: CIBuildModel,
@@ -17,6 +29,26 @@ class SmokeTests(
     task: String = "smokeTest",
     splitNumber: Int = 1,
     flakyTestStrategy: FlakyTestStrategy,
+    /**
+     * Give the distribution under test a version derived from its own contents instead of a wall-clock
+     * timestamp. Only worth it for the smoke tests that run nested Gradle builds (`gradleBuildSmokeTest`).
+     *
+     * Those nested builds execute with the distribution this build produces, and the build cache key of
+     * every cacheable task embeds the version of the executing Gradle: `RegistryAwareClassLoaderHierarchyHasher`
+     * identifies the Gradle runtime classloaders as `"runtime:$gradleVersion"`, which feeds each task's
+     * implementation hash. With the default wall-clock timestamp that version is unique per CI run, so every
+     * run gets a private cache namespace and the nested builds recompile Gradle from scratch - measured at
+     * ~5% task avoidance, ~12min for a single test method.
+     *
+     * Gradleception already solves this (see [Gradleception]): build a throwaway distribution with a fixed
+     * timestamp, hash it, then use that hash as the version qualifier. The version then depends only on the
+     * distribution's contents, so runs whose sources produce identical distributions reuse each other's cache
+     * entries, while genuinely different distributions still get distinct versions - which matters because the
+     * smoke tests share (and the artifact cache restores) one integration-test Gradle user home, whose
+     * version-scoped caches would otherwise be at risk of serving content from a different distribution.
+     * Gradleception measures ~87% task avoidance with this scheme.
+     */
+    deterministicDistributionVersion: Boolean = false,
 ) : OsAwareBaseGradleBuildType(os = Os.LINUX, stage = stage, init = {
         val suffix = if (flakyTestStrategy == FlakyTestStrategy.ONLY) "_FlakyTestQuarantine" else ""
         id("${model.projectId}_SmokeTest_$id$suffix")
@@ -28,18 +60,62 @@ class SmokeTests(
             tcParallelTests(splitNumber)
         }
 
+        if (deterministicDistributionVersion) {
+            params {
+                // Override the default commit id so the build steps produce a reproducible distribution.
+                param("env.BUILD_COMMIT_ID", "HEAD")
+            }
+        }
+
+        val deterministicVersionParameters =
+            if (deterministicDistributionVersion) {
+                listOf("-PignoreIncomingBuildReceipt=true", "-PbuildTimestamp=$DOGFOOD_TIMESTAMP")
+            } else {
+                emptyList()
+            }
+
         applyTestDefaults(
             model,
             this,
             ":smoke-test:$task",
             timeout = if (flakyTestStrategy == FlakyTestStrategy.ONLY) 30 else 120,
             extraParameters =
-                listOf(
-                    stage.getBuildScanCustomValueParam(),
-                    buildScanTagParam("SmokeTests"),
-                    "-PtestJavaVersion=${testJava.version.major}",
-                    "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
-                    "-PflakyTests=$flakyTestStrategy",
+                (
+                    listOf(
+                        stage.getBuildScanCustomValueParam(),
+                        buildScanTagParam("SmokeTests"),
+                        "-PtestJavaVersion=${testJava.version.major}",
+                        "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
+                        "-PflakyTests=$flakyTestStrategy",
+                    ) + deterministicVersionParameters
                 ).joinToString(" "),
+            preSteps = {
+                if (deterministicDistributionVersion) {
+                    // Runs with the wrapper, i.e. with the released Gradle the rest of CI uses, so this step
+                    // itself hits the remote cache the same way CompileAll does.
+                    gradleWrapper {
+                        name = "BUILD_DISTRIBUTION_TO_HASH"
+                        tasks = "clean :distributions-full:install"
+                        gradleParams =
+                            (
+                                buildToolGradleParameters() +
+                                    listOf(
+                                        "-Pgradle_installPath=$DOGFOOD_INSTALL_DIR",
+                                        buildScanTagParam("SmokeTests"),
+                                    ) + deterministicVersionParameters + functionalTestParameters(Os.LINUX)
+                            ).joinToString(" ")
+                    }
+                    script {
+                        name = "CALCULATE_MD5_VERSION_FOR_DISTRIBUTION_UNDER_TEST"
+                        workingDir = "%teamcity.build.checkoutDir%/$DOGFOOD_INSTALL_DIR"
+                        scriptContent =
+                            """
+                            set -x
+                            MD5=`find . -type f | sort | xargs md5sum | md5sum | awk '{ print $1 }'`
+                            echo "##teamcity[setParameter name='env.ORG_GRADLE_PROJECT_versionQualifier' value='gradleception-${'$'}MD5']"
+                            """.trimIndent()
+                    }
+                }
+            },
         )
     })

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -14,13 +14,38 @@ import model.CIBuildModel
 import model.Stage
 
 /*
- * The values below must stay in sync with Gradleception: using the same fixed timestamp and the same
- * `gradleception-` qualifier prefix means an identical source tree yields an identical version string in
- * both build types, so they share build cache entries instead of each populating its own namespace.
+ * Must stay in sync with Gradleception: the same fixed timestamp and the same `gradleception-` qualifier
+ * prefix mean an identical source tree yields an identical version string in both build types, so they
+ * share build cache entries instead of each populating its own namespace.
  */
 private const val DOGFOOD_TIMESTAMP = "19800101010101+0000"
 private const val DOGFOOD_INSTALL_DIR = "dogfood-for-hash"
 
+/**
+ * Smoke tests run against the Gradle distribution this build produces, so that distribution's version
+ * decides what they can reuse - and by default it carried a wall-clock build timestamp, unique per CI run.
+ *
+ * Two consequences, both of which this build works around by giving the distribution a version derived from
+ * its own contents (a fixed timestamp plus the MD5 of a throwaway install, exactly as [Gradleception] does):
+ *
+ * 1. `DistributionTest.gradleDistribution` is a `@get:Nested` task input, so a distribution that differs on
+ *    every run made every `SmokeTest` task's inputs differ on every run. Despite `SmokeTest` being declared
+ *    `@CacheableTask`, no smoke test task ever hit the cache. Now an unchanged distribution and unchanged
+ *    test code mean the whole task is served from the cache.
+ *
+ * 2. For the smoke tests whose nested builds are gradle/gradle itself (`gradleBuildSmokeTest`), the build
+ *    cache key of every cacheable task embeds the version of the *executing* Gradle:
+ *    `RegistryAwareClassLoaderHierarchyHasher` identifies the Gradle runtime classloaders as
+ *    `"runtime:$gradleVersion"`, which feeds each task's implementation hash. A per-run version gave each
+ *    run a private cache namespace, so those nested builds recompiled Gradle from scratch - 5.3% task
+ *    avoidance, 12min for a single test method.
+ *
+ * The version has to be derived from the distribution's contents rather than simply pinned to a constant.
+ * These tests share one integration-test Gradle user home which the artifact cache restores across builds,
+ * so a constant version could let its version-scoped caches (`caches/<version>/kotlin-dsl/scripts`) serve
+ * content compiled against a different distribution. Hashing the contents keeps distinct distributions on
+ * distinct versions.
+ */
 class SmokeTests(
     model: CIBuildModel,
     stage: Stage,
@@ -29,26 +54,6 @@ class SmokeTests(
     task: String = "smokeTest",
     splitNumber: Int = 1,
     flakyTestStrategy: FlakyTestStrategy,
-    /**
-     * Give the distribution under test a version derived from its own contents instead of a wall-clock
-     * timestamp. Only worth it for the smoke tests that run nested Gradle builds (`gradleBuildSmokeTest`).
-     *
-     * Those nested builds execute with the distribution this build produces, and the build cache key of
-     * every cacheable task embeds the version of the executing Gradle: `RegistryAwareClassLoaderHierarchyHasher`
-     * identifies the Gradle runtime classloaders as `"runtime:$gradleVersion"`, which feeds each task's
-     * implementation hash. With the default wall-clock timestamp that version is unique per CI run, so every
-     * run gets a private cache namespace and the nested builds recompile Gradle from scratch - measured at
-     * ~5% task avoidance, ~12min for a single test method.
-     *
-     * Gradleception already solves this (see [Gradleception]): build a throwaway distribution with a fixed
-     * timestamp, hash it, then use that hash as the version qualifier. The version then depends only on the
-     * distribution's contents, so runs whose sources produce identical distributions reuse each other's cache
-     * entries, while genuinely different distributions still get distinct versions - which matters because the
-     * smoke tests share (and the artifact cache restores) one integration-test Gradle user home, whose
-     * version-scoped caches would otherwise be at risk of serving content from a different distribution.
-     * Gradleception measures ~87% task avoidance with this scheme.
-     */
-    deterministicDistributionVersion: Boolean = false,
 ) : OsAwareBaseGradleBuildType(os = Os.LINUX, stage = stage, init = {
         val suffix = if (flakyTestStrategy == FlakyTestStrategy.ONLY) "_FlakyTestQuarantine" else ""
         id("${model.projectId}_SmokeTest_$id$suffix")
@@ -60,19 +65,12 @@ class SmokeTests(
             tcParallelTests(splitNumber)
         }
 
-        if (deterministicDistributionVersion) {
-            params {
-                // Override the default commit id so the build steps produce a reproducible distribution.
-                param("env.BUILD_COMMIT_ID", "HEAD")
-            }
+        params {
+            // Override the default commit id so the build steps produce a reproducible distribution.
+            param("env.BUILD_COMMIT_ID", "HEAD")
         }
 
-        val deterministicVersionParameters =
-            if (deterministicDistributionVersion) {
-                listOf("-PignoreIncomingBuildReceipt=true", "-PbuildTimestamp=$DOGFOOD_TIMESTAMP")
-            } else {
-                emptyList()
-            }
+        val reproducibleDistributionParameters = listOf("-PignoreIncomingBuildReceipt=true", "-PbuildTimestamp=$DOGFOOD_TIMESTAMP")
 
         applyTestDefaults(
             model,
@@ -87,34 +85,32 @@ class SmokeTests(
                         "-PtestJavaVersion=${testJava.version.major}",
                         "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
                         "-PflakyTests=$flakyTestStrategy",
-                    ) + deterministicVersionParameters
+                    ) + reproducibleDistributionParameters
                 ).joinToString(" "),
             preSteps = {
-                if (deterministicDistributionVersion) {
-                    // Runs with the wrapper, i.e. with the released Gradle the rest of CI uses, so this step
-                    // itself hits the remote cache the same way CompileAll does.
-                    gradleWrapper {
-                        name = "BUILD_DISTRIBUTION_TO_HASH"
-                        tasks = "clean :distributions-full:install"
-                        gradleParams =
-                            (
-                                buildToolGradleParameters() +
-                                    listOf(
-                                        "-Pgradle_installPath=$DOGFOOD_INSTALL_DIR",
-                                        buildScanTagParam("SmokeTests"),
-                                    ) + deterministicVersionParameters + functionalTestParameters(Os.LINUX)
-                            ).joinToString(" ")
-                    }
-                    script {
-                        name = "CALCULATE_MD5_VERSION_FOR_DISTRIBUTION_UNDER_TEST"
-                        workingDir = "%teamcity.build.checkoutDir%/$DOGFOOD_INSTALL_DIR"
-                        scriptContent =
-                            """
-                            set -x
-                            MD5=`find . -type f | sort | xargs md5sum | md5sum | awk '{ print $1 }'`
-                            echo "##teamcity[setParameter name='env.ORG_GRADLE_PROJECT_versionQualifier' value='gradleception-${'$'}MD5']"
-                            """.trimIndent()
-                    }
+                // Runs with the wrapper, i.e. with the released Gradle the rest of CI uses, so this step
+                // itself hits the remote cache the same way CompileAll does.
+                gradleWrapper {
+                    name = "BUILD_DISTRIBUTION_TO_HASH"
+                    tasks = "clean :distributions-full:install"
+                    gradleParams =
+                        (
+                            buildToolGradleParameters() +
+                                listOf(
+                                    "-Pgradle_installPath=$DOGFOOD_INSTALL_DIR",
+                                    buildScanTagParam("SmokeTests"),
+                                ) + reproducibleDistributionParameters + functionalTestParameters(Os.LINUX)
+                        ).joinToString(" ")
+                }
+                script {
+                    name = "CALCULATE_MD5_VERSION_FOR_DISTRIBUTION_UNDER_TEST"
+                    workingDir = "%teamcity.build.checkoutDir%/$DOGFOOD_INSTALL_DIR"
+                    scriptContent =
+                        """
+                        set -x
+                        MD5=`find . -type f | sort | xargs md5sum | md5sum | awk '{ print $1 }'`
+                        echo "##teamcity[setParameter name='env.ORG_GRADLE_PROJECT_versionQualifier' value='gradleception-${'$'}MD5']"
+                        """.trimIndent()
                 }
             },
         )

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -732,9 +732,6 @@ enum class SpecificBuild {
                 GRADLE_BUILD_SMOKE_TEST_NAME,
                 splitNumber = 4,
                 flakyTestStrategy = flakyTestStrategy,
-                // These are the only smoke tests that run nested Gradle builds against the distribution
-                // under test, so they are the only ones whose build cache hit rate depends on its version.
-                deterministicDistributionVersion = true,
             )
     },
     ConfigCacheSmokeTestsMinJavaVersion {

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -732,6 +732,9 @@ enum class SpecificBuild {
                 GRADLE_BUILD_SMOKE_TEST_NAME,
                 splitNumber = 4,
                 flakyTestStrategy = flakyTestStrategy,
+                // These are the only smoke tests that run nested Gradle builds against the distribution
+                // under test, so they are the only ones whose build cache hit rate depends on its version.
+                deterministicDistributionVersion = true,
             )
     },
     ConfigCacheSmokeTestsMinJavaVersion {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
@@ -21,16 +21,29 @@ import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
-import java.text.SimpleDateFormat
 
 @Requires([
     TestExecutionPreconditions.NotConfigCached,
 ])
 abstract class AbstractGradleceptionSmokeTest extends AbstractSmokeTest {
 
-    public static final String TEST_BUILD_TIMESTAMP = "-PbuildTimestamp=" + newTimestamp()
+    /**
+     * The version the nested build stamps on its own output. A wall-clock value changes on every test run,
+     * which invalidates the build cache entry of every task that embeds the version - the build receipt, the
+     * jars, the distribution zips. Pin it so those stay cacheable across runs.
+     *
+     * This is deliberately different from the timestamp the CI build configuration gives the distribution
+     * that *runs* these nested builds (see {@code SmokeTests.kt}), matching how Gradleception distinguishes
+     * its two dogfooding distributions. The version of the running distribution - not this one - is what
+     * determines the cache keys of the bulk of the nested build's tasks.
+     */
+    public static final String FIXED_BUILD_TIMESTAMP = "19800202020202+0000"
+    public static final String TEST_BUILD_TIMESTAMP = "-PbuildTimestamp=" + FIXED_BUILD_TIMESTAMP
     private static final String DISABLE_IP = "-Dorg.gradle.isolated-projects=false"
-    private static final List<String> GRADLE_BUILD_TEST_ARGS = [DISABLE_IP, TEST_BUILD_TIMESTAMP]
+    // The nested build is a fresh checkout with no incoming-distributions/, but be explicit: an incoming
+    // build receipt would silently win over TEST_BUILD_TIMESTAMP (see BuildTimestampValueSource).
+    private static final String IGNORE_INCOMING_BUILD_RECEIPT = "-PignoreIncomingBuildReceipt=true"
+    private static final List<String> GRADLE_BUILD_TEST_ARGS = [DISABLE_IP, TEST_BUILD_TIMESTAMP, IGNORE_INCOMING_BUILD_RECEIPT]
 
     private SmokeTestGradleRunner.SmokeTestBuildResult result
 
@@ -91,15 +104,5 @@ abstract class AbstractGradleceptionSmokeTest extends AbstractSmokeTest {
     private SmokeTestGradleRunner runnerWithTestKitDir(File testKitDir, List<String> gradleArgs) {
         runnerWithGradleUserHome(IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir, *(gradleArgs as String[]))
             .withTestKitDir(testKitDir)
-    }
-
-    private static String newTimestamp() {
-        newTimestampDateFormat().format(new Date())
-    }
-
-    static SimpleDateFormat newTimestampDateFormat() {
-        new SimpleDateFormat('yyyyMMddHHmmssZ').tap {
-            setTimeZone(TimeZone.getTimeZone("UTC"))
-        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/5101

> **Effect:** a full smoke-test pass drops from **553 min to 169 min** of batch run time (34 batches
> across 9 build types) when the Gradle distribution is unchanged, and `can build Gradle distribution`
> drops from **11.8 min to 3.0 min** when it isn't. Verified over two full runs of every smoke test
> build type — details under [Results](#results).

## Why

Follow-up to #38222 / https://github.com/gradle/gradle-private/issues/5263.

#38222 fixed dependency *downloading* for the smoke tests, and that part works: the nested builds in
`GradleBuild*SmokeTest` now download **0 MB**, and the `intTestHomeDir` restore brings back ~1 GiB in
about 8s. But the tests were still slow — [example](https://ge.gradle.org/s/qy26yekqy3vww/tests/overview),
`can build Gradle distribution` alone taking 12 min — for a completely different reason.

The nested builds these tests run execute with the distribution the smoke-test build produces, and the
build cache key of every cacheable task embeds the version of the *executing* Gradle:
`RegistryAwareClassLoaderHierarchyHasher` identifies the Gradle runtime classloaders as
`"runtime:$gradleVersion"` (and `gradle-api:`, `gradle-core-api:`, `plugins:`), which feeds each task's
implementation hash.

That version came from the pipeline's build receipt timestamp, so it was unique per CI run. Every run
therefore got a private build cache namespace and the nested builds recompiled Gradle from scratch:

```
executed_cacheable            n=420    1739.3s serial
avoided_from_remote_cache     n=104      64.3s
avoided_from_local_cache      n=63       33.7s
avoidance ratio: 5.3%
```

The keys make the mechanism unambiguous. Same source, three different keys for
`:base-services:compileJava`, the only variable being which Gradle ran the build:

| build | Gradle running it | cache key | outcome |
|---|---|---|---|
| CompileAll, commit 768e46b | 9.7.0-rc-1 | `c5fe5dc0…` | remote hit |
| CompileAll, commit 2b51fe5 | 9.7.0-rc-1 | `c5fe5dc0…` *(same)* | remote hit |
| nested smoke, 768e46b | 9.8.0-20260727045715+0000 | `2fe631d1…` | executed |
| nested smoke, 2b51fe5 | 9.8.0-20260727070528+0000 | `5a1a0f9a…` | executed |

Two CompileAll builds on different commits — and therefore with different *produced* versions — agree on
the key, which isolates the executing version as the cause. The produced version only moves the handful
of tasks that embed it (`:base-services:jar` differs between those two builds; it isn't cacheable anyway).

## What

Adopt the scheme `Gradleception` already uses for exactly this reason — its comment says *"To avoid
unnecessary rerun"*: build a throwaway distribution with a fixed timestamp, hash it, and use that hash
as the version qualifier, with `env.BUILD_COMMIT_ID=HEAD` so the distribution is reproducible.

The version then depends only on the distribution's *contents*. Runs whose sources produce identical
distributions share cache entries — including the ones Gradleception itself pushes, since the fixed
timestamp and `gradleception-` qualifier prefix match, so an identical source tree yields an identical
version string in both build types. Verified: the qualifier is stable across commits that don't change
the distribution (`gradleception-b2e96589…` on both 768e46b and a5d58d5), which is why Gradleception
sustains ~87% avoidance where these tests managed 5%.

Keeping the version content-derived rather than simply constant matters here. These tests share one
integration-test Gradle user home which the artifact cache restores across builds, so a constant version
could let its version-scoped caches (`caches/<version>/kotlin-dsl/scripts`) serve content compiled
against a different distribution. A content hash gives distinct distributions distinct versions.

Applied to **all** smoke test build types, because there is a second effect that isn't confined to the
Gradle-build tests. `DistributionTest.gradleDistribution` is a `@get:Nested` task input, so a distribution
stamped with a wall-clock timestamp made every `SmokeTest` task's inputs differ on every run. Despite
`SmokeTest` being declared `@CacheableTask`, no smoke test task ever hit the cache — confirmed on master,
where `:smoke-test:smokeTest` and `:smoke-test:androidProjectSmokeTest` carry no `FROM-CACHE` or
`UP-TO-DATE` marker. With a reproducible distribution, an unchanged distribution plus unchanged test code
means the whole task is served from the cache, which is what the annotation already asked for.

The nested-build reuse is still concentrated in `gradleBuildSmokeTest` — those are the only nested builds
that are both large and wired to the Develocity remote cache (the third-party-plugin builds publish no
scans at all; the Android ones publish 36 but total ~5.5 min). The task-level cacheability is what makes
this worth applying everywhere.

Also pins the timestamp the nested build stamps on its own output (deliberately a *different* fixed
value, mirroring how Gradleception distinguishes its two dogfooding distributions). That one only governs
the tasks that embed the version — build receipt, jars, distribution zips — but a wall-clock value made
even those uncacheable across runs.

## Results

### All smoke tests, twice

All 9 build types, 34 batch builds per run, on this branch. Run 2 used `--rebuild-deps` so TeamCity
could not deduplicate it onto run 1's builds.

| | run 1 | run 2 |
|---|---|---|
| total batch run time | **553 min** | **169 min** |
| batches | 34, all SUCCESS | 34, all SUCCESS |
| `response status 500` from the edge | 0 | 0 |

Every batch in run 1 ran the hash step and computed the same qualifier,
`gradleception-b2e965897b7687473d6dfe9cf28664f0`, across all 9 build types. Run 2 served the test task
from the cache in every shape:

```
> Task :smoke-test:smokeTest                          FROM-CACHE
> Task :smoke-test:androidProjectSmokeTest            FROM-CACHE
> Task :smoke-test:configCacheSmokeTest               FROM-CACHE
> Task :smoke-test:configCacheAndroidProjectSmokeTest FROM-CACHE
> Task :smoke-test:isolatedProjectsSmokeTest          FROM-CACHE
> Task :smoke-test:gradleBuildSmokeTest               FROM-CACHE
```

Uniform across every build type — no batch is an outlier, all 34 landed in 4.5–5.5 min:

| build type | batches | run 1 total | run 2 total |
|---|---|---|---|
| `AndroidProjectSmokeTests` | 4 | 61.1 min | **19.1 min** |
| `ConfigCacheAndroidProjectSmokeTests` | 4 | 62.9 min | **20.6 min** |
| `ConfigCacheSmokeTestsMaxJavaVersion` | 4 | 57.8 min | **20.9 min** |
| `ConfigCacheSmokeTestsMinJavaVersion` | 4 | 69.6 min | **20.4 min** |
| `GradleBuildSmokeTests` | 4 | 88.9 min | **19.6 min** |
| `IsolatedProjectsAndroidProjectSmokeTests` | 4 | 62.6 min | **19.2 min** |
| `IsolatedProjectsSmokeTestsMaxJavaVersion` | 4 | 54.0 min | **19.4 min** |
| `SmokeTestsMaxJavaVersion` | 4 | 55.8 min | **19.4 min** |
| `SmokeTestsMinJavaVersion` | 2 | 40.6 min | **10.0 min** |
| **all 9** | **34** | **553 min** | **169 min** |

The largest single batch improvement was `GradleBuildSmokeTests_Batch_1_1` at 33.9 → 4.8 min; the
smallest, `SmokeTestsMinJavaVersion_Batch_1_1` at 20.3 → 4.9 min.

The residual ~5 min is the checkout, the artifact-cache restore and `BUILD_DISTRIBUTION_TO_HASH`.

### Nested-build reuse in the Gradle-build tests

Measured separately, before the change was made unconditional. Baseline is the median over the 40 most
recent successful runs across all four batches.

| test | before | after |
|---|---|---|
| `can build Gradle distribution` | 11.8 min | **3.0 min** |
| `performs static validation of plugins used by the Gradle build` | 10.0 min | **4.4 min** |

The nested `binDistributionZip` build itself: **12.0 min → 2.9 min**. Its
`:base-services:compileJava` is now keyed `18ac566e3008d210aa588529ab579bc3` — the same key
Gradleception's nested `install` uses — where before it was a per-run unique `2fe631d1…`. Nested builds
reach 89–99% avoidance.

`BUILD_DISTRIBUTION_TO_HASH` is the added cost: 5.1 min cold, **1.1 min warm** (92.1% avoidance, 428
remote hits), since it runs on the wrapper's Gradle and so shares CompileAll's cache entries.

Two earlier runs of that measurement were degraded by a Develocity outage — 9 and 19
`response status 500` from `usw2-edge.gradle.org/cache`, disabling the remote cache mid-build, with
`uploading: 0` so nothing was pushed. See gradle-private#5293 and gradle-private#5290. The figures above
are from a run that saw none, and the all-smoke-tests runs above also saw none.

## Note for reviewers

Smoke test tasks become **cacheable across builds** — that is the point of the change, not a side effect,
but it is a behaviour change worth reviewing deliberately. An unchanged distribution and unchanged test code
now skip the tests entirely (observed: a re-run finished in 0.8 min with
`:smoke-test:gradleBuildSmokeTest -> avoided_from_remote_cache`).

I checked the things that could make this unsafe and did not find a problem: no smoke test parses or asserts
on the version string; the only `GradleVersion.current()` uses are in expected-deprecation-message strings
whose two sides both derive from this build; nothing asserts on timestamp recency or snapshot-ness; and the
version already carried a qualifier and timestamp before this change.

One item for a reviewer to weigh: the `FlakyTestQuarantine` variants get this too. `flakyTests=ONLY` changes
`includeTags`/`includeSpockAnnotation` so they compute a different cache key from the normal builds, and in
practice each quarantine run lands on a distinct commit (they run roughly nightly), so a changed
distribution still forces execution. But if master has not moved since the previous quarantine run, that
run would now be served from the cache and would not exercise the flaky tests. Guarding on
`flakyTestStrategy != ONLY` would avoid it at the cost of one conditional.

One caveat worth knowing about `env.BUILD_COMMIT_ID=HEAD`: it also feeds `gradleBuildCurrent`'s git ref.
`RemoteProject` does `git clone --no-checkout` then `git checkout <ref>`, and a clone of a detached-HEAD
repo propagates that commit to the clone's HEAD, so `HEAD` resolves to the same commit the SHA would.
Confirmed locally against a detached HEAD that differed from the branch tip, and in CI
(`Your branch is up to date with 'origin/bz-slow-smoke-test'`).

## Follow-up

Gradleception computes the identical MD5 in the same pipeline, so `BUILD_DISTRIBUTION_TO_HASH` is
redundant work. If Gradleception published its qualifier as an artifact or parameter, this build could
consume it and drop the step entirely.
