### PR TITLE
Exempt well-known debug/profile agents from third-party agent handling

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -807,7 +807,7 @@
   {
     "name": "instrumentation-agent-services",
     "path": "platforms/core-runtime/instrumentation-agent-services",
-    "unitTests": false,
+    "unitTests": true,
     "functionalTests": true,
     "crossVersionTests": false
   },

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default ReadyForNightly performance baseline
-defaultRfnPerformanceBaselines=9.8.0-commit-9baf7fc17b2
+defaultRfnPerformanceBaselines=9.8.0-commit-cfe00294911
 # Default ReadyForRelease performance baseline
 defaultRfrPerformanceBaselines=9.7.0-commit-8943fa5e8c4
 systemProp.dependency.analysis.test.analysis=false

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTestKitIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTestKitIntegrationTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions.ApplyInstrumentationAgentOption
 import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.test.preconditions.OsTestPreconditions
-
+import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
 import org.gradle.testkit.runner.ConfigurationCacheOutcome
 import org.gradle.testkit.runner.GradleRunner
@@ -107,9 +107,9 @@ class ConfigurationCacheTestKitIntegrationTest extends AbstractConfigurationCach
     }
 
     def "JDWP debug agent does not cause a configuration-cache problem [#mode]"() {
-        // JDWP attaches via `-agentlib:`, which the detection flags conservatively as a third-party agent
-        // (any JVMTI agent can subscribe to ClassFileLoadHook and transform bytecode). JDWP itself does
-        // not register a transformer, so the build proceeds cleanly via the compose path.
+        // JDWP attaches via `-agentlib:jdwp`. Unlike an arbitrary JVMTI agent, it never rewrites bytecode
+        // during normal class loading, so the detection exempts it and the build proceeds via the same
+        // (substitution) path as a regular build - debugging exercises the production instrumentation.
         when:
         def result = testRunner(mode)
             .withJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0")
@@ -125,7 +125,9 @@ class ConfigurationCacheTestKitIntegrationTest extends AbstractConfigurationCach
 
     def "native JVMTI agent attached via -agentpath: does not cause a configuration-cache problem [#mode]"() {
         // Use the JDK-shipped JDWP shared library so we exercise the -agentpath: codepath without
-        // requiring a custom native artifact in the test fixtures.
+        // requiring a custom native artifact in the test fixtures. Note the JDWP library is itself exempt
+        // from third-party detection (see the -agentlib:jdwp test above); this test only checks that the
+        // -agentpath: form is parsed and does not break the configuration cache.
         given:
         def jdwpLibrary = jdwpAgentLibraryPath()
 
@@ -208,13 +210,29 @@ class ConfigurationCacheTestKitIntegrationTest extends AbstractConfigurationCach
         when:
         def result = testRunner(PluginResolutionMode.INJECTED_CLASSPATH)
             .withJvmArguments("-javaagent:${agentJar}")
-            .withArguments("--configuration-cache", "-Dorg.gradle.internal.instrumentation.agent=false")
+            .withArguments("--configuration-cache", "-D${ApplyInstrumentationAgentOption.GRADLE_PROPERTY}=false")
             .buildAndFail()
 
         then:
         def output = result.output
         output.contains(JAVA_AGENT_PROBLEM_MESSAGE)
         result.configurationCacheOutcome == ConfigurationCacheOutcome.DISCARDED
+    }
+
+    // The counterpart of the test above: because JDWP is exempt from third-party agent detection, the
+    // unsafe condition is not met and no problem is reported. This is the one assertion that flips with
+    // the exemption, so it is what keeps the exemption from being silently reverted.
+    def "JDWP debug agent with Gradle's instrumentation agent disabled is not a CC problem [INJECTED_CLASSPATH]"() {
+        when:
+        def result = testRunner(PluginResolutionMode.INJECTED_CLASSPATH)
+            .withJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0")
+            .withArguments("--configuration-cache", "-D${ApplyInstrumentationAgentOption.GRADLE_PROPERTY}=false")
+            .build()
+
+        then:
+        def output = result.output
+        !output.contains(JAVA_AGENT_PROBLEM_MESSAGE)
+        result.configurationCacheOutcome == ConfigurationCacheOutcome.STORED
     }
 
     def "third-party Java agent with Gradle's instrumentation agent disabled without CC succeeds [#mode]"() {
@@ -224,7 +242,7 @@ class ConfigurationCacheTestKitIntegrationTest extends AbstractConfigurationCach
         when:
         def result = testRunner(mode)
             .withJvmArguments("-javaagent:${agentJar}")
-            .withArguments("-Dorg.gradle.internal.instrumentation.agent=false")
+            .withArguments("-D${ApplyInstrumentationAgentOption.GRADLE_PROPERTY}=false")
             .build()
 
         then:

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/InstrumentingClassLoader.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/InstrumentingClassLoader.java
@@ -48,6 +48,20 @@ public interface InstrumentingClassLoader {
     byte @Nullable [] instrumentClass(@Nullable String className, @Nullable ProtectionDomain protectionDomain, byte[] classfileBuffer);
 
     /**
+     * Reports whether this classloader re-instruments the bytecode the JVM supplies on every class load
+     * (the "compose" path used when a third-party agent is present), as opposed to substituting bytecode that
+     * was pre-instrumented earlier during the artifact transform.
+     * <p>
+     * This matters for debugger-initiated class redefinition (Hot Code Replace): only a classloader that
+     * re-instruments the supplied bytecode can honor a redefinition of an instrumented class. A substituting
+     * classloader ignores the redefined bytes and keeps serving the pre-instrumented definition, so the
+     * hot-swap silently has no effect.
+     *
+     * @return {@code true} if redefined (hot-swapped) bytecode of an instrumented class takes effect
+     */
+    boolean canReinstrumentClasses();
+
+    /**
      * This is called by the agent if a throwable is thrown while instrumenting a class during the call of the {@link #instrumentClass(String, ProtectionDomain, byte[])} method,
      * or anywhere else in the agent. Throwing an exception from this method has no effect on the class loading.
      * <p>

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -19,8 +19,8 @@ package org.gradle.internal.classloader;
 import org.apache.commons.io.IOUtils;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
-import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.ClassLoadTimeTransform;
+import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.TransformedClassPath;
 import org.jspecify.annotations.Nullable;
 
@@ -184,6 +184,14 @@ public class VisitableURLClassLoader extends URLClassLoader implements ClassLoad
             }
             // No third-party agent to compose with; substitute the bytes Gradle rewrote during artifact transform.
             return replacer.getInstrumentedClass(className, protectionDomain);
+        }
+
+        @Override
+        public boolean canReinstrumentClasses() {
+            // The compose path re-instruments whatever bytecode the JVM supplies, so redefined (hot-swapped)
+            // bytes are picked up. The substitution path serves bytecode captured during the artifact transform
+            // and ignores the supplied buffer, so redefinition has no effect.
+            return classLoadTimeTransform != null;
         }
 
         @Override

--- a/platforms/core-runtime/classloaders/src/test/groovy/org/gradle/internal/classloader/InstrumentingVisitableURLClassLoaderTest.groovy
+++ b/platforms/core-runtime/classloaders/src/test/groovy/org/gradle/internal/classloader/InstrumentingVisitableURLClassLoaderTest.groovy
@@ -24,11 +24,7 @@ import java.security.CodeSource
 import java.security.ProtectionDomain
 import java.security.cert.Certificate
 
-/**
- * Verifies the instrumenting classloader forwards the loaded class's protection domain to the class-load-time transform.
- */
 class InstrumentingVisitableURLClassLoaderTest extends Specification {
-
     def "passes the protection domain of the loaded class to the class-load-time transform"() {
         given:
         def seen = []
@@ -49,5 +45,24 @@ class InstrumentingVisitableURLClassLoaderTest extends Specification {
 
         then:
         seen == [protectionDomain]
+    }
+
+    def "honors class redefinition only when a class-load-time transform re-instruments the supplied bytecode"() {
+        given:
+        def original = new File("lib.jar")
+        def classpath = TransformedClassPath.builderWithExactSize(1)
+            .addUntransformed(original)
+            .build()
+        ClassLoadTimeTransform transform = { ProtectionDomain protectionDomain, String className, byte[] classfileBuffer -> classfileBuffer }
+
+        expect: "the compose path re-instruments the JVM-supplied bytes, so a hot-swap can take effect"
+        classLoaderFrom(classpath.withClassLoadTimeTransform(transform)).canReinstrumentClasses()
+
+        and: "the substitution path serves pre-instrumented bytes and ignores the supplied buffer"
+        !classLoaderFrom(classpath).canReinstrumentClasses()
+    }
+
+    private static InstrumentingClassLoader classLoaderFrom(TransformedClassPath classpath) {
+        (InstrumentingClassLoader) VisitableURLClassLoader.fromClassPath("test", getClass().classLoader, classpath)
     }
 }

--- a/platforms/core-runtime/instrumentation-agent-services/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-agent-services/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
 
     compileOnly(libs.jspecify)
 
+    testImplementation(testFixtures(projects.logging))
+
+    integTestImplementation(projects.classloaders)
     integTestImplementation(projects.launcher)
     integTestDistributionRuntimeOnly(projects.distributionsCore)
 }

--- a/platforms/core-runtime/instrumentation-agent-services/src/integTest/groovy/org/gradle/internal/instrumentation/agent/BuildScriptClasspathInstrumentationPathIntegrationTest.groovy
+++ b/platforms/core-runtime/instrumentation-agent-services/src/integTest/groovy/org/gradle/internal/instrumentation/agent/BuildScriptClasspathInstrumentationPathIntegrationTest.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.agent
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.classloader.InstrumentingClassLoader
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+
+/**
+ * Verifies which of the two instrumentation paths the buildscript classpath ends up on, depending on the
+ * agents attached to the build JVM.
+ * <p>
+ * Both paths are meant to be behaviorally equivalent, so no ordinary build output distinguishes them.
+ * The probe therefore asks the buildscript classloader directly, via
+ * {@link InstrumentingClassLoader#canReinstrumentClasses()}:
+ * <ul>
+ *     <li><b>substitution</b> - the artifact transform pre-instrumented the classpath and the classloader
+ *     serves those bytes. This is what a regular build does.</li>
+ *     <li><b>runtime transformation</b> - a third-party agent may rewrite bytecode, so Gradle re-instruments
+ *     whatever the JVM supplies in order to compose with it.</li>
+ * </ul>
+ * The point of the exemptions in {@link AgentUtils} is that a debugging or profiling session stays on the
+ * same path a regular build uses, so these tests are what keeps an exemption from silently regressing.
+ */
+@Requires(
+    value = TestExecutionPreconditions.NotEmbeddedExecutor,
+    reason = "The build runs in the test JVM under the embedded executor, so the agent switches under test cannot be applied to it"
+)
+class BuildScriptClasspathInstrumentationPathIntegrationTest extends AbstractIntegrationSpec {
+    private static final String SUBSTITUTION = "substitution"
+    private static final String RUNTIME_TRANSFORMATION = "runtime-transformation"
+    private static final String NOT_INSTRUMENTING = "none"
+
+    def setup() {
+        executer.requireIsolatedDaemons()
+        withInstrumentationPathProbe()
+    }
+
+    def "buildscript classpath uses the substitution path when no third-party agent is attached"() {
+        when:
+        succeeds("probe")
+
+        then:
+        instrumentationPathIs(SUBSTITUTION)
+    }
+
+    def "a third-party Java agent moves the buildscript classpath onto the runtime-transformation path"() {
+        given:
+        withThirdPartyJavaAgent()
+
+        when:
+        succeeds("probe")
+
+        then:
+        instrumentationPathIs(RUNTIME_TRANSFORMATION)
+    }
+
+    def "the JDWP debug agent keeps the buildscript classpath on the substitution path"() {
+        given: "the debug agent attached the way an IDE attaches it"
+        withJdwpAgent()
+
+        when:
+        succeeds("probe")
+
+        then: "debugging exercises the same instrumentation a regular build does"
+        instrumentationPathIs(SUBSTITUTION)
+    }
+
+    def "the JDWP debug agent alongside a third-party Java agent still uses the runtime-transformation path"() {
+        given: "an exempt agent does not excuse a non-exempt one"
+        withJdwpAgent()
+        withThirdPartyJavaAgent()
+
+        when:
+        succeeds("probe")
+
+        then:
+        instrumentationPathIs(RUNTIME_TRANSFORMATION)
+    }
+
+    private void instrumentationPathIs(String expectedPath) {
+        // Asserting the exact line rules out the probe silently reporting NOT_INSTRUMENTING, which would
+        // otherwise make every expectation above vacuously true.
+        outputContains("instrumentation path = $expectedPath")
+    }
+
+    private void withJdwpAgent() {
+        // Port 0 lets the OS pick a free one, and the daemon does not wait for a debugger to attach.
+        executer.withBuildJvmOpts("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0")
+    }
+
+    private void withThirdPartyJavaAgent() {
+        def builder = artifactBuilder()
+        builder.sourceFile("TestAgent.java") << javaSnippet("""
+            import java.lang.instrument.Instrumentation;
+
+            public class TestAgent {
+                public static void premain(String args, Instrumentation inst) {
+                    // Registering no transformer is enough: the detection is based on the JVM arguments,
+                    // because an agent can install a transformer at any point.
+                }
+            }
+        """)
+        builder.manifestAttributes("Premain-Class": "TestAgent")
+        def agentJar = file("test-agent.jar")
+        builder.buildJar(agentJar)
+        executer.withBuildJvmOpts("-javaagent:${agentJar.absolutePath}")
+    }
+
+    private void withInstrumentationPathProbe() {
+        // A buildSrc class is a project dependency on the buildscript classpath, so it goes through the
+        // instrumenting resolver and is loaded by the classloader whose path we want to observe.
+        file("buildSrc/src/main/java/test/Probe.java") << javaSnippet("""
+            package test;
+
+            public class Probe {
+            }
+        """)
+        buildFile buildScriptSnippet("""
+            import ${InstrumentingClassLoader.name}
+
+            tasks.register("probe") {
+                doLast {
+                    def loader = test.Probe.classLoader
+                    if (loader instanceof InstrumentingClassLoader) {
+                        boolean canReinstrument = loader.canReinstrumentClasses()
+                        println("instrumentation path = " + (canReinstrument ? "$RUNTIME_TRANSFORMATION" : "$SUBSTITUTION"))
+                    } else {
+                        println("instrumentation path = $NOT_INSTRUMENTING")
+                    }
+                }
+            }
+        """)
+    }
+}

--- a/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/AgentUtils.java
+++ b/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/AgentUtils.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.instrumentation.agent;
 
+import java.util.function.Predicate;
+
 /**
  * Common utilities used for Gradle's own Java agents.
  */
@@ -33,29 +35,101 @@ public final class AgentUtils {
      * @return {@code true} if the argument looks like a switch, {@code false} otherwise
      */
     public static boolean isGradleInstrumentationAgentSwitch(String jvmArg) {
-        return isJavaAgentSwitch(jvmArg) && jvmArg.contains(AGENT_MODULE_NAME);
+        return isJavaAgentSwitchMatching(jvmArg, AgentUtils::isGradleInstrumentationAgent);
     }
 
     /**
-     * Matches any third-party agent switch (Java or native JVMTI) that could install a bytecode transformer.
-     * Gradle's own instrumentation agent is excluded.
+     * Matches any third-party agent switch (Java or native JVMTI) that could feed Gradle's instrumentation agent with altered bytecode.
+     * Gradle's own instrumentation agent is excluded, and so are the known non-instrumenting JVMTI agents.
+     *
+     * @see #isGradleInstrumentationAgent(String)
+     * @see #isExemptAgentShortName(String)
+     * @see #isExemptAgentLibraryFileName(String)
      */
     static boolean isThirdPartyAgentSwitch(String jvmArg) {
-        if (isJavaAgentSwitch(jvmArg)) {
-            return !jvmArg.contains(AGENT_MODULE_NAME);
+        // Java Agents usually transform bytecode.
+        if (isJavaAgentSwitchMatching(jvmArg, agentJar -> !isGradleInstrumentationAgent(agentJar))) {
+            // This is `-javaagent:` and not our own agent.
+            return true;
         }
-        return isJvmtiAgentSwitch(jvmArg);
+
+        // Native JVMTI agents attached via `-agentlib:` or `-agentpath:`
+        // can transform bytecode at class load or redefine classes, the same way a Java agent can.
+        // They run after Gradle's own instrumentation so their transformations are safe (though we don't detect inputs added by them).
+        // However, when they redefine existing classes (and provide the bytecodes), these go through the full instrumentation pipeline.
+        // Without runtime transformation capability, Gradle's agent will revert the changes back to the pre-instrumented original versions.
+        // We cannot figure out if the native agent redefines classes, so we err on the side of caution.
+
+        // That said, some JVMTI agents are used for debugging and profiling work, and we know they only redefine classes in some uncommon workflows.
+        // Treating them as third-party agents would force buildscript instrumentation onto runtime transformation capability,
+        // so a debugging or profiling session would exercise a different code path than a regular build does in production.
+        // Exempt the ones we recognize so those sessions run the same instrumentation as production.
+        // So far, we exclude:
+        //  - JDWP (java debugger): it may redefine classes when attempting Hot Code Replace, but we emit a warning there, and it is not used often for Gradle work.
+        //  - AsyncProfiler: it can only transform classes, but never redefines them (as of 4.5).
+        if (isAgentSwitchMatching(jvmArg, "-agentlib:", libName -> !isExemptAgentShortName(libName))) {
+            return true;
+        }
+        return isAgentSwitchMatching(jvmArg, "-agentpath:", libPath -> !isExemptAgentLibraryFileName(libPath));
     }
 
-    private static boolean isJavaAgentSwitch(String jvmArg) {
-        return jvmArg.startsWith("-javaagent:");
+    private static boolean isJavaAgentSwitchMatching(String jvmArg, Predicate<String> agentPathCheck) {
+        return isAgentSwitchMatching(jvmArg, "-javaagent:", agentPathCheck);
+    }
+
+    private static boolean isAgentSwitchMatching(String jvmArg, String switchPrefix, Predicate<String> agentCheck) {
+        if (!jvmArg.startsWith(switchPrefix)) {
+            return false;
+        }
+        int agentParamsPosition = jvmArg.indexOf('=', switchPrefix.length());
+        String agent = jvmArg.substring(
+            switchPrefix.length(),
+            agentParamsPosition < 0 ? jvmArg.length() : agentParamsPosition
+        );
+        return agentCheck.test(agent);
     }
 
     /**
-     * Native JVMTI agents attached via {@code -agentlib:} or {@code -agentpath:} can subscribe to
-     * {@code ClassFileLoadHook} and transform bytecode at class load, the same way a Java agent can.
+     * Checks if the JAR path points to Gradle's own instrumentation agent.
      */
-    private static boolean isJvmtiAgentSwitch(String jvmArg) {
-        return jvmArg.startsWith("-agentlib:") || jvmArg.startsWith("-agentpath:");
+    private static boolean isGradleInstrumentationAgent(String jarPath) {
+        return jarPath.contains(AGENT_MODULE_NAME);
+    }
+
+    /**
+     * Checks if the name is the name of the known exempt agent.
+     *
+     * @param name the short name in an {@code -agentlib:<name>} switch, as passed to {@code System.loadLibrary}
+     */
+    private static boolean isExemptAgentShortName(String name) {
+        // These are only case-insensitive on some OSes,
+        // but let's be generous rather than trying to figure out the exact OS.
+        return name.equalsIgnoreCase("jdwp")             // JDWP debug agent
+            || name.equalsIgnoreCase("asyncProfiler");   // async-profiler
+    }
+
+    /**
+     * Checks if the path corresponds to the known exempt agent.
+     *
+     * @param agentLibPath the platform-specific path to agent's shared library
+     */
+    private static boolean isExemptAgentLibraryFileName(String agentLibPath) {
+        String fileName = getFileName(agentLibPath);
+        // We assume that Windows and macOS use case-insensitive file systems.
+        // Filenames are OS-specific, so we can be more precise than isExemptAgentShortName for free.
+        // equalsIgnoreCase uses generic case folding rules, which are fine for the ASCII strings we're dealing with here.
+
+        // JDWP debug agent, shipped with the JDK.
+        return fileName.equals("libjdwp.so")                        // Linux
+            || fileName.equalsIgnoreCase("libjdwp.dylib")           // macOS
+            || fileName.equalsIgnoreCase("jdwp.dll")                // Windows
+            // async-profiler, which supports Linux and macOS only.
+            || fileName.equals("libasyncProfiler.so")               // Linux
+            || fileName.equalsIgnoreCase("libasyncProfiler.dylib"); // macOS
+    }
+
+    private static String getFileName(String path) {
+        int separatorPos = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        return separatorPos >= 0 ? path.substring(separatorPos + 1) : path;
     }
 }

--- a/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/DefaultClassFileTransformer.java
+++ b/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/DefaultClassFileTransformer.java
@@ -18,12 +18,15 @@ package org.gradle.internal.instrumentation.agent;
 
 import org.gradle.internal.classloader.InstrumentingClassLoader;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class DefaultClassFileTransformer implements ClassFileTransformer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClassFileTransformer.class);
     private static final AtomicBoolean INSTALLED = new AtomicBoolean();
 
     @Override
@@ -38,12 +41,29 @@ class DefaultClassFileTransformer implements ClassFileTransformer {
             return null;
         }
         InstrumentingClassLoader instrumentingLoader = (InstrumentingClassLoader) loader;
+        byte[] instrumented = doTransform(instrumentingLoader, className, protectionDomain, classfileBuffer);
+        if (classBeingRedefined != null && instrumented != null && className != null && !instrumentingLoader.canReinstrumentClasses()) {
+            // Another agent requested a class on the build script classpath to be redefined (i.e. it supplied its new bytecode).
+            // On the substitution path we serve bytecode captured during the artifact transform and cannot apply the freshly compiled definition,
+            // so the swap silently has no effect.
+            // Warn so the developer isn't misled into thinking the edit was applied. A typical use case is the debugger requested Hot Code Replace.
+            // In most other cases, we detect the agent and set up the runtime-transformation pipeline.
+            LOGGER.warn("Redefinition (e.g. due to Hot Code Replace) of the class {} had no effect. " +
+                "Gradle serves pre-instrumented bytecode for buildscript and plugin classes, so the recompiled definition is ignored. " +
+                "Restart the build to pick up the change.",
+                className.replace('/', '.')
+            );
+        }
+        return instrumented;
+    }
+
+    private byte @Nullable [] doTransform(InstrumentingClassLoader loader, @Nullable String className, @Nullable ProtectionDomain protectionDomain, byte[] classfileBuffer) {
         try {
-            return instrumentingLoader.instrumentClass(className, protectionDomain, classfileBuffer);
+            return loader.instrumentClass(className, protectionDomain, classfileBuffer);
         } catch (Throwable th) {
             // Throwing exception from the ClassFileTransformer has no effect - if it happens, the class is loaded unchanged silently.
             // This is not something we want, so we notify the class loader about this.
-            instrumentingLoader.transformFailed(className, th);
+            loader.transformFailed(className, th);
             return null;
         }
     }

--- a/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/ThirdPartyAgentDetection.java
+++ b/platforms/core-runtime/instrumentation-agent-services/src/main/java/org/gradle/internal/instrumentation/agent/ThirdPartyAgentDetection.java
@@ -28,6 +28,11 @@ import java.lang.management.ManagementFactory;
  * <p>The result is computed on first call from the JVM's startup arguments and cached.
  * Agents attached at runtime via the Attach API are not detected and are not supported by
  * Gradle's buildscript instrumentation.
+ *
+ * <p>Some non-instrumenting JVMTI agents, such as the JDWP debug agent and async-profiler, are
+ * deliberately not reported as third-party agents, so that a plain debugging or profiling session
+ * exercises the same instrumentation path as a regular build. See
+ * {@link AgentUtils#isThirdPartyAgentSwitch(String)}.
  */
 public final class ThirdPartyAgentDetection {
 

--- a/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/AgentUtilsTest.groovy
+++ b/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/AgentUtilsTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.agent
+
+import spock.lang.Specification
+
+class AgentUtilsTest extends Specification {
+
+    def "third-party Java agents are detected"() {
+        expect:
+        AgentUtils.isThirdPartyAgentSwitch("-javaagent:/path/to/some-agent.jar")
+        AgentUtils.isThirdPartyAgentSwitch("-javaagent:/path/to/some-agent.jar=options")
+    }
+
+    def "Gradle's own instrumentation agent is not a third-party agent"() {
+        expect:
+        !AgentUtils.isThirdPartyAgentSwitch("-javaagent:/path/to/${AgentUtils.AGENT_MODULE_NAME}-1.0.jar")
+    }
+
+    def "can detect gradle agent switch"() {
+        expect:
+        AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:${AgentUtils.AGENT_MODULE_NAME}.jar")
+        AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:${AgentUtils.AGENT_MODULE_NAME}-1.0.jar")
+        AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:/path/to/gradle/${AgentUtils.AGENT_MODULE_NAME}-1.0.jar")
+        AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:/path/to/gradle/${AgentUtils.AGENT_MODULE_NAME}-1.0.jar=options")
+        AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:C:\\path\\to\\gradle\\${AgentUtils.AGENT_MODULE_NAME}-1.0.jar")
+
+        !AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:/path/to/another-agent.jar")
+        !AgentUtils.isGradleInstrumentationAgentSwitch("-javaagent:/path/to/another-agent.jar=exclude=${AgentUtils.AGENT_MODULE_NAME}-1.0.jar")
+    }
+
+    def "generic native JVMTI agents are treated as third-party agents"() {
+        expect:
+        AgentUtils.isThirdPartyAgentSwitch("-agentlib:asan")
+        AgentUtils.isThirdPartyAgentSwitch("-agentpath:/usr/lib/libasan.so=options")
+        // A library whose name merely contains an exempt name but isn't the exempt agent library is not exempt.
+        AgentUtils.isThirdPartyAgentSwitch("-agentpath:/usr/lib/libmyjdwp.so")
+        AgentUtils.isThirdPartyAgentSwitch("-agentpath:/usr/lib/libasyncProfilerHelper.so")
+    }
+
+    def "the JDWP debug agent is exempt from third-party detection: #jvmArg"() {
+        expect:
+        !AgentUtils.isThirdPartyAgentSwitch(jvmArg)
+
+        where:
+        jvmArg << [
+            "-agentlib:jdwp",
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005",
+            "-agentpath:/usr/lib/jvm/temurin-17/lib/libjdwp.so=transport=dt_socket,server=y,suspend=n",
+            "-agentpath:/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home/lib/libjdwp.dylib=transport=dt_socket",
+            "-agentpath:C:\\Program Files\\Java\\jdk-17\\bin\\jdwp.dll=transport=dt_socket,server=y",
+        ]
+    }
+
+    def "the async-profiler agent is exempt from third-party detection: #jvmArg"() {
+        expect:
+        !AgentUtils.isThirdPartyAgentSwitch(jvmArg)
+
+        where:
+        jvmArg << [
+            "-agentlib:asyncProfiler",
+            "-agentlib:asyncProfiler=start,event=cpu,file=profile.html",
+            "-agentpath:/opt/async-profiler/lib/libasyncProfiler.so=start,event=cpu,file=profile.jfr",
+            "-agentpath:/opt/async-profiler/lib/libasyncProfiler.dylib=start,event=alloc,file=profile.html",
+        ]
+    }
+
+    def "non-agent JVM arguments are not third-party agents: #jvmArg"() {
+        expect:
+        !AgentUtils.isThirdPartyAgentSwitch(jvmArg)
+
+        where:
+        jvmArg << ["-Xmx2g", "-Dfoo=bar", "-ea", "--add-opens=java.base/java.lang=ALL-UNNAMED"]
+    }
+}

--- a/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/DefaultClassFileTransformerTest.groovy
+++ b/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/DefaultClassFileTransformerTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.agent
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.classloader.InstrumentingClassLoader
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.security.ProtectionDomain
+
+class DefaultClassFileTransformerTest extends Specification {
+    private static final byte[] ORIGINAL = [1, 2, 3] as byte[]
+    private static final byte[] INSTRUMENTED = [4, 5, 6] as byte[]
+    private static final String INTERNAL_NAME = TestClass.name.replace('.', '/')
+
+    final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+    @Rule
+    final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    final DefaultClassFileTransformer transformer = new DefaultClassFileTransformer()
+
+    def "classes loaded by a classloader that doesn't instrument are left alone"() {
+        expect:
+        runTransform(getClass().classLoader) == null
+        warnings().empty
+    }
+
+    def "substituting classloader warns that a redefinition had no effect"() {
+        given:
+        def loader = loader(canReinstrument: false)
+
+        when:
+        def result = runTransform(loader)
+
+        then: "the pre-instrumented bytecode is served instead of the supplied one"
+        Arrays.equals(result, INSTRUMENTED)
+
+        and:
+        warnings().size() == 1
+        // The warning has to name the class the way a developer sees it, not in the JVM's internal form.
+        warnings()[0].contains(TestClass.name)
+        !warnings()[0].contains(INTERNAL_NAME)
+    }
+
+    def "no warning is emitted on an initial class load"() {
+        given:
+        def loader = loader(canReinstrument: false)
+
+        when: "classBeingRedefined is null, so this is a plain class load rather than a redefinition"
+        def result = runTransform(loader, null)
+
+        then:
+        Arrays.equals(result, INSTRUMENTED)
+        warnings().empty
+    }
+
+    def "no warning is emitted when the classloader re-instruments the supplied bytecode"() {
+        given: "the runtime-transformation path, where a redefinition does take effect"
+        def loader = loader(canReinstrument: true)
+
+        when:
+        def result = runTransform(loader)
+
+        then:
+        Arrays.equals(result, INSTRUMENTED)
+        warnings().empty
+    }
+
+    def "no warning is emitted when the redefined class is not instrumented by Gradle"() {
+        given:
+        def loader = loader(canReinstrument: false, instrumented: null)
+
+        when:
+        def result = runTransform(loader)
+
+        then: "the class is left as the JVM supplied it, so the redefinition does take effect"
+        result == null
+        warnings().empty
+    }
+
+    def "instrumentation failure is reported to the classloader instead of being warned about"() {
+        given:
+        def failure = new RuntimeException("boom")
+        def loader = loader(canReinstrument: false, failure: failure)
+
+        when:
+        def result = runTransform(loader)
+
+        then:
+        result == null
+        loader.failures == [failure]
+        warnings().empty
+    }
+
+    private byte[] runTransform(ClassLoader loader, Class<TestClass> classBeingRedefined = TestClass) {
+        return transformer.transform(loader, INTERNAL_NAME, classBeingRedefined, TestClass.protectionDomain, ORIGINAL)
+    }
+
+    private List<String> warnings() {
+        outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }*.message
+    }
+
+    private static TestInstrumentingClassLoader loader(Map<String, ?> args) {
+        new TestInstrumentingClassLoader(
+            args.containsKey("instrumented") ? (byte[]) args.instrumented : INSTRUMENTED,
+            (boolean) args.canReinstrument,
+            (Throwable) args.failure
+        )
+    }
+
+    private static class TestInstrumentingClassLoader extends ClassLoader implements InstrumentingClassLoader {
+        private final byte[] instrumented
+        private final boolean canReinstrument
+        private final Throwable failure
+        final List<Throwable> failures = []
+
+        TestInstrumentingClassLoader(byte[] instrumented, boolean canReinstrument, Throwable failure) {
+            this.instrumented = instrumented
+            this.canReinstrument = canReinstrument
+            this.failure = failure
+        }
+
+        @Override
+        byte[] instrumentClass(String className, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+            if (failure != null) {
+                throw failure
+            }
+            return instrumented
+        }
+
+        @Override
+        boolean canReinstrumentClasses() {
+            return canReinstrument
+        }
+
+        @Override
+        void transformFailed(String className, Throwable cause) {
+            failures << cause
+        }
+    }
+}
+

--- a/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/TestClass.groovy
+++ b/platforms/core-runtime/instrumentation-agent-services/src/test/groovy/org/gradle/internal/instrumentation/agent/TestClass.groovy
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.agent
+
+class TestClass {}

--- a/platforms/core-runtime/instrumentation-agent/src/main/java/org/gradle/instrumentation/agent/Agent.java
+++ b/platforms/core-runtime/instrumentation-agent/src/main/java/org/gradle/instrumentation/agent/Agent.java
@@ -48,6 +48,9 @@ public class Agent {
     public static boolean installTransformer(ClassFileTransformer transformer) {
         Instrumentation inst = instrumentation;
         if (inst != null) {
+            // We have some assumptions about the order in which transformations are applied, when there are multiple agents/transforms.
+            // Changing the transformer to be retransform-capable here will change the order and break those assumptions.
+            // See DefaultClassFileTransformer and AgentUtils for more information.
             inst.addTransformer(transformer);
             return true;
         }

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -722,6 +722,10 @@ When process isolation is used, the worker action is executed in a separate work
 
 In simple cases, when the libraries also provide command-line entry points (`public static void main()` method), you can also use the link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[`JavaExec`] task to isolate the library.
 
+The agent also affects hot-swapping build logic classes in a running build.
+It prevents Hot Code Replace of such classes: Gradle logs a warning and ignores the recompiled definition.
+You should not rely on Hot Code Replace when debugging build logic; restart the build to pick up such a change.
+
 [[config_cache:secrets]]
 == Handling of Credentials and Secrets
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_requirements.adoc
@@ -722,9 +722,9 @@ When process isolation is used, the worker action is executed in a separate work
 
 In simple cases, when the libraries also provide command-line entry points (`public static void main()` method), you can also use the link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[`JavaExec`] task to isolate the library.
 
-The agent also affects hot-swapping build logic classes in a running build.
-It prevents Hot Code Replace of such classes: Gradle logs a warning and ignores the recompiled definition.
-You should not rely on Hot Code Replace when debugging build logic; restart the build to pick up such a change.
+Gradle's instrumentation agent also affects hot-swapping build logic classes in a running build.
+Gradle serves pre-instrumented bytecode for buildscript and plugin classes, so a Hot Code Replace of such a class is ignored: Gradle logs a warning and keeps the pre-instrumented definition.
+You should not rely on Hot Code Replace when debugging build logic; restart the build to pick up your edit.
 
 [[config_cache:secrets]]
 == Handling of Credentials and Secrets
@@ -791,6 +791,9 @@ $ export GRADLE_ENCRYPTION_KEY="your-generated-key-here"
 The Configuration Cache supports third-party `-javaagent:` attachments to the build JVM (for example a coverage agent such as Jacoco, IntelliJ's `idea_rt.jar`, or a custom user agent) in regular daemon builds and in <<test_kit#test_kit, TestKit>>'s default (daemon) mode.
 
 Only agents attached at JVM startup are supported. Agents attached dynamically via the Attach API after the JVM has started are not detected and may cause incorrect bytecode observation on classes loaded after attachment.
+
+The JDWP debug agent and async-profiler are recognized and do not trigger third-party agent handling, so a debugging or profiling session runs the same instrumentation path as a regular build.
+Note that debugger-initiated Hot Code Replace of instrumented buildscript or plugin classes is not honored, see <<config_cache:requirements:bytecode_modifications_and_isolation, Bytecode Modifications and Java Agent>> for details.
 
 It is not supported when TestKit runs in embedded mode (`withDebug(true)`). To use a third-party Java agent with the Configuration Cache from there, drop `withDebug(true)` and let TestKit use its daemon default.
 

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -436,6 +436,13 @@ public abstract class DefaultScriptCompilationHandler implements ScriptCompilati
         }
 
         @Override
+        public boolean canReinstrumentClasses() {
+            // The compiled script classloader always substitutes bytecode instrumented during the artifact
+            // transform and never re-instruments the JVM-supplied buffer, so it cannot honor a hot-swap.
+            return false;
+        }
+
+        @Override
         public void transformFailed(@Nullable String className, Throwable cause) {
             errorHandler.classLoadingError(className, cause);
         }


### PR DESCRIPTION
Attaching a debugger passes -agentlib:jdwp (or -agentpath:.../libjdwp) to the daemon JVM. Detection flagged this conservatively as a third-party agent, which switched buildscript classpath instrumentation onto the load-time "compose" path. As a result, simply attaching a debugger made Gradle developers debug a different code path than the one that runs in production, where no third-party agent is present.

Unlike an arbitrary JVMTI agent, JDWP never rewrites bytecode during normal class loading; it only redefines classes on an explicit debugger command (Hot Code Replace). So it does not need the compose path. Exempt it from detection so a plain debugging session exercises the same substitution-based instrumentation as a regular build.

The trade-off is that the substitution path serves bytecode captured during the artifact transform and ignores the buffer the JVM supplies, so a debugger-initiated redefinition of an instrumented buildscript or plugin class is silently discarded. Gradle cannot veto the debugger's redefinition, so instead of misleading the developer, warn when a hot-swap of an instrumented class has no effect. The classloader now reports whether it honors redefinition (only the compose path does), and the agent's transformer logs a warning otherwise.
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
