### PR TITLE
Add deprecation nag to Configuration.setVisible()

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -47,7 +47,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
             """
             plugins {
                 `kotlin-dsl`
-                id("dev.detekt") version "2.0.0-alpha.4"
+                id("dev.detekt") version "2.0.0-alpha.5"
             }
 
             $repositoriesBlock
@@ -80,6 +80,13 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
             """.trimIndent()
         )
 
+        // This is necessary until https://github.com/detekt/detekt/issues/9558 is resolved
+        executer.expectDocumentedDeprecationWarning(
+            "The Configuration.setVisible(boolean) method has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
+        )
         build("generateScriptPluginAdapters", "detekt")
     }
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -83,7 +83,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
         // This is necessary until https://github.com/detekt/detekt/issues/9558 is resolved
         executer.expectDocumentedDeprecationWarning(
             "The Configuration.setVisible(boolean) method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 10. " +
+                "This is scheduled to be removed in Gradle 11. " +
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
         )

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -45,7 +45,7 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
     @Test
     @Category(Flaky::class) // https://github.com/gradle/gradle-private/issues/4723
     fun `stdlib and reflect are pinned to the embedded kotlin version for requested plugins`() {
-        val requestedKotlinVersion = "2.1.21"
+        val requestedKotlinVersion = "2.3.21"
         withBuildScript(
             """
             buildscript {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -91,6 +91,14 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
     }
 
     /**
+     * Output: This is scheduled to be removed in Gradle 11.
+     */
+    public WithDeprecationTimeline willBeRemovedInGradle11() {
+        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE11);
+        return new WithDeprecationTimeline(this);
+    }
+
+    /**
      * Output: This will fail with an error in Gradle 10.
      */
     public WithDeprecationTimeline willBecomeAnErrorInGradle10() {

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
@@ -74,6 +74,18 @@ class DeprecationMessagesTest extends Specification {
         problemsService.assertProblemEmittedOnce({ it.definition.id.displayName == 'Summary is deprecated.' })
     }
 
+    def "logs deprecation message scheduled for removal in Gradle 11"() {
+        given:
+        def builder = new DeprecationMessageBuilder()
+        builder.setSummary(summary)
+
+        when:
+        builder.willBeRemovedInGradle11().withUserManual("feature_lifecycle", "sec:deprecated").nagUser()
+
+        then:
+        expectMessage "$summary This is scheduled to be removed in Gradle 11. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/feature_lifecycle.html#sec:deprecated in the Gradle documentation."
+    }
+
     def "logs deprecation message with custom problem id"() {
         def deprecationDisplayName = "summary deprecation"
         given:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -2225,7 +2225,7 @@ tasks.named("assemble") {
 
 Prior to Gradle 9.0.0, any configuration with `isVisible()` returning `true` would implicitly trigger artifact creation when running the `assemble` task.
 This behavior was removed in Gradle 9.0.0, and the `Configuration.visible` property no longer has any effect.
-The property is now deprecated and will be removed in Gradle 10.0.0.
+The property is now deprecated and will be removed in Gradle 11.0.0.
 You can safely remove any usage of `visible`.
 
 If you want the artifacts of a configuration to be built when running the `assemble` task, add an explicit task dependency on `assemble`:

--- a/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-avoid/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-avoid/tests/sanityCheck.sample.conf
@@ -1,7 +1,4 @@
 executable: gradle
 args: tasks
-expected-output-file: usePluginsBlock-avoid.out
-allow-additional-output: true // Time to produce I/O may vary
-allow-disordered-output: true // Kotlin tasks list will include an additional Kotlin DSL Extensions task
 # Do not fail for the Configuration.setVisible deprecation emitted by the protobuf plugin until https://github.com/google/protobuf-gradle-plugin/issues/815 is fixed
 flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-do/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-do/tests/sanityCheck.sample.conf
@@ -1,7 +1,4 @@
 executable: gradle
 args: tasks
-expected-output-file: usePluginsBlock-avoid.out
-allow-additional-output: true // Time to produce I/O may vary
-allow-disordered-output: true // Kotlin tasks list will include an additional Kotlin DSL Extensions task
 # Do not fail for the Configuration.setVisible deprecation emitted by the protobuf plugin until https://github.com/google/protobuf-gradle-plugin/issues/815 is fixed
 flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-do/tests/usePluginsBlock-do.sample.conf
+++ b/platforms/documentation/docs/src/snippets/best-practices/usePluginsBlock-do/tests/usePluginsBlock-do.sample.conf
@@ -3,3 +3,5 @@ args: tasks
 expected-output-file: usePluginsBlock-do.out
 allow-additional-output: true // Time to produce I/O may vary
 allow-disordered-output: true // Kotlin tasks list will include an additional Kotlin DSL Extensions task
+# Do not fail for the Configuration.setVisible deprecation emitted by the protobuf plugin until https://github.com/google/protobuf-gradle-plugin/issues/815 is fixed
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/fundamentals/authoring-builds/dsl/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/fundamentals/authoring-builds/dsl/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'java'
 // end::use-plugin[]
 // tag::use-community-plugin[]
-    id 'org.springframework.boot' version '3.3.1'
+    id 'org.springframework.boot' version '4.1.0'
 // tag::use-plugin[]
 }
 // end::use-plugin[]

--- a/platforms/documentation/docs/src/snippets/fundamentals/authoring-builds/dsl/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/fundamentals/authoring-builds/dsl/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
 // end::use-plugin[]
 // tag::use-community-plugin[]
-    id("org.springframework.boot") version "3.3.1"
+    id("org.springframework.boot") version "4.1.0"
 // tag::use-plugin[]
 }
 // end::use-plugin[]

--- a/platforms/documentation/docs/src/snippets/fundamentals/developing-plugins/dsl/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/fundamentals/developing-plugins/dsl/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'java'
 // end::use-plugin[]
 // tag::use-community-plugin[]
-    id 'org.springframework.boot' version '3.3.1'
+    id 'org.springframework.boot' version '4.1.0'
 // tag::use-plugin[]
 }
 // end::use-plugin[]

--- a/platforms/documentation/docs/src/snippets/fundamentals/developing-plugins/dsl/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/fundamentals/developing-plugins/dsl/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
 // end::use-plugin[]
 // tag::use-community-plugin[]
-    id("org.springframework.boot") version "3.3.1"
+    id("org.springframework.boot") version "4.1.0"
 // tag::use-plugin[]
 }
 // end::use-plugin[]

--- a/platforms/documentation/docs/src/snippets/reference/plugin-development/defaultDependency/common/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
+++ b/platforms/documentation/docs/src/snippets/reference/plugin-development/defaultDependency/common/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
@@ -8,7 +8,6 @@ import org.gradle.api.artifacts.Configuration;
 public class DataProcessingPlugin implements Plugin<Project> {
     public void apply(Project project) {
         Configuration dataFiles = project.getConfigurations().create("dataFiles", c -> {
-            c.setVisible(false);
             c.setCanBeConsumed(false);
             c.setCanBeResolved(true);
             c.setDescription("The data artifacts to be processed for this plugin.");

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
@@ -114,7 +114,6 @@ class ToolingApiResolveIntegrationTest extends AbstractIntegrationSpec {
                 sources {
                     extendsFrom runtimeClasspath
                     canBeConsumed = false
-                    visible = false
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
                         attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))

--- a/platforms/jvm/toolchains-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/toolchains-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -44,7 +44,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
     private static final String SET_VISIBLE_DEPRECATION =
         "The Configuration.setVisible(boolean) method has been deprecated. " +
-            "This is scheduled to be removed in Gradle 10. " +
+            "This is scheduled to be removed in Gradle 11. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
 

--- a/platforms/jvm/toolchains-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/toolchains-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -34,11 +34,19 @@ import org.gradle.test.preconditions.OsTestPreconditions
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 import org.gradle.util.internal.TextUtil
+import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
 class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
 
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests
+
+    // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
+    private static final String SET_VISIBLE_DEPRECATION =
+        "The Configuration.setVisible(boolean) method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 10. " +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
 
     def setup() {
         captureBuildOperations()
@@ -438,7 +446,13 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             }
         """
 
+        and:
+        def kotlinCallsSetVisibleMethod = VersionNumber.parse(kotlinPluginVersion).baseVersion < VersionNumber.parse("2.3.20")
+
         when:
+        if (kotlinCallsSetVisibleMethod) {
+            executer.expectDocumentedDeprecationWarning(SET_VISIBLE_DEPRECATION)
+        }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         def eventsOnCompile = toolchainEvents(":compileKotlin")
         def eventsOnTest = toolchainEvents(":test")
@@ -454,6 +468,10 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertToolchainUsages(eventsOnTest, jdkMetadata, "JavaLauncher")
 
         when:
+        // The second invocation is a configuration cache hit, so configuration (and the nag) does not re-run
+        if (kotlinCallsSetVisibleMethod && GradleContextualExecuter.notConfigCache) {
+            executer.expectDocumentedDeprecationWarning(SET_VISIBLE_DEPRECATION)
+        }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         eventsOnCompile = toolchainEvents(":compileKotlin")
         eventsOnTest = toolchainEvents(":test")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationAPIDeprecationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationAPIDeprecationsIntegrationTest.groovy
@@ -39,4 +39,24 @@ class ConfigurationAPIDeprecationsIntegrationTest extends AbstractIntegrationSpe
         ConfigurationAPIDeprecations.expectIsVisibleMethodDeprecation(executer)
         succeeds "test"
     }
+
+    def "sensible deprecation warning when setVisible() method is invoked"() {
+        buildFile << """
+            configurations {
+                foo {
+                    visible = true
+                }
+            }
+
+            task test {
+                doLast {
+                    println "done"
+                }
+            }
+        """
+
+        expect:
+        ConfigurationAPIDeprecations.expectSetVisibleMethodDeprecation(executer)
+        succeeds "test"
+    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
@@ -32,7 +32,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
 
@@ -68,7 +67,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
                     extendsFrom(configurations.implementation)
@@ -95,7 +93,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
                     extendsFrom(configurations.implementation)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -361,7 +361,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Deprecated
     public boolean isVisible() {
         DeprecationLogger.deprecateMethod(Configuration.class, "isVisible")
-            .willBeRemovedInGradle10()
+            .willBeRemovedInGradle11()
             .withUpgradeGuideSection(9, "deprecate-visible-property")
             .nagUser();
         return visible;
@@ -371,7 +371,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Deprecated
     public Configuration setVisible(boolean visible) {
         DeprecationLogger.deprecateMethod(Configuration.class, "setVisible(boolean)")
-            .willBeRemovedInGradle10()
+            .willBeRemovedInGradle11()
             .withUpgradeGuideSection(9, "deprecate-visible-property")
             .nagUser();
         validateMutation(MutationType.BASIC_STATE);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -370,8 +370,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Override
     @Deprecated
     public Configuration setVisible(boolean visible) {
+        DeprecationLogger.deprecateMethod(Configuration.class, "setVisible(boolean)")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecate-visible-property")
+            .nagUser();
         validateMutation(MutationType.BASIC_STATE);
-        // TODO: Create a deprecation warning once https://youtrack.jetbrains.com/issue/KT-78754 is resolved
         this.visible = visible;
         return this;
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -926,7 +926,6 @@ This method is only meant to be called on configurations which allow the (non-de
     }
 
     private Configuration prepareConfigurationForCopyTest(configuration = conf()) {
-        configuration.visible = false
         configuration.transitive = false
         configuration.description = "descript"
         configuration.exclude([group: "value"])

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.FileSystemTestPreconditions
 
@@ -189,6 +190,7 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        ConfigurationAPIDeprecations.expectSetVisibleMethodDeprecation(executer)
         succeeds("assemble")
 
         and:

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
@@ -22,7 +22,7 @@ class ConfigurationAPIDeprecations {
     static void expectIsVisibleMethodDeprecation(GradleExecuter executer) {
         executer.expectDocumentedDeprecationWarning(
             "The Configuration.isVisible method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 10. " +
+                "This is scheduled to be removed in Gradle 11. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
         )
     }
@@ -30,7 +30,7 @@ class ConfigurationAPIDeprecations {
     static void expectSetVisibleMethodDeprecation(GradleExecuter executer) {
         executer.expectDocumentedDeprecationWarning(
             "The Configuration.setVisible(boolean) method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 10. " +
+                "This is scheduled to be removed in Gradle 11. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
         )
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
@@ -26,4 +26,12 @@ class ConfigurationAPIDeprecations {
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
         )
     }
+
+    static void expectSetVisibleMethodDeprecation(GradleExecuter executer) {
+        executer.expectDocumentedDeprecationWarning(
+            "The Configuration.setVisible(boolean) method has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
+        )
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -110,6 +110,7 @@ class KotlinGradlePluginVersions {
     static final VersionNumber KOTLIN_2_1_21 = VersionNumber.parse('2.1.21')
     static final VersionNumber KOTLIN_2_2_0 = VersionNumber.parse('2.2.0')
     static final VersionNumber KOTLIN_2_3_0 = VersionNumber.parse('2.3.0')
+    static final VersionNumber KOTLIN_2_3_20 = VersionNumber.parse('2.3.20')
     static final VersionNumber KOTLIN_2_3_21 = VersionNumber.parse('2.3.21')
     static final VersionNumber KOTLIN_2_4_0 = VersionNumber.parse('2.4.0')
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidProjectSmokeTest.groovy
@@ -69,6 +69,7 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
         return runnerForLocation(projectDir, agpVersion, "assembleDebug", *excludingCCIncompatibleTasks())
             .deprecations(AndroidProjectDeprecations) {
                 expectProjectDependencyNotationDeprecation()
+                expectSetVisibleDeprecation()
             }
             .build()
     }
@@ -77,6 +78,7 @@ class AbstractAndroidProjectSmokeTest extends AbstractSmokeTest implements Runne
         return runnerForLocation(projectDir, agpVersion, "assembleDebug", *excludingCCIncompatibleTasks())
             .deprecations(AndroidProjectDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(GradleContextualExecuter.isNotConfigCache())
+                expectSetVisibleDeprecationIf(GradleContextualExecuter.isNotConfigCache())
             }
             .build()
     }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
@@ -130,6 +130,7 @@ class AndroidGradleRecipesKotlinSmokeTest extends AbstractSmokeTest implements R
         def runner = mixedRunner(agpVersion, kotlinVersionNumber, taskName)
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecation()
             }
 
         when: 'running the build for the 1st time'
@@ -146,6 +147,7 @@ class AndroidGradleRecipesKotlinSmokeTest extends AbstractSmokeTest implements R
         when: 'running the build for the 2nd time'
         result = runner.deprecations(AndroidDeprecations) {
             expectProjectDependencyNotationDeprecationIf(GradleContextualExecuter.isNotConfigCache() && VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+            expectSetVisibleDeprecationIf(GradleContextualExecuter.isNotConfigCache())
         }.build()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -58,6 +58,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         def result = runner
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecation()
             }
             .build()
 
@@ -78,6 +79,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         result = runner
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(GradleContextualExecuter.isNotConfigCache() && VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecationIf(GradleContextualExecuter.isNotConfigCache())
             }
             .build()
 
@@ -97,6 +99,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         result = runner
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(GradleContextualExecuter.isNotConfigCache() && VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecationIf(GradleContextualExecuter.isNotConfigCache())
             }
             .build()
 
@@ -115,11 +118,13 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         agpRunner(agpVersion, 'clean')
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecation()
             }
             .build()
         result = runner
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(GradleContextualExecuter.isNotConfigCache() && VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecationIf(GradleContextualExecuter.isNotConfigCache())
             }.build()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectCachingSmokeTest.groovy
@@ -95,6 +95,7 @@ class AndroidProjectCachingSmokeTest extends AbstractAndroidProjectSmokeTest {
         runnerForLocation(relocatedDir, agpVersion, "clean", *ossLicensesTasksExcludes, *excludingCCIncompatibleTasks())
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecation()
+                expectSetVisibleDeprecation()
             }
             .build()
         result = buildCachedLocation(relocatedDir, agpVersion)

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
@@ -102,6 +102,7 @@ class AndroidProjectLintSmokeTest extends AndroidProjectSmokeTest {
             .ignoreStackTraces("Android Lint may log stack traces when computing SARIF quick-fix edits fails")
             .deprecations(AndroidProjectDeprecations) {
                 expectProjectDependencyNotationDeprecation()
+                expectSetVisibleDeprecation()
             }
             .build()
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
@@ -62,7 +62,16 @@ class ErrorPronePluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         expect:
-        runner('compileJava').build()
+        // The deprecation warning is expected until https://github.com/tbroyer/gradle-errorprone-plugin/issues/188 is fixed
+        runner('compileJava')
+            .expectDeprecationWarning(
+                "The Configuration.setVisible(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+                "https://github.com/tbroyer/gradle-errorprone-plugin/issues/188"
+            )
+            .build()
     }
 
     @Override

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
@@ -66,7 +66,7 @@ class ErrorPronePluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         runner('compileJava')
             .expectDeprecationWarning(
                 "The Configuration.setVisible(boolean) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 10. " +
+                    "This is scheduled to be removed in Gradle 11. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
                 "https://github.com/tbroyer/gradle-errorprone-plugin/issues/188"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
@@ -46,7 +46,7 @@ class JenkinsJpiPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         return super.runner(tasks)
             .expectDeprecationWarning(
                 "The Configuration.setVisible(boolean) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 10. " +
+                    "This is scheduled to be removed in Gradle 11. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
                 "https://github.com/jenkinsci/gradle-jpi-plugin/issues/415"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
 @Requires(JdkVersionTestPreconditions.Jdk11OrLater)
 class JenkinsJpiPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
+
     @Override
     Map<String, Versions> getPluginsToValidate() {
         [
@@ -37,5 +38,18 @@ class JenkinsJpiPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     @Override
     List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
         [parentMethodInvocationDeprecation('jenkinsPlugin')]
+    }
+
+    @Override
+    SmokeTestGradleRunner runner(String... tasks) {
+        // The jpi plugin calls the deprecated Configuration.setVisible(boolean) method
+        return super.runner(tasks)
+            .expectDeprecationWarning(
+                "The Configuration.setVisible(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+                "https://github.com/jenkinsci/gradle-jpi-plugin/issues/415"
+            )
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -222,6 +222,10 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
     List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
         def kotlinVersionNumber = VersionNumber.parse(version)
         def deprecations = [parentMethodInvocationDeprecation('kotlin')]
+        if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_20) {
+            // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
+            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
+        }
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_21) {
             deprecations << "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration".toString()
         }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -224,7 +224,7 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def deprecations = [parentMethodInvocationDeprecation('kotlin')]
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_20) {
             // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
-            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
+            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 11. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
         }
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_21) {
             deprecations << "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration".toString()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -253,7 +253,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def deprecations = [parentMethodInvocationDeprecation('kotlin')]
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_20) {
             // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
-            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
+            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 11. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
         }
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_20) {
             deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-api-jars'. Declare a Usage attribute with value 'java-api' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -251,6 +251,10 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         }
         def kotlinVersionNumber = VersionNumber.parse(version)
         def deprecations = [parentMethodInvocationDeprecation('kotlin')]
+        if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_3_20) {
+            // The Kotlin plugin calls the deprecated Configuration.setVisible(boolean) method until KT-78754 was fixed in Kotlin 2.3.20 / 2.4.0
+            deprecations << "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate-visible-property".toString()
+        }
         if (kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_20) {
             deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-api-jars'. Declare a Usage attribute with value 'java-api' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()
             deprecations << "Declaring a Usage attribute with a legacy value has been deprecated. This will fail with an error in Gradle 10. A Usage attribute was declared with value 'java-runtime-jars'. Declare a Usage attribute with value 'java-runtime' and a LibraryElements attribute with value 'jar' instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecate_legacy_usage_values".toString()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
@@ -65,5 +65,13 @@ class PalantirConsistentVersionsPluginSmokeTest extends AbstractSmokeTest {
                 "Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#dependency_project_notation",
                 "https://github.com/palantir/gradle-consistent-versions/issues/1637"
             )
+            // The deprecation warning is expected until https://github.com/palantir/gradle-consistent-versions/issues/1700 is fixed
+            .expectDeprecationWarning(
+                "The Configuration.setVisible(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+                "https://github.com/palantir/gradle-consistent-versions/issues/1700"
+            )
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
@@ -68,7 +68,7 @@ class PalantirConsistentVersionsPluginSmokeTest extends AbstractSmokeTest {
             // The deprecation warning is expected until https://github.com/palantir/gradle-consistent-versions/issues/1700 is fixed
             .expectDeprecationWarning(
                 "The Configuration.setVisible(boolean) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 10. " +
+                    "This is scheduled to be removed in Gradle 11. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
                 "https://github.com/palantir/gradle-consistent-versions/issues/1700"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PaparazziPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PaparazziPluginSmokeTest.groovy
@@ -71,6 +71,7 @@ class PaparazziPluginSmokeTest extends AbstractSmokeTest implements RunnerFactor
             .maybeExpectLegacyDeprecationWarning("The Project.getProperties method has been deprecated. This will fail with an error in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecated_get_properties")
             .deprecations(AndroidDeprecations) {
                 expectProjectDependencyNotationDeprecationIf(VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("9.3.0"))
+                expectSetVisibleDeprecation()
             }
             .build()
     }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -87,4 +87,17 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
         [parentMethodInvocationDeprecation('play')]
     }
+
+    @Override
+    SmokeTestGradleRunner runner(String... tasks) {
+        // The playframework plugin calls the deprecated Configuration.setVisible(boolean) method
+        return super.runner(tasks)
+            .expectDeprecationWarning(
+                "The Configuration.setVisible(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+                "https://github.com/gradle/playframework/issues/218"
+            )
+    }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -94,7 +94,7 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         return super.runner(tasks)
             .expectDeprecationWarning(
                 "The Configuration.setVisible(boolean) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 10. " +
+                    "This is scheduled to be removed in Gradle 11. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
                 "https://github.com/gradle/playframework/issues/218"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
@@ -34,7 +34,7 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     private static final String PROTOBUF_SET_VISIBLE_FOLLOWUP = "https://github.com/google/protobuf-gradle-plugin/issues/815"
     private static final String SET_VISIBLE_DEPRECATION =
         "The Configuration.setVisible(boolean) method has been deprecated. " +
-            "This is scheduled to be removed in Gradle 10. " +
+            "This is scheduled to be removed in Gradle 11. " +
             "Consult the upgrading guide for further information: " +
             "${DOCS.getDocumentationFor("upgrading_version_9", "deprecate-visible-property")}"
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import spock.lang.Issue
 
@@ -27,6 +28,15 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
     // https://central.sonatype.com/artifact/com.google.protobuf/protobuf-java/versions
     private static protobufToolsVersion = "4.31.1"
+
+    // The protobuf plugin calls the deprecated Configuration.setVisible(boolean) method.
+    // The deprecation warning is expected until https://github.com/google/protobuf-gradle-plugin/issues/815 is fixed
+    private static final String PROTOBUF_SET_VISIBLE_FOLLOWUP = "https://github.com/google/protobuf-gradle-plugin/issues/815"
+    private static final String SET_VISIBLE_DEPRECATION =
+        "The Configuration.setVisible(boolean) method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 10. " +
+            "Consult the upgrading guide for further information: " +
+            "${DOCS.getDocumentationFor("upgrading_version_9", "deprecate-visible-property")}"
 
     @Issue("https://plugins.gradle.org/plugin/com.google.protobuf")
     def "protobuf plugin"() {
@@ -68,6 +78,7 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
         when:
         def result = runner('compileJava')
+            .expectDeprecationWarning(SET_VISIBLE_DEPRECATION, PROTOBUF_SET_VISIBLE_FOLLOWUP)
             .build()
 
         then:
@@ -75,7 +86,9 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         result.task(":compileJava").outcome == SUCCESS
 
         when:
+        // The second invocation is a configuration cache hit, so configuration (and the nag) does not re-run
         result = runner('compileJava')
+            .expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache, SET_VISIBLE_DEPRECATION, PROTOBUF_SET_VISIBLE_FOLLOWUP)
             .build()
 
         then:
@@ -116,6 +129,6 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
     @Override
     List<String> getSubprojectExtensionDeprecations(String testedPluginId, String version) {
-        [parentMethodInvocationDeprecation('protobuf')]
+        [parentMethodInvocationDeprecation('protobuf'), SET_VISIBLE_DEPRECATION]
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
@@ -48,7 +48,16 @@ class SpotBugsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """.stripIndent()
 
         when:
-        def result = runner('spotbugsMain').build()
+        // The deprecation warning is expected until https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1773 is fixed
+        def result = runner('spotbugsMain')
+            .expectDeprecationWarning(
+                "The Configuration.setVisible(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+                "https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1773"
+            )
+            .build()
 
         then:
         file('build/reports/spotbugs').isDirectory()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
@@ -52,7 +52,7 @@ class SpotBugsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         def result = runner('spotbugsMain')
             .expectDeprecationWarning(
                 "The Configuration.setVisible(boolean) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 10. " +
+                    "This is scheduled to be removed in Gradle 11. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
                 "https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1773"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -34,4 +34,17 @@ trait WithAndroidDeprecations {
         )
     }
 
+    void expectSetVisibleDeprecationIf(boolean condition) {
+        if (condition) {
+            expectSetVisibleDeprecation()
+        }
+    }
+
+    void expectSetVisibleDeprecation() {
+        runner.expectDeprecationWarning(
+            "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+            "https://issuetracker.google.com/issues/540783786"
+        )
+    }
+
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -42,7 +42,7 @@ trait WithAndroidDeprecations {
 
     void expectSetVisibleDeprecation() {
         runner.expectDeprecationWarning(
-            "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
+            "The Configuration.setVisible(boolean) method has been deprecated. This is scheduled to be removed in Gradle 11. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property",
             "https://issuetracker.google.com/issues/540783786"
         )
     }


### PR DESCRIPTION
The Kotlin plugin previously called Configuration.setVisible() in a number of places (KT-78754), which meant adding a runtime nag would have produced failing tests across kotlin-dsl, kotlin-embeddable and user builds with no meaningful way to resolve them. Now that the embedded Kotlin no longer uses the deprecated API, add the nag, mirroring the existing isVisible() deprecation.  We also expect the deprecation in various places where we test 3rd party plugins that also use this method.

Fixes #34290

### Related Followup PRs

* https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1773
* https://github.com/detekt/detekt/issues/9558
* https://github.com/google/protobuf-gradle-plugin/issues/815
* https://issuetracker.google.com/issues/540783786
* https://github.com/gradle/playframework/issues/218
* https://github.com/tbroyer/gradle-errorprone-plugin/issues/188
* https://github.com/palantir/gradle-consistent-versions/issues/1700
* https://github.com/jenkinsci/gradle-jpi-plugin/issues/415

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
