### PR TITLE
Fix flaky MultiProducerSingleConsumerProcessorTest

### DIFF
--- a/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessorTest.groovy
+++ b/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessorTest.groovy
@@ -303,18 +303,19 @@ class MultiProducerSingleConsumerProcessorTest extends ConcurrentSpec {
         def failureInstance = new RuntimeException("failed")
         def processor = newProcessor { throw failureInstance }
         processor.start()
+        processor.submit(1)
+        // Joining the worker guarantees the failure is visible and the worker has
+        // finished unwinding, so start() reports the failure instead of racing
+        // against the worker still being marked as running.
+        stopQuietly(processor)
 
         when:
-        processor.submit(1)
+        processor.start()
 
         then:
-        def e = waitForFailure { processor.start() }
-        e instanceof IllegalStateException
+        def e = thrown(IllegalStateException)
         e.message == "Cannot restart processor after it failed."
         e.cause.is(failureInstance)
-
-        cleanup:
-        stopQuietly(processor)
     }
 
     def "processes more than batch size"() {


### PR DESCRIPTION
## Problem

`MultiProducerSingleConsumerProcessorTest` is one of the flakiest tests in `:concurrent`. Develocity shows **225 flaky + 1 failed out of 1101 executions (20.5%)** since 2026-07-01, all of it concentrated in a single feature: `"cannot start after failure"`.

The failure is always the same wrong-message assertion:

```
Condition not satisfied:

e.message == "Cannot restart processor after it failed."
| |       |
| |       false
| Cannot start processor after it has been started.
java.lang.IllegalStateException: Cannot start processor after it has been started.
	at MultiProducerSingleConsumerProcessor.start(MultiProducerSingleConsumerProcessor.java:108)
	at MultiProducerSingleConsumerProcessorTest.waitForFailure(MultiProducerSingleConsumerProcessorTest.groovy:397)
```

## Root cause

A race in the test, not in the processor.

`start()` checks `running` before `failure`, and `running` is only cleared by the worker's `finally` block — which runs *after* `failure` is assigned. So there is a window where the processor has already failed but still reports itself as started.

The test called `processor.start()` immediately after `submit(1)` and did nothing to wait for the worker to unwind, so it raced that window. `waitForFailure` did not help here: it returns the *first* throwable, and `start()` always throws, so it captured whichever branch won the race rather than waiting for the failure to propagate.

## Fix

Stop the processor before asserting. `stop()` joins the worker thread, which establishes a happens-before edge, so both `failure` and `running == false` are guaranteed visible and `start()` deterministically takes the failure branch. `waitForFailure` is dropped from this feature since it was never doing useful work for `start()` (it remains in use by two other features).

Stopping first does not weaken the test. `workerLoop`'s condition is `while (running || !queue.isEmpty())`, so `stop()` clearing `running` cannot drop the queued value — the worker still drains `1`, the action still throws, and `failure` is still set before the worker exits.

## Verification

A standalone harness driving the real `MultiProducerSingleConsumerProcessor` through the test's exact sequence:

| Sequence | Result |
|---|---|
| Before the fix | `Cannot start processor after it has been started.` in **2000/2000** runs |
| After the fix | `Cannot restart processor after it failed.` in **2000/2000** runs |

Locally the main thread wins the race every time, which is why this reproduces at 100% off-CI while CI sees ~20%.

**Local:** `:concurrent:test --tests "*MultiProducerSingleConsumerProcessorTest*"` — one `--rerun-tasks` run (17 tests, 0 failures) plus **20 consecutive runs** with `-PrerunAllTests`, all green.

**CI:** `Util_RerunFlakyTestLinuxAmd64` pinned to `a27641c`, `testJavaVersion=25`/`openjdk` (matching the JDK the unit-test buckets use), 10 builds × 10 runs = **100 executions, all green**, with `supportTestRetry = false` so nothing is masked by retries. Zero occurrences of `Cannot start processor after it has been started.` across all build logs.

| Build | Executions |
|---|---|
| [115834076](https://builds.gradle.org/build/115834076) | 10 ✅ |
| [115834111](https://builds.gradle.org/build/115834111) [115834113](https://builds.gradle.org/build/115834113) [115834115](https://builds.gradle.org/build/115834115) [115834117](https://builds.gradle.org/build/115834117) [115834119](https://builds.gradle.org/build/115834119) [115834121](https://builds.gradle.org/build/115834121) [115834123](https://builds.gradle.org/build/115834123) [115834125](https://builds.gradle.org/build/115834125) [115834127](https://builds.gradle.org/build/115834127) | 90 ✅ |

Against the historical 20.5% per-execution flake rate, 100 clean executions puts the odds of the old bug surviving undetected at roughly 1e-10.

## Note

Not changed here: `start()` could check `failure` before `running` for a more informative error and consistency with `submit()`, which does check `failure` first. That is a genuine (minor) wart, but it would **not** fix this test — `failure` is still unset at that point in 2000/2000 local runs, so `start()` would fall through to the `running` check anyway. Worth a separate follow-up.
