### PR TITLE
Check that the IDEA project SDK supports the project language level

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/XmlFactories.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/XmlFactories.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.basics
+
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+
+
+/**
+ * Creates a [DocumentBuilder] that does not resolve external entities.
+ *
+ * Build logic cannot use `org.gradle.internal.xml.XmlFactories`, since that lives in the
+ * distribution this build produces, so this is the equivalent for build logic.
+ */
+fun createSecureDocumentBuilder(): DocumentBuilder =
+    DocumentBuilderFactory.newInstance().apply {
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        setFeature("http://xml.org/sax/features/external-general-entities", false)
+        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        isExpandEntityReferences = false
+        setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+        setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+        setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+    }.newDocumentBuilder()

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/AbstractVersionsUpdateTask.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/AbstractVersionsUpdateTask.kt
@@ -25,9 +25,6 @@ import org.gradle.internal.util.PropertiesUtils
 import org.gradle.work.DisableCachingByDefault
 import java.net.URI
 import java.util.Properties
-import javax.xml.XMLConstants
-import javax.xml.parsers.DocumentBuilder
-import javax.xml.parsers.DocumentBuilderFactory
 
 @DisableCachingByDefault(because = "Not worth tracking")
 abstract class AbstractVersionsUpdateTask : DefaultTask() {
@@ -61,19 +58,6 @@ abstract class AbstractVersionsUpdateTask : DefaultTask() {
             "File '$docFile' does not contain the expected compatibility line: '$linePrefix'"
         }
     }
