### PR TITLE
Archive CI reports only for test tasks that ran a test

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -77,7 +77,12 @@ class FlakyTestQuarantine(
         name = "Flaky Test Quarantine - ${testCoverage.asName()}"
         description = "Run all flaky tests skipped multiple times"
 
-        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = 60)
+        // Unlike the regular functional test builds, a quarantine build is not split into buckets and does not use
+        // test distribution, so it runs every test task of its coverage on a single agent. For AllVersionsCrossVersion
+        // that is one task per tested Gradle version per subproject - over a thousand of them - and how long they take
+        // depends entirely on how much of that the build cache can serve. Runs have landed anywhere between 45 minutes
+        // and well past an hour, so the timeout has to accommodate a cold cache.
+        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = 120)
 
         if (os == Os.LINUX) {
             steps {

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
@@ -120,11 +120,13 @@ abstract class TestFilesCleanupService @Inject constructor(
     override fun onFinish(event: FinishEvent) {
         if (event is TaskFinishEvent && taskPathToReports.containsKey(event.descriptor.taskPath)) {
             val taskPath = event.descriptor.taskPath
-            when (val result = event.result) {
+            when (event.result) {
                 is TaskSuccessResult -> {
-                    if (producedSomethingWorthArchiving(taskPath, result)) {
+                    val testResults = readTestResults(taskPath)
+                    // A task that isn't a test task has no result store to inspect, so archive its reports as before.
+                    if (testResults == null || testResults.ranAnyTest) {
                         addExecutedTaskPath(taskPath)
-                        if (containsFailedTest(taskPath)) {
+                        if (testResults?.containsFailedTest == true) {
                             addFailedTaskPath(taskPath)
                         }
                     }
@@ -141,38 +143,44 @@ abstract class TestFilesCleanupService @Inject constructor(
         }
     }
 
-    /**
-     * Whether a successful task produced reports this build has any reason to archive.
-     *
-     * A task that was up-to-date or came from the build cache didn't produce anything in this build,
-     * and it can't have failed either: a failing task is never up-to-date and its outputs are never
-     * cached. Its restored reports are identical to those an earlier build already published.
-     *
-     * A test task that ran can still end up with nothing to report, because a filter excluded every
-     * test it would have run - `-PflakyTests=ONLY` does exactly that for most tasks. Its reports are
-     * empty, so there is nothing worth archiving either.
-     *
-     * Skipping both matters most where a single build has a task per tested Gradle version per
-     * subproject: the flaky test quarantine build for AllVersionsCrossVersion has over a thousand of
-     * them, which used to blow past TeamCity's limit on the number of artifacts a build may publish.
-     */
     private
-    fun producedSomethingWorthArchiving(taskPath: String, result: TaskSuccessResult): Boolean =
-        !result.isUpToDate && !result.isFromCache && ranAnyTest(taskPath)
+    class TestTaskResults(val ranAnyTest: Boolean, val containsFailedTest: Boolean)
 
     /**
-     * Whether a test task recorded any test result. Always true for tasks that aren't test tasks,
-     * as there is no result store to inspect for those.
+     * Reads what a test task recorded, or `null` if the task isn't a test task.
+     *
+     * A test task can finish successfully without running a single test, because a filter excluded
+     * every test it would have run. `-PflakyTests=ONLY` does that to almost every task of the flaky
+     * test quarantine build for AllVersionsCrossVersion: it has one task per tested Gradle version
+     * per subproject, over a thousand of them, and only the handful in subprojects that actually
+     * have flaky cross-version tests select anything. The reports of the rest are empty, and
+     * archiving them used to blow past TeamCity's limit on the number of artifacts a build may
+     * publish.
+     *
+     * Note that an empty run is not the same as an empty result store: the store always holds the
+     * root result of a task whose test JVM started, so [SerializableTestResultStore.hasResults] is
+     * true even when nothing ran. The root is the only result written without a parent, and it is
+     * written last, so a result with a parent is an actual test class or test case.
      */
     private
-    fun ranAnyTest(taskPath: String): Boolean {
-        val binaryResultsDir = testTaskPathToBinaryResultsDir[taskPath] ?: return true
-        return SerializableTestResultStore(binaryResultsDir.get().toPath()).hasResults()
-    }
-
-    private
-    fun containsFailedTest(taskPath: String): Boolean {
-        return testTaskPathToBinaryResultsDir[taskPath]?.let { containsFailedTest(it.get()) } == true
+    fun readTestResults(taskPath: String): TestTaskResults? {
+        val binaryResultsDir = testTaskPathToBinaryResultsDir[taskPath] ?: return null
+        val store = SerializableTestResultStore(binaryResultsDir.get().toPath())
+        if (!store.hasResults()) {
+            return TestTaskResults(ranAnyTest = false, containsFailedTest = false)
+        }
+        var ranAnyTest = false
+        var containsFailedTest = false
+        store.forEachResult(SerializableTestResultStore.ResultProcessor { _, parentId, result, _ ->
+            if (parentId != null) {
+                ranAnyTest = true
+            }
+            // A task with a flaky result counts as failed, same as one with a plain failure
+            if (result.resultType == TestResult.ResultType.FAILURE) {
+                containsFailedTest = true
+            }
+        })
+        return TestTaskResults(ranAnyTest, containsFailedTest)
     }
 
     private
@@ -298,22 +306,6 @@ abstract class TestFilesCleanupService @Inject constructor(
         } else {
             prepareReportForCiPublishing(reports)
         }
-    }
-
-    // We count the test task containing flaky result as failed
-    private
-    fun containsFailedTest(testBinaryResultsDir: File): Boolean {
-        var containingFailures = false
-
-        val store = SerializableTestResultStore(testBinaryResultsDir.toPath())
-        if (store.hasResults()) {
-            store.forEachResult { result ->
-                if (result.innerResult.resultType == TestResult.ResultType.FAILURE) {
-                    containingFailures = true
-                }
-            }
-        }
-        return containingFailures
     }
 
     /**

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
@@ -120,11 +120,13 @@ abstract class TestFilesCleanupService @Inject constructor(
     override fun onFinish(event: FinishEvent) {
         if (event is TaskFinishEvent && taskPathToReports.containsKey(event.descriptor.taskPath)) {
             val taskPath = event.descriptor.taskPath
-            when (event.result) {
+            when (val result = event.result) {
                 is TaskSuccessResult -> {
-                    addExecutedTaskPath(taskPath)
-                    if (containsFailedTest(taskPath)) {
-                        addFailedTaskPath(taskPath)
+                    if (producedSomethingWorthArchiving(taskPath, result)) {
+                        addExecutedTaskPath(taskPath)
+                        if (containsFailedTest(taskPath)) {
+                            addFailedTaskPath(taskPath)
+                        }
                     }
                 }
 
@@ -137,6 +139,35 @@ abstract class TestFilesCleanupService @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Whether a successful task produced reports this build has any reason to archive.
+     *
+     * A task that was up-to-date or came from the build cache didn't produce anything in this build,
+     * and it can't have failed either: a failing task is never up-to-date and its outputs are never
+     * cached. Its restored reports are identical to those an earlier build already published.
+     *
+     * A test task that ran can still end up with nothing to report, because a filter excluded every
+     * test it would have run - `-PflakyTests=ONLY` does exactly that for most tasks. Its reports are
+     * empty, so there is nothing worth archiving either.
+     *
+     * Skipping both matters most where a single build has a task per tested Gradle version per
+     * subproject: the flaky test quarantine build for AllVersionsCrossVersion has over a thousand of
+     * them, which used to blow past TeamCity's limit on the number of artifacts a build may publish.
+     */
+    private
+    fun producedSomethingWorthArchiving(taskPath: String, result: TaskSuccessResult): Boolean =
+        !result.isUpToDate && !result.isFromCache && ranAnyTest(taskPath)
+
+    /**
+     * Whether a test task recorded any test result. Always true for tasks that aren't test tasks,
+     * as there is no result store to inspect for those.
+     */
+    private
+    fun ranAnyTest(taskPath: String): Boolean {
+        val binaryResultsDir = testTaskPathToBinaryResultsDir[taskPath] ?: return true
+        return SerializableTestResultStore(binaryResultsDir.get().toPath()).hasResults()
     }
 
     private

--- a/build-logic/buildquality/src/test/kotlin/gradlebuild/testcleanup/TestFilesCleanupServiceTest.kt
+++ b/build-logic/buildquality/src/test/kotlin/gradlebuild/testcleanup/TestFilesCleanupServiceTest.kt
@@ -52,6 +52,7 @@ class TestFilesCleanupServiceTest {
             include(":flaky-test-with-leftover")
             include(":flaky-test-without-leftover")
             include(":successful-report")
+            include(":test-without-selected-tests")
             """.trimIndent()
         )
 
@@ -74,6 +75,7 @@ class TestFilesCleanupServiceTest {
         projectDir.resolve("flaky-test-with-leftover/src/test/java/FlakyTest.java").writeFlakyTest(true)
         projectDir.resolve("flaky-test-without-leftover/src/test/java/FlakyTest.java").writeFlakyTest(true)
         projectDir.resolve("successful-report").mkdirs()
+        projectDir.resolve("test-without-selected-tests/src/test/java/FlakyTest.java").writeFlakyTest(false)
 
         projectDir.resolve("build.gradle.kts").writeText(
             """
@@ -118,6 +120,18 @@ class TestFilesCleanupServiceTest {
                         }
                     }
                     useJUnitPlatform()
+                }
+            }
+
+            // Runs a real Test task that selects no test at all, like `-PflakyTests=ONLY` does to most
+            // tasks of the flaky test quarantine build. Its reports are empty and must not be archived.
+            project(":test-without-selected-tests") {
+                configureTestWithLeftover(false, false)
+                tasks.named<Test>("test").configure {
+                    filter {
+                        isFailOnNoMatchingTests = false
+                        includeTestsMatching("NoSuchTestClass")
+                    }
                 }
             }
 
@@ -191,6 +205,15 @@ class TestFilesCleanupServiceTest {
     }
 
     private
+    fun assertArchivedFilesNotSeen(vararg archiveFileNames: String) {
+        val rootDirFiles = projectDir.resolve("build").walk().toList()
+
+        archiveFileNames.forEach { fileName ->
+            assertTrue(rootDirFiles.none { it.name == fileName }, "File $fileName should not have been archived")
+        }
+    }
+
+    private
     fun assertLeftoverFilesCleanedUpEventually(vararg leftoverFiles: String) {
         leftoverFiles.forEach {
             assertTrue(projectDir.resolve(it).walk().filter { it.isFile }.toList().isEmpty())
@@ -215,6 +238,17 @@ class TestFilesCleanupServiceTest {
         assertEquals(TaskOutcome.SUCCESS, result.task(":flaky-test-without-leftover:test")!!.outcome)
 
         assertArchivedFilesSeen("report-flaky-test-without-leftover-test.zip")
+    }
+
+    @Test
+    fun `reports of a test task that selected no test are not archived`() {
+        val result = run(":test-without-selected-tests:test").build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":test-without-selected-tests:test")!!.outcome)
+
+        assertArchivedFilesNotSeen(
+            "report-test-without-selected-tests-test.zip",
+            "report-test-without-selected-tests.zip"
+        )
     }
 
     @Test


### PR DESCRIPTION
## Why

[Flaky Test Quarantine - AllVersionsCrossVersion #2](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_10/116157870) failed after every test passed:

```
Tests passed: 871; failed to publish artifacts: The number of internal artifacts (1128)
exceeds the current threshold of 1000.
```

`gradlebuild.cross-version-tests` registers one `Test` task per released Gradle version in each subproject that has cross-version tests. `TestFilesCleanupService` zips the HTML report directory of every executed task into `build/report-<project>-<task>.zip`, which the default artifact rules publish under the hidden `.teamcity/gradle-logs` path. Develocity confirms the scale: that build had **1102** cross-version test tasks - 19 subprojects x 58 tested versions - and 1102 report zips plus per-project trace zips and TeamCity's own internal files is the 1128.

The regular `AllVersionsCrossVersion` check never hits this because it is split into 14 version-range buckets, so each build sees ~1/14 of the tasks. `FlakyTestQuarantine` creates a single build per coverage and runs all versions at once. The config was only re-enabled on 2026-07-31 by f48219ee05e, so this is the first time it has been hit.

**Almost none of those reports contain anything.** Of the 188 tasks that actually executed in that build, Develocity records **163 that discovered zero test classes**:

| subproject | executed tasks | discovered 0 test classes |
| --- | --- | --- |
| `:precondition-tester` | 58 | 58 |
| `:wrapper-main` | 52 | 52 |
| `:tooling-native` | 52 | 52 |
| `:ide-plugins` | 1 | 1 |
| `:tooling-api` | 25 | 0 |

`-PflakyTests=ONLY` sets `includeTags("none() | Flaky")` plus `includeSpockAnnotation(Flaky)`, and `:tooling-api` is the only subproject with `@Flaky` cross-version tests (9 files out of 291 specs). Everywhere else the filter selects nothing, so the task starts a test JVM, runs no test, and writes an empty HTML report. `:precondition-tester` is the clearest case: its `src/crossVersionTest` holds nothing but a `.gitkeep`, yet it contributes 58 report zips per build.

## What

Archive a successful task's reports only when it actually ran a test.

**Cache state is not consulted.** A task restored from the build cache is treated exactly like one that executed - if its results contain tests, its reports are archived.

The emptiness check cannot be `SerializableTestResultStore.hasResults()`. That method reports whether the results file has any entry, and `Writer.completed()` writes an entry for every completed descriptor **including the root**, which always completes once the test JVM starts. So `hasResults()` is true even when no test ran. The root is written last and is the only result without a parent, so **a result with a parent is an actual test class or test case** - that is the signal used here.

Reading the store once now produces both signals, replacing the separate pass `containsFailedTest` used to make, so this is one fewer read per test task than before.

Unchanged: failing tasks (`TaskFailureResult`) are always archived; skipped/NO-SOURCE tasks are still ignored via the existing `else` branch; non-test `Reporting` tasks have no result store to inspect and keep their current behaviour; leftover `teŝt files` archiving is untouched.

### Why not the earlier revision

The first version of this PR also skipped tasks that were `FROM-CACHE` or `UP-TO-DATE`, which @cobexer correctly pushed back on. Measuring it afterwards showed that filter was doing *all* of the work and the empty-results check was doing none: verification build [#4](https://builds.gradle.org/build/116196017) executed 184 cross-version tasks and published exactly 184 zips, the same per-subproject breakdown, including all 174 from the three subprojects that discover zero test classes. The `hasResults()` check filtered nothing, for the reason explained above. Dropping the cache guard and fixing the emptiness check addresses the review and gets a strictly better result.

## Verification

New regression test `reports of a test task that selected no test are not archived`: a real `Test` task with a filter that matches nothing runs, succeeds, and must produce no report zip. It fails against the previous implementation. Full `TestFilesCleanupServiceTest` run: 5/5 green ([scan](https://ge.gradle.org/s/favkgrfpeinhy)).

Quarantine build on this branch: [#5, 116236682](https://builds.gradle.org/build/116236682) - **SUCCESS, 62 internal artifacts** against 1128 before.

What it published: 58 `:tooling-api` cross-version report zips (one per tested version), `report-tooling-api.zip`, `report-tooling-api-daemon.zip`, and 2 `.psoutput`. Nothing else.

Two things make this run a strong check rather than a lucky one:

- **It was a fully cold cache.** All 1102 cross-version test tasks executed - no cache hits at all - which is the worst case for artifact count. The earlier cache-based revision would have archived all 1102 here and failed again; this is exactly the fragility that made the cache guard the wrong mechanism.
- **Nothing that ran a test lost its report.** All 1259 tests in the build are in `org.gradle.integtests.tooling.*`, i.e. every test came from `:tooling-api`, and all 58 of its tasks kept their reports. No other subproject ran a single test.

**The cached case is now demonstrated too.** A warm re-run, [#6, 116239316](https://builds.gradle.org/build/116239316), hit the cache for every `:tooling-api` task - **58 of 58 `FROM-CACHE`**, zero tests executed in the build, TeamCity reports 0 test occurrences - and still archived **all 58** report zips from the restored result stores (61 artifacts total; the `-daemon` leftover zip is absent because nothing ran). That is exactly @cobexer's requirement: a cached test task's reports are archived. Meanwhile the other 1044 cached tasks were still correctly skipped, because their restored stores contain no test results.

The two runs bracket the extremes:

| run | cache | cross-version tasks executed | artifacts | `:tooling-api` zips |
| --- | --- | --- | --- | --- |
| [#5](https://builds.gradle.org/build/116236682) | cold | 1102 of 1102 | 62 | 58 |
| [#6](https://builds.gradle.org/build/116239316) | warm | 0 of 1102 | 61 | 58 |

The artifact count is stable across both because it now tracks what has test results, not what the cache happened to serve - unlike the earlier revision, whose count scaled with cache misses and would have hit ~1102 on run #5.

## Also: raise the timeout to 120 minutes

Separate symptom of the same config. A quarantine build is not split into buckets and does not use test distribution, unlike the regular functional test builds, so it runs every test task of its coverage on one agent and its wall clock is governed by build cache hit rate:

| run | outcome | cross-version tasks still executing at the end |
| --- | --- | --- |
| [#1](https://builds.gradle.org/build/116150703) | timeout at 60m | ~660 across 12 subprojects, cold cache |
| [#2](https://builds.gradle.org/build/116157870) | 45m52s | - |
| [#3](https://builds.gradle.org/build/116162593) | timeout at 60m | 52 `:tooling-api` tasks, ~33 minutes for that tail alone |
| [#4](https://builds.gradle.org/build/116196017) | success | warm cache |

In #3, ~900 tasks completed in the first 20 minutes at 40-60/min - the cached ones - then throughput collapsed to 1-2/min for the remaining 33 minutes as `:tooling-api` executed one Gradle distribution per version. 60 minutes leaves no headroom for a cold cache.

Raising the timeout is a band-aid. The real fix is to give quarantine builds the same version-range bucketing and test distribution the regular `AllVersionsCrossVersion` builds get, which would also cap the artifact count structurally. That is a larger change and belongs in its own PR.
