### PR TITLE
Reduce gradle memory usage: Make DependencySubstitutionsInternal lazy in DefaultResolutionStrategy

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
@@ -96,7 +96,7 @@ public class ResolutionStrategyFactory implements Factory<ResolutionStrategyInte
             capabilityNotationParser
         );
 
-        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forResolutionStrategy(
+        Factory<DependencySubstitutionsInternal> dependencySubstitutionsFactory = () -> DefaultDependencySubstitutions.forResolutionStrategy(
             currentBuild, moduleSelectorNotationParser, instantiator, objectFactory, attributesFactory, capabilityNotationParser
         );
 
@@ -104,7 +104,7 @@ public class ResolutionStrategyFactory implements Factory<ResolutionStrategyInte
 
         return instantiator.newInstance(DefaultResolutionStrategy.class,
             cachePolicy,
-            dependencySubstitutions,
+            dependencySubstitutionsFactory,
             globalDependencySubstitutionRules,
             vcsResolver,
             moduleIdentifierFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -41,6 +41,8 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.internal.Factories;
+import org.gradle.internal.Factory;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.rules.SpecRuleAction;
 import org.gradle.internal.typeconversion.NormalizedTimeUnit;
@@ -68,7 +70,8 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private final DefaultComponentSelectionRules componentSelectionRules;
 
     private final CachePolicy cachePolicy;
-    private final DependencySubstitutionsInternal dependencySubstitutions;
+    private @Nullable Factory<DependencySubstitutionsInternal> dependencySubstitutionsFactory;
+    private @Nullable DependencySubstitutionsInternal dependencySubstitutions;
     private final GlobalDependencyResolutionRules globalDependencySubstitutionRules;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final VcsResolver vcsResolver;
@@ -91,7 +94,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Inject
     public DefaultResolutionStrategy(
         CachePolicy cachePolicy,
-        DependencySubstitutionsInternal dependencySubstitutions,
+        Factory<DependencySubstitutionsInternal> dependencySubstitutionsFactory,
         GlobalDependencyResolutionRules globalDependencySubstitutionRules,
         VcsResolver vcsResolver,
         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
@@ -101,7 +104,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         ObjectFactory objectFactory
     ) {
         this.cachePolicy = cachePolicy;
-        this.dependencySubstitutions = dependencySubstitutions;
+        this.dependencySubstitutionsFactory = dependencySubstitutionsFactory;
         this.globalDependencySubstitutionRules = globalDependencySubstitutionRules;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.componentSelectionRules = new DefaultComponentSelectionRules(moduleIdentifierFactory);
@@ -117,7 +120,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     @Override
     public void maybeDiscardStateRequiredForGraphResolution() {
-        if (!keepStateRequiredForGraphResolution) {
+        if (!keepStateRequiredForGraphResolution && dependencySubstitutions != null) {
             dependencySubstitutions.discard();
         }
     }
@@ -127,7 +130,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         mutationValidator = validator;
         cachePolicy.setMutationValidator(validator);
         componentSelectionRules.setMutationValidator(validator);
-        dependencySubstitutions.setMutationValidator(validator);
+        if (dependencySubstitutions != null) {
+            dependencySubstitutions.setMutationValidator(validator);
+        }
     }
 
     @Override
@@ -229,7 +234,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public ResolutionStrategy eachDependency(Action<? super DependencyResolveDetails> rule) {
         mutationValidator.validateMutation(STRATEGY);
-        dependencySubstitutions.allWithDependencyResolveDetails(rule, componentSelectorConverter);
+        getOrCreateDependencySubstitutions().allWithDependencyResolveDetails(rule, componentSelectorConverter);
         return this;
     }
 
@@ -240,7 +245,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (!forcedModules.isEmpty()) {
             result = result.add(new ModuleForcingResolveRule(forcedModules));
         }
-        result = result.add(dependencySubstitutions.getRuleAction());
+        if (dependencySubstitutions != null) {
+            result = result.add(dependencySubstitutions.getRuleAction());
+        }
         if (useGlobalDependencySubstitutionRules.get()) {
             result = result.add(globalDependencySubstitutionRules.getDependencySubstitutionRules().getRuleAction());
         }
@@ -255,7 +262,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public boolean resolveGraphToDetermineTaskDependencies() {
         return assumeFluidDependencies
-            || dependencySubstitutions.rulesMayAddProjectDependency()
+            || (dependencySubstitutions != null && dependencySubstitutions.rulesMayAddProjectDependency())
             || (useGlobalDependencySubstitutionRules.get() && globalDependencySubstitutionRules.getDependencySubstitutionRules().rulesMayAddProjectDependency())
             || vcsResolver.hasRules();
     }
@@ -306,14 +313,23 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         return this;
     }
 
-    @Override
-    public DependencySubstitutionsInternal getDependencySubstitution() {
+    private DependencySubstitutionsInternal getOrCreateDependencySubstitutions() {
+        if (dependencySubstitutions == null) {
+            dependencySubstitutions = dependencySubstitutionsFactory.create();
+            dependencySubstitutions.setMutationValidator(mutationValidator);
+            dependencySubstitutionsFactory = null;
+        }
         return dependencySubstitutions;
     }
 
     @Override
+    public DependencySubstitutionsInternal getDependencySubstitution() {
+        return getOrCreateDependencySubstitutions();
+    }
+
+    @Override
     public ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action) {
-        action.execute(dependencySubstitutions);
+        action.execute(getOrCreateDependencySubstitutions());
         return this;
     }
 
@@ -324,7 +340,11 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     @Override
     public DefaultResolutionStrategy copy() {
-        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), dependencySubstitutions.copy(), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution, objectFactory);
+        // When the substitutions were never realized, propagate the factory so the copy stays lazy as well
+        Factory<DependencySubstitutionsInternal> childDependencySubstitutionsFactory = dependencySubstitutions != null
+            ? Factories.constant(dependencySubstitutions.copy())
+            : dependencySubstitutionsFactory;
+        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), childDependencySubstitutionsFactory, globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution, objectFactory);
 
         if (conflictResolution == ConflictResolution.strict) {
             out.failOnVersionConflict();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -35,6 +35,8 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons
 import org.gradle.internal.Actions
+import org.gradle.internal.Factories
+import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.rules.NoInputsRuleAction
@@ -62,7 +64,7 @@ class DefaultResolutionStrategySpec extends Specification {
     def dependencyLockingProvider = Mock(DependencyLockingProvider)
 
     def moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    def strategy = new DefaultResolutionStrategy(cachePolicy, dependencySubstitutions, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null, TestUtil.objectFactory())
+    def strategy = new DefaultResolutionStrategy(cachePolicy, Factories.constant(dependencySubstitutions), globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null, TestUtil.objectFactory())
 
     def "allows setting forced modules"() {
         expect:
@@ -89,7 +91,7 @@ class DefaultResolutionStrategySpec extends Specification {
         strategy.force 'org.foo:bar:1.0'
 
         when:
-        strategy.forcedModules = ['hello:world:1.0', [group:'g', name:'n', version:'1']]
+        strategy.forcedModules = ['hello:world:1.0', [group: 'g', name: 'n', version: '1']]
 
         then:
         def versions = strategy.forcedModules as List
@@ -127,10 +129,11 @@ class DefaultResolutionStrategySpec extends Specification {
         1 * dependencySubstitutions.allWithDependencyResolveDetails(action, componentSelectorConverter)
     }
 
-    def "provides dependency resolve rule with forced modules first and then user specified rules"() {
+    def "provides dependency resolve rule when given action with forced modules first and then user specified rules"() {
         def mid = DefaultModuleIdentifier.newId('org', 'foo')
         given:
         strategy.force 'org:bar:1.0', 'org:foo:2.0'
+        strategy.dependencySubstitution(Actions.doNothing()) // realize the lazy dependency substitutions
         def details = Mock(DependencySubstitutionInternal)
         def substitutionAction = Mock(Action)
 
@@ -146,6 +149,26 @@ class DefaultResolutionStrategySpec extends Specification {
 
         then: //user rules follow:
         1 * substitutionAction.execute(details)
+        0 * details._
+    }
+
+    def "dependency substitution factory isn't realized when no action was given"() {
+        def mid = DefaultModuleIdentifier.newId('org', 'foo')
+        given:
+        strategy.force 'org:bar:1.0', 'org:foo:2.0'
+        def details = Mock(DependencySubstitutionInternal)
+
+        when:
+        strategy.dependencySubstitutionRule.execute(details)
+
+        then: //forced modules:
+        _ * details.requested >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
+        _ * details.oldRequested >> newSelector(mid, "1.0")
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, "2.0"), ComponentSelectionReasons.FORCED)
+        _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
+
+        then:
+        0 * dependencySubstitutions._
         0 * details._
     }
 
@@ -179,6 +202,7 @@ class DefaultResolutionStrategySpec extends Specification {
         strategy.failOnChangingVersions()
         strategy.force("org:foo:1.0")
         strategy.componentSelection.addRule(new NoInputsRuleAction<ComponentSelection>({}))
+        strategy.eachDependency(Actions.doNothing()) // realize the lazy dependency substitutions
 
         when:
         def copy = strategy.copy()
@@ -194,8 +218,46 @@ class DefaultResolutionStrategySpec extends Specification {
         strategy.dependencySubstitution == dependencySubstitutions
         copy.dependencySubstitution == newDependencySubstitutions
 
-        ((ResolutionStrategyInternal)copy).isFailingOnDynamicVersions() == ((ResolutionStrategyInternal)strategy).isFailingOnDynamicVersions()
-        ((ResolutionStrategyInternal)copy).isFailingOnChangingVersions() == ((ResolutionStrategyInternal)strategy).isFailingOnChangingVersions()
+        ((ResolutionStrategyInternal) copy).isFailingOnDynamicVersions() == ((ResolutionStrategyInternal) strategy).isFailingOnDynamicVersions()
+        ((ResolutionStrategyInternal) copy).isFailingOnChangingVersions() == ((ResolutionStrategyInternal) strategy).isFailingOnChangingVersions()
+    }
+
+    def "dependency substitutions are only created when needed"() {
+        given:
+        def substitutions = Mock(DependencySubstitutionsInternal)
+        def factory = Mock(Factory)
+        def lazyStrategy = new DefaultResolutionStrategy(cachePolicy, factory, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null, TestUtil.objectFactory())
+        lazyStrategy.useGlobalDependencySubstitutionRules.set(false)
+
+        when: "methods that do not require substitutions are called"
+        lazyStrategy.setMutationValidator(Mock(MutationValidator))
+        lazyStrategy.getDependencySubstitutionRule()
+        lazyStrategy.resolveGraphToDetermineTaskDependencies()
+        lazyStrategy.maybeDiscardStateRequiredForGraphResolution()
+
+        then: "the substitutions are not created"
+        0 * factory._
+
+        when: "the substitutions are accessed"
+        def result = lazyStrategy.dependencySubstitution
+
+        then: "they are created and the current validator is applied"
+        1 * factory.create() >> substitutions
+        1 * substitutions.setMutationValidator(_)
+        result == substitutions
+    }
+
+    def "copy of unrealized strategy keeps dependency substitutions lazy"() {
+        given:
+        def factory = Mock(Factory)
+        def lazyStrategy = new DefaultResolutionStrategy(cachePolicy, factory, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null, TestUtil.objectFactory())
+
+        when:
+        def copy = lazyStrategy.copy()
+
+        then: "neither the strategy nor its copy realized the substitutions"
+        0 * factory._
+        copy != null
     }
 
     def "configures changing modules cache with jdk5+ units"() {
@@ -254,66 +316,93 @@ class DefaultResolutionStrategySpec extends Specification {
         def validator = Mock(MutationValidator)
         strategy.setMutationValidator(validator)
 
-        when: strategy.failOnVersionConflict()
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.failOnVersionConflict()
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.failOnDynamicVersions()
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.failOnDynamicVersions()
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.failOnChangingVersions()
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.failOnChangingVersions()
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.failOnNonReproducibleResolution()
-        then: 2 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.failOnNonReproducibleResolution()
+        then:
+        2 * validator.validateMutation(STRATEGY)
 
-        when: strategy.force("org.utils:api:1.3")
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.force("org.utils:api:1.3")
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.forcedModules = ["org.utils:api:1.4"]
-        then: (1.._) * validator.validateMutation(STRATEGY)
+        when:
+        strategy.forcedModules = ["org.utils:api:1.4"]
+        then:
+        (1.._) * validator.validateMutation(STRATEGY)
 
         // DependencySubstitutionsInternal.allWithDependencyResolveDetails() will call back to validateMutation() instead
-        when: strategy.eachDependency(Actions.doNothing())
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.eachDependency(Actions.doNothing())
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.componentSelection.all(Actions.doNothing())
-        then: 1 * validator.validateMutation(STRATEGY)
+        when:
+        strategy.componentSelection.all(Actions.doNothing())
+        then:
+        1 * validator.validateMutation(STRATEGY)
 
-        when: strategy.componentSelection(new Action<ComponentSelectionRules>() {
+        when:
+        strategy.componentSelection(new Action<ComponentSelectionRules>() {
             @Override
             void execute(ComponentSelectionRules componentSelectionRules) {
                 componentSelectionRules.all(Actions.doNothing())
             }
         })
-        then: 1 * validator.validateMutation(STRATEGY)
+        then:
+        1 * validator.validateMutation(STRATEGY)
     }
 
     def "mutation is not checked for copy"() {
         given:
-        dependencySubstitutions.copy() >> Mock(DependencySubstitutionsInternal)
         def validator = Mock(MutationValidator)
         strategy.setMutationValidator(validator)
         def copy = strategy.copy()
 
-        when: copy.failOnVersionConflict()
-        then: 0 * validator.validateMutation(_)
+        when:
+        copy.failOnVersionConflict()
+        then:
+        0 * validator.validateMutation(_)
 
-        when: copy.force("org.utils:api:1.3")
-        then: 0 * validator.validateMutation(_)
+        when:
+        copy.force("org.utils:api:1.3")
+        then:
+        0 * validator.validateMutation(_)
 
-        when: copy.forcedModules = ["org.utils:api:1.4"]
-        then: 0 * validator.validateMutation(_)
+        when:
+        copy.forcedModules = ["org.utils:api:1.4"]
+        then:
+        0 * validator.validateMutation(_)
 
-        when: copy.componentSelection.all(Actions.doNothing())
-        then: 0 * validator.validateMutation(_)
+        when:
+        copy.componentSelection.all(Actions.doNothing())
+        then:
+        0 * validator.validateMutation(_)
 
-        when: copy.componentSelection(new Action<ComponentSelectionRules>() {
+        when:
+        copy.componentSelection(new Action<ComponentSelectionRules>() {
             @Override
             void execute(ComponentSelectionRules componentSelectionRules) {
                 componentSelectionRules.all(Actions.doNothing())
             }
         })
-        then: 0 * validator.validateMutation(_)
+        then:
+        0 * validator.validateMutation(_)
     }
 
     def 'provides the expected DependencyLockingProvider'() {


### PR DESCRIPTION
DefaultResolutionStrategy eagerly created a DefaultDependencySubstitutions instance (including its rule converter and notation parser machinery) for every configuration, even when no dependency substitution rules are ever declared.

Defer creation until first access, replaying the mutation validator when the substitutions are realized, and propagate the unrealized factory on copy() so copied strategies stay lazy. Methods that only read the rules now short-circuit on an unrealized instance, which is equivalent since a fresh substitutions object contributes no rules.

The issue this pr partially addresses - https://github.com/gradle/gradle/issues/38752

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [+] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [+] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [+] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [+] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [+] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. - Not needed
- [+] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [+] Update User Guide, DSL Reference, and Javadoc for public-facing changes. - Not needed
- [+] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [+] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
