### PR TITLE
Fix Groovy 4.0.x max target Java version in test coverage fixture

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -90,7 +90,8 @@ class GroovyCoverage {
         return switch (groovyVersion.major) {
             case 6 -> JavaVersion.VERSION_27
             case 5 -> JavaVersion.VERSION_27
-            case 4 -> groovyVersion >= VersionNumber.parse('4.0.33') ? JavaVersion.VERSION_27 : JavaVersion.VERSION_26
+            // Groovy 4.0.33 added target support for Java 26 and 27; earlier 4.0.x releases top out at Java 25
+            case 4 -> (groovyVersion >= VersionNumber.parse('4.0.33') ? JavaVersion.VERSION_27 : JavaVersion.VERSION_25)
             case 3 -> JavaVersion.VERSION_17
             default -> throw new IllegalArgumentException("Computing effective target for Groovy version $groovyVersion is not supported")
         }


### PR DESCRIPTION
Fixes the `AllVersionsIntegMultiVersion` failure in
[Gradle_Master_Check_AllVersionsIntegMultiVersion_33_bucket4 #2778](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsIntegMultiVersion_33_bucket4/116076846):

```
GroovyCompileToolchainIntegrationTest.can compile source and run tests using Java 26 for Groovy  [4.0.29]

Condition not satisfied:

JavaVersion.forClass(groovyClassFile("GroovyBar.class").bytes) == groovyTarget
|           |                                                     |
|           1.8                                                   26
|                                                                 false
```

## Root cause

`GroovyCoverage.maxTargetJavaVersion` claims Groovy 4.x releases before 4.0.33 can target Java 26. They cannot — Groovy only added Java 26/27 to `CompilerConfiguration`'s JDK-to-bytecode map in **4.0.33**. For 4.0.29 a requested target of 26 is silently discarded, and because 26 is also absent from the map, `defaultTargetBytecode()` falls back to `1.8` too — hence major version 52 in the class file.

The bound was correct (`VERSION_25`) until 0ee6eca13cd0 ("Support Java 27"), which bumped it to `VERSION_26` at the same time as introducing the 4.0.33 boundary. The 4.0.33 boundary itself is right; only the pre-4.0.33 value was wrong.

This is why the failure looks flaky: the test is skipped unless the agent actually has a Java 26 JDK installed, so it only fails on the subset of agents that do.

## Verification

Ran `CompilerConfiguration.setTargetBytecode` against the real jars:

| Groovy | request 25 | request 26 | request 27 |
|---|---|---|---|
| 4.0.29 | 25 | **25** | **25** |
| 4.0.32 | 25 | **25** | **25** |
| 4.0.33 | 25 | 26 | 27 |

And confirmed the JDK-to-bytecode map contents directly (`javap` on `CompilerConfiguration`):

- 3.0.25 → max 17 (matches `case 3`)
- 4.0.29 / 4.0.32 → max 25 (**was 26**, now 25)
- 4.0.33 → max 27 (matches)
- 5.0.8 → max 27 (matches `case 5`)
- 6.0.0-alpha-2 → max 27 (matches `case 6`)

So the other branches of the switch are all correct; this changes only the one wrong value.
