### PR TITLE
Honor nested `Gradle.settingsEvaluated` callbacks

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -158,6 +158,10 @@ class CrossBuildConfigurationReportingGradle(
         return delegate.getBuildListenerBroadcaster()
     }
 
+    override fun notifySettingsEvaluated(settings: SettingsInternal) {
+        shouldNotBeUsed()
+    }
+
     override fun getServices(): ServiceRegistry {
         onBuildMutableStateAccess("getServices")
         return delegate.services

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -368,6 +368,9 @@ class CrossProjectConfigurationReportingGradle(
     override fun getBuildListenerBroadcaster(): BuildListener =
         delegate.buildListenerBroadcaster
 
+    override fun notifySettingsEvaluated(settings: SettingsInternal) =
+        delegate.notifySettingsEvaluated(settings)
+
     override fun getServices(): ServiceRegistry =
         delegate.services
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -119,13 +119,23 @@ Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or late
 
 See the [Looking up services in scripts](userguide/service_injection.html#looking_up_services) section in the Gradle User Manual for more details.
 
-#### Nested `Gradle.settingsEvaluated` callbacks are now honored
+#### Nested `Gradle.settingsEvaluated` callbacks are honored
 
+Gradle now honors nested [`Gradle.settingsEvaluated`](javadoc/org/gradle/api/invocation/Gradle.html#settingsEvaluated(org.gradle.api.Action)) callbacks.
 Previously, a `settingsEvaluated` callback registered from within another `settingsEvaluated` callback was silently ignored.
 
-Such callbacks are now executed after all previously added callbacks finish executing, in the same lifecycle phase, matching the behavior of nested [`Project.afterEvaluate`](javadoc/org/gradle/api/Project.html#afterEvaluate(org.gradle.api.Action)) callbacks.
+Nested callbacks now run after all previously registered callbacks finish, within the same lifecycle phase, matching the behavior of nested [`Project.afterEvaluate`](javadoc/org/gradle/api/Project.html#afterEvaluate(org.gradle.api.Action)):
 
-See [`Gradle.settingsEvaluated`](javadoc/org/gradle/api/invocation/Gradle.html#settingsEvaluated(org.gradle.api.Action)) for details.
+```kotlin
+gradle.settingsEvaluated {
+    // runs first
+    gradle.settingsEvaluated {
+        // runs after all outer callbacks finish, in the same phase
+    }
+}
+```
+
+See the [`settingsEvaluated`](userguide/build_lifecycle.html#settings_evaluated) section in the Gradle User Manual for more details.
 
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -119,6 +119,14 @@ Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or late
 
 See the [Looking up services in scripts](userguide/service_injection.html#looking_up_services) section in the Gradle User Manual for more details.
 
+#### Nested `Gradle.settingsEvaluated` callbacks are now honored
+
+Previously, a `settingsEvaluated` callback registered from within another `settingsEvaluated` callback was silently ignored.
+
+Such callbacks are now executed after all previously added callbacks finish executing, in the same lifecycle phase, matching the behavior of nested [`Project.afterEvaluate`](javadoc/org/gradle/api/Project.html#afterEvaluate(org.gradle.api.Action)) callbacks.
+
+See [`Gradle.settingsEvaluated`](javadoc/org/gradle/api/invocation/Gradle.html#settingsEvaluated(org.gradle.api.Action)) for details.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
@@ -339,6 +339,9 @@ include::sample[dir="snippets/reference/runtime-configuration/callbacks/kotlin",
 include::sample[dir="snippets/reference/runtime-configuration/callbacks/groovy",files="callbacks.init.gradle[tags=settingsevaluated]"]
 ====
 
+NOTE: A callback registered from within a `settingsEvaluated` callback is executed in the same lifecycle phase, after all previously registered callbacks finish.
+This matches the behavior of nested link:{javadocPath}/org/gradle/api/Project.html#afterEvaluate(org.gradle.api.Action)[`Project.afterEvaluate`].
+
 [[projects_loaded]]
 ==== `projectsLoaded`
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -221,6 +221,9 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * The settings object is fully configured and is ready to use to load the build projects. The
      * {@link org.gradle.api.initialization.Settings} object is passed to the closure as a parameter.
      *
+     * <p>If you call this method within a <code>settingsEvaluated</code> closure, the passed closure executes after
+     * all previously added <code>settingsEvaluated</code> closures finish executing.</p>
+     *
      * @param closure The closure to execute.
      */
     void settingsEvaluated(Closure closure);
@@ -229,6 +232,9 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * Adds an action to be called when the build settings have been loaded and evaluated.
      *
      * The settings object is fully configured and is ready to use to load the build projects.
+     *
+     * <p>If you call this method within a <code>settingsEvaluated</code> action, the passed action executes after
+     * all previously added <code>settingsEvaluated</code> actions finish executing.</p>
      *
      * @param action The action to execute.
      * @since 3.4

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/NestedSettingsEvaluatedCallbacksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/NestedSettingsEvaluatedCallbacksIntegrationTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+/**
+ * Tests that {@code Gradle.settingsEvaluated} callbacks can register further {@code settingsEvaluated} callbacks,
+ * which are honoured within the same lifecycle phase, similar to nested {@code Project.afterEvaluate}.
+ */
+class NestedSettingsEvaluatedCallbacksIntegrationTest extends AbstractIntegrationSpec {
+
+    def "settingsEvaluated callback can register nested settingsEvaluated callbacks"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            def events = []
+            gradle.settingsEvaluated {
+                events << 'outer1'
+                gradle.settingsEvaluated {
+                    events << 'nested1'
+                    gradle.settingsEvaluated {
+                        events << 'nested2'
+                    }
+                }
+            }
+            gradle.settingsEvaluated {
+                events << 'outer2'
+            }
+            gradle.projectsLoaded {
+                println "events: " + events
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputContains("events: [outer1, outer2, nested1, nested2]")
+    }
+
+    def "nested settingsEvaluated callback can mutate settings"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            gradle.settingsEvaluated { settings ->
+                gradle.settingsEvaluated {
+                    settings.include 'sub'
+                }
+            }
+        """
+        file("sub").mkdirs()
+
+        when:
+        succeeds(":sub:help")
+
+        then:
+        executed(":sub:help")
+    }
+
+    def "settingsEvaluated callbacks run inside the evaluate settings build operation"() {
+        def operations = new BuildOperationsFixture(executer, temporaryFolder)
+        settingsFile << """
+            import org.gradle.internal.operations.*
+
+            rootProject.name = 'root'
+            def runCallbackOperation = { name ->
+                gradle.services.get(BuildOperationRunner).run(new RunnableBuildOperation() {
+                    void run(BuildOperationContext context) {}
+                    BuildOperationDescriptor.Builder description() {
+                        BuildOperationDescriptor.displayName(name)
+                    }
+                })
+            }
+            gradle.settingsEvaluated {
+                runCallbackOperation('outer callback op')
+                gradle.settingsEvaluated {
+                    runCallbackOperation('nested callback op')
+                }
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        def evaluateSettings = operations.only(EvaluateSettingsBuildOperationType)
+        operations.first('outer callback op').parentId == evaluateSettings.id
+        operations.first('nested callback op').parentId == evaluateSettings.id
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -107,6 +107,16 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      */
     BuildListener getBuildListenerBroadcaster();
 
+    /**
+     * Fires {@link BuildListener#settingsEvaluated(org.gradle.api.initialization.Settings)} for this build.
+     *
+     * <p>Callbacks registered via {@link Gradle#settingsEvaluated(org.gradle.api.Action)} or
+     * {@link Gradle#settingsEvaluated(groovy.lang.Closure)} while the notification is in progress are also fired
+     * before this method returns, so a {@code settingsEvaluated} callback can register further
+     * {@code settingsEvaluated} callbacks, similar to nested {@link org.gradle.api.Project#afterEvaluate(org.gradle.api.Action)}.</p>
+     */
+    void notifySettingsEvaluated(SettingsInternal settings);
+
     @UsedByScanPlugin
     ServiceRegistry getServices();
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -33,7 +33,7 @@ public class SettingsEvaluatedCallbackFiringSettingsProcessor implements Setting
     public SettingsState process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameterInternal startParameter) {
         SettingsState state = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         SettingsInternal settings = state.getSettings();
-        gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
+        gradle.notifySettingsEvaluated(settings);
         settings.preventFromFurtherMutation();
         return state;
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -95,6 +95,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     private final ListenerBroadcast<ProjectEvaluationListener> projectEvaluationListenerBroadcast;
     private final MutableActionSet<Project> rootProjectActions = new MutableActionSet<>();
     private @Nullable List<IncludedBuildInternal> includedBuilds;
+    private @Nullable ListenerBroadcast<BuildListener> pendingSettingsEvaluated;
     private @Nullable GradleLifecycle lifecycle;
     private @Nullable Supplier<? extends ClassLoaderScope> classLoaderScope;
     private @Nullable ClassLoaderScope baseProjectClassLoaderScope;
@@ -380,12 +381,36 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
     @Override
     public void settingsEvaluated(@SuppressWarnings("rawtypes") Closure closure) {
-        registerBuildListener("settingsEvaluated", closure);
+        settingsEvaluatedListeners().add(new ClosureBackedMethodInvocationDispatch("settingsEvaluated", closure));
     }
 
     @Override
     public void settingsEvaluated(Action<? super Settings> action) {
-        buildListenerBroadcast.add("settingsEvaluated", action);
+        settingsEvaluatedListeners().add("settingsEvaluated", action);
+    }
+
+    /**
+     * Returns the broadcast that {@code settingsEvaluated} callbacks should currently be registered with. While the
+     * {@code settingsEvaluated} event is being fired, new callbacks are collected in a pending batch that is fired
+     * before {@link #notifySettingsEvaluated(SettingsInternal)} returns, so callbacks can register further callbacks.
+     */
+    private ListenerBroadcast<BuildListener> settingsEvaluatedListeners() {
+        return pendingSettingsEvaluated != null ? pendingSettingsEvaluated : buildListenerBroadcast;
+    }
+
+    @Override
+    public void notifySettingsEvaluated(SettingsInternal settings) {
+        pendingSettingsEvaluated = new ListenerBroadcast<>(BuildListener.class);
+        try {
+            buildListenerBroadcast.getSource().settingsEvaluated(settings);
+            while (!pendingSettingsEvaluated.isEmpty()) {
+                ListenerBroadcast<BuildListener> batch = pendingSettingsEvaluated;
+                pendingSettingsEvaluated = new ListenerBroadcast<>(BuildListener.class);
+                batch.getSource().settingsEvaluated(settings);
+            }
+        } finally {
+            pendingSettingsEvaluated = null;
+        }
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -264,6 +264,54 @@ class DefaultGradleSpec extends Specification {
         1 * action.execute(_)
     }
 
+    def "notifySettingsEvaluated fires callbacks registered by other settings evaluated callbacks"() {
+        given:
+        def settings = Stub(SettingsInternal)
+        def events = []
+        gradle.settingsEvaluated {
+            events << 'outer1'
+            gradle.settingsEvaluated {
+                events << 'nested1'
+                gradle.settingsEvaluated {
+                    events << 'nested2'
+                }
+            }
+        }
+        gradle.settingsEvaluated {
+            events << 'outer2'
+        }
+
+        when:
+        gradle.notifySettingsEvaluated(settings)
+
+        then:
+        events == ['outer1', 'outer2', 'nested1', 'nested2']
+    }
+
+    def "settings evaluated callbacks are fired exactly once"() {
+        given:
+        def settings = Stub(SettingsInternal)
+        def count = 0
+        gradle.settingsEvaluated {
+            count++
+            gradle.settingsEvaluated {
+                count++
+            }
+        }
+
+        when:
+        gradle.notifySettingsEvaluated(settings)
+
+        then:
+        count == 2
+
+        when:
+        gradle.buildListenerBroadcaster.settingsEvaluated(settings)
+
+        then:
+        count == 3 // only the directly registered callback remains in the broadcast
+    }
+
     def "broadcasts before settings events to actions"() {
         given:
         def action = Mock(Action)


### PR DESCRIPTION
Callbacks registered from within a `settingsEvaluated` callback were silently ignored. They now fire in the same lifecycle phase, in registration batches, matching nested `Project.afterEvaluate`.

### Context
Fixes the nested registration case of gradle/gradle#17914, following the approach from gradle/gradle#5200.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
