### PR TITLE
Rebalance AllVersionsCrossVersion buckets for agents without TestDistribution

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -21,6 +21,12 @@ val QUICK_CROSS_VERSION_BUCKETS =
         listOf("9.0", "99.0"), // 9.0 <=version < 99.0
     )
 
+/**
+ * Buckets for AllVersionsCrossVersionTest on operating systems that use TestDistribution
+ * (see [GradleVersionRangeCrossVersionTestBucket]). TestDistribution spreads the test classes of a
+ * bucket over many executors, so a build's duration does not follow the amount of work in its range
+ * and coarse buckets are good enough.
+ */
 val ALL_CROSS_VERSION_BUCKETS =
     listOf(
         listOf("0.0", "5.0"), // 0.0 <= version < 5.0
@@ -39,6 +45,67 @@ val ALL_CROSS_VERSION_BUCKETS =
         listOf("9.3", "99.0"), // 9.3 <=version < 99.0
     )
 
+/**
+ * Buckets for AllVersionsCrossVersionTest on operating systems without TestDistribution
+ * (see [GradleVersionRangeCrossVersionTestBucket]). Such a bucket runs on a single agent, so its
+ * duration is proportional to the test time of the versions it covers and the ranges have to be
+ * balanced by that test time to keep every build under an hour.
+ *
+ * Test time per version grows steeply with the version, which is why the ranges get narrower
+ * towards the top and cover a single version from 8.1 onwards. The open-ended last bucket grows
+ * with every new minor version, so a new bucket has to be split off it regularly.
+ */
+val ALL_CROSS_VERSION_BUCKETS_WITHOUT_TEST_DISTRIBUTION =
+    listOf(
+        listOf("0.0", "5.2"), // 0.0 <= version < 5.2
+        listOf("5.2", "6.0"), // 5.2 <=version < 6.0
+        listOf("6.0", "6.4"), // 6.0 <=version < 6.4
+        listOf("6.4", "6.7"), // 6.4 <=version < 6.7
+        listOf("6.7", "7.0"), // 6.7 <=version < 7.0
+        listOf("7.0", "7.2"), // 7.0 <=version < 7.2
+        listOf("7.2", "7.4"), // 7.2 <=version < 7.4
+        listOf("7.4", "7.6"), // 7.4 <=version < 7.6
+        listOf("7.6", "8.1"), // 7.6 <=version < 8.1
+        listOf("8.1", "8.2"), // 8.1 <=version < 8.2
+        listOf("8.2", "8.3"), // 8.2 <=version < 8.3
+        listOf("8.3", "8.4"), // 8.3 <=version < 8.4
+        listOf("8.4", "8.5"), // 8.4 <=version < 8.5
+        listOf("8.5", "8.6"), // 8.5 <=version < 8.6
+        listOf("8.6", "8.7"), // 8.6 <=version < 8.7
+        listOf("8.7", "8.8"), // 8.7 <=version < 8.8
+        listOf("8.8", "8.9"), // 8.8 <=version < 8.9
+        listOf("8.9", "8.10"), // 8.9 <=version < 8.10
+        listOf("8.10", "8.11"), // 8.10 <=version < 8.11
+        listOf("8.11", "8.12"), // 8.11 <=version < 8.12
+        listOf("8.12", "8.13"), // 8.12 <=version < 8.13
+        listOf("8.13", "8.14"), // 8.13 <=version < 8.14
+        listOf("8.14", "9.0"), // 8.14 <=version < 9.0
+        listOf("9.0", "9.1"), // 9.0 <=version < 9.1
+        listOf("9.1", "9.2"), // 9.1 <=version < 9.2
+        listOf("9.2", "9.3"), // 9.2 <=version < 9.3
+        listOf("9.3", "9.4"), // 9.3 <=version < 9.4
+        listOf("9.4", "9.5"), // 9.4 <=version < 9.5
+        listOf("9.5", "9.6"), // 9.5 <=version < 9.6
+        listOf("9.6", "99.0"), // 9.6 <=version < 99.0
+    )
+
+fun crossVersionTestParallelizationMethod(os: Os): ParallelizationMethod =
+    when (os) {
+        Os.LINUX -> ParallelizationMethod.TestDistribution
+        else -> ParallelizationMethod.None
+    }
+
+/**
+ * Derived from [crossVersionTestParallelizationMethod] so that the bucket ranges and the way a
+ * bucket is parallelized can never get out of sync.
+ */
+fun allCrossVersionBucketsFor(os: Os): List<List<String>> =
+    if (crossVersionTestParallelizationMethod(os) == ParallelizationMethod.TestDistribution) {
+        ALL_CROSS_VERSION_BUCKETS
+    } else {
+        ALL_CROSS_VERSION_BUCKETS_WITHOUT_TEST_DISTRIBUTION
+    }
+
 typealias BuildProjectToSubprojectTestClassTimes = Map<String, Map<String, List<TestClassTime>>>
 
 interface FunctionalTestBucketProvider {
@@ -52,7 +119,8 @@ class DefaultFunctionalTestBucketProvider(
     val model: CIBuildModel,
     testBucketsJson: File,
 ) : FunctionalTestBucketProvider {
-    private val allCrossVersionTestBucketProvider = CrossVersionTestBucketProvider(ALL_CROSS_VERSION_BUCKETS, model)
+    private val allCrossVersionTestBucketProviders =
+        Os.entries.associateWith { CrossVersionTestBucketProvider(allCrossVersionBucketsFor(it), model) }
     private val quickCrossVersionTestBucketProvider = CrossVersionTestBucketProvider(QUICK_CROSS_VERSION_BUCKETS, model)
     private val functionalTestBucketProvider = StatisticBasedFunctionalTestBucketProvider(model, testBucketsJson)
 
@@ -69,7 +137,7 @@ class DefaultFunctionalTestBucketProvider(
             }
 
             testCoverage.testType == TestType.ALL_VERSIONS_CROSS_VERSION -> {
-                allCrossVersionTestBucketProvider.createFunctionalTestsFor(
+                allCrossVersionTestBucketProviders.getValue(testCoverage.os).createFunctionalTestsFor(
                     stage,
                     testCoverage,
                 )
@@ -177,23 +245,16 @@ class GradleVersionRangeCrossVersionTestBucket(
         stage: Stage,
         testCoverage: TestCoverage,
         bucketIndex: Int,
-    ): FunctionalTest {
-        val parallelizationMethod =
-            when (testCoverage.os) {
-                Os.LINUX -> ParallelizationMethod.TestDistribution
-                else -> ParallelizationMethod.None
-            }
-
-        return FunctionalTest(
+    ): FunctionalTest =
+        FunctionalTest(
             model,
             testCoverage.getBucketUuid(model, bucketIndex),
             "${testCoverage.asName()} ($startInclusive <= gradle <$endExclusive)",
             "${testCoverage.asName()} for gradle ($startInclusive <= gradle <$endExclusive)",
             testCoverage,
             stage,
-            parallelizationMethod,
+            crossVersionTestParallelizationMethod(testCoverage.os),
             emptyList(),
             extraParameters = "-PonlyTestGradleVersion=$startInclusive-$endExclusive",
         )
-    }
 }

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -23,26 +23,27 @@ val QUICK_CROSS_VERSION_BUCKETS =
 
 /**
  * Buckets for AllVersionsCrossVersionTest on operating systems that use TestDistribution
- * (see [GradleVersionRangeCrossVersionTestBucket]). TestDistribution spreads the test classes of a
- * bucket over many executors, so a build's duration does not follow the amount of work in its range
- * and coarse buckets are good enough.
+ * (see [GradleVersionRangeCrossVersionTestBucket]). TestDistribution flattens every test task to a
+ * fixed floor, so a build's duration follows the number of test tasks in its range - one per version
+ * per subproject with cross-version tests - and not the test time of those versions. The ranges are
+ * therefore balanced by version count, weighted by how many subprojects test each version.
  */
 val ALL_CROSS_VERSION_BUCKETS =
     listOf(
         listOf("0.0", "5.0"), // 0.0 <= version < 5.0
         listOf("5.0", "6.0"), // 5.0 <=version < 6.0
-        listOf("6.0", "7.3"), // 6.0 <=version < 7.3
-        listOf("7.3", "7.6"), // 7.3 <=version < 7.6
-        listOf("7.6", "8.2"), // 7.6 <=version < 8.2
-        listOf("8.2", "8.4"), // 8.2 <=version < 8.4
-        listOf("8.4", "8.6"), // 8.4 <=version < 8.6
-        listOf("8.6", "8.8"), // 8.6 <=version < 8.8
-        listOf("8.8", "8.10"), // 8.8 <=version < 8.10
-        listOf("8.10", "8.12"), // 8.10 <=version < 8.12
-        listOf("8.12", "8.13"), // 8.12 <=version < 8.13
-        listOf("8.13", "9.0"), // 8.13 <=version < 9.0
+        listOf("6.0", "6.5"), // 6.0 <=version < 6.5
+        listOf("6.5", "7.0"), // 6.5 <=version < 7.0
+        listOf("7.0", "7.4"), // 7.0 <=version < 7.4
+        listOf("7.4", "8.0"), // 7.4 <=version < 8.0
+        listOf("8.0", "8.3"), // 8.0 <=version < 8.3
+        listOf("8.3", "8.6"), // 8.3 <=version < 8.6
+        listOf("8.6", "8.9"), // 8.6 <=version < 8.9
+        listOf("8.9", "8.12"), // 8.9 <=version < 8.12
+        listOf("8.12", "9.0"), // 8.12 <=version < 9.0
         listOf("9.0", "9.3"), // 9.0 <=version < 9.3
-        listOf("9.3", "99.0"), // 9.3 <=version < 99.0
+        listOf("9.3", "9.5"), // 9.3 <=version < 9.5
+        listOf("9.5", "99.0"), // 9.5 <=version < 99.0
     )
 
 /**

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -8,7 +8,6 @@ import configurations.stageWithOsTriggers
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
 import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnText
-import model.ALL_CROSS_VERSION_BUCKETS
 import model.CIBuildModel
 import model.DefaultFunctionalTestBucketProvider
 import model.JsonBasedGradleSubprojectProvider
@@ -16,6 +15,7 @@ import model.QUICK_CROSS_VERSION_BUCKETS
 import model.StageName
 import model.TestCoverage
 import model.TestType
+import model.allCrossVersionBucketsFor
 import model.ignoredSubprojects
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -140,6 +140,7 @@ class CIConfigIntegrationTests {
             testType: TestType,
             functionalTests: List<BaseGradleBuildType>,
         ) {
+            assertEquals(buckets.size, functionalTests.size)
             buckets.forEachIndexed { index: Int, startEndVersion: List<String> ->
                 assertTrue(functionalTests[index].name.contains("(${startEndVersion[0]} <= gradle <${startEndVersion[1]})"))
                 assertEquals("clean ${testType.asCamelCase()}Test", functionalTests[index].getGradleTasks())
@@ -158,7 +159,7 @@ class CIConfigIntegrationTests {
                 when {
                     functionalTestProject.name.contains("AllVersionsCrossVersion") -> {
                         assertProjectAreSplitByGradleVersionCorrectly(
-                            ALL_CROSS_VERSION_BUCKETS,
+                            allCrossVersionBucketsFor(functionalTestProject.testCoverage.os),
                             TestType.ALL_VERSIONS_CROSS_VERSION,
                             functionalTestProject.functionalTests,
                         )
@@ -345,11 +346,13 @@ class CIConfigIntegrationTests {
 
     @Test
     fun allVersionsAreIncludedInCrossVersionTests() {
-        assertEquals("0.0", ALL_CROSS_VERSION_BUCKETS[0][0])
-        assertEquals("99.0", ALL_CROSS_VERSION_BUCKETS[ALL_CROSS_VERSION_BUCKETS.size - 1][1])
+        Os.entries.map { allCrossVersionBucketsFor(it) }.distinct().forEach { buckets ->
+            assertEquals("0.0", buckets[0][0])
+            assertEquals("99.0", buckets[buckets.size - 1][1])
 
-        (1 until ALL_CROSS_VERSION_BUCKETS.size).forEach {
-            assertEquals(ALL_CROSS_VERSION_BUCKETS[it - 1][1], ALL_CROSS_VERSION_BUCKETS[it][0])
+            (1 until buckets.size).forEach {
+                assertEquals(buckets[it - 1][1], buckets[it][0])
+            }
         }
     }
 }


### PR DESCRIPTION
The `AllVersionsCrossVersion` ranges were drawn before 8.x and 9.x existed and lump 13 of the 6.x/7.x versions into a single bucket. That bucket is the slowest build in the Ready for Release stage on both operating systems, for two different reasons, so this splits the ranges into an OS-specific list and rebalances each one against what actually drives its duration.

**Windows/macOS — no TestDistribution, so duration follows test time.** A bucket runs serially on a single agent. Rebalanced into 30 ranges by measured serial test time, which takes the worst bucket from `6.0 <= gradle <7.3` at ~220min — close to the 240min timeout — down to ~59min, with every bucket under an hour. This raises concurrent agent demand for the coverage from 14 to 30.

**Linux — TestDistribution flattens each test task to a fixed floor, so duration follows the *number* of test tasks.** `6.0 <= gradle <7.3` runs 229 test tasks against 58 for `9.3 <= gradle <99.0`, which is why it takes ~46min while its siblings take 11-26min despite a comparable amount of test time. Rebalanced by version count, still 14 buckets: worst bucket ~22min, and the total agent-minutes the coverage occupies is unchanged.

Also:

- Derive the list from `crossVersionTestParallelizationMethod(os)` so the ranges and the parallelization method cannot drift apart.
- Assert the generated bucket count matches the list in `assertProjectAreSplitByGradleVersionCorrectly`.

Boundaries come from per-version statistics over the last 30 days of the respective build types. All 57 tested versions stay covered on both lists and the ranges are gapless from 0.0 to 99.0.

Worth reviewing:

- The Windows change needs 16 more concurrent agents for this coverage. I have not measured agent queue wait, so part of the wall-clock win may be eaten by queueing.
- Ready for Release goes from ~5h to ~3h15, not to 1h. Past that, `NoDaemon_12_bucket3` (150min) and `NoDaemon_13_bucket6` (147min) are the critical path.

Both open-ended last buckets grow with every new minor version and need splitting again periodically — roughly every two releases for Windows, every three for Linux.
