### PR TITLE
Allow source dependencies to be resolved when CC is degraded

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -249,6 +249,18 @@ class ConfigurationCacheFingerprintController internal constructor(
             return Idle()
         }
 
+        override fun <T> resolveScriptsForProject(project: ProjectIdentity, action: () -> T): T {
+            if (!atConfigurationTime()) {
+                // Scripts resolved after the configuration phase cannot be fingerprinted
+                // anymore. This happens, for example, when a source dependency's build is
+                // configured lazily while resolving a dependency at execution time. When the
+                // build has gracefully degraded the fingerprint is discarded, so it is safe
+                // to run the action without recording anything.
+                return action()
+            }
+            return super.resolveScriptsForProject(project, action)
+        }
+
         override fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
             if (!atConfigurationTime()) {
                 return

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelSourceDependencyIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.vcs.fixtures.GitHttpRepository
 import org.junit.Rule
@@ -66,7 +66,7 @@ class ParallelSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         repo.createLightWeightTag('1.2')
     }
 
-    @ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36610")
+    @UnsupportedWithConfigurationCache(because = "parallel population of source dependencies can only happen at execution time, which the configuration cache can only support by degrading to vintage execution, making the configuration cache run identical to the non-CC run")
     def "can populate into same dir in parallel"() {
         given:
         createDirs("A", "B", "C", "D")
@@ -102,7 +102,7 @@ class ParallelSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds('resolve', '--parallel', '--max-workers=4')
     }
 
-    @ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36610")
+    @UnsupportedWithConfigurationCache(because = "parallel population of source dependencies can only happen at execution time, which the configuration cache can only support by degrading to vintage execution, making the configuration cache run identical to the non-CC run")
     def "can populate from multiple Gradle invocations in parallel"() {
         given:
         createDirs("A")

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyGracefulDegradationIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyGracefulDegradationIntegrationTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.junit.Rule
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/36610")
+class SourceDependencyGracefulDegradationIntegrationTest extends AbstractIntegrationSpec implements SourceDependencies {
+
+    @Rule
+    GitFileRepository repo = new GitFileRepository('dep', temporaryFolder.getTestDirectory())
+
+    def configurationCache = newConfigurationCacheFixture()
+
+    @Override
+    void setupExecuter() {
+        super.setupExecuter()
+        executer.withConfigurationCacheEnabled()
+    }
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'consumer'
+            sourceControl.vcsMappings.withModule("org.test:dep") {
+                from(GitVersionControlSpec) {
+                    url = uri('${repo.url}')
+                }
+            }
+        """
+
+        repo.file("settings.gradle") << """
+            rootProject.name = 'dep'
+            gradle.rootProject {
+                configurations.create('default')
+                group = 'org.test'
+                version = '1.0'
+            }
+        """
+        repo.commit('initial')
+        repo.createLightWeightTag('1.0')
+    }
+
+    def "resolves a source dependency at execution time when the configuration cache gracefully degrades"() {
+        given:
+        buildFile << """
+            abstract class ResolveTask extends DefaultTask {
+                @javax.inject.Inject
+                abstract org.gradle.api.internal.ConfigurationCacheDegradationController getDegradationController()
+            }
+
+            configurations {
+                compile
+            }
+            dependencies {
+                compile 'org.test:dep:1.0'
+            }
+            tasks.register('resolve', ResolveTask) { task ->
+                // Opt this task into graceful configuration-cache degradation. This keeps
+                // the configuration-cache fingerprint controller in its 'Paused' state and
+                // permits execution-time project access. Resolving the source dependency
+                // then configures its build while the controller is 'Paused', which is the
+                // scenario that must degrade gracefully rather than throw.
+                degradationController.requireConfigurationCacheDegradation(task, provider { "Resolves a source dependency at execution time" })
+                doLast {
+                    project.configurations.compile.each { }
+                }
+            }
+        """
+
+        expect:
+        succeeds('resolve')
+    }
+}

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyGracefulDegradationIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyGracefulDegradationIntegrationTest.groovy
@@ -17,11 +17,14 @@
 package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 import spock.lang.Issue
 
 @Issue("https://github.com/gradle/gradle/issues/36610")
+@Requires(value = TestExecutionPreconditions.NotConfigCached, reason = "handles CC explicitly")
 class SourceDependencyGracefulDegradationIntegrationTest extends AbstractIntegrationSpec implements SourceDependencies {
 
     @Rule


### PR DESCRIPTION
Fixes #36610

Under the configuration cache, a build that resolves a **source (VCS) dependency at execution time** failed with:
```
Could not resolve all dependencies for configuration ':C:compile'
- 'resolveScriptsForProject' is illegal while in 'Paused' state.
```
even though the build had gracefully degraded. Source-dependency resolution lazily configures the dependency's build at execution time (via `resolveScriptsForProject`). Under graceful degradation, the configuration-cache fingerprint is never committed, so the fingerprint controller is still in its `Paused` state at execution time and `Paused` did not tolerate that callback (it inherited the throwing base implementation), so the build crashed instead of degrading cleanly.

**Fix:** `ConfigurationCacheFingerprintController.Paused` now overrides `resolveScriptsForProject` to run the action without recording a fingerprint once past configuration time (`!atConfigurationTime()`), mirroring the existing tolerant `Idle`/`Committed` overrides and the execution-time guard already on `Paused.projectObserved`. Configuration-time calls in the `Paused` state still fail loudly via the base implementation, so no strictness is lost. In a non-degrading build the controller has already transitioned `Paused -> Committed` before tasks run, so this changes behavior only in the graceful-degradation window (where the entry is discarded anyway).

However, this only fixes the outermost issue with `ParallelSourceDependencyIntegrationTest` where this issue was surfaced. These tests verify *parallel population of source dependencies*, which they exercise by resolving at execution time via undeclared configuration access. Under the configuration cache, that scenario can only proceed by degrading to vintage execution, making the CC run identical to the forking/embedded run, so it adds no meaningful coverage for the parallelism case. Moving this configuration access to anything that is compatible with configuration cache inherently removes the parallelism that is fundamental to the test.  So, this is not a problem with the test, but rather a scenario that can't be meaningfully exercised under CC, and the methods are now skipped (not expected-to-fail) under `configCacheIntegTest`.  Instead, we add a new integration test that directly reproduces the issue described in #36610.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
