### PR TITLE
Make build scoped compiled script cache thread-safe

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScopeInMemoryCachingScriptClassCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScopeInMemoryCachingScriptClassCompiler.java
@@ -22,8 +22,8 @@ import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.Cast;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This in-memory cache is responsible for caching compiled build scripts during a build.
@@ -31,11 +31,14 @@ import java.util.Map;
  * which will use the delegate script class compiler in case of a miss. The lookup in this cache is
  * more efficient than looking in the global cache, as we do not check the script's hash code here,
  * assuming that it did not change during the build.
+ *
+ * <p>Instances are build-scoped and {@link #compile} is called concurrently once projects are
+ * configured in parallel, so the cache must be thread-safe.
  */
 public class BuildScopeInMemoryCachingScriptClassCompiler implements ScriptClassCompiler {
     private final CrossBuildInMemoryCachingScriptClassCache cache;
     private final ScriptClassCompiler scriptClassCompiler;
-    private final Map<ScriptCacheKey, CompiledScript<?, ?>> cachedCompiledScripts = new HashMap<>();
+    private final Map<ScriptCacheKey, CompiledScript<?, ?>> cachedCompiledScripts = new ConcurrentHashMap<>();
 
     public BuildScopeInMemoryCachingScriptClassCompiler(CrossBuildInMemoryCachingScriptClassCache cache, ScriptClassCompiler scriptClassCompiler) {
         this.cache = cache;
@@ -47,6 +50,10 @@ public class BuildScopeInMemoryCachingScriptClassCompiler implements ScriptClass
         ScriptCacheKey key = new ScriptCacheKey(source.getClassName(), targetScope.getExportClassLoader(), operation.getId());
         CompiledScript<T, M> compiledScript = Cast.uncheckedCast(cachedCompiledScripts.get(key));
         if (compiledScript == null) {
+            // Deliberately not computeIfAbsent: compiling a script is a long-running operation that
+            // can re-enter script compilation, which must not happen inside a mapping function.
+            // Two threads racing on the same key may both compile, but the delegate cache is itself
+            // thread-safe and returns the same result, so the duplicated work is the only cost.
             compiledScript = cache.getOrCompile(target, source, targetScope, operation, scriptBaseClass, verifier, scriptClassCompiler);
             cachedCompiledScripts.put(key, compiledScript);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScopeInMemoryCachingScriptClassCompilerConcurrencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScopeInMemoryCachingScriptClassCompilerConcurrencyTest.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal
+
+import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory
+import org.gradle.groovy.scripts.ScriptSource
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+
+@Timeout(120)
+class BuildScopeInMemoryCachingScriptClassCompilerConcurrencyTest extends Specification {
+
+    private static final int THREADS = 8
+    private static final int ROUNDS = 100
+    private static final int ROUND_TIMEOUT_SECONDS = 10
+
+    // Class names sharing a String.hashCode(), so all keys land in one bucket. An unsynchronized
+    // HashMap only fails observably once a bucket is treeified, which needs 8 colliding entries;
+    // with well-spread keys the same race corrupts the map silently instead of throwing.
+    private static final List<String> COLLIDING_CLASS_NAMES = (0..<128).collect { int combination ->
+        (0..<7).collect { int bit -> (combination >> bit) & 1 ? "BB" : "Aa" }.join()
+    }
+
+    private final ClassLoader classLoader = new ClassLoader() {}
+    private final Map<String, CompiledScript<?, ?>> compiledScripts =
+        COLLIDING_CLASS_NAMES.collectEntries { [it, [:] as CompiledScript] }
+
+    // Daemon threads: a corrupted map can spin forever inside get(), ignoring interruption, and
+    // would otherwise keep the test JVM alive after the test has failed.
+    private final ExecutorService executorService = Executors.newFixedThreadPool(THREADS, { Runnable runnable ->
+        def thread = new Thread(runnable, "script-class-cache-race")
+        thread.daemon = true
+        thread
+    } as ThreadFactory)
+
+    def cleanup() {
+        executorService.shutdownNow()
+    }
+
+    def "compiles concurrently without corrupting the build scoped cache"() {
+        given:
+        def failures = new ConcurrentLinkedQueue<Throwable>()
+
+        when:
+        int stuckRound = -1
+
+        // A fresh compiler per round: the race is on populating the map, not on reading a warm one.
+        for (int round = 0; round < ROUNDS && stuckRound < 0; round++) {
+            def compiler = newCompiler()
+
+            def results = executorService.invokeAll((0..<THREADS).collect {
+                { ->
+                    try {
+                        COLLIDING_CLASS_NAMES.each { String className ->
+                            def compiled = compile(compiler, className)
+
+                            if (!compiled.is(compiledScripts[className])) {
+                                throw new IllegalStateException("Cache returned the wrong script for $className")
+                            }
+                        }
+                    } catch (Throwable failure) {
+                        failures.add(failure)
+                    }
+
+                    null
+                } as Callable
+            }, ROUND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+            // Stuck threads are unrecoverable, so every later round would starve the pool.
+            if (results.any { it.cancelled }) {
+                stuckRound = round
+            }
+        }
+
+        then:
+        if (stuckRound >= 0) {
+            throw new AssertionError(
+                "Concurrent compile() left a thread spinning inside the cache in round $stuckRound: " +
+                    "the map is corrupted and lookups no longer terminate", failures.peek()
+            )
+        }
+
+        if (!failures.empty) {
+            throw new AssertionError(
+                "Concurrent compile() corrupted the cache: ${failures.size()} of ${THREADS * ROUNDS} tasks failed",
+                failures.peek()
+            )
+        }
+    }
+
+    private ScriptClassCompiler newCompiler() {
+        new BuildScopeInMemoryCachingScriptClassCompiler(delegateCache(), null)
+    }
+
+    private CompiledScript<?, ?> compile(ScriptClassCompiler compiler, String className) {
+        compiler.compile(
+            [getClassName: { className }] as ScriptSource,
+            Script,
+            new Object(),
+            [getExportClassLoader: { classLoader }] as ClassLoaderScope,
+            // Constant id: keeps every key's hash equal, leaving the class name as the only difference.
+            [getId: { "test" }] as CompileOperation,
+            null
+        )
+    }
+
+    // Not a Spock mock: those synchronize internally, serializing the calls this test needs to overlap.
+    private CrossBuildInMemoryCachingScriptClassCache delegateCache() {
+        new CrossBuildInMemoryCachingScriptClassCache([newCache: { null }] as CrossBuildInMemoryCacheFactory) {
+            @Override
+            CompiledScript getOrCompile(
+                Object target,
+                ScriptSource source,
+                ClassLoaderScope targetScope,
+                CompileOperation operation,
+                Class scriptBaseClass,
+                org.gradle.api.Action verifier,
+                ScriptClassCompiler delegate
+            ) {
+                compiledScripts[source.className]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #38667

### Context

`BuildScopeInMemoryCachingScriptClassCompiler` caches compiled build scripts for the duration of a build in a plain `HashMap`. The instance is build-scoped and `compile()` is reached from `BuildScriptProcessor` while a project is being configured, so with `org.gradle.configuration-cache.parallel=true` it is called concurrently from `DefaultBuildOperationQueue` worker threads. Concurrent `put`s corrupt the map.

On a ~1000-project Kotlin DSL build this surfaces as an intermittent configuration failure naming an arbitrary project - whichever one lost the race:

```
A problem occurred configuring project ':services:platform:payment'.
> class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode

Caused by: java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode
      at org.gradle.groovy.scripts.internal.BuildScopeInMemoryCachingScriptClassCompiler.compile(BuildScopeInMemoryCachingScriptClassCompiler.java:51)
      at org.gradle.groovy.scripts.DefaultScriptCompilerFactory$ScriptCompilerImpl.compile(DefaultScriptCompilerFactory.java:49)
      at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:131)
      at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:46)
```

Gradle's own `gradle.properties` enables both `org.gradle.configuration-cache.parallel` and `org.gradle.unsafe.isolated-projects`, so the Gradle build is exposed to this too.

The delegate this class wraps, `CrossBuildInMemoryCachingScriptClassCache`, is already thread-safe - only the build-scope wrapper was not.

`computeIfAbsent` is deliberately not used: `getOrCompile` compiles a script, which is long-running and can re-enter script compilation, so it must not run inside a mapping function. Two threads racing on the same key may both compile, but the delegate returns the same result, so duplicated work is the only cost.

### Verification

New unit test, `BuildScopeInMemoryCachingScriptClassCompilerConcurrencyTest`: 8 threads over 100 rounds with a fresh compiler per round, and 128 script class names engineered to share a `String.hashCode()` so every key lands in one bucket. That last part is what makes the race observable - a `HashMap` only fails loudly once a bucket is treeified, which needs 8 colliding entries; with well-spread keys the same corruption stays silent.

Locally on Linux / JDK 25:

| | result |
|---|---|
| with the fix | 3/3 runs pass, ~6s |
| with the fix reverted | 5/5 runs fail in ~15s |

The reverted runs fail with `AssertionError: Concurrent compile() left a thread spinning inside the cache in round N`, caused by a `StackOverflowError` inside `HashMap` - a thread walking a cyclic tree bin never returns. That is a different symptom from the `ClassCastException` above; both come from the same corruption, and which one surfaces depends on the interleaving.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :core:quickTest`.

On the unchecked items, and two caveats:

- No integration test: the defect is a data race with no deterministic user-visible trigger. Provoking it from an integration test would mean generating a build with ~1000 scripts and retrying until it happens. The unit test covers it deterministically instead.
- No user-facing docs: internal class, no public API change.
- `sanityCheck` passes except four Swift performance scenario tests, which fail on my machine with "Swift 6 toolchain is required for this performance test but was not found on the agent". Unrelated to this change.
- `:core:quickTest` runs 3526 tests locally with one failure, `TaskTimeoutIntegrationTest > timeout stops long running work items with process isolation`. It is annotated `@Flaky(because = 'gradle-private#5086')` in the repo and fails identically on a clean `master` checkout without this change, so it is pre-existing and unrelated.