### PR TITLE
Update project JDK to 25 in IDEA config

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -69,5 +69,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="25" project-jdk-type="JavaSDK" />
 </project>


### PR DESCRIPTION
Language level was bumped to JDK_25 but the project SDK still pointed to a JDK named 17, causing "Module JDK is misconfigured" in IntelliJ.
