### PR TITLE
Exclude Java 27 from Groovy test coverage on release

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -99,7 +99,12 @@ class GroovyCoverage {
     private static Set<String> groovyVersionsSupportedByJdk(JavaVersion javaVersion) {
         def allVersions = allVersions()
 
-        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_26)) {
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_27)) {
+            // This branch does not support Java 27. None of the covered Groovy versions can be used with it:
+            // 4.0.x bundles an ASM that fails to read class file major version 71, and 5.0.x cannot target Java 27.
+            // JDK 27 is present on the test executor images, so it has to be excluded explicitly here.
+            return Collections.emptySet()
+        } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_26)) {
             return VersionCoverage.versionsAtLeast(allVersions, '4.0.29')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_25)) {
             return VersionCoverage.versionsAtLeast(allVersions, '3.0.25')


### PR DESCRIPTION
The TDimages provide JDK 27, but this branch does not support Java 27. `groovyVersionsSupportedByJdk` treated any JDK compatible with Java 26 as supporting Groovy 4.0.29+, so JDK 27 became the highest "supported" JDK for Groovy 4.0.29, 4.0.32 and 5.0.2. That made `GroovyCompileToolchainIntegrationTest` run its Java 27 variants and made all other tests for those Groovy versions compile under JDK 27:

- Groovy 4.0.29/4.0.32 fail with "Unsupported class file major version 71", because their bundled ASM cannot read Java 27 class files.
- Groovy 5.0.2 compiles but clamps the target to Java 26, while `getEffectiveTarget` predicts the Java 8 fallback.

Whether a build went red depended on whether its tests happened to run on a remote test executor, which is why this looked flaky.

Report no supported Groovy versions for Java 27 instead. The Java 27 variants are skipped again, and `groovyVersionsSupportedByAvailableJdks` falls through to the next lower JDK for every Groovy version, so no coverage is lost.
