### PR TITLE
Make process-global stdout/stderr capture thread safe

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/config/LoggingSourceSystem.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/config/LoggingSourceSystem.java
@@ -39,4 +39,17 @@ public interface LoggingSourceSystem extends LoggingSystem {
      * @return the state of this logging system immediately before the changes are applied.
      */
     Snapshot startCapture();
+
+    /**
+     * Releases one capture previously acquired by {@link #startCapture()}.
+     *
+     * <p>Logging systems that mutate process-global state are shared by many scopes which may be started and
+     * stopped concurrently — for example one scope per project during Isolated Projects parallel configuration.
+     * Such systems must keep capture active until every scope that started it has ended it, rather than letting
+     * whichever scope finishes first restore its own snapshot and disable capture for the others.</p>
+     *
+     * <p>Implementations that hold no process-global state need not do anything.</p>
+     */
+    default void endCapture() {
+    }
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
@@ -381,6 +381,12 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
         public void stop() {
             try {
                 if (originalState != null) {
+                    if (enabled) {
+                        // Release the capture this scope acquired in start()/enableCapture(). Restoring the
+                        // snapshot alone is not enough for logging systems backed by process-global state, since
+                        // sibling scopes configured in parallel may still be capturing.
+                        loggingSystem.endCapture();
+                    }
                     loggingSystem.restore(originalState);
                 }
             } finally {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManagerFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManagerFactory.java
@@ -45,7 +45,7 @@ public class DefaultLoggingManagerFactory implements LoggingManagerFactory {
     }
 
     @Override
-    public LoggingManagerInternal createLoggingManager() {
+    public synchronized LoggingManagerInternal createLoggingManager() {
         if (!created) {
             created = true;
             return getRoot();

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
@@ -36,6 +36,20 @@ import java.util.concurrent.atomic.AtomicReference;
  * A {@link LoggingSourceSystem} which routes content written to a {@code PrintStream} to a {@link OutputEventListener}.
  * Generates a {@link StyledTextOutputEvent} instance when a line of text is written to the {@code PrintStream}.
  * Generates a {@link LogLevelChangeEvent} when the log level for this {@code LoggingSystem} is changed.
+ *
+ * <p>This type mutates process-global state ({@code System.out} / {@code System.err}) on behalf of many
+ * independent scopes, and those scopes are started and stopped concurrently: under Isolated Projects each
+ * project is configured on its own build operation worker thread, and each project script is wrapped in a
+ * {@code start()}/{@code stop()} pair by {@code DefaultScriptRunnerFactory}. The same is true of parallel task
+ * execution. Two properties are therefore required, and both are implemented here:</p>
+ *
+ * <ul>
+ *     <li>All state transitions are guarded by a single monitor, so a snapshot/mutate/restore sequence on one
+ *     thread cannot interleave with another thread's.</li>
+ *     <li>Capture is reference counted, so one scope ending cannot tear down capture while sibling scopes are
+ *     still active. Previously the last scope to restore its snapshot won, which silently dropped everything
+ *     written to {@code System.out} by projects that were still being configured.</li>
+ * </ul>
  */
 abstract class PrintStreamLoggingSystem implements LoggingSourceSystem {
     private final AtomicReference<StandardOutputListener> destination = new AtomicReference<StandardOutputListener>();
@@ -49,8 +63,13 @@ abstract class PrintStreamLoggingSystem implements LoggingSourceSystem {
         public void endOfStream(@Nullable Throwable failure) {
         }
     });
+    private final Object lock = new Object();
     private PrintStreamDestination original;
-    private boolean enabled;
+    /**
+     * The number of scopes that currently have capture enabled. Capture is installed while this is positive.
+     */
+    private int captureCount;
+    private boolean installed;
     private LogLevel logLevel;
     private final StandardOutputListener listener;
     private final OutputEventListener outputEventListener;
@@ -72,64 +91,106 @@ abstract class PrintStreamLoggingSystem implements LoggingSourceSystem {
 
     @Override
     public Snapshot snapshot() {
-        return new SnapshotImpl(enabled, logLevel);
+        synchronized (lock) {
+            return new SnapshotImpl(logLevel);
+        }
     }
 
     @Override
     public void restore(Snapshot state) {
         SnapshotImpl snapshot = (SnapshotImpl) state;
-        enabled = snapshot.enabled;
-        logLevel = snapshot.logLevel;
-        if (enabled) {
+        synchronized (lock) {
+            boolean levelChanged = snapshot.logLevel != logLevel;
+            logLevel = snapshot.logLevel;
+            boolean wasInstalled = installed;
+            // Capture is driven purely by the reference count. Restoring the snapshot's `enabled` flag here would
+            // let a scope that finishes early uninstall capture out from under sibling scopes that are still
+            // running. Scopes release their own capture via endCapture().
+            reconcileCapture();
+            if (levelChanged && installed && wasInstalled) {
+                // install() emits this itself when it newly installs, so only do it when capture was already up.
+                outstr.flush();
+                outputEventListener.onOutput(new LogLevelChangeEvent(logLevel));
+            }
+        }
+    }
+
+    @Override
+    public Snapshot setLevel(LogLevel logLevel) {
+        synchronized (lock) {
+            Snapshot snapshot = new SnapshotImpl(this.logLevel);
+            if (logLevel != this.logLevel) {
+                this.logLevel = logLevel;
+                if (captureCount > 0) {
+                    outstr.flush();
+                    outputEventListener.onOutput(new LogLevelChangeEvent(logLevel));
+                }
+            }
+            return snapshot;
+        }
+    }
+
+    @Override
+    public Snapshot startCapture() {
+        synchronized (lock) {
+            Snapshot snapshot = new SnapshotImpl(logLevel);
+            captureCount++;
+            reconcileCapture();
+            return snapshot;
+        }
+    }
+
+    @Override
+    public void endCapture() {
+        synchronized (lock) {
+            if (captureCount > 0) {
+                captureCount--;
+            }
+            reconcileCapture();
+        }
+    }
+
+    private void reconcileCapture() {
+        if (captureCount > 0) {
             install();
         } else {
             uninstall();
         }
     }
 
-    @Override
-    public Snapshot setLevel(LogLevel logLevel) {
-        Snapshot snapshot = snapshot();
-        if (logLevel != this.logLevel) {
-            this.logLevel = logLevel;
-            if (enabled) {
-                outstr.flush();
-                outputEventListener.onOutput(new LogLevelChangeEvent(logLevel));
-            }
-        }
-        return snapshot;
-    }
-
-    @Override
-    public Snapshot startCapture() {
-        Snapshot snapshot = snapshot();
-        if (!enabled) {
-            install();
-        }
-        return snapshot;
-    }
-
     private void uninstall() {
+        if (!installed) {
+            return;
+        }
+        outstr.flush();
         if (original != null) {
-            outstr.flush();
             destination.set(original);
             set(original.originalStream);
             original = null;
         }
+        installed = false;
     }
 
     private void install() {
+        if (installed) {
+            return;
+        }
         if (original == null) {
             PrintStream originalStream = get();
-            original = new PrintStreamDestination(originalStream);
+            // Never snapshot our own capture stream as the stream to restore later: that would make
+            // uninstall() point System.out at outstr with `destination` writing back into outstr, a
+            // self-referential sink that silently discards everything written to it.
+            if (originalStream != outstr) {
+                original = new PrintStreamDestination(originalStream);
+            }
         }
-        enabled = true;
         outstr.flush();
         outputEventListener.onOutput(new LogLevelChangeEvent(logLevel));
         destination.set(listener);
         if (get() != outstr) {
             set(outstr);
         }
+        installed = true;
     }
 
     private static class PrintStreamDestination implements StandardOutputListener {
@@ -146,11 +207,9 @@ abstract class PrintStreamLoggingSystem implements LoggingSourceSystem {
     }
 
     private static class SnapshotImpl implements Snapshot {
-        private final boolean enabled;
         private final LogLevel logLevel;
 
-        public SnapshotImpl(boolean enabled, LogLevel logLevel) {
-            this.enabled = enabled;
+        public SnapshotImpl(LogLevel logLevel) {
             this.logLevel = logLevel;
         }
     }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
@@ -145,6 +145,7 @@ class DefaultLoggingManagerTest extends Specification {
         loggingManager.stop()
 
         then:
+        1 * slf4jLoggingSystem.endCapture()
         1 * slf4jLoggingSystem.restore(slf4jSnapshot)
         1 * javaUtilLoggingSystem.restore(javaUtilSnapshot)
         1 * loggingRouter.restore(routerSnapshot)
@@ -174,6 +175,7 @@ class DefaultLoggingManagerTest extends Specification {
         loggingManager.stop()
 
         then:
+        1 * slf4jLoggingSystem.endCapture()
         1 * loggingRouter.restore(routerSnapshot)
         1 * slf4jLoggingSystem.restore(slf4jSnapshot)
         1 * javaUtilLoggingSystem.restore(javaUtilSnapshot)
@@ -244,6 +246,7 @@ class DefaultLoggingManagerTest extends Specification {
         loggingManager.stop()
 
         then:
+        1 * slf4jLoggingSystem.endCapture()
         1 * slf4jLoggingSystem.restore(slf4jSnapshot)
         1 * javaUtilLoggingSystem.restore(javaUtilSnapshot)
         1 * loggingRouter.restore(routerSnapshot)

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
@@ -57,6 +57,7 @@ class PrintStreamLoggingSystemTest extends Specification {
         stream != originalStream
 
         when:
+        loggingSystem.endCapture()
         loggingSystem.restore(snapshot)
 
         then:
@@ -67,7 +68,7 @@ class PrintStreamLoggingSystemTest extends Specification {
         def stream2 = new PrintStream(new ByteArrayOutputStream())
 
         given:
-        loggingSystem.restore(loggingSystem.startCapture())
+        endCapture(loggingSystem.startCapture())
         stream = stream2
 
         when:
@@ -77,10 +78,94 @@ class PrintStreamLoggingSystemTest extends Specification {
         stream != stream2
 
         when:
-        loggingSystem.restore(snapshot)
+        endCapture(snapshot)
 
         then:
         stream == stream2
+    }
+
+    def "capture stays installed until every scope that started it has ended it"() {
+        given: 'two scopes start capture, as sibling projects configured in parallel do'
+        def outer = loggingSystem.startCapture()
+        def inner = loggingSystem.startCapture()
+        def capturing = stream
+
+        when: 'the inner scope finishes'
+        endCapture(inner)
+
+        then: 'capture is still installed, so the outer scope keeps being captured'
+        stream == capturing
+        stream != originalStream
+
+        when:
+        endCapture(outer)
+
+        then: 'the last scope to leave tears capture down'
+        stream == originalStream
+    }
+
+    def "a scope that never started capture does not tear down capture held by another scope"() {
+        given:
+        def capturingScope = loggingSystem.startCapture()
+        def capturing = stream
+
+        and: 'a second scope only snapshots and restores, without capturing'
+        def nonCapturingScope = loggingSystem.snapshot()
+
+        when:
+        loggingSystem.restore(nonCapturingScope)
+
+        then:
+        stream == capturing
+        stream != originalStream
+
+        cleanup:
+        endCapture(capturingScope)
+    }
+
+    def "concurrent scopes never lose output"() {
+        given:
+        def threads = 8
+        def iterations = 200
+        def start = new java.util.concurrent.CountDownLatch(1)
+        def done = new java.util.concurrent.CountDownLatch(threads)
+        def failure = new java.util.concurrent.atomic.AtomicReference<Throwable>()
+        // Hold capture open for the whole run, as the build-level scope does.
+        def buildScope = loggingSystem.startCapture()
+
+        when:
+        (1..threads).each { t ->
+            Thread.start {
+                try {
+                    start.await()
+                    iterations.times {
+                        def scope = loggingSystem.startCapture()
+                        stream.println("out")
+                        loggingSystem.endCapture()
+                        loggingSystem.restore(scope)
+                    }
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e)
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+        start.countDown()
+        done.await()
+
+        then:
+        failure.get() == null
+        and: 'capture was never torn down while the build scope held it, so nothing reached the original stream'
+        original.toString() == ''
+
+        cleanup:
+        endCapture(buildScope)
+    }
+
+    private void endCapture(snapshot) {
+        loggingSystem.endCapture()
+        loggingSystem.restore(snapshot)
     }
 
     def onStartsCapturingWhenNotAlreadyCapturing() {
@@ -156,7 +241,7 @@ class PrintStreamLoggingSystemTest extends Specification {
 
         when:
         stream.print("info")
-        loggingSystem.restore(snapshot)
+        endCapture(snapshot)
 
         then:
         1 * listener.onOutput({ it instanceof StyledTextOutputEvent && it.spans[0].text == 'info' })
@@ -171,7 +256,7 @@ class PrintStreamLoggingSystemTest extends Specification {
         def capturing = stream
 
         when:
-        loggingSystem.restore(snapshot)
+        endCapture(snapshot)
         capturing.println("info-1")
         stream.println('info-2')
 
@@ -187,14 +272,14 @@ info-2
         def off = loggingSystem.snapshot()
         loggingSystem.setLevel(LogLevel.INFO)
         loggingSystem.startCapture()
-        loggingSystem.restore(off)
+        endCapture(off)
         def snapshot = loggingSystem.snapshot()
         loggingSystem.setLevel(LogLevel.ERROR)
         loggingSystem.startCapture()
         def capturing = stream
 
         when:
-        loggingSystem.restore(snapshot)
+        endCapture(snapshot)
         capturing.println("info-1")
         stream.println('info-2')
 
@@ -206,11 +291,13 @@ info-2
         0 * listener._
     }
 
-    def restoreStartsCapturingWhenCapturingWasOnWhenSnapshotTaken() {
+    def restoreKeepsCapturingWhileTheScopeStillHoldsCapture() {
         def off = loggingSystem.snapshot()
         loggingSystem.setLevel(LogLevel.WARN)
         loggingSystem.startCapture()
         def snapshot = loggingSystem.snapshot()
+        // Restoring a snapshot taken before capture started must not disable capture, because this scope has
+        // not released it yet.
         loggingSystem.restore(off)
 
         when:


### PR DESCRIPTION
Draft — **this does not yet fix the reported symptom.** Opening it to share the investigation and the hardening done so far.

Context: #38702

## Status

`ProjectSchemaAccessorsIntegrationTest.can access configurations registered by declared plugins via jit accessor` fails ~76% of the time in `Check_IsolatedProjects_*_bucket8` (152F/45P master, 28F/11P release) and ~0.5% everywhere else. The cause is that a subproject's configuration-time `println` is silently discarded during Isolated Projects parallel project configuration — see #38702 for the full write-up and a standalone reproducer.

I measured this change against that reproducer (10 attempts, fresh Gradle user home each, `help -q` with `-Dorg.gradle.isolated-projects=true`, counting whether all expected markers reach the client):

| Distribution | Runs with complete output |
|---|---|
| `master` | 1/10 |
| with this change | 3/10 |

So the race this PR closes is **not** the (only) cause. I am posting the hardening because it is independently correct, and the diff documents what has been ruled in.

## What this changes

`PrintStreamLoggingSystem` mutates process-global `System.out` / `System.err` on behalf of many scopes, and those scopes start and stop concurrently:

- Under Isolated Projects each project is configured on its own build operation worker thread (`DefaultProjectsPreparer.configureHierarchyInParallel` → `TaskPathProjectEvaluator`).
- `DefaultScriptRunnerFactory` wraps every script in a `getStandardOutputCapture().start()` / `.stop()` pair, and for a project script that resolves to a **per-project** `DefaultLoggingManager` (`ProjectScopeServices` creates one per project).
- All of those managers share the same `PrintStreamLoggingSystem` singletons from `LoggingServiceRegistry`.
- Parallel task execution does the same thing per task (`TaskExecution` + the per-task manager from `AbstractTask`).

None of that state was synchronized — `original`, `enabled` and `logLevel` were plain non-volatile fields and `snapshot()`/`restore()`/`startCapture()`/`install()`/`uninstall()` were unguarded — and capture was not reference counted, so:

1. **Sibling scopes tear down each other's capture.** Project A snapshots (`enabled == false`) and installs; project B snapshots (`enabled == true`) so its `startCapture()` is a no-op; A finishes and restores its `enabled == false` snapshot, uninstalling capture while B is still configuring and printing. Last restore wins.
2. **`install()` could snapshot its own capture stream as the "original".** With no guard against `get() == outstr`, a racing `uninstall()` that has already nulled `original` lets the next `install()` set `original = PrintStreamDestination(outstr)`. A later `uninstall()` then points `System.out` at `outstr` with `destination` writing back into `outstr` — a self-referential sink that silently discards everything.

This PR:

- guards every state transition in `PrintStreamLoggingSystem` with a single monitor;
- reference counts capture, so capture stays installed until every scope that started it has ended it, via a new `LoggingSourceSystem.endCapture()` (default no-op) called from `DefaultLoggingManager.StartableLoggingSystem.stop()`;
- never snapshots `outstr` as the stream to restore later;
- makes `DefaultLoggingManagerFactory.createLoggingManager()` synchronized, so the root manager cannot be handed to two project scopes racing on it.

Behaviour change worth review: `restore()` no longer drives capture on/off from the snapshot's `enabled` flag — the reference count is now the single source of truth, and scopes release their own capture explicitly. The existing unit tests encoded the old "last restore wins" contract and have been updated accordingly.

## Still open

`restore()` still writes `logLevel = snapshot.logLevel` unconditionally. A scope restoring a stale level could leave the global stdout capture level wrong, and events below the threshold would then be filtered out downstream — which would also explain output that reaches neither the console nor the daemon log. I have not tested that yet; it is my next suspect.

## Tests

- `PrintStreamLoggingSystemTest` — updated for the new contract, plus new coverage for sibling scopes, a non-capturing scope restoring while another holds capture, and a concurrent 8-thread × 200-iteration stress case asserting nothing escapes to the original stream.
- `DefaultLoggingManagerTest` — updated for the new `endCapture()` interaction.
- `:logging:test` passes locally.
