### PR TITLE
Point Predictive Test Selection at the Develocity server, not the Edge

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -35,7 +35,6 @@ import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
 import gradlebuild.basics.BuildParams.DEFAULT_RFN_PERFORMANCE_BASELINES
 import gradlebuild.basics.BuildParams.DEFAULT_RFR_PERFORMANCE_BASELINES
-import gradlebuild.basics.BuildParams.DEVELOCITY_SERVER_URL_ENV
 import gradlebuild.basics.BuildParams.ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS
 import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
@@ -55,6 +54,7 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_MAX_PROJECTS
 import gradlebuild.basics.BuildParams.PERFORMANCE_STAGE_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
 import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
+import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_SERVER_URL
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
 import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
 import gradlebuild.basics.BuildParams.RUN_IDE_IN_HEADLESS_MODE
@@ -127,8 +127,8 @@ object BuildParams {
     const val PERFORMANCE_STAGE_ENV = "PERFORMANCE_STAGE"
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val RERUN_ALL_TESTS = "rerunAllTests"
-    const val DEVELOCITY_SERVER_URL_ENV = "DEVELOCITY_SERVER_URL"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
+    const val PREDICTIVE_TEST_SELECTION_SERVER_URL = "predictiveTestSelectionServerUrl"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"
@@ -388,8 +388,10 @@ val Project.testSplitOnlyTestGradleVersion: String
     get() = project.stringPropertyOrEmpty(TEST_SPLIT_ONLY_TEST_GRADLE_VERSION)
 
 
-val Project.develocityServerUrl: Provider<String>
-    get() = environmentVariable(DEVELOCITY_SERVER_URL_ENV)
+// The Develocity server that serves Predictive Test Selection. Deliberately not derived from
+// DEVELOCITY_SERVER_URL: CI points that at a Develocity Edge, and Edges do not serve PTS.
+val Project.predictiveTestSelectionServerUrl: Provider<String>
+    get() = gradleProperty(PREDICTIVE_TEST_SELECTION_SERVER_URL)
 
 
 val Project.predictiveTestSelectionEnabled: Provider<Boolean>

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -20,13 +20,13 @@ import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
-import gradlebuild.basics.develocityServerUrl
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionLocalExecutors
 import gradlebuild.basics.maxTestDistributionPartitionSecond
 import gradlebuild.basics.maxTestDistributionRemoteExecutors
 import gradlebuild.basics.predictiveTestSelectionEnabled
+import gradlebuild.basics.predictiveTestSelectionServerUrl
 import gradlebuild.basics.rerunAllTests
 import gradlebuild.basics.testDistributionDogfoodingTag
 import gradlebuild.basics.testDistributionEnabled
@@ -341,14 +341,17 @@ fun configureTests() {
             }
         }
 
+        // Set on every test task, not only the PTS-enabled ones: the selection server is shared per
+        // build invocation, so tasks that disagree fail with "Client was already created for a
+        // different server".
+        // Don't move this line into the lambda as it may cause config cache problems
+        val ptsServerUrl = project.predictiveTestSelectionServerUrl.getOrElse("https://ge.gradle.org")
+        extensions.findByType<DevelocityTestConfiguration>()?.predictiveTestSelection {
+            (this as PredictiveTestSelectionConfigurationInternal).server = uri(ptsServerUrl)
+        }
+
         if (project.supportsPredictiveTestSelection() && !isUnitTest()) {
-            // Falling back to https://ge.gradle.org when absent (e.g. GitHub actions for contributor PRs,
-            // which use a public Build Scan instance).
-            // Don't move this line into the lambda as it may cause config cache problems
-            val ptsServerUrl = project.develocityServerUrl.getOrElse("https://ge.gradle.org")
             extensions.findByType<DevelocityTestConfiguration>()?.predictiveTestSelection {
-                this as PredictiveTestSelectionConfigurationInternal
-                server = uri(ptsServerUrl)
                 enabled.convention(project.predictiveTestSelectionEnabled)
             }
         }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5300

### Context

PTS has been silently disabled on every CI check build that runs it since #38164 (2026-06-10). Builds report:

