### PR TITLE
Decouple DefaultTaskExecutionGraph from plan execution

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -486,8 +486,6 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         "graph.allTasks"                     | [":b:help", ":help"]             | false
         "graph.getDependencies(help)"        | [":b:help"]                      | false
         "graph.getDependencies(compileJava)" | [":b:compileJava"]               | false
-        "graph.filteredTasks"                | [":b:compileJava"]               | false
-        "graph.filteredTasks"                | [":b:compileJava", "-x:classes"] | false
 
         combined:
         mode << ALL_MODES

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.cache.Cleanup
@@ -347,8 +349,9 @@ class ConfigurationCacheState(
         val scheduledWorkPerBuild = mutableMapOf<BuildIdentifier, ScheduledWork>()
         host.visitBuilds { state ->
             val gradle = state.mutableModel
-            scheduledWorkPerBuild[state.buildIdentifier] = gradle.taskGraph.collectScheduledWork()
-            val hasScheduledWork = gradle.taskGraph.hasScheduledWork()
+            val planContents = gradle.taskGraph.executionPlan?.contents
+            scheduledWorkPerBuild[state.buildIdentifier] = planContents?.scheduledNodes ?: ScheduledWork(ImmutableList.of(), ImmutableSet.of())
+            val hasScheduledWork = (planContents?.size() ?: 0) > 0
             builds[state] = BuildToStore(state, hasScheduledWork, hasChildren = gradle.isRootBuild)
             if (hasScheduledWork && state is StandAloneNestedBuild) {
                 // Also require the owner of a buildSrc build

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.cache.Cleanup
@@ -333,8 +335,9 @@ class ConfigurationCacheState(
         val scheduledWorkPerBuild = mutableMapOf<BuildIdentifier, ScheduledWork>()
         host.visitBuilds { state ->
             val gradle = state.mutableModel
-            scheduledWorkPerBuild[state.buildIdentifier] = gradle.taskGraph.collectScheduledWork()
-            val hasScheduledWork = gradle.taskGraph.hasScheduledWork()
+            val planContents = gradle.taskGraph.executionPlan?.contents
+            scheduledWorkPerBuild[state.buildIdentifier] = planContents?.scheduledNodes ?: ScheduledWork(ImmutableList.of(), ImmutableSet.of())
+            val hasScheduledWork = (planContents?.size() ?: 0) > 0
             builds[state] = BuildToStore(state, hasScheduledWork, hasChildren = gradle.isRootBuild)
             if (hasScheduledWork && state is StandAloneNestedBuild) {
                 // Also require the owner of a buildSrc build

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -27,10 +27,8 @@ import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.execution.plan.FinalizedExecutionPlan
-import org.gradle.execution.plan.ScheduledWork
 import org.gradle.execution.taskgraph.TaskExecutionGraphExecutionListener
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
-import org.gradle.internal.build.ExecutionResult
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.util.Path
@@ -60,6 +58,10 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
 
     override fun removeTaskExecutionGraphListener(listener: TaskExecutionGraphListener) {
         delegate.removeTaskExecutionGraphListener(listener.wrap())
+    }
+
+    override fun getGraphExecutionListeners(): TaskExecutionGraphExecutionListener {
+        return delegate.graphExecutionListeners
     }
 
     override fun addExecutionListener(listener: TaskExecutionGraphExecutionListener) {
@@ -124,13 +126,6 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     override fun getDependencies(task: Task): MutableSet<Task> {
         checkCrossProjectTaskAccess(task)
         val result = delegate.getDependencies(task)
-        observingTasksMaybeFromOtherProjects(result)
-        return result
-    }
-
-    override
-    fun getFilteredTasks(): MutableSet<Task> {
-        val result = delegate.filteredTasks
         observingTasksMaybeFromOtherProjects(result)
         return result
     }
@@ -205,13 +200,11 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
         delegate.populate(plan)
     }
 
-    override fun execute(plan: FinalizedExecutionPlan): ExecutionResult<Void> =
-        delegate.execute(plan)
+    override fun depopulate() =
+        delegate.depopulate()
 
-    override fun collectScheduledWork(): ScheduledWork =
-        delegate.collectScheduledWork()
-
-    override fun size(): Int = delegate.size()
+    override fun getExecutionPlan(): FinalizedExecutionPlan? =
+        delegate.executionPlan
 
     override fun getLegacyTaskListenerBroadcast() = delegate.legacyTaskListenerBroadcast
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -18,10 +18,10 @@ package org.gradle.internal.cc.impl.promo
 
 import org.gradle.BuildResult
 import org.gradle.api.Task
-import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.logging.Logging
+import org.gradle.execution.plan.QueryableExecutionPlan
 import org.gradle.initialization.RootBuildLifecycleListener
 import org.gradle.initialization.layout.ResolvedBuildLayout
 import org.gradle.internal.Factory
@@ -55,6 +55,7 @@ internal class ConfigurationCachePromoHandler(
     private val degradationController: DefaultConfigurationCacheDegradationController,
     private val documentationRegistry: DocumentationRegistry
 ) : RootBuildLifecycleListener, ProblemsListener {
+
     private val problems = object {
         @Volatile
         private var _seenProblems = false // if ever, only goes false -> true
@@ -87,7 +88,7 @@ internal class ConfigurationCachePromoHandler(
         rootBuildLayout = rootBuildGradle.serviceOf<ResolvedBuildLayout>()
     }
 
-    private fun onRootBuildTaskGraphIsAboutToExecute(graph: TaskExecutionGraph) {
+    private fun onRootBuildTaskGraphIsAboutToExecute(graph: QueryableExecutionPlan) {
         if (!problems.arePresent()) {
             // Collecting degradation reasons may be somewhat expensive, let's skip it if the build is already incompatible.
             // We can only collect the reasons before the start of the execution phase. CC does that too.
@@ -135,7 +136,8 @@ internal class ConfigurationCachePromoHandler(
 
     override fun onExecutionTimeProblem(problem: PropertyProblem) = onProblem(problem)
 
-    private fun TaskExecutionGraph.hasIncompatibleTasks() = allTasks.any { !(it as TaskInternal).isCompatibleWithConfigurationCache }
+    private fun QueryableExecutionPlan.hasIncompatibleTasks() = tasks.any { !(it as TaskInternal).isCompatibleWithConfigurationCache }
 
     private fun runWithoutBuildDefinition() = rootBuildLayout.isBuildDefinitionMissing
+
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -225,7 +225,7 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId, taskReferences: MutableList<RestoredTaskReference>): List<Node> =
+    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId, taskReferences: MutableList<RestoredTaskReference>): ImmutableList<Node> =
         buildCollection({ ImmutableList.builderWithExpectedSize<Node>(it) }) {
             val node = nodeForId(readSmallInt())
             readSuccessorReferencesOf(node, nodeForId)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -226,7 +226,7 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId, taskReferences: MutableList<RestoredTaskReference>): List<Node> =
+    fun ReadContext.readEdgesAndGroupMembership(nodeForId: NodeForId, taskReferences: MutableList<RestoredTaskReference>): ImmutableList<Node> =
         buildCollection({ ImmutableList.builderWithExpectedSize<Node>(it) }) {
             val node = nodeForId(readSmallInt())
             readSuccessorReferencesOf(node, nodeForId)

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.composite.internal
 
 import org.gradle.api.Action
+import org.gradle.api.BuildCancelledException
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.GradleInternal
@@ -47,6 +48,7 @@ import org.gradle.execution.plan.PlanExecutor
 import org.gradle.execution.plan.SelfExecutingNode
 import org.gradle.execution.plan.TaskDependencyResolver
 import org.gradle.execution.plan.TaskNodeFactory
+import org.gradle.initialization.BuildCancellationToken
 import org.gradle.initialization.DefaultBuildCancellationToken
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildState
@@ -179,6 +181,38 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         result.failures.empty
         childNode.executed
         node.executed
+
+        where:
+        workers << [1, manyWorkers]
+    }
+
+    def "stops running work and fails with exception when build is cancelled"() {
+        def services = new TreeServices(workers)
+        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
+        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childNode = new CancellingNode("child build node", cancellationToken)
+        def node = new DelegateNode("main build node", [childNode])
+
+        when:
+        def result = scheduleAndRun(services) { builder ->
+            builder.withWorkGraph(build.state) { graphBuilder ->
+                def task = task(build, node)
+                graphBuilder.addEntryTasks([task])
+            }
+            builder.withWorkGraph(childBuild.state) { graphBuilder ->
+                def task = task(childBuild, childNode)
+                graphBuilder.addEntryTasks([task])
+            }
+        }
+
+        then:
+        childNode.executed
+        !node.executed
+
+        and:
+        // Every build that still had work to start is cancelled
+        !result.failures.empty
+        result.failures.every { it instanceof BuildCancelledException }
 
         where:
         workers << [1, manyWorkers]
@@ -524,6 +558,22 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
                     action.run()
                 }
             }
+        }
+    }
+
+    private static class CancellingNode extends TestNode {
+        private final BuildCancellationToken cancellationToken
+
+        CancellingNode(String displayName, BuildCancellationToken cancellationToken) {
+            super(displayName)
+            this.cancellationToken = cancellationToken
+        }
+
+        @Override
+        void execute(NodeExecutionContext context) {
+            cancellationToken.cancel()
+            // Sleeping while cancelled gives every worker a chance to notice before this node completes
+            super.execute(context)
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
@@ -66,7 +66,7 @@ public class BuildOperationFiringBuildWorkerExecutor implements BuildWorkExecuto
                 builder.details(new RunRootBuildWorkBuildOperationType.Details(buildStartTime));
             }
             builder.metadata(BuildOperationCategory.RUN_WORK);
-            builder.totalProgress(gradle.getTaskGraph().size());
+            builder.totalProgress(plan.getContents().size());
             return builder;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
@@ -18,34 +18,79 @@ package org.gradle.execution;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.execution.plan.LocalTaskNode;
 import org.gradle.execution.plan.Node;
+import org.gradle.execution.plan.NodeExecutor;
+import org.gradle.execution.plan.PlanExecutor;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.internal.build.ExecutionResult;
+import org.gradle.internal.operations.BuildOperationRef;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
+import org.gradle.internal.service.ServiceRegistry;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public class SelectedTaskExecutionAction implements BuildWorkExecutor {
+
+    private final ServiceRegistry buildScopeServices;
+    private final PlanExecutor planExecutor;
+    private final BuildOperationRunner buildOperationRunner;
+    private final NodeExecutor nodeExecutor;
+
+    public SelectedTaskExecutionAction(
+        ServiceRegistry buildScopeServices,
+        PlanExecutor planExecutor,
+        BuildOperationRunner buildOperationRunner,
+        NodeExecutor nodeExecutor
+    ) {
+        this.buildScopeServices = buildScopeServices;
+        this.planExecutor = planExecutor;
+        this.buildOperationRunner = buildOperationRunner;
+        this.nodeExecutor = nodeExecutor;
+    }
+
     @Override
     public ExecutionResult<Void> execute(GradleInternal gradle, FinalizedExecutionPlan plan) {
         TaskExecutionGraphInternal taskGraph = gradle.getTaskGraph();
+        if (plan != taskGraph.getExecutionPlan()) {
+            throw new IllegalStateException("Executed plan inconsistent with build's execution plan.");
+        }
         bindAllReferencesOfProject(plan);
-        return taskGraph.execute(plan);
+        taskGraph.getGraphExecutionListeners().beforeGraphExecutionStarts(plan.getContents());
+        BuildOperationRef parentOperation = buildOperationRunner.getCurrentOperation();
+        try (ProjectExecutionServiceRegistry projectExecutionServices = new ProjectExecutionServiceRegistry(buildScopeServices)) {
+            return planExecutor.process(
+                plan.asWorkSource(),
+                node -> {
+                    CurrentBuildOperationRef.instance().with(parentOperation, () -> {
+                        NodeExecutionContext context = projectExecutionServices.forProject(node.getOwningProject());
+                        if (nodeExecutor.execute(node, context)) {
+                            return;
+                        }
+                        throw new IllegalStateException("Unknown type of node: " + node);
+                    });
+                }
+            );
+        } finally {
+            plan.close();
+            taskGraph.depopulate();
+        }
     }
 
-    private void bindAllReferencesOfProject(FinalizedExecutionPlan plan) {
+    private static void bindAllReferencesOfProject(FinalizedExecutionPlan plan) {
         Set<Project> seen = new HashSet<>();
-        plan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
-            for (Node node : nodes) {
-                if (node instanceof LocalTaskNode) {
-                    ProjectInternal taskProject = node.getOwningProject();
-                    if (seen.add(taskProject)) {
-                        taskProject.bindAllModelRules();
-                    }
+        for (Node node : plan.getContents().getScheduledNodes().getScheduledNodes()) {
+            if (node instanceof LocalTaskNode) {
+                ProjectInternal taskProject = node.getOwningProject();
+                if (seen.add(taskProject)) {
+                    taskProject.bindAllModelRules();
                 }
             }
-        });
+        }
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -340,7 +340,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
     }
 
     @Override
-    public ScheduledNodes getScheduledNodes() {
+    public ScheduledWork getScheduledNodes() {
         if (scheduledNodes == null) {
             throw new IllegalStateException("Nodes have not been scheduled yet.");
         }
@@ -354,7 +354,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         }
         // We're not filtering entryNodes to only contain scheduled nodes here to avoid performance penalty for clients that
         // don't care about the entry nodes at all.
-        return new ScheduledWork(scheduledNodes, entryNodes);
+        return new ScheduledWork(scheduledNodes, ImmutableSet.copyOf(entryNodes));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizedExecutionPlan.java
@@ -26,26 +26,6 @@ import java.io.Closeable;
  */
 @ThreadSafe
 public interface FinalizedExecutionPlan extends Describable, Closeable {
-    FinalizedExecutionPlan EMPTY = new FinalizedExecutionPlan() {
-        @Override
-        public WorkSource<Node> asWorkSource() {
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public QueryableExecutionPlan getContents() {
-            return QueryableExecutionPlan.EMPTY;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "empty";
-        }
-
-        @Override
-        public void close() {
-        }
-    };
 
     /**
      * Returns this plan as a {@link WorkSource} ready for execution.
@@ -62,4 +42,5 @@ public interface FinalizedExecutionPlan extends Describable, Closeable {
      */
     @Override
     void close();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
@@ -18,10 +18,7 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.Task;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
-import java.util.function.BiConsumer;
 
 /**
  * An execution plan that has been finalized and can no longer be mutated.
@@ -29,37 +26,6 @@ import java.util.function.BiConsumer;
  * <p>Implementations may or may not be thread-safe.</p>
  */
 public interface QueryableExecutionPlan {
-    QueryableExecutionPlan EMPTY = new QueryableExecutionPlan() {
-        @Override
-        public Set<Task> getTasks() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<Task> getRequestedTasks() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<Task> getFilteredTasks() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public int size() {
-            return 0;
-        }
-
-        @Override
-        public ScheduledNodes getScheduledNodes() {
-            return visitor -> visitor.accept(Collections.emptyList(), Collections.emptySet());
-        }
-
-        @Override
-        public TaskNode getNode(Task task) {
-            throw new IllegalStateException();
-        }
-    };
 
     /**
      * @return The set of all available tasks. This includes tasks that have not yet been executed, as well as tasks that have been processed.
@@ -79,7 +45,7 @@ public interface QueryableExecutionPlan {
     /**
      * Returns a snapshot of the current set of scheduled nodes, which can later be visited.
      */
-    ScheduledNodes getScheduledNodes();
+    ScheduledWork getScheduledNodes();
 
     /**
      * Returns the node for the supplied task that is part of this execution plan.
@@ -93,15 +59,4 @@ public interface QueryableExecutionPlan {
      */
     int size();
 
-    /**
-     * An immutable snapshot of the set of scheduled nodes.
-     */
-    interface ScheduledNodes {
-        /**
-         * Invokes the consumer with the list of scheduled nodes and the set of entry nodes. Entry nodes may not be a subset of scheduled nodes.
-         *
-         * @param visitor the consumer of nodes and entry nodes
-         */
-        void visitNodes(BiConsumer<List<Node>, Set<Node>> visitor);
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ScheduledWork.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ScheduledWork.java
@@ -19,27 +19,18 @@ package org.gradle.execution.plan;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.function.BiConsumer;
-
 /**
  * An immutable snapshot of the currently scheduled nodes, together with the information about which nodes are entry points.
  */
-public class ScheduledWork implements QueryableExecutionPlan.ScheduledNodes {
+public class ScheduledWork {
+
     private final ImmutableList<Node> scheduledNodes;
     private final ImmutableSet<Node> entryNodes;
 
-    public ScheduledWork(List<? extends Node> scheduledNodes, Collection<? extends Node> entryNodes) {
+    public ScheduledWork(ImmutableList<Node> scheduledNodes, ImmutableSet<Node> entryNodes) {
         // Checking that entryNodes are a subset of scheduledNodes can be expensive, so it is omitted from here.
-        this.scheduledNodes = ImmutableList.copyOf(scheduledNodes);
-        this.entryNodes = ImmutableSet.copyOf(entryNodes);
-    }
-
-    @Override
-    public void visitNodes(BiConsumer<List<Node>, Set<Node>> visitor) {
-        visitor.accept(scheduledNodes, entryNodes);
+        this.scheduledNodes = scheduledNodes;
+        this.entryNodes = entryNodes;
     }
 
     /**
@@ -61,4 +52,5 @@ public class ScheduledWork implements QueryableExecutionPlan.ScheduledNodes {
     public ImmutableSet<Node> getEntryNodes() {
         return entryNodes;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.taskgraph;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import groovy.lang.Closure;
@@ -27,28 +26,18 @@ import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
-import org.gradle.execution.ProjectExecutionServiceRegistry;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.execution.plan.Node;
-import org.gradle.execution.plan.NodeExecutor;
-import org.gradle.execution.plan.PlanExecutor;
-import org.gradle.execution.plan.ScheduledWork;
 import org.gradle.execution.plan.TaskNode;
 import org.gradle.internal.Cast;
 import org.gradle.internal.InternalListener;
-import org.gradle.internal.MutableReference;
-import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.BuildOperationRunner;
-import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.listener.ClosureBackedMethodInvocationDispatch;
 import org.gradle.util.Path;
 import org.jspecify.annotations.NullMarked;
@@ -63,36 +52,29 @@ import java.util.Set;
 @SuppressWarnings("deprecation")
 @NullMarked
 public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTaskExecutionGraph.class);
 
-    private final PlanExecutor planExecutor;
-    private final NodeExecutor nodeExecutor;
     private final GradleInternal gradleInternal;
     private final ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
     private final ListenerBroadcast<TaskExecutionGraphExecutionListener> internalGraphListeners;
     private final ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> taskListeners;
     private final BuildScopeListenerRegistrationListener buildScopeListenerRegistrationListener;
-    private final ServiceRegistry globalServices;
     private final BuildOperationRunner buildOperationRunner;
     private final ListenerBuildOperationDecorator listenerBuildOperationDecorator;
-    private FinalizedExecutionPlan executionPlan;
+    private @Nullable FinalizedExecutionPlan executionPlan;
     private List<Task> allTasks = Collections.emptyList();
     private boolean hasFiredWhenReady;
 
     public DefaultTaskExecutionGraph(
-        PlanExecutor planExecutor,
-        NodeExecutor nodeExecutor,
         BuildOperationRunner buildOperationRunner,
         ListenerBuildOperationDecorator listenerBuildOperationDecorator,
         GradleInternal gradleInternal,
         ListenerBroadcast<TaskExecutionGraphListener> graphListeners,
         ListenerBroadcast<TaskExecutionGraphExecutionListener> internalGraphListeners,
         ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> taskListeners,
-        BuildScopeListenerRegistrationListener buildScopeListenerRegistrationListener,
-        ServiceRegistry globalServices
+        BuildScopeListenerRegistrationListener buildScopeListenerRegistrationListener
     ) {
-        this.planExecutor = planExecutor;
-        this.nodeExecutor = nodeExecutor;
         this.buildOperationRunner = buildOperationRunner;
         this.listenerBuildOperationDecorator = listenerBuildOperationDecorator;
         this.gradleInternal = gradleInternal;
@@ -100,13 +82,13 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         this.internalGraphListeners = internalGraphListeners;
         this.taskListeners = taskListeners;
         this.buildScopeListenerRegistrationListener = buildScopeListenerRegistrationListener;
-        this.globalServices = globalServices;
-        this.executionPlan = FinalizedExecutionPlan.EMPTY;
     }
 
     @Override
     public void populate(FinalizedExecutionPlan plan) {
-        executionPlan.close();
+        // TODO: Only store the execution plan for as long as we are executing whenReady
+        //  callbacks. We do not own the execution plan and should not store long-lived
+        //  references to it.
         executionPlan = plan;
         // Take a snapshot of all tasks, as nodes are removed from the plan as they execute
         allTasks = ImmutableList.copyOf(executionPlan.getContents().getTasks());
@@ -119,37 +101,8 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
-    public ExecutionResult<Void> execute(FinalizedExecutionPlan plan) {
-        assertIsThisGraphsPlan(plan);
-        if (!hasFiredWhenReady) {
-            throw new IllegalStateException("Task graph should be populated before execution starts.");
-        }
-
-        internalGraphListeners.getSource().beforeGraphExecutionStarts(this);
-
-        try (ProjectExecutionServiceRegistry projectExecutionServices = new ProjectExecutionServiceRegistry(globalServices)) {
-            return executeWithServices(projectExecutionServices);
-        } finally {
-            executionPlan.close();
-            executionPlan = FinalizedExecutionPlan.EMPTY;
-        }
-    }
-
-    private void assertIsThisGraphsPlan(FinalizedExecutionPlan plan) {
-        if (plan != executionPlan) {
-            // Temporarily handle only a single plan
-            throw new IllegalArgumentException();
-        }
-    }
-
-    private ExecutionResult<Void> executeWithServices(ProjectExecutionServiceRegistry projectExecutionServices) {
-        return planExecutor.process(
-            executionPlan.asWorkSource(),
-            new BuildOperationAwareExecutionAction(
-                buildOperationRunner.getCurrentOperation(),
-                new InvokeNodeExecutorsAction(nodeExecutor, projectExecutionServices)
-            )
-        );
+    public void depopulate() {
+        executionPlan = null;
     }
 
     @Override
@@ -200,6 +153,11 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     @Override
     public void removeExecutionListener(TaskExecutionGraphExecutionListener listener) {
         internalGraphListeners.remove(listener);
+    }
+
+    @Override
+    public TaskExecutionGraphExecutionListener getGraphExecutionListeners() {
+        return internalGraphListeners.getSource();
     }
 
     @Override
@@ -260,12 +218,22 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
     @Override
     public boolean hasTask(Task task) {
+        if (executionPlan == null) {
+            // TODO: Deprecate calling this method before whenReady is called
+            return false;
+        }
+
         return executionPlan.getContents().getTasks().contains(task);
     }
 
     @Nullable
     @Override
     public Task findTask(String path) {
+        if (executionPlan == null) {
+            // TODO: Deprecate calling this method before whenReady is called
+            return null;
+        }
+
         for (Task task : executionPlan.getContents().getTasks()) {
             if (task.getPath().equals(path)) {
                 return task;
@@ -280,28 +248,21 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
-    public int size() {
-        return executionPlan.getContents().size();
-    }
-
-    @Override
     public List<Task> getAllTasks() {
         return allTasks;
     }
 
     @Override
-    public ScheduledWork collectScheduledWork() {
-        MutableReference<ScheduledWork> result = MutableReference.of(null);
-        executionPlan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
-            result.set(new ScheduledWork(nodes, entryNodes));
-        });
-        ScheduledWork scheduledWork = result.get();
-        Preconditions.checkState(scheduledWork != null, "No scheduled work found");
-        return scheduledWork;
+    public @Nullable FinalizedExecutionPlan getExecutionPlan() {
+        return executionPlan;
     }
 
     @Override
     public Set<Task> getDependencies(Task task) {
+        if (executionPlan == null) {
+            throw new IllegalStateException("Task graph has not been populated yet.");
+        }
+
         Node node = executionPlan.getContents().getNode(task);
         ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
         for (Node dependencyNode : node.getDependencySuccessors()) {
@@ -317,59 +278,8 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         internalGraphListeners.removeAll();
         graphListeners.removeAll();
         taskListeners.removeAll();
-        executionPlan.close();
-        executionPlan = FinalizedExecutionPlan.EMPTY;
+        executionPlan = null;
         allTasks = Collections.emptyList();
-    }
-
-    /**
-     * This action wraps the execution of a node into a build operation.
-     */
-    private static class BuildOperationAwareExecutionAction implements Action<Node> {
-        private final BuildOperationRef parentOperation;
-        private final Action<Node> delegate;
-
-        BuildOperationAwareExecutionAction(BuildOperationRef parentOperation, Action<Node> delegate) {
-            this.parentOperation = parentOperation;
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void execute(Node node) {
-            CurrentBuildOperationRef.instance().with(parentOperation, () -> delegate.execute(node));
-        }
-    }
-
-    private static class InvokeNodeExecutorsAction implements Action<Node> {
-        private final NodeExecutor nodeExecutor;
-        private final ProjectExecutionServiceRegistry projectExecutionServices;
-
-        public InvokeNodeExecutorsAction(NodeExecutor nodeExecutor, ProjectExecutionServiceRegistry projectExecutionServices) {
-            this.nodeExecutor = nodeExecutor;
-            this.projectExecutionServices = projectExecutionServices;
-        }
-
-        @Override
-        public void execute(Node node) {
-            NodeExecutionContext context = projectExecutionServices.forProject(node.getOwningProject());
-            if (nodeExecutor.execute(node, context)) {
-                return;
-            }
-            throw new IllegalStateException("Unknown type of node: " + node);
-        }
-    }
-
-    @Override
-    public Set<Task> getFilteredTasks() {
-        /*
-            Note: we currently extract this information from the execution plan because it's
-            buried under functions in #filter. This could be detangled/simplified by introducing
-            excludeTasks(Iterable<Task>) as an analog to addEntryTasks(Iterable<Task>).
-
-            This is too drastic a change for the stage in the release cycle were exposing this information
-            was necessary, therefore the minimal change solution was implemented.
-         */
-        return executionPlan.getContents().getFilteredTasks();
     }
 
     @Override
@@ -430,4 +340,5 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         }
 
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphExecutionListener.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphExecutionListener.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.taskgraph;
 
+import org.gradle.execution.plan.QueryableExecutionPlan;
 import org.gradle.internal.InternalListener;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scope;
@@ -27,11 +28,13 @@ import org.jspecify.annotations.NullMarked;
 @EventScope(Scope.Build.class)
 @NullMarked
 public interface TaskExecutionGraphExecutionListener extends InternalListener {
+
     /**
-     * Called immediately before the graph starts executing tasks.
-     * No execution-related changes have been made to the graph yet.
+     * Called immediately before the work in the plan starts executing. No nodes have started yet,
+     * so the plan is not yet mutated and still describes all scheduled work.
      *
-     * @param graph the graph to be executed
+     * @param plan the work to be executed
      */
-    void beforeGraphExecutionStarts(TaskExecutionGraphInternal graph);
+    void beforeGraphExecutionStarts(QueryableExecutionPlan plan);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -18,17 +18,14 @@ package org.gradle.execution.taskgraph;
 import org.gradle.api.Task;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
-import org.gradle.execution.plan.ScheduledWork;
-import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Set;
-
 // Public `TaskExecutionGraph` service shadowed at the project scope by the IP reporting wrapper
 @ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
+
     /**
      * Adds the internal listener for task execution graph events.
      * These listeners are not persisted through the configuration cache, beware if you want to receive graph execution events with CC enabled.
@@ -45,6 +42,11 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     void removeExecutionListener(TaskExecutionGraphExecutionListener listener);
 
     /**
+     * Get an aggregate view of all listeners registered by {@link #addExecutionListener(TaskExecutionGraphExecutionListener)}.
+     */
+    TaskExecutionGraphExecutionListener getGraphExecutionListeners();
+
+    /**
      * Find a task with the given path in the task graph.
      *
      * @param path the path of the task to find in the task graph
@@ -59,29 +61,19 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     void populate(FinalizedExecutionPlan plan);
 
     /**
-     * Executes the given work. Discards the contents of this graph when completed. Should call {@link #populate(FinalizedExecutionPlan)} prior to
-     * calling this method.
+     * Detaches the work attached by {@link #populate(FinalizedExecutionPlan)}, so that queries against this
+     * graph no longer see it.
      */
-    ExecutionResult<Void> execute(FinalizedExecutionPlan plan);
+    void depopulate();
 
     /**
-     * Set of requested tasks.
+     * Get the execution plan that Configuration Cache should serialize.
+     *
+     * @return null if the graph is not populated
      */
-    Set<Task> getFilteredTasks();
-
-    /**
-     * Returns the number of work items in this graph.
-     */
-    int size();
-
-    default boolean hasScheduledWork() {
-        return size() > 0;
-    }
-
-    /**
-     * Returns a snapshot of currently scheduled nodes.
-     */
-    ScheduledWork collectScheduledWork();
+    // TODO: We should find another way for CC to access this work graph rather
+    // than routing it through an internal interface of a public API.
+    @Nullable FinalizedExecutionPlan getExecutionPlan();
 
     /**
      * Resets the lifecycle for this graph.
@@ -90,4 +82,5 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
 
     @SuppressWarnings("deprecation")
     org.gradle.api.execution.TaskExecutionListener getLegacyTaskListenerBroadcast();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.execution.plan.ExecutionPlan;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.execution.plan.QueryableExecutionPlan;
+import org.gradle.execution.plan.ScheduledWork;
 import org.gradle.execution.plan.ToPlannedNodeConverterRegistry;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -95,7 +96,7 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
             QueryableExecutionPlan contents = plan.getContents();
             Set<Task> requestedTasks = contents.getRequestedTasks();
             Set<Task> filteredTasks = contents.getFilteredTasks();
-            QueryableExecutionPlan.ScheduledNodes scheduledWork = contents.getScheduledNodes();
+            ScheduledWork scheduledWork = contents.getScheduledNodes();
 
             PlannedNodeGraph plannedNodeGraph = computePlannedNodeGraph(scheduledWork);
 
@@ -127,9 +128,9 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
             }
         }
 
-        private PlannedNodeGraph computePlannedNodeGraph(QueryableExecutionPlan.ScheduledNodes scheduledWork) {
+        private PlannedNodeGraph computePlannedNodeGraph(ScheduledWork scheduledWork) {
             PlannedNodeGraph.Collector collector = new PlannedNodeGraph.Collector(converterRegistry);
-            scheduledWork.visitNodes((nodes, entryNodes) -> collector.collectNodes(nodes));
+            collector.collectNodes(scheduledWork.getScheduledNodes());
             return collector.getGraph();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -373,7 +373,7 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         private final ExecutionPlan plan;
         private final List<Consumer<LocalTaskNode>> handlers = new ArrayList<>();
         private final List<BiConsumer<EntryTaskSelector.Context, QueryableExecutionPlan>> finalizations = new ArrayList<>();
-        private FinalizedExecutionPlan finalizedPlan;
+        private @Nullable FinalizedExecutionPlan finalizedPlan;
         private boolean empty = true;
 
         public DefaultBuildWorkPlan(DefaultBuildLifecycleController owner, ExecutionPlan plan) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkPreparer.java
@@ -22,10 +22,15 @@ import org.gradle.execution.plan.ExecutionPlanFactory;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.internal.execution.BuildOutputCleanupRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.function.Consumer;
 
 public class DefaultBuildWorkPreparer implements BuildWorkPreparer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBuildWorkPreparer.class);
+
     private final ExecutionPlanFactory executionPlanFactory;
 
     public DefaultBuildWorkPreparer(ExecutionPlanFactory executionPlanFactory) {
@@ -50,9 +55,16 @@ public class DefaultBuildWorkPreparer implements BuildWorkPreparer {
             plan.setContinueOnFailure(true);
         }
         FinalizedExecutionPlan finalizedExecutionPlan = plan.finalizePlan();
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Tasks to be executed: {}", plan.getContents().getTasks());
+            LOGGER.info("Tasks that were excluded: {}", plan.getContents().getFilteredTasks());
+        }
+
         taskGraph.populate(finalizedExecutionPlan);
         BuildOutputCleanupRegistry buildOutputCleanupRegistry = gradle.getServices().get(BuildOutputCleanupRegistry.class);
         buildOutputCleanupRegistry.resolveOutputs();
         return finalizedExecutionPlan;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -17,8 +17,6 @@ package org.gradle.internal.buildevents;
 
 import org.gradle.BuildResult;
 import org.gradle.StartParameter;
-import org.gradle.api.execution.TaskExecutionGraph;
-import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
@@ -27,7 +25,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.execution.WorkValidationWarningReporter;
-import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.internal.InternalBuildListener;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
@@ -41,7 +38,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * A {@link org.gradle.BuildListener} which logs the build progress.
  */
-public class BuildLogger implements InternalBuildListener, TaskExecutionGraphListener {
+public class BuildLogger implements InternalBuildListener {
     private final Logger logger;
     private final BuildExceptionReporter exceptionReporter;
     private final BuildResultLogger resultLogger;
@@ -110,14 +107,6 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
     @Override
     public void projectsEvaluated(Gradle gradle) {
         logger.info("All projects evaluated.");
-    }
-
-    @Override
-    public void graphPopulated(TaskExecutionGraph graph) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Tasks to be executed: {}", graph.getAllTasks());
-            logger.info("Tasks that were excluded: {}", ((TaskExecutionGraphInternal)graph).getFilteredTasks());
-        }
     }
 
     @SuppressWarnings("deprecation")

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.execution;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import org.gradle.TaskExecutionRequest;
 import org.gradle.api.internal.GradleInternal;
@@ -70,12 +71,11 @@ public class TaskGraphBuildExecutionAction implements BuildWorkExecutor {
     }
 
     private void renderTaskGraph(GradleInternal gradle, FinalizedExecutionPlan plan) {
-        plan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
-            String invocation = renderRequestedTasks(gradle.getStartParameter());
-            StyledTextOutput output = textOutputFactory.create(TaskGraphBuildExecutionAction.class);
-            DirectedGraphRenderer<TaskInfo> renderer = new DirectedGraphRenderer<>(new NodeRenderer(), new NodesGraph());
-            renderer.renderTo(new RootNode(entryNodes, invocation), output);
-        });
+        ImmutableSet<Node> entryNodes = plan.getContents().getScheduledNodes().getEntryNodes();
+        String invocation = renderRequestedTasks(gradle.getStartParameter());
+        StyledTextOutput output = textOutputFactory.create(TaskGraphBuildExecutionAction.class);
+        DirectedGraphRenderer<TaskInfo> renderer = new DirectedGraphRenderer<>(new NodeRenderer(), new NodesGraph());
+        renderer.renderTo(new RootNode(entryNodes, invocation), output);
     }
 
     private static String renderRequestedTasks(StartParameterInternal startParameter) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -865,9 +865,17 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         GradleInternal gradle,
         StyledTextOutputFactory textOutputFactory,
         BuildOperationRunner buildOperationRunner,
-        ConfigurationTimeBarrier configurationTimeBarrier
+        ConfigurationTimeBarrier configurationTimeBarrier,
+        ServiceRegistry buildScopeServices,
+        PlanExecutor planExecutor
     ) {
-        BuildWorkExecutor delegate = new SelectedTaskExecutionAction();
+        BuildWorkExecutor delegate = new SelectedTaskExecutionAction(
+            buildScopeServices,
+            planExecutor,
+            buildOperationRunner,
+            new DefaultNodeExecutor()
+        );
+
         BuildWorkExecutor executor;
         if (gradle.getStartParameter().isDryRun()) {
             executor = new DryRunBuildExecutionAction(delegate, textOutputFactory, configurationTimeBarrier);
@@ -919,24 +927,20 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     @SuppressWarnings("deprecation")
     @Provides
     TaskExecutionGraphInternal createTaskExecutionGraph(
-        PlanExecutor planExecutor,
         BuildOperationRunner buildOperationRunner,
         ListenerBuildOperationDecorator listenerBuildOperationDecorator,
         GradleInternal gradleInternal,
-        ListenerManager listenerManager,
-        ServiceRegistry gradleScopedServices
+        ListenerManager listenerManager
     ) {
         return new DefaultTaskExecutionGraph(
-            planExecutor,
-            new DefaultNodeExecutor(),
             buildOperationRunner,
             listenerBuildOperationDecorator,
             gradleInternal,
             listenerManager.createAnonymousBroadcaster(TaskExecutionGraphListener.class),
             listenerManager.createAnonymousBroadcaster(TaskExecutionGraphExecutionListener.class),
             listenerManager.createAnonymousBroadcaster(org.gradle.api.execution.TaskExecutionListener.class),
-            listenerManager.getBroadcaster(BuildScopeListenerRegistrationListener.class),
-            gradleScopedServices
+            listenerManager.getBroadcaster(BuildScopeListenerRegistrationListener.class)
         );
     }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
+import org.gradle.api.Action
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.TaskDependencyFactory
+import org.gradle.execution.plan.AbstractExecutionPlanSpec
+import org.gradle.execution.plan.DefaultPlanExecutor
+import org.gradle.execution.plan.FinalizedExecutionPlan
+import org.gradle.execution.plan.LocalTaskNode
+import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.NodeExecutor
+import org.gradle.execution.plan.PlanExecutor
+import org.gradle.execution.plan.QueryableExecutionPlan
+import org.gradle.execution.plan.ScheduledWork
+import org.gradle.execution.plan.WorkSource
+import org.gradle.execution.taskgraph.TaskExecutionGraphExecutionListener
+import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
+import org.gradle.internal.build.ExecutionResult
+import org.gradle.internal.operations.BuildOperationRef
+import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.internal.operations.CurrentBuildOperationRef
+import org.gradle.internal.operations.OperationIdentifier
+import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.junit.Rule
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Tests {@link SelectedTaskExecutionAction}.
+ */
+class SelectedTaskExecutionActionTest extends AbstractExecutionPlanSpec {
+
+    @Rule
+    ConcurrentTestUtil concurrent = new ConcurrentTestUtil()
+
+    ServiceRegistry buildScopeServices = Stub(ServiceRegistry) {
+        get(TaskDependencyFactory) >> TestFiles.taskDependencyFactory()
+    }
+    PlanExecutor planExecutor = Mock(DefaultPlanExecutor)
+    BuildOperationRunner buildOperationRunner = new TestBuildOperationRunner()
+    NodeExecutor nodeExecutor = Mock(NodeExecutor)
+
+    SelectedTaskExecutionAction underTest = new SelectedTaskExecutionAction(
+        buildScopeServices,
+        planExecutor,
+        buildOperationRunner,
+        nodeExecutor
+    )
+
+    TaskExecutionGraphExecutionListener executionGraphExecutionListener = Mock(TaskExecutionGraphExecutionListener)
+    FinalizedExecutionPlan populatedPlan
+    TaskExecutionGraphInternal taskExecutionGraph = Mock(TaskExecutionGraphInternal) {
+        getGraphExecutionListeners() >> executionGraphExecutionListener
+        getExecutionPlan() >> { populatedPlan }
+    }
+    GradleInternal gradle = Mock(GradleInternal) {
+        getTaskGraph() >> taskExecutionGraph
+    }
+
+    def "closes plan after executing"() {
+        def plan = newPlan()
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * plan.close()
+    }
+
+    def "depopulates task graph after executing"() {
+        def plan = newPlan()
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * taskExecutionGraph.depopulate()
+    }
+
+    def "notifies task graph execution listener after executing"() {
+        def plan = newPlan()
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * executionGraphExecutionListener.beforeGraphExecutionStarts(plan.getContents())
+    }
+
+    def "notifies task graph execution listener before starting execution"() {
+        def plan = newPlan()
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * executionGraphExecutionListener.beforeGraphExecutionStarts(_)
+
+        then:
+        1 * planExecutor.process(_, _)
+    }
+
+    def "closes plan and depopulates task graph when execution fails"() {
+        def plan = newPlan()
+        def failure = new RuntimeException("broken")
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * planExecutor.process(_, _) >> { throw failure }
+        1 * plan.close()
+        1 * taskExecutionGraph.depopulate()
+
+        and:
+        def thrown = thrown(RuntimeException)
+        thrown.is(failure)
+    }
+
+    def "binds the model rules of every project that owns a scheduled task"() {
+        def otherProject = project(project, "other")
+        def plan = newPlan([taskNodeOwnedBy(project), taskNodeOwnedBy(otherProject)])
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * project.bindAllModelRules()
+        1 * otherProject.bindAllModelRules()
+    }
+
+    def "binds the model rules of a project only once when it owns several scheduled tasks"() {
+        def plan = newPlan([taskNodeOwnedBy(project), taskNodeOwnedBy(project)])
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * project.bindAllModelRules()
+    }
+
+    def "does not bind model rules for scheduled nodes that are not tasks"() {
+        def plan = newPlan([Mock(Node) { getOwningProject() >> project }])
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        0 * project.bindAllModelRules()
+    }
+
+    def "fails when the node executor does not know how to execute a node"() {
+        def node = Mock(Node)
+        def plan = newPlan()
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        1 * planExecutor.process(_, _) >> { WorkSource<Node> source, Action<Node> nodeAction ->
+            nodeAction.execute(node)
+        }
+        1 * nodeExecutor.execute(node, _) >> false
+
+        and:
+        def failure = thrown(IllegalStateException)
+        failure.message.startsWith("Unknown type of node: ")
+    }
+
+    def "runs nodes with the build operation captured on the thread that started execution"() {
+        def callingThread = Thread.currentThread()
+        def parentOperation = Stub(BuildOperationRef) {
+            getId() >> new OperationIdentifier(42L)
+        }
+        def buildOperationRunner = Stub(BuildOperationRunner) {
+            getCurrentOperation() >> {
+                // Verify the build operation from the calling thread is captured
+                assert Thread.currentThread() == callingThread
+                parentOperation
+            }
+        }
+        def action = new SelectedTaskExecutionAction(buildScopeServices, planExecutor, buildOperationRunner, nodeExecutor)
+        def node = Mock(Node)
+        def plan = newPlan()
+        def operationWhileExecuting = new AtomicReference<BuildOperationRef>()
+
+        when:
+        action.execute(gradle, plan)
+
+        then:
+        1 * planExecutor.process(_, _) >> { WorkSource<Node> source, Action<Node> nodeAction ->
+            concurrent.start { nodeAction.execute(node) }.completed()
+        }
+        1 * nodeExecutor.execute(node, _) >> {
+            operationWhileExecuting.set(CurrentBuildOperationRef.instance().get())
+            true
+        }
+
+        and:
+        operationWhileExecuting.get().is(parentOperation)
+    }
+
+    def "can execute multiple times"() {
+        def plan = newPlan()
+        def plan2 = newPlan()
+        def planResult = Stub(ExecutionResult)
+        def planResult2 = Stub(ExecutionResult)
+
+        when:
+        populatedPlan = plan
+        def result = underTest.execute(gradle, plan)
+
+        then:
+        1 * planExecutor.process(plan.asWorkSource(), _) >> planResult
+        result.is(planResult)
+
+        when:
+        populatedPlan = plan2
+        def result2 = underTest.execute(gradle, plan2)
+
+        then:
+        1 * planExecutor.process(plan2.asWorkSource(), _) >> planResult2
+        result2.is(planResult2)
+    }
+
+    def "fails when given a plan that the task graph was not populated with"() {
+        def otherPlan = newPlan()
+        def plan = newPlan()
+        populatedPlan = otherPlan
+
+        when:
+        underTest.execute(gradle, plan)
+
+        then:
+        thrown(IllegalStateException)
+        0 * planExecutor.process(_, _)
+        0 * taskExecutionGraph.depopulate()
+    }
+
+    FinalizedExecutionPlan newPlan(List<Node> scheduledNodes) {
+        populatedPlan = Mock(FinalizedExecutionPlan) {
+            getContents() >> Stub(QueryableExecutionPlan) {
+                getScheduledNodes() >> new ScheduledWork(ImmutableList.copyOf(scheduledNodes), ImmutableSet.copyOf(scheduledNodes))
+            }
+            asWorkSource() >> Stub(WorkSource)
+        }
+    }
+
+    LocalTaskNode taskNodeOwnedBy(ProjectInternal owner) {
+        Mock(LocalTaskNode) {
+            getOwningProject() >> owner
+        }
+    }
+
+    FinalizedExecutionPlan newPlan() {
+        populatedPlan = Mock(FinalizedExecutionPlan) {
+            getContents() >> Stub(QueryableExecutionPlan)
+            asWorkSource() >> Stub(WorkSource)
+        }
+
+    }
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -38,7 +38,6 @@ import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.FileSystemTestPreconditions
-
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.ToBeImplemented
@@ -2413,9 +2412,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     }
 
     List<Node> getScheduledNodes() {
-        def result = []
-        executionPlan.scheduledNodes.visitNodes { nodes, entryNodes -> result.addAll(nodes) }
-        return result
+        return executionPlan.scheduledNodes.scheduledNodes
     }
 
     private static class TestNode extends CreationOrderedNode implements SelfExecutingNode {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.execution.plan
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.CircularReferenceException
 import org.gradle.api.Task
@@ -695,6 +697,27 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         failures[0] instanceof BuildCancelledException
     }
 
+    def "does not fail when build is cancelled after the last task has started"() {
+        def failures = []
+        Task a = task("a")
+        Task b = task("b")
+
+        when:
+        addToGraphAndPopulate([a, b])
+
+        then:
+        executedTasks == [a, b]
+
+        when:
+        coordinator.withStateLock {
+            finalizedPlan.cancelExecution()
+        }
+        finalizedPlan.collectFailures(failures)
+
+        then:
+        failures.empty
+    }
+
     def "continues to return tasks and rethrows failure on completion when failure handler indicates that execution should continue"() {
         def failures = []
         RuntimeException failure = new RuntimeException()
@@ -861,6 +884,34 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         then:
         executes(c)
         filtered(b)
+    }
+
+    def "will execute a task whose dependencies have been filtered when an unrelated task fails"() {
+        given:
+        def failures = []
+        RuntimeException failure = new RuntimeException()
+        Task a = task("a", failure: failure)
+        Task b = filteredTask("b")
+        Task c = task("c", dependsOn: [b])
+        Spec<Task> filter = Mock()
+
+        and:
+        filter.isSatisfiedBy(_) >> { Task t -> t != b }
+
+        when:
+        executionPlan.setContinueOnFailure(true)
+        executionPlan.addFilter(filter)
+        addToGraphAndPopulate([a, c])
+
+        then:
+        executes(a, c)
+        filtered(b)
+
+        when:
+        finalizedPlan.collectFailures(failures)
+
+        then:
+        failures == [failure]
     }
 
     def "does not build graph for or execute tasks that have already executed in a previous plan"() {
@@ -1184,6 +1235,6 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     }
 
     private ScheduledWork scheduledWork(Node... nodes) {
-        return new ScheduledWork(nodes as List<Node>, nodes as List<Node>)
+        return new ScheduledWork(ImmutableList.copyOf(nodes), ImmutableSet.copyOf(nodes))
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultPlanExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultPlanExecutorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.execution.plan
 
 import org.gradle.api.Action
+import org.gradle.api.BuildCancelledException
 import org.gradle.api.Project
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.TaskStateInternal
@@ -113,4 +114,48 @@ class DefaultPlanExecutorTest extends Specification {
         1 * workSource.collectFailures([])
         0 * workSource._
     }
+
+    def "no work is started when cancellation is requested before the first work item is selected"() {
+        when:
+        def result = executor.process(workSource, worker)
+
+        then:
+        result.failures.empty
+        1 * workerLeaseService.currentWorkerLease >> workerLease
+
+        then:
+        1 * cancellationHandler.isCancellationRequested() >> true
+        1 * workSource.cancelExecution()
+        1 * workSource.executionState() >> WorkSource.State.NoMoreWorkToStart
+
+        then:
+        1 * workerLease.tryLock() >> true
+        3 * workSource.allExecutionComplete() >> true
+        1 * workSource.collectFailures([])
+        0 * workSource._
+        0 * worker._
+    }
+
+    def "failures collected from the work source are reported in the result"() {
+        def cancellation = new BuildCancelledException()
+
+        when:
+        def result = executor.process(workSource, worker)
+
+        then:
+        result.failures == [cancellation]
+        1 * workerLeaseService.currentWorkerLease >> workerLease
+
+        then:
+        1 * cancellationHandler.isCancellationRequested() >> true
+        1 * workSource.cancelExecution()
+        1 * workSource.executionState() >> WorkSource.State.NoMoreWorkToStart
+
+        then:
+        1 * workerLease.tryLock() >> true
+        3 * workSource.allExecutionComplete() >> true
+        1 * workSource.collectFailures(_) >> { arguments -> arguments[0].add(cancellation) }
+        0 * workSource._
+    }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -17,83 +17,28 @@
 package org.gradle.execution.taskgraph
 
 import org.gradle.api.Action
-import org.gradle.api.BuildCancelledException
-import org.gradle.api.CircularReferenceException
-import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionGraphListener
 import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener
-import org.gradle.api.internal.TaskInputsInternal
-import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.TaskOutputsInternal
-import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.project.ProjectStateRegistry
-import org.gradle.api.internal.project.taskfactory.TestTaskIdentities
-import org.gradle.api.internal.tasks.NodeExecutionContext
-import org.gradle.api.internal.tasks.TaskDependencyFactory
-import org.gradle.api.internal.tasks.TaskDependencyInternal
-import org.gradle.api.internal.tasks.TaskDestroyablesInternal
-import org.gradle.api.internal.tasks.TaskLocalStateInternal
-import org.gradle.api.internal.tasks.TaskStateInternal
-import org.gradle.api.specs.Spec
-import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.configuration.internal.TestListenerBuildOperationDecorator
 import org.gradle.execution.plan.AbstractExecutionPlanSpec
-import org.gradle.execution.plan.DefaultExecutionPlan
-import org.gradle.execution.plan.DefaultPlanExecutor
-import org.gradle.execution.plan.ExecutionNodeAccessHierarchies
-import org.gradle.execution.plan.ExecutionNodeAccessHierarchy
 import org.gradle.execution.plan.FinalizedExecutionPlan
-import org.gradle.execution.plan.LocalTaskNode
-import org.gradle.execution.plan.Node
-import org.gradle.execution.plan.NodeExecutor
-import org.gradle.execution.plan.OrdinalGroupFactory
-import org.gradle.execution.plan.PlanExecutor
-import org.gradle.execution.plan.SelfExecutingNode
-import org.gradle.execution.plan.TaskDependencyResolver
-import org.gradle.execution.plan.TaskNodeDependencyResolver
-import org.gradle.execution.plan.TaskNodeFactory
-import org.gradle.initialization.BuildCancellationToken
-import org.gradle.internal.buildoption.DefaultInternalOptions
-import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ManagedExecutor
+import org.gradle.execution.plan.QueryableExecutionPlan
 import org.gradle.internal.event.DefaultListenerManager
-import org.gradle.internal.file.Stat
 import org.gradle.internal.operations.TestBuildOperationRunner
-import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.Scope
-import org.gradle.internal.work.DefaultWorkerLeaseService
-import org.gradle.internal.work.DefaultWorkerLimits
-import org.gradle.internal.work.ResourceLockStatistics
-import org.gradle.internal.work.WorkerLeaseRegistry
-import org.gradle.util.Path
-import org.gradle.util.TestUtil
-
-import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 
 class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
-    def cancellationToken = Mock(BuildCancellationToken)
+
     def listenerManager = new DefaultListenerManager(Scope.Build)
     def graphListeners = listenerManager.createAnonymousBroadcaster(TaskExecutionGraphListener.class)
     def internalGraphListeners = listenerManager.createAnonymousBroadcaster(TaskExecutionGraphExecutionListener.class)
     def taskExecutionListeners = listenerManager.createAnonymousBroadcaster(TaskExecutionListener.class)
     def listenerRegistrationListener = listenerManager.getBroadcaster(BuildScopeListenerRegistrationListener.class)
-    def nodeExecutor = Mock(NodeExecutor)
     def buildOperationRunner = new TestBuildOperationRunner()
     def listenerBuildOperationDecorator = new TestListenerBuildOperationDecorator()
-    def workerLimits = new DefaultWorkerLimits(1)
-    def workerLeases = new DefaultWorkerLeaseService(coordinator, workerLimits, ResourceLockStatistics.NO_OP)
-    def executorFactory = Mock(ExecutorFactory)
-    def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService())
-    def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-    def projectStateRegistry = Stub(ProjectStateRegistry)
-    def executionPlan = newExecutionPlan()
     def taskGraph = new DefaultTaskExecutionGraph(
-        new DefaultPlanExecutor(workerLimits, executorFactory, workerLeases, cancellationToken, coordinator, new DefaultInternalOptions([:])),
-        nodeExecutor,
         buildOperationRunner,
         listenerBuildOperationDecorator,
         thisBuild,
@@ -101,198 +46,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         internalGraphListeners,
         taskExecutionListeners,
         listenerRegistrationListener,
-        Stub(ServiceRegistry) {
-            get(TaskDependencyFactory) >> TestFiles.taskDependencyFactory()
-        }
     )
-    WorkerLeaseRegistry.WorkerLeaseCompletion parentWorkerLease
-    def executedTasks = []
-    def failures = []
-
-    def setup() {
-        parentWorkerLease = workerLeases.startWorker()
-        _ * executorFactory.create(_) >> Mock(ManagedExecutor)
-        _ * nodeExecutor.execute(_ as Node, _ as NodeExecutionContext) >> { Node node, NodeExecutionContext context ->
-            if (node instanceof LocalTaskNode) {
-                executedTasks << node.task
-                return true
-            } else if (node instanceof SelfExecutingNode) {
-                return true
-            } else {
-                return false
-            }
-        }
-        _ * projectStateRegistry.withMutableStateOfAllProjects(_) >> { Runnable r -> r.run() }
-    }
-
-    def cleanup() {
-        parentWorkerLease.leaseFinish()
-        workerLeases.stop()
-    }
-
-    def "collects task failures"() {
-        def failure = new RuntimeException()
-        def a = brokenTask("a", failure)
-
-        given:
-        def finalizedPlan = populate([a])
-
-        when:
-        def result = taskGraph.execute(finalizedPlan)
-
-        then:
-        result.failures == [failure]
-    }
-
-    def "stops running nodes and fails with exception when build is cancelled"() {
-        def a = task("a")
-        def b = task("b")
-
-        given:
-        cancellationToken.cancellationRequested >>> [false, false, true]
-
-        when:
-        populateAndExecute([a, b])
-
-        then:
-        failures.size() == 1
-        failures[0] instanceof BuildCancelledException
-        executedTasks == [a]
-    }
-
-    def "does not fail with exception when build is cancelled after last node has started"() {
-        def a = task("a")
-        def b = task("b")
-
-        given:
-        cancellationToken.cancellationRequested >>> [false, false, false, false, true]
-
-        when:
-        populateAndExecute([a, b])
-
-        then:
-        failures.empty
-        executedTasks == [a, b]
-    }
-
-    def "does not fail with exception when build is cancelled and no tasks scheduled"() {
-        given:
-        cancellationToken.cancellationRequested >>> [true]
-
-        when:
-        populateAndExecute([])
-
-        then:
-        failures.empty
-    }
-
-    def "executes tasks in dependency order"() {
-        Task a = task("a")
-        Task b = task("b", a)
-        Task c = task("c", b, a)
-        Task d = task("d", c)
-
-        when:
-        populateAndExecute([d])
-
-        then:
-        executedTasks == [a, b, c, d]
-        failures.empty
-    }
-
-    def "executes dependencies in name order"() {
-        Task a = task("a")
-        Task b = task("b")
-        Task c = task("c")
-        Task d = task("d", b, a, c)
-
-        when:
-        populateAndExecute([d])
-
-        then:
-        executedTasks == [a, b, c, d]
-        failures.empty
-    }
-
-    def "executes tasks in a single batch in name order"() {
-        Task a = task("a")
-        Task b = task("b")
-        Task c = task("c")
-
-        when:
-        populateAndExecute([b, c, a])
-
-        then:
-        executedTasks == [a, b, c]
-        failures.empty
-    }
-
-    def "executes batches in order added"() {
-        Task a = task("a")
-        Task b = task("b")
-        Task c = task("c")
-        Task d = task("d")
-
-        when:
-        executionPlan.addEntryTasks([c, b])
-        executionPlan.addEntryTasks([d, a])
-        execute()
-
-        then:
-        executedTasks == [b, c, a, d]
-        failures.empty
-    }
-
-    def "executes shared dependencies of batches once only"() {
-        Task a = task("a")
-        Task b = task("b")
-        Task c = task("c", a, b)
-        Task d = task("d")
-        Task e = task("e", b, d)
-
-        when:
-        executionPlan.addEntryTasks([c])
-        executionPlan.addEntryTasks([e])
-        execute()
-
-        then:
-        executedTasks == [a, b, c, d, e]
-        failures.empty
-    }
-
-    def "adding tasks adds dependencies"() {
-        Task a = task("a")
-        Task b = task("b", a)
-        Task c = task("c", b, a)
-        Task d = task("d", c)
-
-        when:
-        populate([d])
-
-        then:
-        taskGraph.hasTask(":a")
-        taskGraph.hasTask(a)
-        taskGraph.hasTask(":b")
-        taskGraph.hasTask(b)
-        taskGraph.hasTask(":c")
-        taskGraph.hasTask(c)
-        taskGraph.hasTask(":d")
-        taskGraph.hasTask(d)
-        taskGraph.allTasks == [a, b, c, d]
-    }
-
-    def "get all tasks returns tasks in execution order"() {
-        Task d = task("d")
-        Task c = task("c")
-        Task b = task("b", d, c)
-        Task a = task("a", b)
-
-        when:
-        populate([a])
-
-        then:
-        taskGraph.allTasks == [c, d, b, a]
-    }
 
     def "is empty when no tasks have been added"() {
         expect:
@@ -301,14 +55,14 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     }
 
     def "retains all tasks list after execute until next execution"() {
-        Task a = task("a")
-        Task b = task("b", a)
-        Task c = task("c")
+        Task a = createTask("a")
+        Task b = createTask("b")
+        Task c = createTask("c")
 
         when:
-        def finalizedPlan = populate([b])
+        populate([a, b])
         taskGraph.allTasks
-        taskGraph.execute(finalizedPlan)
+        taskGraph.depopulate()
 
         then:
         // tests existing behaviour, not desired behaviour
@@ -317,11 +71,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         taskGraph.allTasks == [a, b]
 
         when:
-        def plan2 = newExecutionPlan()
-        plan2.addEntryTasks([c])
-        plan2.determineExecutionPlan()
-        def finalizedPlan2 = plan2.finalizePlan()
-        taskGraph.populate(finalizedPlan2)
+        populate([c])
 
         then:
         !taskGraph.hasTask(":a")
@@ -329,63 +79,44 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         taskGraph.allTasks == [c]
     }
 
-    def "can execute multiple times"() {
-        Task a = brokenTask("a", new RuntimeException())
-        Task b = task("b", a)
-        Task c = task("c")
+    def "allTasks returns tasks from populated plan"() {
+        final Task a = createTask("a")
+        final Task b = createTask("b")
 
         when:
-        populateAndExecute([b])
+        populate([a, b])
 
         then:
-        executedTasks == [a]
-        failures.size() == 1
+        taskGraph.allTasks == [a, b]
+    }
+
+    def "can populate multiple times"() {
+        Task a = createTask("a")
+        Task b = createTask("b")
 
         when:
-        def plan2 = newExecutionPlan()
-        plan2.addEntryTasks([c])
-        plan2.determineExecutionPlan()
-        def finalizedPlan2 = plan2.finalizePlan()
-        taskGraph.populate(finalizedPlan2)
+        populate([a, b])
+
+        then:
+        taskGraph.allTasks == [a, b]
+
+        when:
+        Task c = createTask("c")
+        populate([c])
 
         then:
         taskGraph.allTasks == [c]
-
-        when:
-        executedTasks.clear()
-        def result2 = taskGraph.execute(finalizedPlan2)
-
-        then:
-        executedTasks == [c]
-        result2.failures.empty
-    }
-
-    def "cannot add task with circular reference"() {
-        Task a = createTask("a")
-        Task b = task("b", a)
-        Task c = task("c", b)
-        addDependencies(a, c)
-
-        when:
-        populateAndExecute([c])
-
-        then:
-        thrown(CircularReferenceException)
     }
 
     def "notifies graph listener before first execute"() {
-        def planExecutor = Mock(PlanExecutor)
         def taskGraph = new DefaultTaskExecutionGraph(
-            planExecutor,
-            nodeExecutor,
             buildOperationRunner,
             listenerBuildOperationDecorator,
             thisBuild,
             graphListeners,
             internalGraphListeners,
             taskExecutionListeners,
-            listenerRegistrationListener,
-            Stub(ServiceRegistry)
+            listenerRegistrationListener
         )
         TaskExecutionGraphListener listener = Mock(TaskExecutionGraphListener)
 
@@ -393,53 +124,39 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         taskGraph.addTaskExecutionGraphListener(listener)
         def finalizedPlan = Stub(FinalizedExecutionPlan)
         taskGraph.populate(finalizedPlan)
-        taskGraph.execute(finalizedPlan)
 
         then:
         1 * listener.graphPopulated(_)
 
-        then:
-        1 * planExecutor.process(_, _)
-
         when:
         taskGraph.populate(finalizedPlan)
-        taskGraph.execute(finalizedPlan)
 
         then:
         0 * listener._
     }
 
     def "executes whenReady listener before first execute"() {
-        def planExecutor = Mock(PlanExecutor)
         def taskGraph = new DefaultTaskExecutionGraph(
-            planExecutor,
-            nodeExecutor,
             buildOperationRunner,
             listenerBuildOperationDecorator,
             thisBuild,
             graphListeners,
             internalGraphListeners,
             taskExecutionListeners,
-            listenerRegistrationListener,
-            Stub(ServiceRegistry)
+            listenerRegistrationListener
         )
         def closure = Mock(Closure)
         def action = Mock(Action)
-        Task a = task("a")
 
         when:
         taskGraph.whenReady(closure)
         taskGraph.whenReady(action)
         def finalizedPlan = Stub(FinalizedExecutionPlan)
         taskGraph.populate(finalizedPlan)
-        taskGraph.execute(finalizedPlan)
 
         then:
         1 * closure.call()
         1 * action.execute(_)
-
-        then:
-        1 * planExecutor.process(_, _)
 
         and:
         with(buildOperationRunner.operations[0]) {
@@ -451,37 +168,10 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         when:
         def finalizedPlan2 = Stub(FinalizedExecutionPlan)
         taskGraph.populate(finalizedPlan2)
-        taskGraph.execute(finalizedPlan2)
 
         then:
         0 * closure._
         0 * action._
-    }
-
-    def "stops execution on first failure when no failure handler provided"() {
-        final RuntimeException failure = new RuntimeException()
-        final Task a = brokenTask("a", failure)
-        final Task b = task("b")
-
-        when:
-        populateAndExecute([a, b])
-
-        then:
-        executedTasks == [a]
-        failures == [failure]
-    }
-
-    def "stops execution on failure when failure handler indicates that execution should stop"() {
-        final RuntimeException failure = new RuntimeException()
-        final Task a = brokenTask("a", failure)
-        final Task b = task("b")
-
-        when:
-        populateAndExecute([a, b])
-
-        then:
-        executedTasks == [a]
-        failures == [failure]
     }
 
     def "notifies before task listeners"() {
@@ -490,8 +180,8 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         }
         def action = Mock(Action)
 
-        final Task a = task("a")
-        final Task b = task("b")
+        final Task a = createTask("a")
+        final Task b = createTask("b")
 
         when:
         taskGraph.beforeTask(closure)
@@ -512,8 +202,8 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         }
         def action = Mock(Action)
 
-        final Task a = task("a")
-        final Task b = task("b")
+        final Task a = createTask("a")
+        final Task b = createTask("b")
 
         when:
         taskGraph.afterTask(closure)
@@ -528,142 +218,13 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
         1 * action.execute(b)
     }
 
-    def "does not execute filtered tasks"() {
-        final Task a = task("a", task("a-dep"))
-        Task b = task("b")
-        Spec<Task> spec = new Spec<Task>() {
-            boolean isSatisfiedBy(Task element) {
-                return element != a
+    private populate(List<Task> tasks) {
+        def finalizedPlan = Mock(FinalizedExecutionPlan) {
+            getContents() >> Mock(QueryableExecutionPlan) {
+                getTasks() >> (tasks as Set)
             }
         }
-
-        when:
-        executionPlan.addFilter(spec)
-        def finalizedPlan = populate([a, b])
-
-        then:
-        taskGraph.allTasks == [b]
-
-        when:
-        def result = taskGraph.execute(finalizedPlan)
-
-        then:
-        executedTasks == [b]
-        result.failures.empty
-    }
-
-    def "does not execute filtered dependencies"() {
-        final Task a = task("a", task("a-dep"))
-        Task b = task("b")
-        Task c = task("c", a, b)
-        Spec<Task> spec = new Spec<Task>() {
-            boolean isSatisfiedBy(Task element) {
-                return element != a
-            }
-        }
-
-        when:
-        executionPlan.addFilter(spec)
-        def finalizedPlan = populate([c])
-
-        then:
-        taskGraph.allTasks == [b, c]
-
-        when:
-        def result = taskGraph.execute(finalizedPlan)
-
-        then:
-        executedTasks == [b, c]
-        result.failures.empty
-    }
-
-    def "will execute a task whose dependencies have been filtered on failure"() {
-        final RuntimeException failure = new RuntimeException()
-        final Task a = brokenTask("a", failure)
-        final Task b = task("b")
-        final Task c = task("c", b)
-
-        when:
-        executionPlan.continueOnFailure = true
-        executionPlan.addFilter(new Spec<Task>() {
-            boolean isSatisfiedBy(Task element) {
-                return element != b
-            }
-        })
-        populateAndExecute([a, c])
-
-        then:
-        executedTasks == [a, c]
-        failures == [failure]
-    }
-
-    private FinalizedExecutionPlan populate(List<Task> tasks) {
-        executionPlan.addEntryTasks(tasks)
-        executionPlan.determineExecutionPlan()
-        def finalizedPlan = executionPlan.finalizePlan()
         taskGraph.populate(finalizedPlan)
-        return finalizedPlan
     }
 
-    void populateAndExecute(List<Task> tasks) {
-        def finalizedPlan = populate(tasks)
-        executedTasks.clear()
-        failures.clear()
-        def result = taskGraph.execute(finalizedPlan)
-        failures.addAll(result.failures)
-    }
-
-    void execute() {
-        executionPlan.determineExecutionPlan()
-        def finalizedPlan = executionPlan.finalizePlan()
-        taskGraph.populate(finalizedPlan)
-        executedTasks.clear()
-        failures.clear()
-        def result = taskGraph.execute(finalizedPlan)
-        failures.addAll(result.failures)
-    }
-
-    private DefaultExecutionPlan newExecutionPlan() {
-        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
-    }
-
-    def task(String name, Task... dependsOn = []) {
-        def mock = createTask(name)
-        addDependencies(mock, dependsOn)
-        return mock
-    }
-
-    def addDependencies(Task task, Task... dependsOn) {
-        _ * task.taskDependencies >> taskDependencyResolvingTo(task, dependsOn as List)
-        _ * task.lifecycleDependencies >> taskDependencyResolvingTo(task, dependsOn as List)
-        _ * task.finalizedBy >> taskDependencyResolvingTo(task, [])
-        _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, [])
-        _ * task.mustRunAfter >> taskDependencyResolvingTo(task, [])
-        _ * task.sharedResources >> []
-    }
-
-    def brokenTask(String name, RuntimeException failure) {
-        def mock = Mock(TaskInternal)
-        _ * mock.name >> name
-        _ * mock.identityPath >> project.identityPath.child(name)
-        _ * mock.project >> project
-        _ * mock.state >> Stub(TaskStateInternal) {
-            getFailure() >> failure
-            rethrowFailure() >> { throw failure }
-        }
-        _ * mock.taskDependencies >> Stub(TaskDependencyInternal)
-        _ * mock.lifecycleDependencies >> Stub(TaskDependencyInternal)
-        _ * mock.finalizedBy >> Stub(TaskDependencyInternal)
-        _ * mock.mustRunAfter >> Stub(TaskDependencyInternal)
-        _ * mock.shouldRunAfter >> Stub(TaskDependencyInternal)
-        _ * mock.sharedResources >> []
-        _ * mock.compareTo(_) >> { Task t -> name.compareTo(t.name) }
-        _ * mock.outputs >> Stub(TaskOutputsInternal)
-        _ * mock.inputs >> Stub(TaskInputsInternal)
-        _ * mock.destroyables >> Stub(TaskDestroyablesInternal)
-        _ * mock.localState >> Stub(TaskLocalStateInternal)
-        _ * mock.path >> ":${name}"
-        _ * mock.taskIdentity >> TestTaskIdentities.create(name, DefaultTask, project as ProjectInternal)
-        return mock
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.build
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.TaskInternal
@@ -25,6 +27,7 @@ import org.gradle.api.internal.project.taskfactory.TestTaskIdentities
 import org.gradle.execution.plan.ExecutionPlan
 import org.gradle.execution.plan.LocalTaskNode
 import org.gradle.execution.plan.QueryableExecutionPlan
+import org.gradle.execution.plan.ScheduledWork
 import org.gradle.execution.plan.ToPlannedNodeConverterRegistry
 import org.gradle.execution.plan.ToPlannedTaskConverter
 import org.gradle.internal.operations.TestBuildOperationRunner
@@ -32,8 +35,6 @@ import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.NodeIdentity
 import org.gradle.util.Path
 import spock.lang.Specification
-
-import java.util.function.BiConsumer
 
 class BuildOperationFiringBuildWorkPreparerTest extends Specification {
     def "build operation provides execution plan when queries with all node types"() {
@@ -46,12 +47,10 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
                 getTaskIdentity() >> ti1
             }
         }
-        List<Node> nodes = [t]
 
-        def scheduledNodesStub = Stub(QueryableExecutionPlan.ScheduledNodes) {
-            visitNodes(_) >> { BiConsumer<List<Node>, Set<Node>> consumer ->
-                consumer.accept(nodes, new HashSet<Node>(nodes))
-            }
+        def scheduledNodesStub = Stub(ScheduledWork) {
+            getScheduledNodes() >> ImmutableList.of(t)
+            getEntryNodes() >> ImmutableSet.of(t)
         }
 
         def executionPlan = Stub(ExecutionPlan) {
@@ -86,7 +85,7 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
 
         def executionPlan = Stub(ExecutionPlan) {
             getContents() >> Stub(QueryableExecutionPlan) {
-                getScheduledNodes() >> Stub(QueryableExecutionPlan.ScheduledNodes)
+                getScheduledNodes() >> Stub(ScheduledWork)
             }
         }
 
@@ -111,7 +110,7 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
 
         def executionPlan = Stub(ExecutionPlan) {
             getContents() >> Stub(QueryableExecutionPlan) {
-                getScheduledNodes() >> Stub(QueryableExecutionPlan.ScheduledNodes)
+                getScheduledNodes() >> Stub(ScheduledWork)
             }
         }
 


### PR DESCRIPTION
DefaultTaskExecutionGraph implements TaskExecutionGraph, a public API for users to query the state of the graph prior to execution. The class also was in the 'main path' of actual execution, which is undesirable.

This commit separates the class's concerns so that it only acts as a public API implementation. All logic related to actually executing a graph has been moved out of the class into SelectedTaskExecutionAction. DefaultTaskExecutionGraph no longer has any ownership claim to the FinalizedExecutionPlan it wraps. Configuration Cache still gets its FinalizedExectionPlan throgh TaskExecutionGraphInternal. This should be relatively easy to change with some extra wiring later on. We should then deprecate querying any methods on TaskExecutionGraph outside of the whenReady callback, allowing DefaultTaskExecutionGraph to remove any final long-lived reference to FinalizedExecutionPlan.

DefaultTaskExecutionGraphSpec was more of an integration test than anything, combining DefaultPlanExecutor and DefaultExecutionPlan. Most of its existing tests were duplicated by tests in DefaultExecutionPlanTest, and in practice those duplicate tests did not belong in that file, as they actually verified behavior of DefaultExecutionPlan. Duplicate and misplaced tests have been deleted and moved to their appropriate files. SelectedTaskExecutionActionTest has been created to test execution logic that was moved out of DefaultTaskExecutionGraph.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
