### PR TITLE
Re-register Groovy 5's verification phase operation for script compilation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyScriptClassCompilerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyScriptClassCompilerIntegrationTest.groovy
@@ -49,4 +49,35 @@ class GroovyScriptClassCompilerIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("value = value")
     }
+
+    def "classes declared in a script get the implicit default constructor and the metaclass accessors"() {
+        // Groovy's Verifier is what adds these. It runs as part of the CLASS_GENERATION phase
+        // operations that CustomCompilationUnit has to re-register, so make sure none of them get
+        // lost - without the Verifier, `new Thing()` fails at runtime with
+        // "Could not find matching constructor for: Thing()".
+        buildFile """
+        class Thing {
+        }
+
+        class ThingWithAField {
+            def value = "field"
+        }
+
+        tasks.register("echo") {
+            doLast {
+                println("declaredConstructors = \$Thing.declaredConstructors")
+                println("thingWithAField = \${new ThingWithAField().value}")
+                println("metaClass = \${new Thing().metaClass != null}")
+            }
+        }
+        """
+
+        when:
+        succeeds("echo")
+
+        then:
+        outputContains("declaredConstructors = [public Thing()]")
+        outputContains("thingWithAField = field")
+        outputContains("metaClass = true")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CustomCompilationUnit.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CustomCompilationUnit.java
@@ -27,6 +27,7 @@ import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.security.CodeSource;
@@ -42,9 +43,38 @@ class CustomCompilationUnit extends CompilationUnit {
         installCustomCodegen(customVerifier);
     }
 
+    /**
+     * Re-registers the operations that {@link CompilationUnit} itself installs for
+     * {@link Phases#CLASS_GENERATION}, because {@link #addPhaseOperation(IPrimaryClassNodeOperation, int)}
+     * below discards all of them, and decorates the first one with our {@code customVerifier}.
+     *
+     * <p>Groovy 4 and earlier used a single {@code classgen} operation, which ran
+     * {@link org.codehaus.groovy.classgen.Verifier} itself. Groovy 5 splits that in two: a
+     * {@code verification} operation (the {@code Verifier}) followed by {@code classgen}. The
+     * {@code Verifier} is what adds the implicit default constructor and the metaclass accessors to
+     * a class, so if it is not re-registered here, every class declared in a script is generated
+     * without any constructor at all and instantiating it fails at runtime with
+     * "Could not find matching constructor for: ...".
+     */
     private void installCustomCodegen(Action<? super ClassNode> customVerifier) {
-        final IPrimaryClassNodeOperation nodeOperation = prepareCustomCodegen(customVerifier);
-        addFirstPhaseOperation(nodeOperation, Phases.CLASS_GENERATION);
+        try {
+            // present on Groovy 5+ only
+            final Field verification = findOperationField("verification");
+            final Field classgen = getOperationField("classgen");
+
+            // the customVerifier has to run before the Verifier does, as it did on Groovy 4
+            final Field firstField = verification != null ? verification : classgen;
+            final IPrimaryClassNodeOperation first = decoratedNodeOperation(customVerifier, getOperation(firstField));
+            firstField.set(this, first);
+
+            // addFirstPhaseOperation pushes to the front, so register in reverse order
+            if (verification != null) {
+                addFirstPhaseOperation(getOperation(classgen), Phases.CLASS_GENERATION);
+            }
+            addFirstPhaseOperation(first, Phases.CLASS_GENERATION);
+        } catch (ReflectiveOperationException e) {
+            throw new GradleException("Unable to install custom rules code generation", e);
+        }
     }
 
     @Override
@@ -54,42 +84,43 @@ class CustomCompilationUnit extends CompilationUnit {
         }
     }
 
