### PR TITLE
Handle plain Enum values in DesugaringAttributeContainerSerializer

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
@@ -36,7 +36,10 @@ public class CoercingStringValueSnapshot extends StringValueSnapshot {
             return type.cast(this);
         }
         if (type.isEnum()) {
-            return type.cast(Enum.valueOf(Cast.uncheckedNonnullCast(type.asSubclass(Enum.class)), getValue()));
+            // TODO: Remove support for raw Enums in Gradle 10.0.0
+            // Once every attribute value implements Named, this branch and findEnumConstant below
+            // both go away: an enum type implementing Named is served by the Named branch.
+            return type.cast(findEnumConstant(Cast.uncheckedNonnullCast(type.asSubclass(Enum.class)), getValue()));
         }
         if (Named.class.isAssignableFrom(type)) {
             return type.cast(instantiator.named(type.asSubclass(Named.class), getValue()));
@@ -45,5 +48,26 @@ public class CoercingStringValueSnapshot extends StringValueSnapshot {
             return type.cast(Integer.parseInt(getValue()));
         }
         return null;
+    }
+
+    /**
+     * Resolves an enum constant from the String form a value of that enum type is written as.
+     * <p>
+     * A value is written as {@link Named#getName()} when its type implements {@link Named} and as
+     * {@link Enum#name()} otherwise. An enum type can be both, so a match on {@code getName()} is
+     * attempted first: {@link Enum#valueOf} alone cannot read back an enum whose {@code getName()}
+     * differs from its {@code name()}.
+     */
+    private static <S extends Enum<S>> S findEnumConstant(Class<S> enumType, String value) {
+        if (Named.class.isAssignableFrom(enumType)) {
+            for (S constant : enumType.getEnumConstants()) {
+                if (((Named) constant).getName().equals(value)) {
+                    return constant;
+                }
+            }
+        }
+        // Also covers a Named enum whose getName() does return name(), and reports the unknown
+        // value the same way as before for anything that matches no constant at all.
+        return Enum.valueOf(enumType, value);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
@@ -37,8 +37,10 @@ import java.util.Optional;
 /**
  * A thread-safe and reusable attribute container serializer that will desugar typed attributes.
  *
- * Attributes that are of types different than {@code String} or {@code boolean} will be desugared
- * before serialization. The process requires the attribute type to implement {@link Named}.
+ * Attributes that are of types different than {@code String}, {@code boolean} or {@link Number} will
+ * be desugared to their name before serialization. The process requires the attribute value to
+ * implement {@link Named}, or — for the deprecated types {@code Attribute.of} still accepts — to be
+ * an {@link Enum}.
  */
 public class DesugaringAttributeContainerSerializer implements AttributeContainerSerializer {
     private final AttributesFactory attributesFactory;
@@ -107,12 +109,28 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
                 encoder.writeString(attribute.getType().getName());
                 encoder.writeString(attributeValue.toString());
             } else {
-                // Attribute.of only accepts String, Boolean, a Number subtype, or a Named subtype;
-                // the first three are handled above, so this branch is reached only via Named subtypes.
-                Named attributeValue = (Named) container.getAttribute(attribute);
                 encoder.writeByte(DESUGARED_ATTRIBUTE);
-                encoder.writeString(attributeValue.getName());
+                encoder.writeString(desugar(attribute, container.getAttribute(attribute)));
             }
+        }
+    }
+
+    /**
+     * Desugars an attribute value to the string form {@link #read} coerces back, mirroring
+     * {@link CoercingStringValueSnapshot#coerce(Class)}.
+     * <p>
+     * {@code Attribute.of} only <em>supports</em> {@code String}, {@code Boolean}, a {@link Number}
+     * subtype or a {@link Named} subtype — the first three are handled by the caller. Any other type
+     * is deprecated rather than rejected until Gradle 10, so a plain (non-{@link Named}) {@link Enum}
+     * can still reach this point, most commonly by way of a component metadata rule.
+     */
+    private static String desugar(Attribute<?> attribute, Object value) {
+        if (value instanceof Named) {
+            return ((Named) value).getName();
+        } else if (value instanceof Enum) {
+            return ((Enum<?>) value).name();
+        } else {
+            throw new IllegalArgumentException("Cannot serialize attribute '" + attribute.getName() + "': values of type '" + attribute.getType().getName() + "' must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ".");
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Attribu
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
@@ -37,8 +38,10 @@ import java.util.Optional;
 /**
  * A thread-safe and reusable attribute container serializer that will desugar typed attributes.
  *
- * Attributes that are of types different than {@code String} or {@code boolean} will be desugared
- * before serialization. The process requires the attribute type to implement {@link Named}.
+ * Attributes that are of types different than {@code String}, {@code boolean} or {@link Number} will
+ * be desugared to their name before serialization. The process requires the attribute value to
+ * implement {@link Named}, or — for the deprecated types {@code Attribute.of} still accepts — to be
+ * an {@link Enum}.
  */
 public class DesugaringAttributeContainerSerializer implements AttributeContainerSerializer {
     private final AttributesFactory attributesFactory;
@@ -107,12 +110,46 @@ public class DesugaringAttributeContainerSerializer implements AttributeContaine
                 encoder.writeString(attribute.getType().getName());
                 encoder.writeString(attributeValue.toString());
             } else {
-                // Attribute.of only accepts String, Boolean, a Number subtype, or a Named subtype;
-                // the first three are handled above, so this branch is reached only via Named subtypes.
-                Named attributeValue = (Named) container.getAttribute(attribute);
                 encoder.writeByte(DESUGARED_ATTRIBUTE);
-                encoder.writeString(attributeValue.getName());
+                encoder.writeString(toSerializedString(attribute, container.getAttribute(attribute)));
             }
+        }
+    }
+
+    /**
+     * Converts an attribute value to the String form {@link #read} coerces back, mirroring
+     * {@link CoercingStringValueSnapshot#coerce(Class)}.
+     * <p>
+     * This is not a lossless representation of the value, only of the identity {@link #read} needs to
+     * recover it: for a {@link Named} value the name, and for a plain {@link Enum} the name of the
+     * constant. Any other state a value carries — fields on an enum constant, for instance — is not
+     * preserved, and a value read back is the constant itself rather than the instance written.
+     * <p>
+     * {@code Attribute.of} only <em>supports</em> {@code String}, {@code Boolean}, a {@link Number}
+     * subtype or a {@link Named} subtype — the first three are handled by the caller. Any other type
+     * is deprecated rather than rejected until Gradle 10, so a plain (non-{@link Named}) {@link Enum}
+     * can still reach this point, most commonly by way of a component metadata rule. Writing such a
+     * value as {@link Enum#name()} is the same representation the publishing path already uses for it
+     * (see {@code ModuleMetadataSpecBuilder#attributeValueFor}), and the one attribute matching produces
+     * when it desugars a value (see {@code DefaultImmutableAttributesEntry#desugar}).
+     */
+    private static String toSerializedString(Attribute<?> attribute, Object value) {
+        if (value instanceof Named) {
+            return ((Named) value).getName();
+        } else if (value instanceof Enum) {
+            // TODO: Remove support for raw Enums in Gradle 10.0.0
+            // Nagging here as well as at Attribute.of catches a consumer that only ever reads such a
+            // value back out of a cache written by an earlier build, and so never declares the
+            // attribute type itself.
+            Class<?> enumType = ((Enum<?>) value).getDeclaringClass();
+            DeprecationLogger.deprecate("Serializing the value of attribute '" + attribute.getName() + "', of the enum type '" + enumType.getName() + "', which does not implement " + Named.class.getName())
+                .withContext("The value is serialized as the name of the enum constant, so any other state the constant carries is lost, and the value cannot be read back if the constant is renamed. Attribute values must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ".")
+                .willBecomeAnErrorInGradle10()
+                .withUpgradeGuideSection(9, "unsupported_attribute_value_type")
+                .nagUser();
+            return ((Enum<?>) value).name();
+        } else {
+            throw new IllegalArgumentException("Cannot serialize attribute '" + attribute.getName() + "': values of type '" + attribute.getType().getName() + "' must be of type String, Boolean, a subtype of Number, or implement " + Named.class.getName() + ".");
         }
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -124,6 +125,67 @@ class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
         result.getAttribute(Attribute.of("flavor", String)) == "vanilla"
     }
 
+    @ExpectDeprecation("as a value type for attribute 'flavor' has been deprecated")
+    def "round-trips a plain Enum attribute value"() {
+        given:
+        // Plain (non-Named) enums are deprecated as attribute value types, but until that becomes an
+        // error in Gradle 10 one can still reach this serializer — e.g. via a component metadata rule.
+        def attribute = Attribute.of("flavor", PlainFlavor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, PlainFlavor.VANILLA)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.name == "flavor"
+
+        and: "the value is written as the constant's name, and coerced back to the constant on read"
+        result.getAttribute(Attribute.of("flavor", String)) == "VANILLA"
+        result.getAttribute(attribute) == PlainFlavor.VANILLA
+    }
+
+    @ExpectDeprecation('Serializing the value of attribute \'flavor\', of the enum type \'org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializerTest$PlainFlavor\', which does not implement org.gradle.api.Named has been deprecated')
+    def "writing a plain Enum attribute value emits its own deprecation"() {
+        given:
+        // Attribute.of already nags whoever declares the type, but a consumer can read a value of
+        // that type back out of a cache an earlier build wrote without ever declaring it itself.
+        def attribute = Attribute.of("flavor", PlainFlavor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, PlainFlavor.VANILLA)
+
+        expect:
+        serialize(container, serializer)
+    }
+
+    @ExpectDeprecation("as a value type for attribute 'flavor' has been deprecated")
+    def "fails with a clear error when an attribute value can not be serialized"() {
+        given:
+        def attribute = Attribute.of("flavor", Unsupported)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new Unsupported())
+
+        when:
+        serialize(container, serializer)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Cannot serialize attribute 'flavor'")
+    }
+
+    def "round-trips a Named Enum attribute value whose getName() differs from name()"() {
+        given:
+        def attribute = Attribute.of("flavor", NamedFlavor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, NamedFlavor.VANILLA)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then: "getName() wins over name() on write, as for any other Named value"
+        result.getAttribute(Attribute.of("flavor", String)) == "vanilla"
+
+        and: "and read coerces the name back to the constant it was written from"
+        result.getAttribute(attribute) == NamedFlavor.VANILLA
+    }
+
     def "round-trips a container holding a mix of value types"() {
         given:
         def container = attributesFactory.concat(ImmutableAttributes.EMPTY, Attribute.of("s", String), "text")
@@ -131,12 +193,16 @@ class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
         container = attributesFactory.concat(container, Attribute.of("l", Long), 2L)
         container = attributesFactory.concat(container, Attribute.of("d", Double), 3.0d)
         container = attributesFactory.concat(container, Attribute.of("b", Boolean), false)
+        container = attributesFactory.concat(container, Attribute.of("n", Flavor), TestUtil.objectInstantiator().named(Flavor, "vanilla"))
+        container = attributesFactory.concat(container, Attribute.of("e", NamedFlavor), NamedFlavor.CHOCOLATE)
 
         when:
         ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
 
         then:
-        result.keySet().size() == 5
+        result.keySet().size() == 7
+        result.getAttribute(Attribute.of("n", Flavor)).name == "vanilla"
+        result.getAttribute(Attribute.of("e", NamedFlavor)) == NamedFlavor.CHOCOLATE
         result.getAttribute(Attribute.of("s", String)) == "text"
         result.getAttribute(Attribute.of("i", Integer)) == 1
         result.getAttribute(Attribute.of("l", Long)) == 2L
@@ -145,4 +211,18 @@ class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
     }
 
     interface Flavor extends Named {}
+
+    enum PlainFlavor { VANILLA, CHOCOLATE }
+
+    enum NamedFlavor implements Named {
+        VANILLA, CHOCOLATE
+
+        @Override
+        String getName() {
+            name().toLowerCase(Locale.ROOT)
+        }
+    }
+
+    // Serializable so the value can be isolated into the container at all, and thus reach the serializer.
+    static class Unsupported implements Serializable {}
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -124,6 +125,38 @@ class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
         result.getAttribute(Attribute.of("flavor", String)) == "vanilla"
     }
 
