### PR TITLE
Silence sun.misc.Unsafe warnings from Gradle's own runtime

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -30,6 +30,11 @@ import java.util.List;
  * For the {@code --enable-native-access} flag, users will get a warning on Java 24+ if the flag is not present.
  * There is no enforcement of the flag at the time of writing.
  * </p>
+ *
+ * <p>
+ * The {@code --sun-misc-unsafe-memory-access} flag suppresses the Java 24+ warning about terminally
+ * deprecated {@code sun.misc.Unsafe} memory-access methods called from Gradle's own runtime.
+ * </p>
  */
 public class JpmsConfiguration {
     /**
@@ -57,6 +62,17 @@ public class JpmsConfiguration {
     private static final List<String> GRADLE_WORKER_JPMS_ARGS_24 = GRADLE_SHARED_JPMS_ARGS_24;
 
     /**
+     * Libraries bundled with Gradle call terminally deprecated {@code sun.misc.Unsafe} memory-access
+     * methods, which make the JVM print a warning to stderr on Java 24+ (see
+     * <a href="https://openjdk.org/jeps/498">JEP 498</a>). For example, {@code org.jctools.util.UnsafeAccess}
+     * calls {@code Unsafe::objectFieldOffset} when Gradle's internal queues are first used.
+     * Users can do nothing about those warnings, so we opt out of them.
+     */
+    private static final List<String> UNSAFE_MEMORY_ACCESS_ARGS_24 = ImmutableList.of(
+        "--sun-misc-unsafe-memory-access=allow"
+    );
+
+    /**
      * Exposes the required packages for the Gradle daemon to work on Java 9+.
      */
     private static final List<String> GRADLE_DAEMON_JPMS_ARGS_9 = ImmutableList.<String>builder()
@@ -72,10 +88,18 @@ public class JpmsConfiguration {
 
     /**
      * Exposes the required packages for the Gradle daemon to work on Java 9+.
-     * Also enables native access for the daemon process.
+     * Also silences the {@code sun.misc.Unsafe} memory-access warnings triggered by Gradle itself.
      */
     private static final List<String> GRADLE_DAEMON_JPMS_ARGS_24 = ImmutableList.<String>builder()
         .addAll(GRADLE_DAEMON_JPMS_ARGS_9)
+        .addAll(UNSAFE_MEMORY_ACCESS_ARGS_24)
+        .build();
+
+    /**
+     * Same as {@link #GRADLE_DAEMON_JPMS_ARGS_24}, but also enables native access for the daemon process.
+     */
+    private static final List<String> GRADLE_DAEMON_JPMS_ARGS_24_NATIVE = ImmutableList.<String>builder()
+        .addAll(GRADLE_DAEMON_JPMS_ARGS_24)
         .addAll(GRADLE_SHARED_JPMS_ARGS_24)
         .build();
 
@@ -111,9 +135,9 @@ public class JpmsConfiguration {
         if (majorVersion < 9) {
             return ImmutableList.of();
         }
-        if (majorVersion < 24 || !usingNativeServices) {
+        if (majorVersion < 24) {
             return GRADLE_DAEMON_JPMS_ARGS_9;
         }
-        return GRADLE_DAEMON_JPMS_ARGS_24;
+        return usingNativeServices ? GRADLE_DAEMON_JPMS_ARGS_24_NATIVE : GRADLE_DAEMON_JPMS_ARGS_24;
     }
 }

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/jvm/JpmsConfigurationTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/jvm/JpmsConfigurationTest.groovy
@@ -130,7 +130,7 @@ class JpmsConfigurationTest extends Specification {
         majorVersion << [9, 11, 17, 21, 23]
     }
 
-    def "forDaemonProcesses returns JPMS args plus native access for Java 24+ with native services"() {
+    def "forDaemonProcesses returns JPMS args plus unsafe opt-out and native access for Java 24+ with native services"() {
         when:
         def result = JpmsConfiguration.forDaemonProcesses(majorVersion, true)
 
@@ -148,6 +148,7 @@ class JpmsConfigurationTest extends Specification {
             "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
             "--add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED",
             "--add-opens=java.base/java.time=ALL-UNNAMED",
+            "--sun-misc-unsafe-memory-access=allow",
             "--enable-native-access=ALL-UNNAMED"
         ]
 
@@ -155,7 +156,7 @@ class JpmsConfigurationTest extends Specification {
         majorVersion << [24, 25, 26]
     }
 
-    def "forDaemonProcesses returns JPMS args only for Java 24+ without native services"() {
+    def "forDaemonProcesses returns JPMS args plus unsafe opt-out for Java 24+ without native services"() {
         when:
         def result = JpmsConfiguration.forDaemonProcesses(majorVersion, false)
 
@@ -173,6 +174,7 @@ class JpmsConfigurationTest extends Specification {
             "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
             "--add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED",
             "--add-opens=java.base/java.time=ALL-UNNAMED",
+            "--sun-misc-unsafe-memory-access=allow",
         ]
 
         where:

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -44,7 +44,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         file('build.gradle') << """
             def inputArguments = java.lang.management.ManagementFactory.runtimeMXBean.inputArguments
             assert inputArguments.contains('-Xmx1024m')
-            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('--add-exports=') && !it.startsWith('--enable-native-access=') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
+            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('--add-exports=') && !it.startsWith('--enable-native-access=') && !it.startsWith('--sun-misc-unsafe-memory-access=') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
         """
 
         when:


### PR DESCRIPTION
## Context

[`NoDaemon Java25 Adoptium Windows Amd64 (bucket16)`](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_13_bucket16/116076848) has been failing consistently on:

```
org.gradle.plugin.devel.plugins.JavaGradlePluginPluginIntegrationTest.can test plugin with ProjectBuilder without warnings or errors
```

```
java.lang.AssertionError: Standard error line 1 contains unexpected JDK warning:
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.jctools.util.UnsafeAccess (.../lib/jctools-core-4.0.5.jar)
WARNING: Please consider reporting this to the maintainers of class org.jctools.util.UnsafeAccess
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

## Root cause

Gradle itself triggers the warning. `WorkerLeaseQueueProcessor` and `MultiProducerSingleConsumerProcessor` use jctools queues, and `org.jctools.util.UnsafeAccess` calls `Unsafe::objectFieldOffset` in its static initializer. On Java 24+ the JVM prints a one-shot warning to stderr for terminally deprecated `sun.misc.Unsafe` memory-access methods ([JEP 498](https://openjdk.org/jeps/498)).

With a daemon the warning lands in the daemon log, so nobody sees it. In no-daemon mode the build JVM's stderr *is* the build's stderr, so the test — which is precisely the test asserting that Gradle emits no JDK warnings — sees it and fails.

## Fix

Pass `--sun-misc-unsafe-memory-access=allow` to daemon processes on Java 24+ (`JpmsConfiguration.forDaemonProcesses`). This is the same treatment we already give `--add-opens`/`--enable-native-access`: flags for warnings that come from Gradle's own runtime and that users can do nothing about.

Worker processes are deliberately left alone, so a warning caused by *user* code in a test/compile worker is still reported (e.g. `JUnit5PlatformFilteringIntegrationTest` relies on that).

`DaemonJvmSettingsIntegrationTest` counts non-JPMS daemon args, so the new flag is added to its filter.

## Verification

Reproduced and verified locally on macOS with Java 25:

| | `:plugin-development:noDaemonIntegTest --tests '...ProjectBuilder without warnings or errors'` |
|---|---|
| before | FAILED — identical `unexpected JDK warning` assertion |
| after | PASSED |

`:base-services:test --tests JpmsConfigurationTest` passes (47 tests).

Branch build of the originally failing job: [`NoDaemon Java25 Adoptium Windows Amd64 (bucket16)` #116115768](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_13_bucket16/116115768)
