### PR TITLE
Update Tooling API docs: reading intermediate models with a phased build action

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
@@ -152,6 +152,33 @@ When the build action queries models through `BuildController.fetch(...)`, the d
 There is no separate opt-in: using `fetch(...)` enables the resilient behaviour for that call.
 Calls made through `getModel(...)` or `findModel(...)` continue to fail fast as before.
 
+Resilient sync affects which models can be built, not the outcome of the operation: starting with the Gradle 9.7 daemon, a broken part of the build still fails the operation as a whole.
+See <<sec:embedding_phased_action_example,Reading intermediate models with a phased build action>> for how a client receives the partial models in that case.
+
+[[sec:embedding_phased_action_example]]
+=== Reading intermediate models with a phased build action
+
+A phased build action, created via link:{javadocPath}/org/gradle/tooling/ProjectConnection.html#action()[`ProjectConnection.action()`], can query models at two points in the build lifecycle:
+
+* The `projectsLoaded` action runs after the settings have been evaluated, before any project is configured.
+This is the place to query models that describe the build structure, such as link:{javadocPath}/org/gradle/tooling/model/gradle/GradleBuild.html[`GradleBuild`].
+* The `buildFinished` action runs at the end of the invocation, after any scheduled tasks have executed.
+
+The result of each action is delivered to its link:{javadocPath}/org/gradle/tooling/IntermediateResultHandler.html[`IntermediateResultHandler`] while the build is still running, as soon as the corresponding phase completes.
+The executer created by the builder produces no final value of its own: `run()` returns `Void`, and the models arrive only through the intermediate handlers.
+
+The following example queries the build structure once projects are loaded, and fetches an Eclipse model at the end of the build, reusing the `FetchEclipseModelAction` shown <<sec:embedding_get_find_vs_fetch,above>>:
+
+====
+include::sample[dir="snippets/integration/fetchModel/common",files="src/main/java/org/gradle/sample/FetchBuildStructureAction.java[tags=projects-loaded-action];src/main/java/org/gradle/sample/PhasedSync.java[tags=phased-sync]"]
+====
+
+[NOTE]
+====
+Starting with the Gradle 9.7 daemon, a resilient sync still fails as a whole when any part of it fails: `run()` throws, even though the intermediate handlers have already received their models.
+A single action passed to link:{javadocPath}/org/gradle/tooling/ProjectConnection.html#action(org.gradle.tooling.BuildAction)[`ProjectConnection.action(BuildAction)`] loses its result in that case, so use a phased build action and read the models from the intermediate handlers.
+====
+
 [[sec:embedding_action_tasks]]
 === Running tasks together with a build action
 
@@ -160,7 +187,7 @@ A build action can request that tasks run as part of the same Gradle invocation:
 * link:{javadocPath}/org/gradle/tooling/BuildActionExecuter.html#forTasks(java.lang.String...)[`BuildActionExecuter.forTasks(...)`] schedules tasks that run before the action executes.
 Passing an empty array runs the build's default tasks.
 Omitting the call (or passing `null`) skips task execution entirely.
-* For two-phase actions created via link:{javadocPath}/org/gradle/tooling/ProjectConnection.html#action()[`ProjectConnection.action()`], the `projectsLoaded` action runs after settings are evaluated and the `buildFinished` action runs after the scheduled tasks have executed.
+* For a phased build action, the scheduled tasks run after the `projectsLoaded` action and before the `buildFinished` action.
 
 Prior to Gradle 9.4, if any of the scheduled tasks failed, Gradle aborted the invocation before the model-producing action got a chance to run.
 The `buildFinished` action of a phased build was skipped entirely, and the client only received the task failure.

--- a/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
@@ -152,7 +152,7 @@ When the build action queries models through `BuildController.fetch(...)`, the d
 There is no separate opt-in: using `fetch(...)` enables the resilient behaviour for that call.
 Calls made through `getModel(...)` or `findModel(...)` continue to fail fast as before.
 
-Resilient sync affects which models can be built, not the outcome of the operation: starting with the Gradle 9.7 daemon, a broken part of the build still fails the operation as a whole.
+Resilient sync affects which models can be built, not whether the operation succeeds: starting with the Gradle 9.7 daemon, a broken part of the build still fails the operation as a whole.
 See <<sec:embedding_phased_action_example,Reading intermediate models with a phased build action>> for how a client receives the partial models in that case.
 
 [[sec:embedding_phased_action_example]]