```
Predictive Test Selection selected all test classes due to: Build plugin encountered an internal error.
com.gradle.enterprise.testacceleration.client.api.TestSelectionException: Unexpected response from server: 404 Not Found (text/plain; charset=utf-8)
```

CI sets `DEVELOCITY_SERVER_URL` to a Develocity **Edge** (`eun-edge.gradle.org` on Hetzner agents, `usw2-edge.gradle.org` on EC2 agents), and #38164 made the PTS selection server follow that variable. Edges proxy the build cache and Build Scan publishing only — they do not serve `/predictive-test-selection/`, confirmed by the Develocity team — so every selection request 404s and the plugin falls back to running all test classes. No coverage was lost, but feature-branch and PR check builds have been running full test sets instead of selected ones.

Pointing `DEVELOCITY_SERVER_URL` back at `ge.gradle.org` is not an option: CI relies on the explicit per-pool Edge URL to pin EU agents to the EU Edge and US agents to the US Edge. Edge discovery cannot express that — it resolves the Edge from the *account's* preferred-location setting (`DefaultEdgeSelectionStrategy.selectInitialEdge` → `BuildAgentCheckInResult.getUserPreferredEdge()`), with no per-build override, so one URL plus one CI user means one Edge.

### What this changes

The PTS selection server now comes from a dedicated `predictiveTestSelectionServerUrl` Gradle property defaulting to `https://ge.gradle.org`, independent of the Develocity server. This mirrors test distribution, which has always targeted `gbt-td.grdev.net` independently of `DEVELOCITY_SERVER_URL`. CI keeps talking to a nearby Edge for caching and scan publishing.

The `server` assignment moves out of the `supportsPredictiveTestSelection() && !isUnitTest()` gate so it applies to every test task, again mirroring `testDistribution`. This matters: `TestAccelerationService` is shared per build invocation and throws `Client was already created for a different server` when two test tasks disagree about the URL. That is exactly what #38164 hit, because the hardcoded `ge.gradle.org` applied only to the gated tasks while the rest defaulted to the Develocity server. Setting it unconditionally keeps all test tasks in agreement without tying PTS to the Edge.

### Verification

Ready for Nightly branch build on `bz-pts-server-url` @ `dee0116`: [#18762](https://builds.gradle.org/build/116203249) — **316/316 chain builds green**.

PTS is live again on both Edge pools, and it is actually deselecting test classes rather than falling back to the full set (Develocity work-unit data for that run):

| Agent pool (`DEVELOCITY_SERVER_URL`) | PTS-enabled test tasks | tasks that deselected | test classes skipped | serial time saved |
|---|---|---|---|---|
| EC2 (`https://usw2-edge.gradle.org`) | 417 | 122 | 2,533 | 12h 48m |
| Windows/Hetzner (`https://eun-edge.gradle.org`) | 423 | 82 | 1,014 | 4h 19m |

Console output on a Hetzner-pool agent — `windows389`, whose resolved `env.DEVELOCITY_SERVER_URL` is `https://eun-edge.gradle.org` — in [`quickFeedbackCrossVersionTest`](https://ge.gradle.org/s/ypjtqtkr5yehi):

```
Predictive Test Selection: 240 of 558 test classes selected with profile 'Standard' (saving 33m 43s serial time)
Predictive Test Selection: 34 of 44 test classes selected with profile 'Standard' (saving 5m 45s serial time)
Predictive Test Selection: 4 of 9 test classes selected with profile 'Standard' (saving 4m 15s serial time)
```

No `selected all test classes due to: ... 404` / `TestSelectionException` anywhere in the run. The Edge keeps serving the build cache as before — that same build recorded 42 remote cache hits and 2m 53s of remote-cache avoidance savings.

Unrelated failure in the run: `JavaIncrementalExecutionPerformanceTest > assemble for non-abi change with file system sensitive archives` flagged a 86.5 ms (1.19%) slowdown vs `9.8.0-commit-896c6f90fef`. Performance tests do not use PTS selection, and the build itself is green.

