### PR TITLE
Simplify BuildTreeWorkController to return a plain ExecutionResult

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -24,7 +24,6 @@ import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.ExecutionResult
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeWorkController
-import org.gradle.internal.buildtree.BuildTreeWorkController.TaskRunResult
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.BuildTreeWorkPreparer
 import org.gradle.internal.cc.impl.heap.HeapDumper
@@ -47,13 +46,13 @@ class ConfigurationCacheAwareBuildTreeWorkController(
             "$path/${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))}"
         }
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): TaskRunResult {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
         val scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder? = taskSelector?.let { selector ->
             { rootBuildState ->
                 addFinalization(rootBuildState, selector::postProcessExecutionPlan)
             }
         }
-        val executionResult: TaskRunResult? = workGraph.withNewWorkGraph { graph ->
+        val executionResult: ExecutionResult<Void>? = workGraph.withNewWorkGraph { graph ->
             val result = Try.ofFailable {
                 cache.loadOrScheduleRequestedTasks(
                     graph = graph,
@@ -62,7 +61,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
             }
 
             if (!result.isSuccessful) {
-                return@withNewWorkGraph TaskRunResult.ofScheduleFailure(result.failure.get())
+                return@withNewWorkGraph ExecutionResult.failed(result.failure.get())
             }
 
             // There are four outcomes:
@@ -79,7 +78,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
                 null
             } else {
                 maybeDumpHeap("cc-hit")
-                TaskRunResult.ofExecutionResult(workExecutor.execute(workGraph.graph))
+                workExecutor.execute(workGraph.graph)
             }
         }
         if (executionResult != null) {
@@ -105,9 +104,9 @@ class ConfigurationCacheAwareBuildTreeWorkController(
                 // The just-stored graph could not be fully restored, so its state is unreliable and must not be executed.
                 // No tasks run, hence no execution-phase failures here; the restoration problem fails the build through
                 // the configuration cache problem report at the end of the build (ConfigurationCacheProblems.report).
-                TaskRunResult.ofExecutionResult(ExecutionResult.succeeded())
+                ExecutionResult.succeeded()
             } else {
-                TaskRunResult.ofExecutionResult(workExecutor.execute(finalizedGraph))
+                workExecutor.execute(finalizedGraph)
             }
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/VintageBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/VintageBuildTreeWorkController.kt
@@ -19,8 +19,8 @@ package org.gradle.internal.cc.impl
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.execution.EntryTaskSelector
 import org.gradle.internal.Try
+import org.gradle.internal.build.ExecutionResult
 import org.gradle.internal.buildtree.BuildTreeWorkController
-import org.gradle.internal.buildtree.BuildTreeWorkController.TaskRunResult
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.buildtree.BuildTreeWorkPreparer
@@ -32,14 +32,14 @@ class VintageBuildTreeWorkController(
     private val taskGraph: BuildTreeWorkGraphController
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): TaskRunResult {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
         return taskGraph.withNewWorkGraph { graph: BuildTreeWorkGraph ->
             val finalizedGraph: Try<BuildTreeWorkGraph.FinalizedGraph> = Try.ofFailable { workPreparer.scheduleRequestedTasks(graph, taskSelector) }
 
             if (finalizedGraph.isSuccessful) {
-                TaskRunResult.ofExecutionResult(workExecutor.execute(finalizedGraph.get()))
+                workExecutor.execute(finalizedGraph.get())
             } else {
-                TaskRunResult.ofScheduleFailure(finalizedGraph.failure.get())
+                ExecutionResult.failed(finalizedGraph.failure.get())
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
@@ -16,14 +16,11 @@
 
 package org.gradle.internal.buildtree;
 
-import com.google.common.base.Preconditions;
 import org.gradle.execution.EntryTaskSelector;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
-
-import java.util.Optional;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface BuildTreeWorkController {
@@ -31,46 +28,5 @@ public interface BuildTreeWorkController {
     /**
      * Schedules and runs requested tasks based on the provided {@code taskSelector}.
      */
-    TaskRunResult scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector);
-
-    class TaskRunResult {
-        private final ExecutionResult<Void> scheduleResult;
-        @Nullable
-        private final ExecutionResult<Void> executionResult;
-
-        private TaskRunResult(ExecutionResult<Void> scheduleResult, @Nullable ExecutionResult<Void> executionResult) {
-            this.scheduleResult = scheduleResult;
-            this.executionResult = executionResult;
-        }
-
-        /**
-         * Returns the result of task configuration and schedule.
-         */
-        public ExecutionResult<Void> getScheduleResult() {
-            return scheduleResult;
-        }
-
-        /**
-         * Returns the result of task execution. If task execution result is not present, it means task configuration and schedule failed and this will throw an exception.
-         */
-        public ExecutionResult<Void> getExecutionResultOrThrow() {
-            scheduleResult.rethrow();
-            return Preconditions.checkNotNull(executionResult);
-        }
-
-        /**
-         * Returns the result of a task execution. If task configuration and schedule failed, this will return an empty result.
-         */
-        public Optional<ExecutionResult<Void>> getExecutionResult() {
-            return Optional.ofNullable(executionResult);
-        }
-
-        public static TaskRunResult ofExecutionResult(ExecutionResult<Void> executionResult) {
-            return new TaskRunResult(ExecutionResult.succeeded(), executionResult);
-        }
-
-        public static TaskRunResult ofScheduleFailure(Throwable scheduleResult) {
-            return new TaskRunResult(ExecutionResult.failed(scheduleResult), null);
-        }
-    }
+    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -24,7 +24,6 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.Try;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.ExecutionResult;
-import org.gradle.internal.buildtree.BuildTreeWorkController.TaskRunResult;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.WorkTypeAware;
 import org.gradle.internal.model.StateTransitionController;
@@ -77,7 +76,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
 
     @Override
     public void scheduleAndRunTasks(@Nullable EntryTaskSelector selector) {
-        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector).getExecutionResultOrThrow());
+        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector));
     }
 
     @Override
@@ -91,7 +90,9 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
             }
 
             // Run tasks
-            ExecutionResult<Void> taskRunResult = runTasks ? runTasks() : ExecutionResult.succeeded();
+            ExecutionResult<Void> taskRunResult = runTasks
+                ? workController.scheduleAndRunRequestedTasks(null)
+                : ExecutionResult.succeeded();
 
             // Allow the model action to run even if tasks failed
             ExecutionResult<BuildTreeModelCreatorResult<T>> buildModelResult = runModelAction(() -> modelCreator.fromBuildModel(action));
@@ -141,14 +142,6 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         return result.getFailure().isPresent()
             ? ExecutionResult.failed(BuildActionExecutionException.wrap(result.getFailure().get()))
             : ExecutionResult.succeeded(result.get());
-    }
-
-    private ExecutionResult<Void> runTasks() {
-        TaskRunResult result = workController.scheduleAndRunRequestedTasks(null);
-        if (!result.getScheduleResult().isSuccessful()) {
-            return result.getScheduleResult();
-        }
-        return result.getExecutionResultOrThrow();
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
@@ -25,8 +25,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static org.gradle.internal.buildtree.BuildTreeWorkController.*
-
 class DefaultBuildTreeLifecycleControllerTest extends Specification {
     def gradle = Mock(GradleInternal)
     def buildController = Mock(BuildLifecycleController)
@@ -46,7 +44,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         controller.scheduleAndRunTasks()
 
         then:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.succeeded())
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null
@@ -63,7 +61,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.failed(failure))
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
 
         and:
         1 * finishExecutor.finishBuildTree([failure]) >> reportableFailure
@@ -78,7 +76,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.succeeded())
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> reportableFailure
@@ -94,7 +92,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         result == "result"
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.succeeded())
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * modelCreator.fromBuildModel(action) >> new BuildTreeModelCreatorResult("result", [], [])
@@ -115,7 +113,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> TaskRunResult.ofExecutionResult(ExecutionResult.failed(failure))
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
         1 * modelCreator.fromBuildModel(action) >> new BuildTreeModelCreatorResult(null, [], [])
         0 * action._
 


### PR DESCRIPTION
TaskRunResult is not needed anymore since we unified resilient and non-resilient logic in previous versions. So we can just return ExecutionResult.
