### PR TITLE
Improve performance of nanoTime on Windows

### DIFF
--- a/platforms/core-execution/worker-shared/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/platforms/core-execution/worker-shared/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -69,6 +69,7 @@ import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
+import org.gradle.internal.time.TimeSourceManager;
 
 import java.util.Collections;
 
@@ -119,8 +120,17 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
     }
 
     @Provides
-    Clock createClock() {
+    Clock createClock(TimeSourceManager timeSourceManager) {
+        // The clock does not consume the manager directly, but depending on it ensures the
+        // time manager's probe and ticker thread starts as soon as the clock service is first used.
         return Time.clock();
+    }
+
+    @Provides
+    TimeSourceManager createTimeSourceManager() {
+        // Only Windows is known to have an expensive high-resolution timer. On other
+        // platforms the manager is disabled.
+        return TimeSourceManager.start(OperatingSystem.current().isWindows());
     }
 
     @Provides({ClassCacheFactory.class, CrossBuildInMemoryCacheFactory.class})

--- a/platforms/core-runtime/time/build.gradle.kts
+++ b/platforms/core-runtime/time/build.gradle.kts
@@ -24,6 +24,8 @@ description = "Monotonic clock implementation"
 dependencies {
     api(projects.stdlibJavaExtensions)
 
+    implementation(libs.jsr305)
+
     compileOnly(libs.jspecify)
 }
 

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/MonotonicClock.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/MonotonicClock.java
@@ -48,18 +48,12 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 class MonotonicClock implements Clock {
 
-    private static final long SYNC_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(3);
-
     private final long syncIntervalMillis;
     private final TimeSource timeSource;
 
     private final AtomicLong syncMillisRef;
     private final AtomicLong syncNanosRef;
     private final AtomicLong currentTime = new AtomicLong();
-
-    MonotonicClock() {
-        this(TimeSource.SYSTEM, SYNC_INTERVAL_MILLIS);
-    }
 
     MonotonicClock(TimeSource timeSource, long syncIntervalMillis) {
         long nanoTime = timeSource.nanoTime();
@@ -116,4 +110,5 @@ class MonotonicClock implements Clock {
             }
         }
     }
+
 }

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/SwappableTimeSource.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/SwappableTimeSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link TimeSource} delegates to some other time source. Allows the underling time source
+ * to be transparently swapped. Intended to be used by {@link TimeSourceManager} to substitute
+ * expensive platform timers with a faster timer, on platforms where the platform timer is
+ * determined to be expensive.
+ */
+@ThreadSafe
+class SwappableTimeSource implements TimeSource {
+
+    private volatile TimeSource delegate;
+
+    SwappableTimeSource(TimeSource initial) {
+        this.delegate = initial;
+    }
+
+    void set(TimeSource timeSource) {
+        delegate = timeSource;
+    }
+
+    TimeSource get() {
+        return delegate;
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return delegate.currentTimeMillis();
+    }
+
+    @Override
+    public long nanoTime() {
+        return delegate.nanoTime();
+    }
+
+}

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/Time.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/Time.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.time;
 
