### PR TITLE
Fix BaseExecSpec regression with stdin/stout/sterr redirects

### DIFF
--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilder.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilder.java
@@ -278,11 +278,19 @@ public class DefaultClientExecHandleBuilder implements ClientExecHandleBuilder, 
         return buildWithEffectiveArguments(argumentsSpec.getAllArguments());
     }
 
+    // One stream for both outputs means the caller wants them merged, so let the process merge them.
+    // Reading them separately would give two threads the same stream, and the one that finishes
+    // first closes it while the other is still writing.
+    private boolean isRedirectingErrorStream() {
+        return redirectErrorStream || streamsSpec.getErrorOutput() == streamsSpec.getStandardOutput();
+    }
+
     @Override
     public ExecHandle buildWithEffectiveArguments(List<String> effectiveArguments) {
         String displayName = this.displayName == null ? String.format("command '%s'", executable) : this.displayName;
         Map<String, String> effectiveEnvironment = getEffectiveEnvironment(getEnvironment());
-        StreamsHandler effectiveOutputHandler = getEffectiveStreamsHandler(streamsHandler, streamsSpec, redirectErrorStream);
+        boolean effectiveRedirectErrorStream = isRedirectingErrorStream();
+        StreamsHandler effectiveOutputHandler = getEffectiveStreamsHandler(streamsHandler, streamsSpec, effectiveRedirectErrorStream);
         return new DefaultExecHandle(
             displayName,
             getWorkingDir(),
@@ -292,7 +300,7 @@ public class DefaultClientExecHandleBuilder implements ClientExecHandleBuilder, 
             effectiveOutputHandler,
             inputHandler,
             listeners,
-            redirectErrorStream,
+            effectiveRedirectErrorStream,
             timeoutMillis,
             daemon,
             executor,

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilder.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilder.java
@@ -281,6 +281,7 @@ public class DefaultClientExecHandleBuilder implements ClientExecHandleBuilder, 
     // One stream for both outputs means the caller wants them merged, so let the process merge them.
     // Reading them separately would give two threads the same stream, and the one that finishes
     // first closes it while the other is still writing.
+    // Only the same object is detected: two streams wrapping one destination still race.
     private boolean isRedirectingErrorStream() {
         return redirectErrorStream || streamsSpec.getErrorOutput() == streamsSpec.getStandardOutput();
     }

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/DefaultExecAction.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/DefaultExecAction.java
@@ -232,7 +232,9 @@ public class DefaultExecAction implements ExecAction {
 
     @Override
     public OutputStream getStandardOutput() {
-        return execSpec.getStandardOutput();
+        OutputStream standardOutput = execSpec.getStandardOutput();
+        // The spec is empty until someone sets a stream. The defaults live on the handle builder.
+        return standardOutput != null ? standardOutput : execHandleBuilder.getStandardOutput();
     }
 
     @Override
@@ -243,7 +245,8 @@ public class DefaultExecAction implements ExecAction {
 
     @Override
     public OutputStream getErrorOutput() {
-        return execSpec.getErrorOutput();
+        OutputStream errorOutput = execSpec.getErrorOutput();
+        return errorOutput != null ? errorOutput : execHandleBuilder.getErrorOutput();
     }
 
     @Override
@@ -253,7 +256,8 @@ public class DefaultExecAction implements ExecAction {
 
     @Override
     public InputStream getStandardInput() {
-        return execSpec.getStandardInput();
+        InputStream standardInput = execSpec.getStandardInput();
+        return standardInput != null ? standardInput : execHandleBuilder.getStandardInput();
     }
 
     @Override

--- a/platforms/core-runtime/process-services/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/platforms/core-runtime/process-services/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.test.preconditions.OsTestPreconditions
 
 import org.gradle.util.TestUtil
 import org.junit.Rule
+import spock.lang.Issue
 
 class DefaultExecActionFactoryTest extends ConcurrentSpec {
     @Rule
@@ -82,6 +83,36 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
 
         then:
         result.exitValue != 0
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38787")
+    def "exec action exposes the documented stream defaults before they are configured"() {
+        when:
+        def execAction = factory.newExecAction()
+
+        then:
+        execAction.standardOutput != null
+        execAction.errorOutput != null
+        execAction.standardInput != null
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38787")
+    def "exec action returns the configured stream instead of the default"() {
+        given:
+        def execAction = factory.newExecAction()
+        def standardOutput = new ByteArrayOutputStream()
+        def errorOutput = new ByteArrayOutputStream()
+        def standardInput = new ByteArrayInputStream(new byte[0])
+
+        when:
+        execAction.standardOutput = standardOutput
+        execAction.errorOutput = errorOutput
+        execAction.standardInput = standardInput
+
+        then:
+        execAction.standardOutput.is(standardOutput)
+        execAction.errorOutput.is(errorOutput)
+        execAction.standardInput.is(standardInput)
     }
 
     @Requires(OsTestPreconditions.NotWindows)

--- a/platforms/core-runtime/process-services/src/testFixtures/groovy/org/gradle/process/ShellScript.groovy
+++ b/platforms/core-runtime/process-services/src/testFixtures/groovy/org/gradle/process/ShellScript.groovy
@@ -107,6 +107,8 @@ abstract class ShellScript {
 
         abstract Builder printText(String text);
 
+        abstract Builder printTextToStdErr(String text);
+
         abstract Builder printEnvironmentVariable(String variableName)
 
         abstract Builder printWorkingDir()
@@ -146,6 +148,11 @@ abstract class ShellScript {
         }
 
         @Override
+        Builder printTextToStdErr(String text) {
+            return addLine("echo '$text' 1>&2")
+        }
+
+        @Override
         Builder printEnvironmentVariable(String variableName) {
             return addLine("echo $variableName=\$$variableName")
         }
@@ -179,6 +186,11 @@ abstract class ShellScript {
         @Override
         Builder printText(String text) {
             return addLine("echo $text")
+        }
+
+        @Override
+        Builder printTextToStdErr(String text) {
+            return addLine("echo $text 1>&2")
         }
 
         @Override

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
+import org.gradle.process.ShellScript
 import org.gradle.process.TestExecHttpServer
 import org.gradle.process.TestJavaMain
 import org.gradle.test.precondition.Requires
@@ -326,6 +327,34 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             'execTask', 'execInjectedTaskAction',
             'javaexecTask','javaexecInjectedTaskAction'
         ]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38787")
+    def "execOperations.exec can redirect error output to the default standard output"() {
+        given:
+        def script = ShellScript.builder()
+            .printTextToStdErr("Written to stderr by the process")
+            .writeTo(testDirectory, "stderr-only")
+
+        buildFile << """
+            def execOperations = services.get(ExecOperations)
+            tasks.register("run") {
+                doLast {
+                    execOperations.exec {
+                        it.commandLine(${ShellScript.cmdToVarargLiterals(script.commandLine)})
+                        it.errorOutput = it.standardOutput
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("run")
+
+        then:
+        // The script writes to stderr only, so this text reaches stdout only if the redirect worked.
+        outputContains("Written to stderr by the process")
+        !result.hasErrorOutput("Written to stderr by the process")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/31282")


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/38787

https://github.com/gradle/gradle/pull/38799/changes/35cd904794c41315f72c9ddb27f247696bc3026f fixes also a possible race condition where we put the same stream object to different threads and whichever reaches EOF first closes it while the other may still be writing: Replicated with 9.6.0 distribution where 1 in 8 runs logged IOException: flush() failed: stream is closed.