+    @ExpectDeprecation("as a value type for attribute 'flavor' has been deprecated")
+    def "desugars a plain Enum attribute value"() {
+        given:
+        // Plain (non-Named) enums are deprecated as attribute value types, but until that becomes an
+        // error in Gradle 10 one can still reach this serializer — e.g. via a component metadata rule.
+        def attribute = Attribute.of("flavor", PlainFlavor)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, PlainFlavor.VANILLA)
+
+        when:
+        ImmutableAttributes result = serialize(container, serializer) as ImmutableAttributes
+
+        then:
+        def resultAttribute = result.keySet().first()
+        resultAttribute.name == "flavor"
+        result.getAttribute(Attribute.of("flavor", String)) == "VANILLA"
+        result.getAttribute(attribute) == PlainFlavor.VANILLA
+    }
+
+    @ExpectDeprecation("as a value type for attribute 'flavor' has been deprecated")
+    def "fails with a clear error when an attribute value can not be desugared"() {
+        given:
+        def attribute = Attribute.of("flavor", Unsupported)
+        def container = attributesFactory.concat(ImmutableAttributes.EMPTY, attribute, new Unsupported())
+
+        when:
+        serialize(container, serializer)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Cannot serialize attribute 'flavor'")
+    }
+
     def "round-trips a container holding a mix of value types"() {
         given:
         def container = attributesFactory.concat(ImmutableAttributes.EMPTY, Attribute.of("s", String), "text")
@@ -145,4 +178,9 @@ class DesugaringAttributeContainerSerializerTest extends SerializerSpec {
     }
 
     interface Flavor extends Named {}
+
+    enum PlainFlavor { VANILLA, CHOCOLATE }
+
+    // Serializable so the value can be isolated into the container at all, and thus reach the serializer.
+    static class Unsupported implements Serializable {}
 }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -389,6 +389,7 @@ public class ModuleMetadataSpecBuilder {
         } else if (value instanceof Named) {
             return ((Named) value).getName();
         } else if (value instanceof Enum) {
+            // TODO: Remove support for raw Enums in Gradle 10.0.0
             return ((Enum<?>) value).name();
         } else {
             return null;

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Attribute.java
@@ -59,6 +59,9 @@ public class Attribute<T> implements Named {
 
     private static void validateSupportedType(String name, Class<?> type) {
         if (!AttributeTypeValidator.isSupportedAttributeType(type)) {
+            // TODO: Remove support for raw Enums in Gradle 10.0.0
+            // Both deprecation branches below become hard failures then, and the partial raw-Enum
+            // handling downstream (serialization, desugaring, coercion, publishing) can be scrubbed.
             if (AttributeTypeValidator.isKGPSpecialCase(type)) {
                 DeprecationLogger.deprecate("Using the enum type " + type.getSimpleName() + " as an attribute value type")
                     .withContext("This enum does not implement Named. All Enums used as Attribute values should implement Named. This enum type is used by the Kotlin Gradle Plugin 2.0.x line. Upgrade to KGP 2.1.0 or later, in which the plugin no longer uses a plain enum for this attribute.")

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeTypeValidator.java
@@ -68,6 +68,7 @@ public final class AttributeTypeValidator {
      * <p>
      * This special case should be removed when compatibility with KGP 2.0.x is no longer required.
      */
+    // TODO: Remove support for raw Enums in Gradle 10.0.0
     public static boolean isKGPSpecialCase(Class<?> type) {
         return KGP_NATIVE_BUNDLE_ENUM_FQN.equals(type.getName());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesEntry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesEntry.java
@@ -103,6 +103,7 @@ public final class DefaultImmutableAttributesEntry<T> implements ImmutableAttrib
         if (Named.class.isAssignableFrom(attribute.getType())) {
             return ((Named) getIsolatedValue()).getName();
         }
+        // TODO: Remove support for raw Enums in Gradle 10.0.0
         if (Enum.class.isAssignableFrom(attribute.getType())) {
             return ((Enum<?>) getIsolatedValue()).name();
         }


### PR DESCRIPTION
### Context

`Gradle_Master_Check_ForceRealizeDependencyManagement_15_bucket3` has been red since build #2754 (2026-07-30) on:

```
EnumAttributeIntegrationTest > component metadata rule adds a plain Enum attribute to a resolved module
  ClassCastException: class MyEnum cannot be cast to class org.gradle.api.Named
```

`Attribute.of` only *supports* `String`, `Boolean`, a `Number` subtype or a `Named` subtype. Since #38409 an unsupported value type is **deprecated rather than rejected**, so unsupported values now survive to places that previously could not see them. `DesugaringAttributeContainerSerializer.write` still assumed its fallback branch was reachable only by `Named` values and cast blindly — the cast itself predates #38409, where it was an `assert` plus a cast.

This is not only a test-harness artifact. A plain enum reaches module metadata via a component metadata rule, and the same serializer backs the `@CacheableRule` result cache, so a rule that sets a plain-enum attribute fails for real users once that cache is written.

The bisect points at f167756dea1 (#38409), which is the commit that *adds* the failing test. It is only red under `-Dorg.gradle.integtest.force.realize.metadata=true` (`DefaultComponentMetadataProcessor.maybeForceRealization` → `forceSerialization`), which is why PR CI and the normal `Check` pipeline stayed green.

Review of the first fix surfaced a second, independent round-trip defect, fixed here as well: an enum that *also* implements `Named` could never be read back. The write path desugars any `Named` value with `getName()`, but `CoercingStringValueSnapshot.coerce` checks `type.isEnum()` **before** its `Named` branch, so read resolved the value with `Enum.valueOf` and threw `No enum constant …` whenever `getName()` differs from `name()`. This predates #38409 — the `Named` write branch is original — and is what a full round-trip test exposes.

### Changes

- `DesugaringAttributeContainerSerializer` writes a plain (non-`Named`) `Enum` as its `name()`, mirroring what `CoercingStringValueSnapshot.coerce` accepts on the way back in, so the value round-trips. This is the same representation the publishing path already uses for a plain enum (`ModuleMetadataSpecBuilder.attributeValueFor`).
- Writing such a value also **nags**, `willBecomeAnErrorInGradle10()`, against the same `unsupported_attribute_value_type` upgrade-guide section as `Attribute.of`. `Attribute.of` only reaches whoever declares the type; a consumer can read a plain-enum value back out of a cache an earlier build wrote without ever declaring it, and this covers that path.
- `CoercingStringValueSnapshot` resolves an enum type that implements `Named` by matching constants on `getName()` first, falling back to `Enum.valueOf`. `getName()` therefore stays the single serialized form for every `Named` value — module metadata cache and publishing alike — so a cache hit and a cache miss cannot desugar the same value differently.
- Value types that genuinely cannot be serialized now throw an `IllegalArgumentException` naming the attribute and the accepted types, instead of a bare `ClassCastException`.
- `desugar` is renamed to `toSerializedString`, documenting that it captures only the identity `read` needs to recover a value, not the value itself: state carried on an enum constant is not preserved.
- Every site carrying partial raw-`Enum` support is marked `// TODO: Remove support for raw Enums in Gradle 10.0.0` — `Attribute.validateSupportedType`, `AttributeTypeValidator.isKGPSpecialCase`, `DefaultImmutableAttributesEntry.desugar`, `ModuleMetadataSpecBuilder.attributeValueFor`, `DesugaringAttributeContainerSerializer.toSerializedString`, `CoercingStringValueSnapshot.coerce` — with the marker on `Attribute` naming the downstream sites, so the 10.0 scrub has one entry point.

Plain enums stay deprecated — this only makes the deprecation period behave as documented, rather than failing with an internal cast error before the deprecation can take effect in Gradle 10.

### Verification

Locally, with the fix applied:

- `./gradlew :core:integForceRealizeTest --tests "*EnumAttributeIntegrationTest"` — 45 tests, 0 failures, 0 skipped (was 1 failure, the one above); still green with the new serializer deprecation in place.
- `./gradlew :dependency-management:test --tests "*DesugaringAttributeContainerSerializerTest"` — 32 tests, 0 failures, including the round-trip specs and the new deprecation spec. The `Named`-enum spec fails without the `CoercingStringValueSnapshot` fix.
- `./gradlew :model-core:test --tests "*Snapshot*" --tests "*Isolat*"` and `--tests "*Attribute*"` in `:core` and `:dependency-management` — green.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective — covered by the existing `EnumAttributeIntegrationTest`, which this PR turns green under force-realize.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes — not applicable, internal classes; Javadoc on the changed methods updated.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck` — left to CI.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