+import org.gradle.internal.os.OperatingSystem;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,7 +25,70 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class Time {
 
-    private static final Clock CLOCK = new MonotonicClock();
+    /**
+     * Reads time directly from the platform.
+     */
+    private static final TimeSource SYSTEM = new TimeSource() {
+        @Override
+        public long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+    };
+
+    /**
+     * The time source backing all instruments created by this class.
+     * <p>
+     * On Windows, since the platform's high-resolution timer can be expensive, this is a
+     * {@link SwappableTimeSource} so that a {@link TimeSourceManager} can substitute a cached
+     * source when it measures the timer to actually be expensive. On other platforms, where
+     * the timer is known to be fast, this reads from the platform directly, avoiding
+     * the additional indirection.
+     */
+    private static final TimeSource TIME_SOURCE = OperatingSystem.current().isWindows() ? new SwappableTimeSource(SYSTEM) : SYSTEM;
+
+    private static final Clock CLOCK = new MonotonicClock(TIME_SOURCE, TimeUnit.SECONDS.toMillis(3));
+
+    /**
+     * Updates {@link #TIME_SOURCE} to read from the given source. Used by {@link TimeSourceManager}
+     * to install a cached time source when the platform time source is measured to be expensive.
+     *
+     * @throws IllegalStateException If called on a platform whose time source is not swappable.
+     */
+    static void installTimeSource(TimeSource timeSource) {
+        swappableTimeSource().set(timeSource);
+    }
+
+    /**
+     * Restores direct platform readings for {@link #TIME_SOURCE}.
+     *
+     * @throws IllegalStateException If called on a platform whose time source is not swappable.
+     */
+    static void uninstallTimeSource() {
+        swappableTimeSource().set(SYSTEM);
+    }
+
+    private static SwappableTimeSource swappableTimeSource() {
+        if (!(TIME_SOURCE instanceof SwappableTimeSource)) {
+            throw new IllegalStateException("The static time source is not swappable on this platform.");
+        }
+        return (SwappableTimeSource) TIME_SOURCE;
+    }
+
+    /**
+     * The time source that is currently active. Returns the installed source, if any,
+     * otherwise the platform time source.
+     */
+    static TimeSource getEffectiveTimeSource() {
+        if (TIME_SOURCE instanceof SwappableTimeSource) {
+            return ((SwappableTimeSource) TIME_SOURCE).get();
+        }
+        return TIME_SOURCE;
+    }
 
     /**
      * A clock that is guaranteed not to go backwards.
@@ -47,22 +112,22 @@ public abstract class Time {
     /**
      * Measures elapsed time.
      *
-     * Timers use System.nanoTime() to measure elapsed time,
+     * Timers use the monotonic high-resolution time source to measure elapsed time,
      * and are therefore not synchronized with {@link #clock()} or the system wall clock.
      *
-     * System.nanoTime() does not consider time elapsed while the system is in hibernation.
+     * The underlying time source does not consider time elapsed while the system is in hibernation.
      * Therefore, timers effectively measure the elapsed time, of which the system was awake.
      */
     public static Timer startTimer() {
-        return new DefaultTimer(TimeSource.SYSTEM);
+        return new DefaultTimer(TIME_SOURCE);
     }
 
     public static CountdownTimer startCountdownTimer(long timeoutMillis) {
-        return new DefaultCountdownTimer(TimeSource.SYSTEM, timeoutMillis, TimeUnit.MILLISECONDS);
+        return new DefaultCountdownTimer(TIME_SOURCE, timeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public static CountdownTimer startCountdownTimer(long timeout, TimeUnit unit) {
-        return new DefaultCountdownTimer(TimeSource.SYSTEM, timeout, unit);
+        return new DefaultCountdownTimer(TIME_SOURCE, timeout, unit);
     }
 
     private Time() {

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSource.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSource.java
@@ -16,22 +16,24 @@
 
 package org.gradle.internal.time;
 
+/**
+ * Provides the current wall clock time and a high-resolution timer for measuring elapsed time.
+ */
 interface TimeSource {
 
+    /**
+     * The current wall clock time, in milliseconds since the epoch.
+     *
+     * @see System#currentTimeMillis()
+     */
     long currentTimeMillis();
 
+    /**
+     * The current reading of a high-resolution timer, in nanoseconds. Only to be used for
+     * measuring elapsed time. Unrelated to the wall clock.
+     *
+     * @see System#nanoTime()
+     */
     long nanoTime();
-
-    TimeSource SYSTEM = new TimeSource() {
-        @Override
-        public long currentTimeMillis() {
-            return System.currentTimeMillis();
-        }
-
-        @Override
-        public long nanoTime() {
-            return System.nanoTime();
-        }
-    };
 
 }

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
@@ -219,10 +219,12 @@ public class TimeSourceManager implements Closeable {
         try {
             while (running) {
                 timeSource.tick();
-                // Thread.sleep rather than LockSupport.parkNanos: on Windows, the JVM raises
-                // the timer resolution (per-process, since Windows 10 2004) to 1ms around
-                // sub-10ms sleeps, while parkNanos waits on the default scheduler quantum
-                // and would achieve a ~15.6ms tick.
+                // Use Thread.sleep rather than LockSupport.parkNanos. On Windows, the JVM wraps the
+                // sleep in a HighResolutionInterval that calls timeBeginPeriod(1) whenever the
+                // requested duration is not a multiple of 10ms, raising the timer resolution to 1ms
+                // for the sleep. Our 1ms tick qualifies. parkNanos is not wrapped this way, so it
+                // waits on the default scheduler quantum and would achieve only a ~15.6ms tick.
+                // See: https://github.com/openjdk/jdk/blob/835c7b1be56316d6468335dffd2bd897f9519760/src/hotspot/os/windows/os_windows.cpp#L5738-L5762
                 Thread.sleep(tickIntervalMillis);
             }
         } catch (InterruptedException ignored) {

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Detects slow platform timers, replacing them with a background thread that periodically updates
+ * a cached timer that the application may read from quickly.
+ * <p>
+ * On most platforms, {@link System#nanoTime()} is a fast userspace read (~20ns). On Windows it
+ * is backed by {@code QueryPerformanceCounter}, which on some machines (notably virtualized ones,
+ * or when the OS has fallen back to the HPET or ACPI timer) costs tens of microseconds per call.
+ * Code that reads the timer per event can disproportional amount of time doing so, leading to
+ * seconds of additional accumulated execution time per build.
+ * <p>
+ * On platforms suspected of an expensive timer, this manager starts a background thread that
+ * measures the actual cost of the platform timer on this machine. If it is inexpensive, the
+ * thread exits and nothing changes. If it is expensive, the thread installs a
+ * {@link CachedTimeSource} into {@link Time} and keeps its reading fresh by caching
+ * the platform timer at a regular interval. Timer readings then cost a volatile load
+ * regardless of the platform timer. The initial probing takes place off the critical path of
+ * application startup. The platform timer remains in-place while probing takes place.
+ * <p>
+ * With the cached source installed, an individual reading may be stale by up to the tick interval.
+ * Durations computed from pairs of readings have an error bounded by the tick interval. Sums and
+ * averages over many measured durations converge on the true values. The tick interval used by this
+ * manager matches the millisecond-level granularity that consumers ({@link Time#clock()} and
+ * {@link Time#startTimer()}) already expose. The clock's timestamps never go backwards, including
+ * across the switchover, which {@link MonotonicClock} guarantees.
+ * <p>
+ * This manager is a global service. Closing the owning registry stops the thread, which
+ * restores direct platform readings.
+ */
+@ServiceScope(Scope.Global.class)
+public class TimeSourceManager implements Closeable {
+
+    private static final long DEFAULT_TICK_MILLIS = 1;
+
+    /**
+     * Above this average cost per {@link System#nanoTime()} call, the caching ticker is
+     * worthwhile. A healthy timer costs ~20-40ns; a pathological one costs thousands of
+     * nanoseconds or more. The threshold leaves room for interpreter overhead, since the
+     * probe may run before the measuring loop is JIT compiled.
+     */
+    private static final long SLOW_NANO_TIME_THRESHOLD_NANOS = 1000;
+
+    /**
+     * The number of calls to {@link System#nanoTime()} to perform in a single probe batch.
+     */
+    private static final int PROBE_BATCH_CALLS = 1_000;
+
+    /**
+     * The maximum number of probe batches to perform when probing.
+     */
+    private static final int PROBE_MAX_BATCHES = 100;
+
+    /**
+     * The maximum time to spend probing.
+     */
+    private static final long PROBE_BUDGET_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
+
+    /**
+     * A sink for probe measurements. Writing the accumulated {@link System#nanoTime()} readings
+     * to a volatile field prevents the JIT from eliminating the calls the probe is meant to measure.
+     */
+    @SuppressWarnings("unused")
+    private static volatile long blackhole;
+
+    /**
+     * The cached time source that is periodically updated by the ticker thread.
+     * It is only valid while the ticker is active.
+     */
+    private final CachedTimeSource timeSource = new CachedTimeSource();
+
+    /**
+     * The background thread that performs platform timer probing, installs the cached
+     * source into {@link Time}, and periodically updates it.
+     */
+    private final @Nullable Thread thread;
+
+    /**
+     * True if this manager should probe the platform timer cost before installing
+     * the cached source. False if the cached source should be installed immediately.
+     * For testing.
+     */
+    private final boolean probeFirst;
+
+    /**
+     * True if the cached source should be installed into {@link Time}. False if
+     * the ticker should only update the cached source. For testing.
+     */
+    private final boolean installIntoTime;
+
+    /**
+     * The time interval between updates of the cached source.
+     */
+    private final long tickIntervalMillis;
+
+    /**
+     * True while the ticker should remain running. False if this manager is not enabled
+     * or has been closed.
+     */
+    private volatile boolean running;
+
+    /**
+     * True if the ticker is starting, started, or stopping. False otherwise. Used
+     * in testing to verify the ticker starts appropriately.
+     */
+    private volatile boolean tickerActive;
+
+    /**
+     * Creates the manager that optionally measures the platform timer cost, and if warranted,
+     * installs the cached source into {@link Time}.
+     */
+    public static TimeSourceManager start(boolean timerSuspectedExpensive) {
+        TimeSourceManager manager = new TimeSourceManager(timerSuspectedExpensive, true, true, DEFAULT_TICK_MILLIS);
+        manager.startThread();
+        return manager;
+    }
+
+    /**
+     * Creates a manager whose ticker runs unconditionally, without probing the timer cost or
+     * installing into {@link Time}. For testing.
+     */
+    static TimeSourceManager startWithoutProbe(long tickIntervalMillis) {
+        TimeSourceManager manager = new TimeSourceManager(true, false, false, tickIntervalMillis);
+        manager.startThread();
+        return manager;
+    }
+
+    /**
+     * Creates a manager whose ticker runs unconditionally and installs into {@link Time},
+     * without probing the timer cost. For testing on platforms with a swappable time source.
+     */
+    static TimeSourceManager startWithoutProbeAndInstall(long tickIntervalMillis) {
+        TimeSourceManager manager = new TimeSourceManager(true, false, true, tickIntervalMillis);
+        manager.startThread();
+        return manager;
+    }
+
+    private TimeSourceManager(
+        boolean enabled,
+        boolean probeFirst,
+        boolean installIntoTime,
+        long tickIntervalMillis
+    ) {
+        this.probeFirst = probeFirst;
+        this.installIntoTime = installIntoTime;
+        this.tickIntervalMillis = tickIntervalMillis;
+        this.running = enabled;
+        this.thread = enabled ? new Thread(this::runTicker, "Cached time source ticker") : null;
+    }
+
+    /**
+     * Starts the background thread that probes the performance of the platform timer,
+     * installing it and periodically updating it if the platform timer is determined
+     * to be expensive.
+     */
+    private void startThread() {
+        if (thread != null) {
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    /**
+     * Return true if the cached source is currently being updated by the ticker thread.
+     * False if the timer on this machine was measured to be performant or if platform
+     * timer probing has not yet finished.
+     */
+    public boolean isTickerActive() {
+        return tickerActive && running;
+    }
+
+    /**
+     * The cached time source managed by this manager. Its reading is only valid while the
+     * ticker is active.
+     */
+    CachedTimeSource getCachedTimeSource() {
+        return timeSource;
+    }
+
+    /**
+     * Run the ticker thread, probing the platform timer cost and installing the cached source
+     * into {@link Time} if warranted.
+     */
+    private void runTicker() {
+        if (probeFirst && (!running || isPlatformTimerFastEnough())) {
+            return;
+        }
+
+        // The source must have a valid reading before anything can observe it
+        timeSource.tick();
+        this.tickerActive = true;
+        if (installIntoTime) {
+            Time.installTimeSource(timeSource);
+        }
+
+        try {
+            while (running) {
+                timeSource.tick();
+                // Thread.sleep rather than LockSupport.parkNanos: on Windows, the JVM raises
+                // the timer resolution (per-process, since Windows 10 2004) to 1ms around
+                // sub-10ms sleeps, while parkNanos waits on the default scheduler quantum
+                // and would achieve a ~15.6ms tick.
+                Thread.sleep(tickIntervalMillis);
+            }
+        } catch (InterruptedException ignored) {
+            // Closed while sleeping
+        } finally {
+            // Restore the platform timer no matter how this thread exits, including on unexpected
+            // errors, so nothing keeps reading a cache that has stopped advancing.
+            if (installIntoTime) {
+                Time.uninstallTimeSource();
+            }
+            this.tickerActive = false;
+        }
+    }
+
+    /**
+     * Return true if the platform timer is fast enough that the cached source is not needed.
+     */
+    private static boolean isPlatformTimerFastEnough() {
+        if (hasUnreasonablySlowPlatformTimer()) {
+            return false;
+        }
+
+        long sink = 0;
+
+        // Warm up the call before measuring it.
+        for (int i = 0; i < PROBE_BATCH_CALLS; i++) {
+            sink += System.nanoTime();
+        }
+
+        long batches = 0;
+        long start = System.nanoTime();
+        long now = start;
+        long deadline = start + PROBE_BUDGET_NANOS;
+        while (now < deadline && batches < PROBE_MAX_BATCHES) {
+            for (int i = 0; i < PROBE_BATCH_CALLS - 1; i++) {
+                sink += System.nanoTime();
+            }
+            now = System.nanoTime();
+            batches++;
+        }
+        blackhole = sink;
+
+        long result = (now - start) / (PROBE_BATCH_CALLS * batches);
+        return result <= SLOW_NANO_TIME_THRESHOLD_NANOS;
+    }
+
+    /**
+     * Return true if the platform timer is much slower than reasonable. Used to detect very
+     * slow timers that would otherwise cause the JIT warmup to take longer than desired.
+     */
+    private static boolean hasUnreasonablySlowPlatformTimer() {
+        long sink = 0;
+        int miniCalls = 16;
+        long miniStart = System.nanoTime();
+        for (int i = 0; i < miniCalls - 1; i++) {
+            sink += System.nanoTime();
+        }
+
+        long stop = System.nanoTime();
+        blackhole = sink;
+
+        long miniAverage = (stop - miniStart) / miniCalls;
+        return miniAverage > 10 * SLOW_NANO_TIME_THRESHOLD_NANOS;
+    }
+
+    @Override
+    public void close() {
+        this.running = false;
+        Thread thread = this.thread;
+        if (thread != null) {
+            thread.interrupt();
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * A {@link TimeSource} whose nano time reading is read from a cached variable that is
+     * periodically updated by the ticker thread. The reading is only valid once the first
+     * {@link #tick()} has happened.
+     */
+    static class CachedTimeSource implements TimeSource {
+
+        private volatile long nanos;
+
+        private void tick() {
+            nanos = System.nanoTime();
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanos;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+    }
+
+}

--- a/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
+++ b/platforms/core-runtime/time/src/main/java/org/gradle/internal/time/TimeSourceManager.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Detects slow platform timers, replacing them with a background thread that periodically updates
+ * a cached timer that the application may read from quickly.
+ * <p>
+ * On most platforms, {@link System#nanoTime()} is a fast userspace read (~20ns). On Windows it
+ * is backed by {@code QueryPerformanceCounter}, which on some machines (notably virtualized ones,
+ * or when the OS has fallen back to the HPET or ACPI timer) costs tens of microseconds per call.
+ * Code that reads the timer per event can then spend seconds of every build querying the time.
+ * For frequently called code, these expensive timers can accumulate to seconds of build time.
+ * <p>
+ * On platforms suspected of an expensive timer, this manager starts a background thread that
+ * measures the actual cost of the platform timer on this machine. If it is inexpensive, the
+ * thread exits and nothing changes. If it is expensive, the thread installs a
+ * {@link CachedTimeSource} into {@link Time} and keeps its reading fresh by caching
+ * the platform timer at a regular interval. Timer readings then cost a volatile load
+ * regardless of the platform timer. The initial probing takes place off the critical path of
+ * application startup. The platform timer remains in-place while probing takes place.
+ * <p>
+ * With the cached source installed, an individual reading may be stale by up to the tick interval.
+ * Durations computed from pairs of readings have an error bounded by the tick interval. Sums and
+ * averages over many measured durations converge on the true values. The tick interval used by this
+ * manager matches the millisecond-level granularity that consumers ({@link Time#clock()} and
+ * {@link Time#startTimer()}) already expose. The clock's timestamps never go backwards, including
+ * across the switchover, which {@link MonotonicClock} guarantees.
+ * <p>
+ * This manager is a global service. Closing the owning registry stops the thread, which
+ * restores direct platform readings.
+ */
+@ServiceScope(Scope.Global.class)
+public class TimeSourceManager implements Closeable {
+
+    private static final long DEFAULT_TICK_MILLIS = 1;
+
+    /**
+     * Above this average cost per {@link System#nanoTime()} call, the caching ticker is
+     * worthwhile. A healthy timer costs ~20-40ns; a pathological one costs thousands of
+     * nanoseconds or more. The threshold leaves room for interpreter overhead, since the
+     * probe may run before the measuring loop is JIT compiled.
+     */
+    private static final long SLOW_NANO_TIME_THRESHOLD_NANOS = 1000;
+
+    /**
+     * The number of calls to {@link System#nanoTime()} to perform in a single probe batch.
+     */
+    private static final int PROBE_BATCH_CALLS = 1_000;
+
+    /**
+     * The maximum number of probe batches to perform when probing.
+     */
+    private static final int PROBE_MAX_BATCHES = 100;
+
+    /**
+     * The maximum time to spend probing.
+     */
+    private static final long PROBE_BUDGET_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
+
+    /**
+     * A sink for probe measurements. Writing the accumulated {@link System#nanoTime()} readings
+     * to a volatile field prevents the JIT from eliminating the calls the probe is meant to measure.
+     */
+    @SuppressWarnings("unused")
+    private static volatile long blackhole;
+
+    /**
+     * The cached time source that is periodically updated by the ticker thread.
+     * It is only valid while the ticker is active.
+     */
+    private final CachedTimeSource timeSource = new CachedTimeSource();
+
+    /**
+     * The background thread that performs platform timer probing, installs the cached
+     * source into {@link Time}, and periodically updates it.
+     */
+    private final @Nullable Thread thread;
+
+    /**
+     * True if this manager should probe the platform timer cost before installing
+     * the cached source. False if the cached source should be installed immediately.
+     * For testing.
+     */
+    private final boolean probeFirst;
+
+    /**
+     * True if the cached source should be installed into {@link Time}. False if
+     * the ticker should only update the cached source. For testing.
+     */
+    private final boolean installIntoTime;
+
+    /**
+     * The time interval between updates of the cached source.
+     */
+    private final long tickIntervalMillis;
+
+    /**
+     * True while the ticker should remain running. False if this manager is not enabled
+     * or has been closed.
+     */
+    private volatile boolean running;
+
+    /**
+     * True if the ticker is starting, started, or stopping. False otherwise. Used
+     * in testing to verify the ticker starts appropriately.
+     */
+    private volatile boolean tickerActive;
+
+    /**
+     * Creates the manager that optionally measures the platform timer cost, and if warranted,
+     * installs the cached source into {@link Time}.
+     */
+    public static TimeSourceManager start(boolean timerSuspectedExpensive) {
+        TimeSourceManager manager = new TimeSourceManager(timerSuspectedExpensive, true, true, DEFAULT_TICK_MILLIS);
+        manager.startThread();
+        return manager;
+    }
+
+    /**
+     * Creates a manager whose ticker runs unconditionally, without probing the timer cost or
+     * installing into {@link Time}. For testing.
+     */
+    static TimeSourceManager startWithoutProbe(long tickIntervalMillis) {
+        TimeSourceManager manager = new TimeSourceManager(true, false, false, tickIntervalMillis);
+        manager.startThread();
+        return manager;
+    }
+
+    /**
+     * Creates a manager whose ticker runs unconditionally and installs into {@link Time},
+     * without probing the timer cost. For testing on platforms with a swappable time source.
+     */
+    static TimeSourceManager startWithoutProbeAndInstall(long tickIntervalMillis) {
+        TimeSourceManager manager = new TimeSourceManager(true, false, true, tickIntervalMillis);
+        manager.startThread();
+        return manager;
+    }
+
+    private TimeSourceManager(
+        boolean enabled,
+        boolean probeFirst,
+        boolean installIntoTime,
+        long tickIntervalMillis
+    ) {
+        this.probeFirst = probeFirst;
+        this.installIntoTime = installIntoTime;
+        this.tickIntervalMillis = tickIntervalMillis;
+        this.running = enabled;
+        this.thread = enabled ? new Thread(this::runTicker, "Cached time source ticker") : null;
+    }
+
+    /**
+     * Starts the background thread that probes the performance of the platform timer,
+     * installing it and periodically updating it if the platform timer is determined
+     * to be expensive.
+     */
+    private void startThread() {
+        if (thread != null) {
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    /**
+     * Return true if the cached source is currently being updated by the ticker thread.
+     * False if the timer on this machine was measured to be performant or if platform
+     * timer probing has not yet finished.
+     */
+    public boolean isTickerActive() {
+        return tickerActive && running;
+    }
+
+    /**
+     * The cached time source managed by this manager. Its reading is only valid while the
+     * ticker is active.
+     */
+    CachedTimeSource getCachedTimeSource() {
+        return timeSource;
+    }
+
+    /**
+     * Run the ticker thread, probing the platform timer cost and installing the cached source
+     * into {@link Time} if warranted.
+     */
+    private void runTicker() {
+        if (probeFirst && (!running || isPlatformTimerFastEnough())) {
+            return;
+        }
+
+        // The source must have a valid reading before anything can observe it
+        timeSource.tick();
+        this.tickerActive = true;
+        if (installIntoTime) {
+            Time.installTimeSource(timeSource);
+        }
+
+        try {
+            while (running) {
+                timeSource.tick();
+                // Thread.sleep rather than LockSupport.parkNanos: on Windows, the JVM raises
+                // the timer resolution (per-process, since Windows 10 2004) to 1ms around
+                // sub-10ms sleeps, while parkNanos waits on the default scheduler quantum
+                // and would achieve a ~15.6ms tick.
+                Thread.sleep(tickIntervalMillis);
+            }
+        } catch (InterruptedException ignored) {
+            // Closed while sleeping
+        } finally {
+            // Restore the platform timer no matter how this thread exits, including on unexpected
+            // errors, so nothing keeps reading a cache that has stopped advancing.
+            if (installIntoTime) {
+                Time.uninstallTimeSource();
+            }
+            this.tickerActive = false;
+        }
+    }
+
+    /**
+     * Return true if the platform timer is fast enough that the cached source is not needed.
+     */
+    private static boolean isPlatformTimerFastEnough() {
+        if (hasUnreasonablySlowPlatformTimer()) {
+            return false;
+        }
+
+        long sink = 0;
+
+        // Warm up the call before measuring it.
+        for (int i = 0; i < PROBE_BATCH_CALLS; i++) {
+            sink += System.nanoTime();
+        }
+
+        long batches = 0;
+        long start = System.nanoTime();
+        long now = start;
+        long deadline = start + PROBE_BUDGET_NANOS;
+        while (now < deadline && batches < PROBE_MAX_BATCHES) {
+            for (int i = 0; i < PROBE_BATCH_CALLS - 1; i++) {
+                sink += System.nanoTime();
+            }
+            now = System.nanoTime();
+            batches++;
+        }
+        blackhole = sink;
+
+        long result = (now - start) / (PROBE_BATCH_CALLS * batches);
+        return result <= SLOW_NANO_TIME_THRESHOLD_NANOS;
+    }
+
+    /**
+     * Return true if the platform timer is much slower than reasonable. Used to detect very
+     * slow timers that would otherwise cause the JIT warmup to take longer than desired.
+     */
+    private static boolean hasUnreasonablySlowPlatformTimer() {
+        long sink = 0;
+        int miniCalls = 16;
+        long miniStart = System.nanoTime();
+        for (int i = 0; i < miniCalls - 1; i++) {
+            sink += System.nanoTime();
+        }
+
+        long stop = System.nanoTime();
+        blackhole = sink;
+
+        long miniAverage = (stop - miniStart) / miniCalls;
+        return miniAverage > 10 * SLOW_NANO_TIME_THRESHOLD_NANOS;
+    }
+
+    @Override
+    public void close() {
+        this.running = false;
+        Thread thread = this.thread;
+        if (thread != null) {
+            thread.interrupt();
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * A {@link TimeSource} whose nano time reading is read from a cached variable that is
+     * periodically updated by the ticker thread. The reading is only valid once the first
+     * {@link #tick()} has happened.
+     */
+    static class CachedTimeSource implements TimeSource {
+
+        private volatile long nanos;
+
+        private void tick() {
+            nanos = System.nanoTime();
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanos;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+    }
+
+}

--- a/platforms/core-runtime/time/src/test/groovy/org/gradle/internal/time/SwappableTimeSourceTest.groovy
+++ b/platforms/core-runtime/time/src/test/groovy/org/gradle/internal/time/SwappableTimeSourceTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time
+
+import spock.lang.Specification
+
+class SwappableTimeSourceTest extends Specification {
+
+    def initial = new MockTimeSource(nanos: 1, millis: 10)
+    def replacement = new MockTimeSource(nanos: 2, millis: 20)
+    def source = new SwappableTimeSource(initial)
+
+    def "reads from the initial delegate"() {
+        expect:
+        source.get().is(initial)
+        source.nanoTime() == 1
+        source.currentTimeMillis() == 10
+    }
+
+    def "reads from the replacement once set"() {
+        when:
+        source.set(replacement)
+
+        then:
+        source.get().is(replacement)
+        source.nanoTime() == 2
+        source.currentTimeMillis() == 20
+    }
+
+    def "can be set back to a previous delegate"() {
+        given:
+        source.set(replacement)
+
+        when:
+        source.set(initial)
+
+        then:
+        source.get().is(initial)
+        source.nanoTime() == 1
+    }
+
+    private static class MockTimeSource implements TimeSource {
+
+        long nanos
+        long millis
+
+        @Override
+        long currentTimeMillis() {
+            return millis
+        }
+
+        @Override
+        long nanoTime() {
+            return nanos
+        }
+
+    }
+
+}

--- a/platforms/core-runtime/time/src/test/groovy/org/gradle/internal/time/TimeSourceManagerTest.groovy
+++ b/platforms/core-runtime/time/src/test/groovy/org/gradle/internal/time/TimeSourceManagerTest.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time
+
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.OsTestPreconditions
+import spock.lang.Specification
+
+class TimeSourceManagerTest extends Specification {
+
+    def "disabled manager is not active"() {
+        given:
+        def manager = TimeSourceManager.start(false)
+
+        expect:
+        !manager.tickerActive
+
+        cleanup:
+        manager.close()
+    }
+
+    def "ticker advances the cached time and readings never decrease"() {
+        given:
+        def manager = TimeSourceManager.startWithoutProbe(1)
+        def timeSource = manager.cachedTimeSource
+
+        expect:
+        ConcurrentTestUtil.poll {
+            assert manager.tickerActive
+        }
+
+        when:
+        def first = timeSource.nanoTime()
+
+        then:
+        ConcurrentTestUtil.poll {
+            assert timeSource.nanoTime() > first
+        }
+
+        and:
+        def previous = timeSource.nanoTime()
+        (1..1000).every {
+            def current = timeSource.nanoTime()
+            def ok = current >= previous
+            previous = current
+            ok
+        }
+
+        cleanup:
+        manager.close()
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "probing manager does not block and stays inactive when the timer is fast"() {
+        given:
+        // This test machine is assumed to have a healthy timer. We disable this test on windows
+        // since our Windows CI machines are known to have slow timers.
+        def manager = TimeSourceManager.start(true)
+
+        expect:
+        ConcurrentTestUtil.poll {
+            assert !manager.tickerActive
+        }
+
+        cleanup:
+        manager.close()
+    }
+
+    def "close stops the ticker"() {
+        given:
+        def manager = TimeSourceManager.startWithoutProbe(1)
+        ConcurrentTestUtil.poll {
+            assert manager.tickerActive
+        }
+
+        when:
+        manager.close()
+
+        then:
+        !manager.tickerActive
+
+        and:
+        // Readings still work after close, they just no longer advance with the ticker
+        manager.cachedTimeSource.nanoTime() > 0
+
+        when:
+        manager.close()
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Requires(OsTestPreconditions.Windows)
+    def "activating the ticker installs the source into Time and stopping restores direct readings"() {
+        when:
+        def manager = TimeSourceManager.startWithoutProbeAndInstall(1)
+
+        then:
+        ConcurrentTestUtil.poll {
+            assert Time.getEffectiveTimeSource().is(manager.cachedTimeSource)
+        }
+
+        and:
+        // The clock still works and remains monotonic while served by the cached time source
+        def t1 = Time.clock().getCurrentTime()
+        def t2 = Time.clock().getCurrentTime()
+        t2 >= t1
+
+        when:
+        manager.close()
+
+        then:
+        ConcurrentTestUtil.poll {
+            assert !Time.getEffectiveTimeSource().is(manager.cachedTimeSource)
+        }
+
+        cleanup:
+        manager.close()
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "the time source cannot be swapped on platforms with a cheap timer"() {
+        when:
+        Time.installTimeSource(new TimeSourceManager.CachedTimeSource())
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+}

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -185,6 +185,17 @@ Gradle provides [Tooling APIs](userguide/third_party_integration.html) that faci
 ### General improvements
 Gradle provides various incremental updates and performance optimizations to ensure the continued reliability of the build ecosystem.
 
+#### Improved performance on Windows machines with slow system clocks
+
+Gradle reads the system clock frequently while a build runs, to capture execution traces, progress events, and log messages.
+On most machines, querying the time is inexpensive.
+However, on some Windows systems, particularly virtualized ones, reading the clock is much slower, and the increased cost can accumulate over the many readings taken during a single build invocation.
+
+Gradle now detects these slow system clocks at startup and switches to a faster source of time for the remainder of the build.
+On affected machines we have measured build time improvements of up to 45%.
+
+Builds on machines with a normal system clock are unaffected, and no change to configuration is required.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ========================================================== -->


### PR DESCRIPTION
Our Windows CI machines report the following System.nanoTime stats:

```
os: Windows 10 10.0 (amd64), cores: 10
jvm: OpenJDK 64-Bit Server VM 17.0.20+8
nanoTime cost, sample 1: 12553 ns/call
nanoTime cost, sample 2: 18071 ns/call
nanoTime cost, sample 3: 19765 ns/call
currentTimeMillis cost: 276 ns/call (sink 1)
parkNanos(1ms) achieved: 15602 us average
Thread.sleep(1) achieved: 1734 us average
Time.clock().getCurrentTime() cost: 41118 ns/call over 5000 calls
```

nanoTime takes on the order of tens of microseconds, and calls to Clock.getCurrentTime as a result
take the same order of magnitude time. Our Clock is used for for build operations timestamps, tapi
progress events, and logging, all of which happen on the fast path. This slow timer causes builds
on our CI machines to take _seconds_ of extra time just due to the slow timer. This is likely
happening in real world builds on Windows machines with similarly configured timers.

To resolve this, we detect slow timers on process startup, by probing the platform timer in a separate
thread. If the system timer is determined to be slow, we use that thread to periodically, every 1ms,
update a volatile field with the current time. We then install a TimeSource backed by this volatile field
instead of the existing System.nanoTime backed timer

Windows perf test results: 
<img width="1107" height="1009" alt="image" src="https://github.com/user-attachments/assets/be3e3bb2-7c0a-4ce7-9d19-1c6f607adda7" />


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
