### PR TITLE
Reduce gradle memory usage: Share default cache policy rules across ResolutionStrategy instances

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheExpirationControl.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheExpirationControl.java
@@ -16,10 +16,16 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.cache.ArtifactResolutionControl;
+import org.gradle.api.internal.artifacts.cache.DependencyResolutionControl;
+import org.gradle.api.internal.artifacts.cache.ModuleResolutionControl;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 
 import java.io.File;
@@ -47,6 +53,15 @@ public interface CacheExpirationControl {
     Expiry artifactExpiry(ModuleComponentArtifactMetadata artifactMetadata, File cachedArtifactFile, Duration age, boolean belongsToChangingModule, boolean moduleDescriptorInSync);
 
     Expiry changingModuleExpiry(ModuleComponentIdentifier component, ResolvedModuleVersion resolvedModuleVersion, Duration age);
+
+    @VisibleForTesting
+    ImmutableList<Action<? super DependencyResolutionControl>> getDependencyCacheRules();
+
+    @VisibleForTesting
+    ImmutableList<Action<? super ModuleResolutionControl>> getModuleCacheRules();
+
+    @VisibleForTesting
+    ImmutableList<Action<? super ArtifactResolutionControl>> getArtifactCacheRules();
 
     interface Expiry {
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultCacheExpirationControl.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultCacheExpirationControl.java
@@ -183,6 +183,21 @@ public class DefaultCacheExpirationControl implements CacheExpirationControl {
         return false;
     }
 
+    @Override
+    public ImmutableList<Action<? super DependencyResolutionControl>> getDependencyCacheRules() {
+        return dependencyCacheRules;
+    }
+
+    @Override
+    public ImmutableList<Action<? super ModuleResolutionControl>> getModuleCacheRules() {
+        return moduleCacheRules;
+    }
+
+    @Override
+    public ImmutableList<Action<? super ArtifactResolutionControl>> getArtifactCacheRules() {
+        return artifactCacheRules;
+    }
+
     private static abstract class AbstractResolutionControl<A, B> implements ResolutionControl<A, B>, Expiry {
 
         private final A request;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -22,8 +22,9 @@ import org.gradle.api.internal.artifacts.cache.DependencyResolutionControl;
 import org.gradle.api.internal.artifacts.cache.ModuleResolutionControl;
 import org.gradle.api.internal.artifacts.configurations.CachePolicy;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultCacheExpirationControl;
 import org.gradle.api.internal.artifacts.ivyservice.CacheExpirationControl;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultCacheExpirationControl;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,30 +36,51 @@ public class DefaultCachePolicy implements CachePolicy {
     private static final int SECONDS_IN_DAY = 24 * 60 * 60;
     private static final int MILLISECONDS_IN_DAY = SECONDS_IN_DAY * 1000;
 
-    final List<Action<? super DependencyResolutionControl>> dependencyCacheRules;
-    final List<Action<? super ModuleResolutionControl>> moduleCacheRules;
-    final List<Action<? super ArtifactResolutionControl>> artifactCacheRules;
+    private static final Action<DependencyResolutionControl> DEFAULT_DYNAMIC_VERSIONS_RULE = dependencyResolutionControl -> {
+        if (!dependencyResolutionControl.getCachedResult().isEmpty()) {
+            dependencyResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+        }
+    };
+    private static final Action<ModuleResolutionControl> DEFAULT_CHANGING_MODULE_RULE = moduleResolutionControl -> {
+        if (moduleResolutionControl.isChanging()) {
+            moduleResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+        }
+    };
+    private static final Action<ArtifactResolutionControl> DEFAULT_CHANGING_MODULE_ARTIFACT_RULE = artifactResolutionControl -> {
+        if (artifactResolutionControl.belongsToChangingModule()) {
+            artifactResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+        }
+    };
+    private static final Action<ArtifactResolutionControl> DEFAULT_MISSING_ARTIFACT_RULE = artifactResolutionControl -> {
+        if (artifactResolutionControl.getCachedResult() == null) {
+            artifactResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+        }
+    };
+
+    private static final ImmutableList<Action<? super DependencyResolutionControl>> DEFAULT_DEPENDENCY_CACHE_RULES = ImmutableList.of(DEFAULT_DYNAMIC_VERSIONS_RULE);
+    private static final ImmutableList<Action<? super ModuleResolutionControl>> DEFAULT_MODULE_CACHE_RULES = ImmutableList.of(DEFAULT_CHANGING_MODULE_RULE);
+    private static final ImmutableList<Action<? super ArtifactResolutionControl>> DEFAULT_ARTIFACT_CACHE_RULES = ImmutableList.of(DEFAULT_MISSING_ARTIFACT_RULE, DEFAULT_CHANGING_MODULE_ARTIFACT_RULE);
+
+    @Nullable
+    List<Action<? super DependencyResolutionControl>> dependencyCacheRules;
+    @Nullable
+    List<Action<? super ModuleResolutionControl>> moduleCacheRules;
+    @Nullable
+    List<Action<? super ArtifactResolutionControl>> artifactCacheRules;
+
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
     private long keepDynamicVersionsFor = MILLISECONDS_IN_DAY;
     private long keepChangingModulesFor = MILLISECONDS_IN_DAY;
     private boolean offline = false;
     private boolean refresh = false;
 
-    @SuppressWarnings("this-escape")
     public DefaultCachePolicy() {
-        this.dependencyCacheRules = new ArrayList<>(1);
-        this.moduleCacheRules = new ArrayList<>(1);
-        this.artifactCacheRules = new ArrayList<>(2);
-
-        cacheDynamicVersionsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        cacheChangingModulesFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        cacheMissingArtifactsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
     }
 
     private DefaultCachePolicy(DefaultCachePolicy policy) {
-        this.dependencyCacheRules = new ArrayList<>(policy.dependencyCacheRules);
-        this.moduleCacheRules = new ArrayList<>(policy.moduleCacheRules);
-        this.artifactCacheRules = new ArrayList<>(policy.artifactCacheRules);
+        this.dependencyCacheRules = policy.dependencyCacheRules == null ? null : new ArrayList<>(policy.dependencyCacheRules);
+        this.moduleCacheRules = policy.moduleCacheRules == null ? null : new ArrayList<>(policy.moduleCacheRules);
+        this.artifactCacheRules = policy.artifactCacheRules == null ? null : new ArrayList<>(policy.artifactCacheRules);
         this.keepDynamicVersionsFor = policy.keepDynamicVersionsFor;
         this.keepChangingModulesFor = policy.keepChangingModulesFor;
         this.offline = policy.offline;
@@ -89,6 +111,9 @@ public class DefaultCachePolicy implements CachePolicy {
     public void cacheDynamicVersionsFor(final int value, final TimeUnit unit) {
         keepDynamicVersionsFor = unit.toMillis(value);
         mutationValidator.validateMutation(STRATEGY);
+        if (dependencyCacheRules == null) {
+            dependencyCacheRules = new ArrayList<>(1);
+        }
         dependencyCacheRules.add(0, dependencyResolutionControl -> {
             if (!dependencyResolutionControl.getCachedResult().isEmpty()) {
                 dependencyResolutionControl.cacheFor(value, unit);
@@ -101,23 +126,20 @@ public class DefaultCachePolicy implements CachePolicy {
         keepChangingModulesFor = units.toMillis(value);
         mutationValidator.validateMutation(STRATEGY);
 
+        if (moduleCacheRules == null) {
+            moduleCacheRules = new ArrayList<>(1);
+        }
         moduleCacheRules.add(0, moduleResolutionControl -> {
             if (moduleResolutionControl.isChanging()) {
                 moduleResolutionControl.cacheFor(value, units);
             }
         });
 
+        if (artifactCacheRules == null) {
+            artifactCacheRules = new ArrayList<>(1);
+        }
         artifactCacheRules.add(0, artifactResolutionControl -> {
             if (artifactResolutionControl.belongsToChangingModule()) {
-                artifactResolutionControl.cacheFor(value, units);
-            }
-        });
-    }
-
-    private void cacheMissingArtifactsFor(final int value, final TimeUnit units) {
-        mutationValidator.validateMutation(STRATEGY);
-        artifactCacheRules.add(0, artifactResolutionControl -> {
-            if (artifactResolutionControl.getCachedResult() == null) {
                 artifactResolutionControl.cacheFor(value, units);
             }
         });
@@ -131,14 +153,28 @@ public class DefaultCachePolicy implements CachePolicy {
     @Override
     public CacheExpirationControl asImmutable() {
         return new DefaultCacheExpirationControl(
-            ImmutableList.copyOf(dependencyCacheRules),
-            ImmutableList.copyOf(moduleCacheRules),
-            ImmutableList.copyOf(artifactCacheRules),
+            withDefaultRules(dependencyCacheRules, DEFAULT_DEPENDENCY_CACHE_RULES),
+            withDefaultRules(moduleCacheRules, DEFAULT_MODULE_CACHE_RULES),
+            withDefaultRules(artifactCacheRules, DEFAULT_ARTIFACT_CACHE_RULES),
             keepDynamicVersionsFor,
             keepChangingModulesFor,
             offline,
             refresh
         );
+    }
+
+    /**
+     * Appends the shared default rules to the user-provided rules, preserving the historic
+     * evaluation order where user rules are evaluated before the default rules.
+     */
+    private static <T> ImmutableList<Action<? super T>> withDefaultRules(@Nullable List<Action<? super T>> userRules, ImmutableList<Action<? super T>> defaultRules) {
+        if (userRules == null) {
+            return defaultRules;
+        }
+        return ImmutableList.<Action<? super T>>builder()
+            .addAll(userRules)
+            .addAll(defaultRules)
+            .build();
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -33,24 +33,13 @@ import java.util.concurrent.TimeUnit;
 import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY;
 
 public class DefaultCachePolicy implements CachePolicy {
+
     private static final int SECONDS_IN_DAY = 24 * 60 * 60;
     private static final int MILLISECONDS_IN_DAY = SECONDS_IN_DAY * 1000;
 
-    private static final Action<DependencyResolutionControl> DEFAULT_DYNAMIC_VERSIONS_RULE = dependencyResolutionControl -> {
-        if (!dependencyResolutionControl.getCachedResult().isEmpty()) {
-            dependencyResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        }
-    };
-    private static final Action<ModuleResolutionControl> DEFAULT_CHANGING_MODULE_RULE = moduleResolutionControl -> {
-        if (moduleResolutionControl.isChanging()) {
-            moduleResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        }
-    };
-    private static final Action<ArtifactResolutionControl> DEFAULT_CHANGING_MODULE_ARTIFACT_RULE = artifactResolutionControl -> {
-        if (artifactResolutionControl.belongsToChangingModule()) {
-            artifactResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
-        }
-    };
+    private static final Action<DependencyResolutionControl> DEFAULT_DYNAMIC_VERSIONS_RULE = dependencyCacheRuleFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+    private static final Action<ModuleResolutionControl> DEFAULT_CHANGING_MODULE_RULE = moduleCacheRuleFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
+    private static final Action<ArtifactResolutionControl> DEFAULT_CHANGING_MODULE_ARTIFACT_RULE = artifactCacheRuleFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
     private static final Action<ArtifactResolutionControl> DEFAULT_MISSING_ARTIFACT_RULE = artifactResolutionControl -> {
         if (artifactResolutionControl.getCachedResult() == null) {
             artifactResolutionControl.cacheFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
@@ -61,12 +50,9 @@ public class DefaultCachePolicy implements CachePolicy {
     private static final ImmutableList<Action<? super ModuleResolutionControl>> DEFAULT_MODULE_CACHE_RULES = ImmutableList.of(DEFAULT_CHANGING_MODULE_RULE);
     private static final ImmutableList<Action<? super ArtifactResolutionControl>> DEFAULT_ARTIFACT_CACHE_RULES = ImmutableList.of(DEFAULT_MISSING_ARTIFACT_RULE, DEFAULT_CHANGING_MODULE_ARTIFACT_RULE);
 
-    @Nullable
-    List<Action<? super DependencyResolutionControl>> dependencyCacheRules;
-    @Nullable
-    List<Action<? super ModuleResolutionControl>> moduleCacheRules;
-    @Nullable
-    List<Action<? super ArtifactResolutionControl>> artifactCacheRules;
+    private @Nullable List<Action<? super DependencyResolutionControl>> dependencyCacheRules;
+    private @Nullable List<Action<? super ModuleResolutionControl>> moduleCacheRules;
+    private @Nullable List<Action<? super ArtifactResolutionControl>> artifactCacheRules;
 
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
     private long keepDynamicVersionsFor = MILLISECONDS_IN_DAY;
@@ -114,11 +100,15 @@ public class DefaultCachePolicy implements CachePolicy {
         if (dependencyCacheRules == null) {
             dependencyCacheRules = new ArrayList<>(1);
         }
-        dependencyCacheRules.add(0, dependencyResolutionControl -> {
+        dependencyCacheRules.add(0, dependencyCacheRuleFor(value, unit));
+    }
+
+    private static Action<DependencyResolutionControl> dependencyCacheRuleFor(int value, TimeUnit unit) {
+        return dependencyResolutionControl -> {
             if (!dependencyResolutionControl.getCachedResult().isEmpty()) {
                 dependencyResolutionControl.cacheFor(value, unit);
             }
-        });
+        };
     }
 
     @Override
@@ -129,20 +119,28 @@ public class DefaultCachePolicy implements CachePolicy {
         if (moduleCacheRules == null) {
             moduleCacheRules = new ArrayList<>(1);
         }
-        moduleCacheRules.add(0, moduleResolutionControl -> {
-            if (moduleResolutionControl.isChanging()) {
-                moduleResolutionControl.cacheFor(value, units);
-            }
-        });
+        moduleCacheRules.add(0, moduleCacheRuleFor(value, units));
 
         if (artifactCacheRules == null) {
             artifactCacheRules = new ArrayList<>(1);
         }
-        artifactCacheRules.add(0, artifactResolutionControl -> {
+        artifactCacheRules.add(0, artifactCacheRuleFor(value, units));
+    }
+
+    private static Action<ArtifactResolutionControl> artifactCacheRuleFor(int value, TimeUnit units) {
+        return artifactResolutionControl -> {
             if (artifactResolutionControl.belongsToChangingModule()) {
                 artifactResolutionControl.cacheFor(value, units);
             }
-        });
+        };
+    }
+
+    private static Action<ModuleResolutionControl> moduleCacheRuleFor(int value, TimeUnit units) {
+        return moduleResolutionControl -> {
+            if (moduleResolutionControl.isChanging()) {
+                moduleResolutionControl.cacheFor(value, units);
+            }
+        };
     }
 
     @Override
@@ -171,7 +169,8 @@ public class DefaultCachePolicy implements CachePolicy {
         if (userRules == null) {
             return defaultRules;
         }
-        return ImmutableList.<Action<? super T>>builder()
+
+        return ImmutableList.<Action<? super T>>builderWithExpectedSize(userRules.size() + defaultRules.size())
             .addAll(userRules)
             .addAll(defaultRules)
             .build();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -31,6 +31,7 @@ import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
 
 class DefaultCachePolicySpec extends Specification {
+
     private static final long SECOND = 1000;
     private static final long MINUTE = SECOND * 60;
     private static final long HOUR = MINUTE * 60;
@@ -245,13 +246,13 @@ class DefaultCachePolicySpec extends Specification {
         def copy = cachePolicy.copy()
 
         !copy.is(cachePolicy)
-        copy.dependencyCacheRules.is(cachePolicy.dependencyCacheRules)
-        copy.moduleCacheRules.is(cachePolicy.moduleCacheRules)
-        copy.artifactCacheRules.is(cachePolicy.artifactCacheRules)
+        copy.asImmutable().dependencyCacheRules.is(cachePolicy.asImmutable().dependencyCacheRules)
+        copy.asImmutable().moduleCacheRules.is(cachePolicy.asImmutable().moduleCacheRules)
+        copy.asImmutable().artifactCacheRules.is(cachePolicy.asImmutable().artifactCacheRules)
 
-        copy.dependencyCacheRules == cachePolicy.dependencyCacheRules
-        copy.moduleCacheRules == cachePolicy.moduleCacheRules
-        copy.artifactCacheRules == cachePolicy.artifactCacheRules
+        copy.asImmutable().dependencyCacheRules == cachePolicy.asImmutable().dependencyCacheRules
+        copy.asImmutable().moduleCacheRules == cachePolicy.asImmutable().moduleCacheRules
+        copy.asImmutable().artifactCacheRules == cachePolicy.asImmutable().artifactCacheRules
     }
 
     def "when rules are not empty copy creates independent rules"() {
@@ -264,22 +265,22 @@ class DefaultCachePolicySpec extends Specification {
 
         then:
         !copy.is(cachePolicy)
-        !copy.dependencyCacheRules.is(cachePolicy.dependencyCacheRules)
-        !copy.moduleCacheRules.is(cachePolicy.moduleCacheRules)
-        !copy.artifactCacheRules.is(cachePolicy.artifactCacheRules)
+        !copy.asImmutable().dependencyCacheRules.is(cachePolicy.asImmutable().dependencyCacheRules)
+        !copy.asImmutable().moduleCacheRules.is(cachePolicy.asImmutable().moduleCacheRules)
+        !copy.asImmutable().artifactCacheRules.is(cachePolicy.asImmutable().artifactCacheRules)
 
-        copy.dependencyCacheRules == cachePolicy.dependencyCacheRules
-        copy.moduleCacheRules == cachePolicy.moduleCacheRules
-        copy.artifactCacheRules == cachePolicy.artifactCacheRules
+        copy.asImmutable().dependencyCacheRules == cachePolicy.asImmutable().dependencyCacheRules
+        copy.asImmutable().moduleCacheRules == cachePolicy.asImmutable().moduleCacheRules
+        copy.asImmutable().artifactCacheRules == cachePolicy.asImmutable().artifactCacheRules
 
         when:
         copy.cacheDynamicVersionsFor(20, TimeUnit.SECONDS)
         copy.cacheChangingModulesFor(20, TimeUnit.SECONDS)
 
         then:
-        copy.dependencyCacheRules != cachePolicy.dependencyCacheRules
-        copy.moduleCacheRules != cachePolicy.moduleCacheRules
-        copy.artifactCacheRules != cachePolicy.artifactCacheRules
+        copy.asImmutable().dependencyCacheRules != cachePolicy.asImmutable().dependencyCacheRules
+        copy.asImmutable().moduleCacheRules != cachePolicy.asImmutable().moduleCacheRules
+        copy.asImmutable().artifactCacheRules != cachePolicy.asImmutable().artifactCacheRules
     }
 
     def "mutation is checked"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -240,10 +240,29 @@ class DefaultCachePolicySpec extends Specification {
         cachePolicy.asImmutable().artifactExpiry(null, null, Duration.ofMillis(1000), true, false).mustCheck
     }
 
-    def "provides a copy"() {
+    def "when rules are empty copy reuses rules"() {
         expect:
         def copy = cachePolicy.copy()
 
+        !copy.is(cachePolicy)
+        copy.dependencyCacheRules.is(cachePolicy.dependencyCacheRules)
+        copy.moduleCacheRules.is(cachePolicy.moduleCacheRules)
+        copy.artifactCacheRules.is(cachePolicy.artifactCacheRules)
+
+        copy.dependencyCacheRules == cachePolicy.dependencyCacheRules
+        copy.moduleCacheRules == cachePolicy.moduleCacheRules
+        copy.artifactCacheRules == cachePolicy.artifactCacheRules
+    }
+
+    def "when rules are not empty copy creates independent rules"() {
+        given:
+        cachePolicy.cacheDynamicVersionsFor(10, TimeUnit.SECONDS)
+        cachePolicy.cacheChangingModulesFor(10, TimeUnit.SECONDS)
+
+        when:
+        def copy = cachePolicy.copy()
+
+        then:
         !copy.is(cachePolicy)
         !copy.dependencyCacheRules.is(cachePolicy.dependencyCacheRules)
         !copy.moduleCacheRules.is(cachePolicy.moduleCacheRules)
@@ -252,6 +271,15 @@ class DefaultCachePolicySpec extends Specification {
         copy.dependencyCacheRules == cachePolicy.dependencyCacheRules
         copy.moduleCacheRules == cachePolicy.moduleCacheRules
         copy.artifactCacheRules == cachePolicy.artifactCacheRules
+
+        when:
+        copy.cacheDynamicVersionsFor(20, TimeUnit.SECONDS)
+        copy.cacheChangingModulesFor(20, TimeUnit.SECONDS)
+
+        then:
+        copy.dependencyCacheRules != cachePolicy.dependencyCacheRules
+        copy.moduleCacheRules != cachePolicy.moduleCacheRules
+        copy.artifactCacheRules != cachePolicy.artifactCacheRules
     }
 
     def "mutation is checked"() {


### PR DESCRIPTION
DefaultCachePolicy allocated its default dependency and artifact cache rules (three lists and four lambdas) for every ResolutionStrategy instance, even when the user never declares custom cache rules. This commit optimizes this behaviour. 

The issue this pr partially addresses - https://github.com/gradle/gradle/issues/38752

### Contributor Checklist
- [+] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [+] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [+] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [+] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [+] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. - Not needed
- [+] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [+] Update User Guide, DSL Reference, and Javadoc for public-facing changes. - Not needed
- [+] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [+] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
