### PR TITLE
Confine Kotlin script compiler stdout redirect to its own thread

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -275,11 +275,42 @@ inline fun <T> redirecting(
     to: OutputStream,
     action: () -> T
 ): T = try {
-    set(PrintStream(to, true))
+    set(PrintStream(ThreadConfinedOutputStream(Thread.currentThread(), to, stream), true))
     action()
 } finally {
     set(stream)
     to.flush()
+}
+
+
+/**
+ * Routes writes made by [owner] to [redirected], and writes made by any other thread to [passthrough].
+ *
+ * [redirecting] mutates the process-global `System.out`/`System.err`. Under Isolated Projects, projects are
+ * configured — and their scripts compiled — concurrently, so another thread may be running a build script that
+ * writes to `System.out` while the redirect is installed. Redirecting unconditionally destroys that output:
+ * [ignoringOutputOf] points the target at a [NullOutputStream], so an unrelated `println` disappears without
+ * reaching either the console or the daemon log. Confining the redirect to the installing thread keeps the
+ * compiler's own output captured while leaving every other thread writing to the stream that was current before.
+ */
+private
+class ThreadConfinedOutputStream(
+    private val owner: Thread,
+    private val redirected: OutputStream,
+    private val passthrough: OutputStream
+) : OutputStream() {
+
+    private
+    fun target(): OutputStream =
+        if (Thread.currentThread() === owner) redirected else passthrough
+
+    override fun write(b: Int) = target().write(b)
+
+    override fun write(b: ByteArray) = target().write(b)
+
+    override fun write(b: ByteArray, off: Int, len: Int) = target().write(b, off, len)
+
+    override fun flush() = target().flush()
 }
 
 


### PR DESCRIPTION
Fixes #38702.

## Problem

`redirecting()` in `KotlinCompiler.kt` swaps the **process-global** `System.out`/`System.err` for a per-compilation `PrintStream` while it compiles a Kotlin script, and `ignoringOutputOf` points that stream at `NullOutputStream.INSTANCE`.

Under Isolated Projects, projects are configured — and their scripts compiled — in parallel. While thread T1 holds the redirect, thread T2 running another project's build script or a task action writes to `System.out` and lands in T1's null sink. The output is **destroyed, not misrouted**: it reaches neither the client console nor the daemon log, while the build still reports `BUILD SUCCESSFUL`.

## Fix

Route the redirect through a thread-confined `OutputStream`: writes from the thread that installed the redirect go to the redirect target, writes from any other thread go to the stream that was current before. One call-site change plus a small private class.

## Evidence

Diagnosis (recorded on #38702):

- Probing `System.out` identity at print time, 16 observations, perfect correlation: `System.out == LinePerThreadBufferingOutputStream` → delivered; `System.out ==` a plain `PrintStream` → lost.
- Kotlin DSL lost output in 6/8 runs vs Groovy DSL 0/8, back to back on the same reproducer — the redirect only exists on the Kotlin script compilation path.
- `logger.quiet` is always delivered (the logging API never touches `System.out`), and `--max-workers=1` always delivers.

Validation of this change:

- Interleaved A/B of two distributions differing only in this commit: **baseline 9/14 rounds lost stdout, patched 0/14**.
- Kotlin compile-error reporting still routes through the collector (checked separately).

CI corroboration from Develocity — `WorkingWithFilesIntegrationTest` over 30 days, 2685 runs, 274 flaky container executions (~10%). Flakiness lands **only** on iterations that compile a Kotlin script not already in the script cache:

| Iteration (per scenario, in `where:` order) | flaky |
|---|---|
| `(set defaults: false) (set values: true)` | 89–100 |
| `(set defaults: true) (set values: false)` | 103–123 |
| `(set defaults: true) (set values: true)` | **0** |

The third row's settings file is identical to row 2's and its project file identical to row 1's, so both scripts are already compiled by the time it runs — no compilation, no redirect window, no lost output. Every flaky iteration is a Kotlin-DSL one; no Declarative-DSL iteration has ever flaked. Other victims in the same `Check_IsolatedProjects_*` buckets: `ProjectSchemaAccessorsIntegrationTest` (~76% in bucket8), `PrecompiledScriptPluginAccessorsTest`, `NestedInputKotlinImplementationTrackingIntegrationTest`.

## Notes

- This is the **root-cause** fix. #38712 (`Make process-global stdout/stderr capture thread safe`) hardens `PrintStreamLoggingSystem`, which is independently correct but is *not* what loses the output — `LineBufferingOutputStream.flush()` drains its buffer before invoking the handler, so the arrangement suspected there would recurse into `StackOverflowError` rather than discard silently. The two changes are complementary and independent.
- `GeneratePrecompiledScriptPluginAccessors.kt` (~lines 684, 689) performs the same global `System.setOut` swap. Same hazard, separate site, not addressed here.
- No test-side change is needed for the affected integration tests — they were correct; the product was dropping their output.

## Still to do before review

- [ ] Add regression coverage asserting a build-script `println` survives parallel configuration under Isolated Projects.
- [ ] Full green CI run.