@@ -165,7 +165,7 @@ This is the place to query models that describe the build structure, such as lin
 * The `buildFinished` action runs at the end of the invocation, after any scheduled tasks have executed.
 
 The result of each action is delivered to its link:{javadocPath}/org/gradle/tooling/IntermediateResultHandler.html[`IntermediateResultHandler`] while the build is still running, as soon as the corresponding phase completes.
-The executer created by the builder produces no final value of its own: `run()` returns `Void`, and the models arrive only through the intermediate handlers.
+The executer produces no final value: `run()` returns `Void`, and the models arrive only through the intermediate handlers.
 
 The following example queries the build structure once projects are loaded, and fetches an Eclipse model at the end of the build, reusing the `FetchEclipseModelAction` shown <<sec:embedding_get_find_vs_fetch,above>>:
 

--- a/platforms/documentation/docs/src/snippets/integration/fetchModel/common/src/main/java/org/gradle/sample/FetchBuildStructureAction.java
+++ b/platforms/documentation/docs/src/snippets/integration/fetchModel/common/src/main/java/org/gradle/sample/FetchBuildStructureAction.java
@@ -1,0 +1,16 @@
+package org.gradle.sample;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+// tag::projects-loaded-action[]
+public class FetchBuildStructureAction implements BuildAction<GradleBuild> {
+    @Override
+    public GradleBuild execute(BuildController controller) {
+        // The build structure is available as soon as the settings have been evaluated,
+        // so this model can be queried from the projectsLoaded phase
+        return controller.fetch(GradleBuild.class).getModel();
+    }
+}
+// end::projects-loaded-action[]

--- a/platforms/documentation/docs/src/snippets/integration/fetchModel/common/src/main/java/org/gradle/sample/PhasedSync.java
+++ b/platforms/documentation/docs/src/snippets/integration/fetchModel/common/src/main/java/org/gradle/sample/PhasedSync.java
@@ -1,0 +1,39 @@
+package org.gradle.sample;
+
+import org.gradle.tooling.BuildActionExecuter;
+import org.gradle.tooling.GradleConnectionException;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
+
+// tag::phased-sync[]
+public class PhasedSync {
+    public void sync(File projectDir) {
+        AtomicReference<GradleBuild> buildStructure = new AtomicReference<>();
+        AtomicReference<EclipseProjectResult> eclipseModel = new AtomicReference<>();
+
+        try (ProjectConnection connection = GradleConnector.newConnector()
+                .forProjectDirectory(projectDir)
+                .connect()) {
+
+            BuildActionExecuter<Void> executer = connection.action()
+                .projectsLoaded(new FetchBuildStructureAction(), buildStructure::set)
+                .buildFinished(new FetchEclipseModelAction(), eclipseModel::set)
+                .build();
+
+            try {
+                executer
+                    .forTasks("generateSources") // optional: tasks to run before the buildFinished action
+                    .run();
+            } catch (GradleConnectionException e) {
+                // The operation failed, for example because a task failed or part of the
+                // build could not be configured. The models that were already delivered
+                // to the intermediate handlers above are still available.
+            }
+        }
+    }
+}
+// end::phased-sync[]


### PR DESCRIPTION
### Context

Follow-up to the resilient sync documentation in the Tooling API user guide:

- Adds a full example of a two-phased build action (`ProjectConnection.action()` with `projectsLoaded` and `buildFinished`) showing how models are read through `IntermediateResultHandler`s. The example lives in the existing `fetchModel` snippet, so it is compiled by the existing sample test.
- Documents that starting with the Gradle 9.7 daemon, a resilient sync still fails as a whole when any part of it fails: `run()` throws after the intermediate handlers have received their models, so clients must read models via intermediate handlers of a phased build action.
- Moves "Running tasks together with a build action" below the new section, so phased actions and `IntermediateResultHandler` are introduced before they are referenced.

Preview locally with `./gradlew serveDocs -PquickDocs` (http://localhost:8000/userguide/tooling_api.html); snippet test: `./gradlew :docs:docsTest --tests '*integration-fetchModel*'`.