-
-    protected
-    fun createSecureDocumentBuilder(): DocumentBuilder =
-        DocumentBuilderFactory.newInstance().apply {
-            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-            setFeature("http://xml.org/sax/features/external-general-entities", false)
-            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-            setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-            isExpandEntityReferences = false
-            setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
-        }.newDocumentBuilder()
 
     protected
     fun fetchVersionsFromMavenMetadata(url: String): List<String> {

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateSmokeTestedIdeVersions.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateSmokeTestedIdeVersions.kt
@@ -17,6 +17,7 @@
 package gradlebuild.buildutils.tasks
 
 import com.google.gson.Gson
+import gradlebuild.basics.createSecureDocumentBuilder
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction

--- a/build-logic/idea/src/main/kotlin/gradlebuild.ide.gradle.kts
+++ b/build-logic/idea/src/main/kotlin/gradlebuild.ide.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import gradlebuild.basics.repoRoot
+import gradlebuild.idea.tasks.CheckIdeaJdkConfiguration
 import org.gradle.plugins.ide.idea.model.IdeaProject
 import org.jetbrains.gradle.ext.CopyrightConfiguration
 import org.jetbrains.gradle.ext.ProjectSettings
@@ -46,6 +47,12 @@ limitations under the License."""
 
 tasks.idea {
     doFirst { throw RuntimeException("To import in IntelliJ, please follow the instructions here: https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#intellij") }
+}
+
+tasks.register<CheckIdeaJdkConfiguration>("checkIdeaJdkConfiguration") {
+    description = "Verifies that .idea/misc.xml's project SDK supports its project language level"
+    group = "verification"
+    ideaMiscXml = repoRoot().file(".idea/misc.xml")
 }
 
 if (idea.project != null) { // may be null during script compilation

--- a/build-logic/idea/src/main/kotlin/gradlebuild/idea/tasks/CheckIdeaJdkConfiguration.kt
+++ b/build-logic/idea/src/main/kotlin/gradlebuild/idea/tasks/CheckIdeaJdkConfiguration.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.idea.tasks
+
+import gradlebuild.basics.createSecureDocumentBuilder
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.w3c.dom.Element
+import java.io.File
+
+
+/**
+ * Verifies that the project SDK committed in `.idea/misc.xml` can support the project language
+ * level committed next to it.
+ *
+ * IntelliJ derives the language level from the Gradle model and rewrites it on sync, but it does
+ * not derive `project-jdk-name`: that is a reference into the developer's global SDK table, so it
+ * can silently fall behind a language level bump and make IntelliJ report
+ * "Module JDK is misconfigured" after import.
+ */
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class CheckIdeaJdkConfiguration : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val ideaMiscXml: RegularFileProperty
+
+    @TaskAction
+    fun check() {
+        val miscXml = ideaMiscXml.get().asFile
+        val projectRootManager = readProjectRootManager(miscXml)
+
+        val languageLevel = projectRootManager.getAttribute("languageLevel")
+        val jdkName = projectRootManager.getAttribute("project-jdk-name")
+
+        val requiredVersion = parseLanguageLevel(languageLevel)
+            ?: throw GradleException("Cannot parse languageLevel '$languageLevel' in $miscXml")
+
+        // 'project-jdk-name' is a free-form label into the developer's SDK table, so a version can
+        // only be inferred by convention. If there is none to infer, there is nothing to verify.
+        val jdkVersion = parseJdkName(jdkName)
+        if (jdkVersion == null) {
+            logger.info("Cannot infer a Java version from project-jdk-name '$jdkName', skipping check")
+            return
+        }
+
+        if (jdkVersion < requiredVersion) {
+            throw GradleException(
+                "${miscXml.name} declares languageLevel '$languageLevel' but project-jdk-name '$jdkName', " +
+                    "which is Java $jdkVersion. IntelliJ reports \"Module JDK is misconfigured\" after import " +
+                    "when the project SDK cannot support the project language level.\n\n" +
+                    "Update the 'ProjectRootManager' component in ${miscXml.path}."
+            )
+        }
+    }
+
+    private
+    fun readProjectRootManager(miscXml: File): Element =
+        createSecureDocumentBuilder()
+            .parse(miscXml).documentElement
+            .getElementsByTagName("component")
+            .let { nodes -> (0 until nodes.length).map { nodes.item(it) as Element } }
+            .singleOrNull { it.getAttribute("name") == "ProjectRootManager" }
+            ?: throw GradleException("No single 'ProjectRootManager' component in $miscXml")
+
+    /**
+     * Handles the language level constants IDEA writes, e.g. `JDK_25`, `JDK_1_8`, `JDK_25_PREVIEW`.
+     */
+    private
+    fun parseLanguageLevel(value: String): Int? =
+        value.removePrefix("JDK_")
+            .removeSuffix("_PREVIEW")
+            .split("_")
+            .mapNotNull { it.toIntOrNull() }
+            .lastOrNull()
+
+    /**
+     * Handles the SDK name this repository commits (`25`) and, best-effort, names a developer may
+     * have locally instead, like `temurin-25`.
+     */
+    private
+    fun parseJdkName(value: String): Int? =
+        value.split(Regex("[^0-9]+"))
+            .lastOrNull { it.isNotEmpty() }
+            ?.toIntOrNull()
+}

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -109,7 +109,8 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
             ":tooling-api:toolingApiShadedJar",
             ":performance:verifyPerformanceScenarioDefinitions",
             ":checkSubprojectsInfo",
-            ":checkTargetRuntimes"
+            ":checkTargetRuntimes",
+            ":checkIdeaJdkConfiguration"
         )
     }
 }


### PR DESCRIPTION
`.idea/misc.xml` commits both the project language level and the project SDK name, and they have to agree. IntelliJ maintains the language level from the Gradle model, but the SDK name is a reference into the developer's own SDK table, so it can silently fall behind — which is how the repo ended up reporting "Module JDK is misconfigured" on import until #38721 fixed it by hand.

- Add a `checkIdeaJdkConfiguration` task that fails when the committed project SDK cannot support the committed language level, and wire it into `sanityCheck`.
- The SDK name is a free-form label, so the task infers a version by convention and skips the check when it cannot.
- Extract `createSecureDocumentBuilder()` into `gradlebuild:basics` so the new task reuses it rather than duplicating the parser hardening. No behaviour change.

The check compares the two values in `misc.xml` against each other rather than against `gradle/gradle-daemon-jvm.properties`, because Gradleception rewrites that file before running `sanityCheck`. The trade-off is that it won't catch both values drifting downwards together.