-    // this is using a decoration of the existing classgen implementation
-    // it can't be implemented as a phase as our customVerifier needs to visit closures as well
-    private IPrimaryClassNodeOperation prepareCustomCodegen(Action<? super ClassNode> customVerifier) {
-        try {
-            final Field classgen = getClassgenField();
-            IPrimaryClassNodeOperation realClassgen = (IPrimaryClassNodeOperation) classgen.get(this);
-            final IPrimaryClassNodeOperation decoratedClassgen = decoratedNodeOperation(customVerifier, realClassgen);
-            classgen.set(this, decoratedClassgen);
-            return decoratedClassgen;
-        } catch (ReflectiveOperationException e) {
-            throw new GradleException("Unable to install custom rules code generation", e);
-        }
+    private IPrimaryClassNodeOperation getOperation(Field field) throws ReflectiveOperationException {
+        return (IPrimaryClassNodeOperation) field.get(this);
     }
 
-    private Field getClassgenField() {
+    private static Field getOperationField(String name) {
+        final Field field = findOperationField(name);
+        if (field == null) {
+            throw new GradleException("Unable to detect class generation in Groovy CompilationUnit");
+        }
+        return field;
+    }
+
+    @Nullable
+    private static Field findOperationField(String name) {
         try {
-            final Field classgen = CompilationUnit.class.getDeclaredField("classgen");
-            classgen.setAccessible(true);
-            return classgen;
+            final Field field = CompilationUnit.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
         } catch (NoSuchFieldException e) {
-            throw new GradleException("Unable to detect class generation in Groovy CompilationUnit", e);
+            return null;
         }
     }
 
-    private static IPrimaryClassNodeOperation decoratedNodeOperation(Action<? super ClassNode> customVerifier, IPrimaryClassNodeOperation realClassgen) {
+    // this is using a decoration of the existing operation
+    // it can't be implemented as a phase as our customVerifier needs to visit closures as well
+    private static IPrimaryClassNodeOperation decoratedNodeOperation(Action<? super ClassNode> customVerifier, IPrimaryClassNodeOperation decorated) {
         return new IPrimaryClassNodeOperation() {
 
             @Override
             public boolean needSortedInput() {
-                return realClassgen.needSortedInput();
+                return decorated.needSortedInput();
             }
 
             @Override
             public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
                 customVerifier.execute(classNode);
-                realClassgen.call(source, context, classNode);
+                decorated.call(source, context, classNode);
             }
         };
     }


### PR DESCRIPTION
### Context

On a Gradle built with Groovy 5 (`-DbundleGroovyMajor=5`), every class declared in a Groovy script is generated with **no constructors at all**, so instantiating one fails at runtime:

```
> Could not find matching constructor for: Thing()
```

`CustomCompilationUnit` overrides `addPhaseOperation` to suppress every operation `CompilationUnit` registers for `Phases.CLASS_GENERATION`, then reflectively recovers the `classgen` field and re-registers it decorated with our `customVerifier`.

Groovy 5 ([GROOVY-10904](https://issues.apache.org/jira/browse/GROOVY-10904), `f8d78e6e`) split that single operation in two — a `verification` operation running `Verifier` and friends, followed by `classgen` for the bytecode generation — and registers **both** at `CLASS_GENERATION`. Since only `classgen` is recovered, `verification` is silently dropped and the `Verifier` never runs for the classes declared in a script. The `Verifier` is what adds the implicit default constructor and `$getStaticMetaClass` / `getMetaClass` / `setMetaClass`.

`javap` of `org.codehaus.groovy.control.CompilationUnit`:

```
# 4.0.23
private final IPrimaryClassNodeOperation classgen;

# 5.0.7
private final IPrimaryClassNodeOperation verification;   <-- new
private final IPrimaryClassNodeOperation classgen;
```

`class Foo { }` in an init script:

| Distribution | `Foo.declaredConstructors` |
| --- | --- |
| 9.7 (Groovy 4.0.32) | `[public Foo()]` |
| 9.8 `-DbundleGroovyMajor=5` | `[]` → *Could not find matching constructor for: Foo()* |
| same + this fix | `[public Foo()]` |

This is what fails the `BUILD_WITH_BUILT_GRADLE` step of `Gradleception with Groovy 5`. Related: #34967.

Note the `customVerifier` is still installed **into the field**, not merely registered as a phase operation: Groovy 5's `classgen` invokes `verification` directly for inner classes, and that is what keeps the `customVerifier` visiting generated closures (`ClosureCreationInterceptingVerifier`, i.e. the `model {}` DSL).

### Verification

Built `:distributions-full:install` both with and without `-DbundleGroovyMajor=5`, before and after the change:

- Groovy 5, before: a script-declared class has no constructors; `new Thing()` fails as above.
- Groovy 5, after: constructor and metaclass accessors are back, scripts run.
- Groovy 4, after: output identical to before the change (the `verification` field is absent, so the original code path is taken unchanged).
- `model {}` DSL works on both, confirming closures are still visited.

Also verified against the TeamCity Gradle runner's init scripts (`init_since_8.gradle`, `init_v2.gradle`), which is where this was first hit — both fail on an unpatched Groovy 5 Gradle and succeed with this change, unmodified. `init_v2.gradle` fails there with a second symptom of the same cause, `Cannot have abstract method CompileTaskErrorOutputPlugin.getBuildEventsListenerRegistry()`, also fixed.

**Caveat on the added integration test:** it cannot fail on a normal (Groovy 4) build — it only has teeth under `-DbundleGroovyMajor=5`, and that build cannot run `:core:embeddedIntegTest` at all, because `:internal-distribution-testing:compileGroovy` fails to compile `RepositoryHttpServer` under Groovy 5 (pre-existing, unrelated to this change). So CI here demonstrates no regression rather than demonstrating the fix; the fix itself was verified with the two distributions by hand as described above. The test is still worth having as coverage once Gradleception with Groovy 5 is green.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team. — n/a, branch is on the main repository
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — see caveat above
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. — the behaviour is only observable through an actual script compilation, so it is covered by the integration test
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — internal only
- [x] Ensure that tests pass sanity check: `./gradlew :core:sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :core:embeddedIntegTest --tests "org.gradle.groovy.scripts.*" --tests "*BuildScript*IntegrationTest"`.
