### PR TITLE
Preserve file collection display names in the configuration cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
@@ -199,7 +199,7 @@ class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurati
         configurationCache.assertStateStoredAndDiscarded {
             hasStoreFailure = false
             serializationProblem "Task `:printDependencies` of type `org.gradle.api.DefaultTask`: " +
-                "value 'fixed(class org.gradle.api.internal.file.DefaultFileCollectionFactory\$ResolvingFileCollection, file collection)' " +
+                "value 'fixed(class org.gradle.api.internal.file.DefaultFileCollectionFactory\$ResolvingFileCollection, configuration ':compileClasspath')' " +
                 "is not assignable to 'org.gradle.api.NamedDomainObjectProvider'"
         }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -398,8 +398,8 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
 
         where:
         concreteType                   | baseType           | creator                                     | reference                                            | deserializedValue
-        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
-        DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | 'file collection'
+        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | "configuration ':some'"
+        DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | "configuration ':some'"
         DefaultSourceDirectorySet      | SourceDirectorySet | ""                                          | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
     }
 
@@ -556,8 +556,8 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
 
         where:
         concreteType                   | baseType           | creator                                     | reference                                            | deserializedValue
-        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
-        DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | 'file collection'
+        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | "configuration ':some'"
+        DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | "configuration ':some'"
         DefaultSourceDirectorySet      | SourceDirectorySet | ""                                          | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
     }
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCollectionCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCollectionCodec.kt
@@ -60,6 +60,7 @@ class FileCollectionCodec(
 
     override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         encodePreservingIdentityOf(value) {
+            writeNullableString(value.displayName.takeIf { it != FileCollectionInternal.DEFAULT_COLLECTION_DISPLAY_NAME })
             encodeContents(value)
         }
     }
@@ -84,16 +85,20 @@ class FileCollectionCodec(
 
     override suspend fun ReadContext.decode(): FileCollectionInternal {
         return decodePreservingIdentity { id ->
-            val fileCollection = decodeContents()
+            val displayName = readNullableString() ?: FileCollectionInternal.DEFAULT_COLLECTION_DISPLAY_NAME
+            val fileCollection = decodeContents(displayName)
             isolate.identities.putInstance(id, fileCollection)
             fileCollection
         }
     }
 
-    suspend fun ReadContext.decodeContents(): FileCollectionInternal = if (readBoolean()) {
+    suspend fun ReadContext.decodeContents(
+        displayName: String = FileCollectionInternal.DEFAULT_COLLECTION_DISPLAY_NAME
+    ): FileCollectionInternal = if (readBoolean()) {
         readNonNull<FileCollectionExecutionTimeValue>().toFileCollection(fileCollectionFactory)
     } else {
         fileCollectionFactory.resolving(
+            displayName,
             readList().map { element ->
                 when (element) {
                     is File -> element

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.resource
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.modes.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
+import spock.lang.Issue
 
 class BrokenTextResourceIntegrationTest extends AbstractIntegrationSpec {
     @Rule
@@ -67,10 +67,7 @@ task text(type: TextTask)
         failure.assertHasCause("Cannot expand TAR '${file}' as it does not exist.")
     }
 
-    @ToBeFixedForConfigurationCache(
-        issue = "https://github.com/gradle/gradle/issues/36695",
-        because = "the underlying file collection looses its display name"
-    )
+    @Issue("https://github.com/gradle/gradle/issues/36695")
     def "reports read of missing archive entry"() {
         given:
         buildFile << """


### PR DESCRIPTION
Fixes #36695

### Context

`FileCollectionCodec` rebuilds a file collection on configuration cache load with `FileCollectionFactory.resolving(sources)` — the overload that always names the result `"file collection"`. Whatever display name the collection had at configuration time was dropped, so error messages got noticeably vaguer once the build ran from the configuration cache. The display name is only used in log and error messages, so this is purely about how a failure reads.

Using the reproducer from the issue, `resources.text.fromArchiveEntry(jar, 'config.txt')` against a jar that does not contain the entry:

Without the configuration cache:

```
> Could not read entry 'config.txt' in archive file collection.
   > Expected entry 'config.txt' in archive file collection to contain exactly one file, however, it contains no files.
```

With the configuration cache:

```
> Could not read file collection.
   > Expected file collection to contain exactly one file, however, it contains no files.
```

### Change

`encode` now writes the collection's display name and `decode` passes it to `FileCollectionFactory.resolving(displayName, sources)`. The name is written only when it differs from `FileCollectionInternal.DEFAULT_COLLECTION_DISPLAY_NAME`, so the common case costs a single null byte — the same "only when it is not the default" approach that `EmptyFileCollection.calculateExecutionTimeValue()` already takes.

I put this in `encode`/`decode` rather than in `encodeContents`/`decodeContents` on purpose. `ConfigurableFileCollectionCodec` reuses those two for the *contents* of a `DefaultConfigurableFileCollection`, and that collection's display name belongs to the outer collection, which gets it back from its owner. Writing it there would put a full string in the cache for every named task property file collection and hand the inner collection a name that is not its own.

Collections that have a `FileCollectionExecutionTimeValue` are untouched: preserving the display name there is up to each execution time value, and `EmptyFileCollection` already does it.

### Tests

`BrokenTextResourceIntegrationTest."reports read of missing archive entry"` was already in the repository, marked `@ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36695")`. I removed the annotation and replaced it with `@Issue`; the test now passes under the `configCache` executer, and I checked that it still fails with the codec change reverted.

This was written with AI assistance; I reviewed and verified every part of it myself.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
