### PR TITLE
Avoid ThreadLocal initialization on read-only paths

### DIFF
--- a/platforms/core-configuration/domain-object-collections/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
+++ b/platforms/core-configuration/domain-object-collections/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
@@ -17,13 +17,25 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.internal.exceptions.Contextual;
+import org.jspecify.annotations.Nullable;
 
 public class DefaultMutationGuard implements MutationGuard {
 
-    private final ThreadLocal<Boolean> mutationGuardState = ThreadLocal.withInitial(SerializableLambdas.supplier(() -> true));
+    /**
+     * The mutation state of the current thread. Null means the default state: mutation is allowed.
+     * <p>
+     * Intentionally not using {@link ThreadLocal#withInitial} with the default value. There are many
+     * instances of this class (e.g. one per configuration), each with its own thread local, and reads
+     * are far more common than wrapped executions. Representing the default state as an absent entry
+     * means reads never write to the thread local map and an entry only exists on a thread while a
+     * wrapped action is executing on it. So, unused entries never accumulate in long-lived threads.
+     *
+     * See <a href="https://github.com/gradle/gradle/issues/13835">gradle/gradle#13835</a>.
+     */
+    @SuppressWarnings("ThreadLocalUsage")
+    private final ThreadLocal<@Nullable Boolean> mutationGuardState = new ThreadLocal<>();
 
     @Override
     public <T> Action<? super T> wrapLazyAction(Action<? super T> action) {
@@ -37,9 +49,8 @@ public class DefaultMutationGuard implements MutationGuard {
 
     @Override
     public boolean isLazyContext() {
-        boolean mutationAllowed = mutationGuardState.get();
-        removeThreadLocalStateIfMutationAllowed(mutationAllowed);
-        return !mutationAllowed;
+        Boolean mutationAllowed = mutationGuardState.get();
+        return mutationAllowed != null && !mutationAllowed;
     }
 
     @Override
@@ -60,42 +71,28 @@ public class DefaultMutationGuard implements MutationGuard {
         return new Action<T>() {
             @Override
             public void execute(T t) {
-                boolean oldIsMutationAllowed = mutationGuardState.get();
+                Boolean oldState = mutationGuardState.get();
                 mutationGuardState.set(allowMutationMethods);
                 try {
                     action.execute(t);
                 } finally {
-                    setMutationGuardState(oldIsMutationAllowed);
+                    if (oldState == null) {
+                        // Restore the default state by removing the entry rather than storing the
+                        // default value. There are many instances of this class in a Gradle invocation,
+                        // e.g., one for each configuration, each with its own thread local. Entries
+                        // left behind would accumulate in the thread local maps of long-lived
+                        // daemon threads until their guard becomes unreachable, and stale entries
+                        // are only cleaned up lazily, degrading all thread local access on those
+                        // threads. Removing here guarantees an entry exists only while a wrapped
+                        // action is executing.
+                        // See https://github.com/gradle/gradle/issues/13835.
+                        mutationGuardState.remove();
+                    } else {
+                        mutationGuardState.set(oldState);
+                    }
                 }
             }
         };
-    }
-
-    private void setMutationGuardState(boolean newState) {
-        if (newState) {
-            removeThreadLocalStateIfMutationAllowed(true);
-        } else {
-            mutationGuardState.set(false);
-        }
-    }
-
-    /**
-     * Removes the thread local for `mutationGuardState` if its value is the default value (true).
-     *
-     * There are many instances of `DefaultMutationGuard` in a Gradle run, e.g. one for each configuration.
-     * Each of those instances creates a new thread local for `Daemon worker`.
-     * After a build, those thread local instances should be removed from the ThreadLocalMap by garbage collection automatically.
-     * It looks like CMS does a good job for removing the unused entries from the ThreadLocalMap, though G1 does not.
-     * So if you are running builds in quick succession, e.g. for profiling, there can be a quick slowdown after some time.
-     *
-     * This methods removes the elements from the ThreadLocalMap when possible, thus avoiding the problem.
-     *
-     * See https://github.com/gradle/gradle/issues/13835.
-     */
-    private void removeThreadLocalStateIfMutationAllowed(boolean mutationAllowed) {
-        if (mutationAllowed) {
-            mutationGuardState.remove();
-        }
     }
 
     private static <T> IllegalStateException createIllegalStateException(Class<T> targetType, String methodName, T target) {

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
@@ -32,7 +32,22 @@ import org.jspecify.annotations.Nullable;
 public final class EvaluationContext {
     private static final EvaluationContext INSTANCE = new EvaluationContext();
 
-    private final ThreadLocal<PerThreadContext> threadLocalContext = ThreadLocal.withInitial(() -> new PerThreadContext(null));
+    /**
+     * Intentionally not using {@link ThreadLocal#withInitial}, for two reasons:
+     * <ul>
+     * <li>Threads that only query the current owner must not pay for instantiating and
+     * storing a context just to observe that nothing is being evaluated.</li>
+     * <li>Every {@code withInitial} thread local in the JVM invokes its supplier through a
+     * single call site inside {@code ThreadLocal.SuppliedThreadLocal}. The JIT sees many
+     * unrelated supplier implementations at that call site and cannot inline or devirtualize
+     * the dispatch, so initialization always goes through a slow virtual call, and heavy
+     * traffic from other suppliers can trigger deoptimization of code this call site was
+     * inlined into.</li>
+     * </ul>
+     * The context is instead created lazily by {@link #getContext()}, a call site this class
+     * owns exclusively.
+     */
+    private static final ThreadLocal<@Nullable PerThreadContext> THREAD_LOCAL_CONTEXT = new ThreadLocal<>();
 
     /**
      * Returns the current instance of EvaluationContext for this thread.
@@ -58,7 +73,8 @@ public final class EvaluationContext {
      */
     @Nullable
     public EvaluationOwner getOwner() {
-        return getContext().getOwner();
+        PerThreadContext context = THREAD_LOCAL_CONTEXT.get();
+        return context == null ? null : context.getOwner();
     }
 
     /**
@@ -127,11 +143,16 @@ public final class EvaluationContext {
     }
 
     private PerThreadContext getContext() {
-        return threadLocalContext.get();
+        PerThreadContext context = THREAD_LOCAL_CONTEXT.get();
+        if (context == null) {
+            context = new PerThreadContext(null);
+            THREAD_LOCAL_CONTEXT.set(context);
+        }
+        return context;
     }
 
     private PerThreadContext setContext(PerThreadContext newContext) {
-        threadLocalContext.set(newContext);
+        THREAD_LOCAL_CONTEXT.set(newContext);
 
         return newContext;
     }


### PR DESCRIPTION
EvaluationContext and DefaultMutationGuard used ThreadLocal.withInitial, which materializes and stores a value on every thread that merely queries the state, and routes initialization through a supplier call site shared by all such thread locals in the JVM, which the JIT cannot inline or devirtualize. DefaultMutationGuard additionally removed the entry again whenever it held the default value, paying the full miss-initialize-remove cycle on every read in the default state.

Represent the default state as an absent entry instead: reads never write to the thread local map, and an entry exists only while a non-default state is active on the thread. For DefaultMutationGuard, this preserves the gradle/gradle#13835 guarantee that unused entries do not accumulate on long-lived daemon threads, without the read-side removal. EvaluationContext's thread local also becomes static, since the class is a singleton.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
