### PR TITLE
Keep type-use annotations in extracted ABI classes

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.packaging.tasks
+
+import java.io.File
+
+
+private
+val KOTLIN_MODULE_PATH = Regex("META-INF/.*\\.kotlin_module")
+
+
+internal
+enum class ContentFilter {
+    VERBATIM,
+    API_ONLY,
+    SKIP
+}
+
+
+/**
+ * What to do with [file] of a classes directory [classDir].
+ */
+internal
+fun contentFilterFor(classDir: File, file: File): ContentFilter =
+    contentFilterFor(file.relativeTo(classDir).path)
+
+
+/**
+ * What to do with the entry at [relativePath] of a classes directory.
+ *
+ * The path takes the separator of either operating system. The rules below need `/`, and
+ * a relative path on Windows comes with `\`.
+ */
+internal
+fun contentFilterFor(relativePath: String): ContentFilter {
+    val path = relativePath.replace('\\', '/')
+    // Extraction keeps the module and the package annotations, so module-info and
+    // package-info need no copy of their own
+    if (path.endsWith(".class")) {
+        return ContentFilter.API_ONLY
+    }
+    if (path == "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule") {
+        return ContentFilter.VERBATIM
+    }
+    if (path == "META-INF/services/org.codehaus.groovy.transform.ASTTransformation") {
+        return ContentFilter.VERBATIM
+    }
+    if (path.matches(KOTLIN_MODULE_PATH)) {
+        return ContentFilter.VERBATIM
+    }
+    return ContentFilter.SKIP
+}

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
@@ -36,8 +36,8 @@ enum class ContentFilter {
  */
 internal
 fun contentFilterFor(relativePath: String): ContentFilter {
-    // Extraction keeps the module and the package annotations, so module-info and
-    // package-info need no copy of their own
+    // The extractor includes the package-private members, so it keeps module-info and
+    // package-info with the module directives and the package annotations of those files
     if (relativePath.endsWith(".class")) {
         return ContentFilter.API_ONLY
     }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ContentFilter.kt
@@ -16,8 +16,6 @@
 
 package gradlebuild.packaging.tasks
 
-import java.io.File
-
 
 private
 val KOTLIN_MODULE_PATH = Regex("META-INF/.*\\.kotlin_module")
@@ -32,34 +30,24 @@ enum class ContentFilter {
 
 
 /**
- * What to do with [file] of a classes directory [classDir].
- */
-internal
-fun contentFilterFor(classDir: File, file: File): ContentFilter =
-    contentFilterFor(file.relativeTo(classDir).path)
-
-
-/**
  * What to do with the entry at [relativePath] of a classes directory.
  *
- * The path takes the separator of either operating system. The rules below need `/`, and
- * a relative path on Windows comes with `\`.
+ * The caller gives a path with `/` as separator on every operating system.
  */
 internal
 fun contentFilterFor(relativePath: String): ContentFilter {
-    val path = relativePath.replace('\\', '/')
     // Extraction keeps the module and the package annotations, so module-info and
     // package-info need no copy of their own
-    if (path.endsWith(".class")) {
+    if (relativePath.endsWith(".class")) {
         return ContentFilter.API_ONLY
     }
-    if (path == "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule") {
+    if (relativePath == "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule") {
         return ContentFilter.VERBATIM
     }
-    if (path == "META-INF/services/org.codehaus.groovy.transform.ASTTransformation") {
+    if (relativePath == "META-INF/services/org.codehaus.groovy.transform.ASTTransformation") {
         return ContentFilter.VERBATIM
     }
-    if (path.matches(KOTLIN_MODULE_PATH)) {
+    if (relativePath.matches(KOTLIN_MODULE_PATH)) {
         return ContentFilter.VERBATIM
     }
     return ContentFilter.SKIP

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -19,10 +19,8 @@ package gradlebuild.packaging.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
@@ -36,16 +34,13 @@ import javax.inject.Inject
  *
  * Keeps only the following:
  *
- * -  API stubs of public classes in the specified packages
+ * - API stubs of the classes, including the package-private ones
  * - `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule`
  * - `META-INF/services/org.codehaus.groovy.transform.ASTTransformation`
  * - `META-INF/\*.kotlin_module`
  */
 @CacheableTask
 abstract class ExtractJavaAbi : DefaultTask() {
-
-    @get:Input
-    abstract val packages: SetProperty<String>
 
     // Do not change this to CompileClasspath. It hashes the input with the ABI extractor of the
     // distribution that runs this build, and that extractor drops the details this task keeps.
@@ -69,7 +64,6 @@ abstract class ExtractJavaAbi : DefaultTask() {
         // The worker process keeps extraction failures and heap out of the build process,
         // IsolatedApiClassExtractor keeps the extractor away from the distribution running this build
         workerExecutor.processIsolation().submit(ExtractJavaAbiAction::class.java) {
-            packages.set(task.packages)
             classesDirectories.setFrom(task.classesDirectories)
             outputDirectory.set(task.outputDirectory)
             extractorClasspath.setFrom(task.extractorClasspath)
@@ -79,7 +73,6 @@ abstract class ExtractJavaAbi : DefaultTask() {
     abstract class ExtractJavaAbiAction @Inject constructor() : WorkAction<ExtractJavaAbiAction.Params> {
 
         interface Params : WorkParameters {
-            val packages: SetProperty<String>
             val classesDirectories: ConfigurableFileCollection
             val outputDirectory: DirectoryProperty
             val extractorClasspath: ConfigurableFileCollection
@@ -87,7 +80,7 @@ abstract class ExtractJavaAbi : DefaultTask() {
 
         override fun execute() {
             val outputDirectory = parameters.outputDirectory.get().asFile
-            IsolatedApiClassExtractor.runUsing(parameters.extractorClasspath, parameters.packages.get()) { extractor ->
+            IsolatedApiClassExtractor.runUsing(parameters.extractorClasspath) { extractor ->
                 parameters.classesDirectories.forEach { classDir ->
                     classDir.walk().forEach { inputFile ->
                         val relativePath = inputFile.relativeTo(classDir).invariantSeparatorsPath

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -85,7 +85,7 @@ abstract class ExtractJavaAbi : DefaultTask() {
 
         override fun execute() {
             val outputDirectory = parameters.outputDirectory.get().asFile
-            IsolatedApiClassExtractor(parameters.extractorClasspath, parameters.packages.get()).use { extractor ->
+            IsolatedApiClassExtractor.runUsing(parameters.extractorClasspath, parameters.packages.get()) { extractor ->
                 parameters.classesDirectories.forEach { classDir ->
                     classDir.walk().forEach { inputFile ->
                         val outputFile = outputDirectory.resolve(inputFile.relativeTo(classDir).path)

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -92,10 +92,10 @@ abstract class ExtractJavaAbi : DefaultTask() {
                 parameters.classesDirectories.forEach { classDir ->
                     classDir.walk().forEach { inputFile ->
                         val outputFile = outputDirectory.resolve(inputFile.relativeTo(classDir).path)
-                        when (inputFile.filtering()) {
+                        when (contentFilterFor(classDir, inputFile)) {
                             ContentFilter.VERBATIM -> {
                                 outputFile.parentFile.mkdirs()
-                                inputFile.copyTo(outputFile)
+                                inputFile.copyTo(outputFile, overwrite = true)
                             }
 
                             ContentFilter.API_ONLY -> {
@@ -114,39 +114,5 @@ abstract class ExtractJavaAbi : DefaultTask() {
                 }
             }
         }
-
-        private
-        fun File.filtering(): ContentFilter {
-            if (name.endsWith(".class")) {
-                return if (name.endsWith("/module-info.class")
-                    || name.endsWith("/package-info.class")
-                ) {
-                    ContentFilter.VERBATIM
-                } else {
-                    ContentFilter.API_ONLY
-                }
-            }
-            if (name.equals("META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule")) {
-                return ContentFilter.VERBATIM
-            }
-            if (name.equals("META-INF/services/org.codehaus.groovy.transform.ASTTransformation")) {
-                return ContentFilter.VERBATIM
-            }
-            if (name.matches(KOTLIN_MODULE_PATH)) {
-                return ContentFilter.VERBATIM
-            }
-            return ContentFilter.SKIP
-        }
-    }
-
-    private
-    enum class ContentFilter {
-        VERBATIM,
-        API_ONLY,
-        SKIP
-    }
-
-    companion object {
-        val KOTLIN_MODULE_PATH = Regex("META-INF/.*\\.kotlin_module")
     }
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -26,13 +26,10 @@ import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.tools.api.ApiClassExtractor
-import org.gradle.internal.tools.api.impl.JavaApiMemberWriter
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
 import java.io.File
-import java.io.InputStream
 import javax.inject.Inject
 
 
@@ -66,16 +63,14 @@ abstract class ExtractJavaAbi : DefaultTask() {
 
     @TaskAction
     fun execute() {
-        // Run using process isolation to avoid using the ABI extractor from the runtime Gradle distribution
-        // FIXME This actually does not achieve the desired goal, and we end up using the runtime distribution
-        //       For a proper fix we need to shade the API extractor
         val task = this
-        workerExecutor.processIsolation {
-            classpath.setFrom(extractorClasspath)
-        }.submit(ExtractJavaAbiAction::class.java) {
+        // The worker process keeps extraction failures and heap out of the build process,
+        // IsolatedApiClassExtractor keeps the extractor away from the distribution running this build
+        workerExecutor.processIsolation().submit(ExtractJavaAbiAction::class.java) {
             packages.set(task.packages)
             classesDirectories.setFrom(task.classesDirectories)
             outputDirectory.set(task.outputDirectory)
+            extractorClasspath.setFrom(task.extractorClasspath)
         }
     }
 
@@ -85,51 +80,37 @@ abstract class ExtractJavaAbi : DefaultTask() {
             val packages: SetProperty<String>
             val classesDirectories: ConfigurableFileCollection
             val outputDirectory: DirectoryProperty
+            val extractorClasspath: ConfigurableFileCollection
         }
 
         override fun execute() {
-            val apiClassExtractor = with(ApiClassExtractor.withWriter(JavaApiMemberWriter.adapter())) {
-                val publicApiPackages = parameters.packages.get()
-                if (publicApiPackages.isNotEmpty()) {
-                    includePackagesMatching(publicApiPackages::contains)
-                } else {
-                    includePackagePrivateMembers()
-                }
-                build()
-            }
+            val outputDirectory = parameters.outputDirectory.get().asFile
+            IsolatedApiClassExtractor(parameters.extractorClasspath, parameters.packages.get()).use { extractor ->
+                parameters.classesDirectories.forEach { classDir ->
+                    classDir.walk().forEach { inputFile ->
+                        val outputFile = outputDirectory.resolve(inputFile.relativeTo(classDir).path)
+                        when (inputFile.filtering()) {
+                            ContentFilter.VERBATIM -> {
+                                outputFile.parentFile.mkdirs()
+                                inputFile.copyTo(outputFile)
+                            }
 
-            // Walk the classesDirectory and find each `.class` file
-            parameters.classesDirectories.forEach { classDir ->
-                classDir.walk().forEach { inputClassFile ->
-                    val relativePath = inputClassFile.relativeTo(classDir).path
-                    val outputClassFile = parameters.outputDirectory.get().asFile.resolve(relativePath)
-                    when (inputClassFile.filtering()) {
-                        ContentFilter.VERBATIM -> {
-                            outputClassFile.parentFile.mkdirs()
-                            inputClassFile.copyTo(outputClassFile)
-                        }
-
-                        ContentFilter.API_ONLY -> {
-                            inputClassFile.inputStream().use { input ->
-                                apiClassExtractor.extractApiClassFrom(input)
+                            ContentFilter.API_ONLY -> {
+                                extractor.extractApiClassFrom(inputFile.readBytes())
                                     .ifPresent { apiClass ->
-                                        outputClassFile.parentFile.mkdirs()
-                                        outputClassFile.outputStream().use { output -> output.write(apiClass) }
+                                        outputFile.parentFile.mkdirs()
+                                        outputFile.writeBytes(apiClass)
                                     }
                             }
-                        }
 
-                        ContentFilter.SKIP -> {
-                            // Skip the file
+                            ContentFilter.SKIP -> {
+                                // Skip the file
+                            }
                         }
                     }
                 }
             }
         }
-
-        private
-        fun ApiClassExtractor.extractApiClassFrom(input: InputStream) =
-            extractApiClassFrom(input.readAllBytes())
 
         private
         fun File.filtering(): ContentFilter {

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
-import java.io.File
 import javax.inject.Inject
 
 
@@ -91,8 +90,9 @@ abstract class ExtractJavaAbi : DefaultTask() {
             IsolatedApiClassExtractor.runUsing(parameters.extractorClasspath, parameters.packages.get()) { extractor ->
                 parameters.classesDirectories.forEach { classDir ->
                     classDir.walk().forEach { inputFile ->
-                        val outputFile = outputDirectory.resolve(inputFile.relativeTo(classDir).path)
-                        when (contentFilterFor(classDir, inputFile)) {
+                        val relativePath = inputFile.relativeTo(classDir).invariantSeparatorsPath
+                        val outputFile = outputDirectory.resolve(relativePath)
+                        when (contentFilterFor(relativePath)) {
                             ContentFilter.VERBATIM -> {
                                 outputFile.parentFile.mkdirs()
                                 inputFile.copyTo(outputFile, overwrite = true)

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/ExtractJavaAbi.kt
@@ -22,7 +22,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -49,7 +48,11 @@ abstract class ExtractJavaAbi : DefaultTask() {
     @get:Input
     abstract val packages: SetProperty<String>
 
-    @get:CompileClasspath
+    // Do not change this to CompileClasspath. It hashes the input with the ABI extractor of the
+    // distribution that runs this build, and that extractor drops the details this task keeps.
+    // A new type-use annotation then leaves this task up to date, and the stub jar keeps the
+    // old annotations.
+    @get:Classpath
     abstract val classesDirectories: ConfigurableFileCollection
 
     @get:OutputDirectory

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
@@ -33,13 +33,10 @@ import java.util.function.Predicate
  * JDK type or accessed reflectively for that reason.
  */
 internal
-class IsolatedApiClassExtractor(classpath: Iterable<File>, packages: Set<String>) : AutoCloseable {
-
-    private
-    val classLoader = URLClassLoader(
-        classpath.map { it.toURI().toURL() }.toTypedArray(),
-        ClassLoader.getPlatformClassLoader()
-    )
+class IsolatedApiClassExtractor private constructor(
+    private val classLoader: URLClassLoader,
+    packages: Set<String>
+) {
 
     private
     val extractorClass = classLoader.loadClass("org.gradle.internal.tools.api.ApiClassExtractor").also {
@@ -89,7 +86,21 @@ class IsolatedApiClassExtractor(classpath: Iterable<File>, packages: Set<String>
         return builderClass.getMethod("build").invoke(configuredBuilder)
     }
 
-    override fun close() {
-        classLoader.close()
+    companion object {
+
+        /**
+         * Runs [block] with an extractor loaded from [classpath], then closes the class loader.
+         *
+         * The class loader also closes when the extractor itself fails to come to life, which the
+         * isolation check does on purpose. The extractor holds the class loader, so it stays inside
+         * this scope.
+         */
+        fun <T> runUsing(classpath: Iterable<File>, packages: Set<String>, block: (IsolatedApiClassExtractor) -> T): T =
+            URLClassLoader(
+                classpath.map { it.toURI().toURL() }.toTypedArray(),
+                ClassLoader.getPlatformClassLoader()
+            ).use { classLoader ->
+                block(IsolatedApiClassExtractor(classLoader, packages))
+            }
     }
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.packaging.tasks
+
+import java.io.File
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
+import java.util.Optional
+import java.util.function.Predicate
+
+
+/**
+ * Extracts API classes using the `org.gradle.internal.tools.api` extractor found on the given classpath.
+ *
+ * The extractor is loaded in a class loader that has no access to the Gradle distribution running this
+ * build. Without that, `org.gradle.internal.tools.api` resolves parent-first against the running
+ * distribution, and we silently extract with the extractor of whatever Gradle version happens to build
+ * this source tree instead of the one built from it. Everything crossing the boundary here is either a
+ * JDK type or accessed reflectively for that reason.
+ */
+internal
+class IsolatedApiClassExtractor(classpath: Iterable<File>, packages: Set<String>) : AutoCloseable {
+
+    private
+    val classLoader = URLClassLoader(
+        classpath.map { it.toURI().toURL() }.toTypedArray(),
+        ClassLoader.getPlatformClassLoader()
+    )
+
+    private
+    val extractorClass = classLoader.loadClass("org.gradle.internal.tools.api.ApiClassExtractor").also {
+        // Nothing else fails when the isolation breaks, we just quietly extract with the wrong extractor
+        check(it.classLoader === classLoader) {
+            "$it was loaded by ${it.classLoader} instead of the isolated class loader, " +
+                "so the extracted API would be the one of the Gradle distribution running this build"
+        }
+    }
+
+    private
+    val extractor = newExtractor(packages)
+
+    private
+    val extractApiClassFromMethod = extractorClass.getMethod("extractApiClassFrom", ByteArray::class.java)
+
+    @Suppress("UNCHECKED_CAST")
+    fun extractApiClassFrom(classBytes: ByteArray): Optional<ByteArray> =
+        try {
+            extractApiClassFromMethod.invoke(extractor, classBytes) as Optional<ByteArray>
+        } catch (e: InvocationTargetException) {
+            // Surface the extractor's own failure, not the reflective wrapper around it
+            throw e.targetException
+        }
+
+    /**
+     * Reflective equivalent of:
+     * ```
+     * ApiClassExtractor.withWriter(JavaApiMemberWriter.adapter())
+     *     .includePackagePrivateMembers() // or .includePackagesMatching(packages::contains)
+     *     .build()
+     * ```
+     */
+    private
+    fun newExtractor(packages: Set<String>): Any {
+        val writerAdapterClass = classLoader.loadClass("org.gradle.internal.tools.api.ApiMemberWriterAdapter")
+        val writerClass = classLoader.loadClass("org.gradle.internal.tools.api.impl.JavaApiMemberWriter")
+        val writerAdapter = writerClass.getMethod("adapter").invoke(null)
+        val builder = extractorClass.getMethod("withWriter", writerAdapterClass).invoke(null, writerAdapter)
+        val builderClass = builder.javaClass
+        val configuredBuilder = if (packages.isEmpty()) {
+            builderClass.getMethod("includePackagePrivateMembers").invoke(builder)
+        } else {
+            builderClass.getMethod("includePackagesMatching", Predicate::class.java)
+                .invoke(builder, Predicate<String> { it in packages })
+        }
+        return builderClass.getMethod("build").invoke(configuredBuilder)
+    }
+
+    override fun close() {
+        classLoader.close()
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/IsolatedApiClassExtractor.kt
@@ -20,7 +20,6 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 import java.util.Optional
-import java.util.function.Predicate
 
 
 /**
@@ -34,8 +33,7 @@ import java.util.function.Predicate
  */
 internal
 class IsolatedApiClassExtractor private constructor(
-    private val classLoader: URLClassLoader,
-    packages: Set<String>
+    private val classLoader: URLClassLoader
 ) {
 
     private
@@ -48,7 +46,7 @@ class IsolatedApiClassExtractor private constructor(
     }
 
     private
-    val extractor = newExtractor(packages)
+    val extractor = newExtractor()
 
     private
     val extractApiClassFromMethod = extractorClass.getMethod("extractApiClassFrom", ByteArray::class.java)
@@ -66,23 +64,18 @@ class IsolatedApiClassExtractor private constructor(
      * Reflective equivalent of:
      * ```
      * ApiClassExtractor.withWriter(JavaApiMemberWriter.adapter())
-     *     .includePackagePrivateMembers() // or .includePackagesMatching(packages::contains)
+     *     .includePackagePrivateMembers()
      *     .build()
      * ```
      */
     private
-    fun newExtractor(packages: Set<String>): Any {
+    fun newExtractor(): Any {
         val writerAdapterClass = classLoader.loadClass("org.gradle.internal.tools.api.ApiMemberWriterAdapter")
         val writerClass = classLoader.loadClass("org.gradle.internal.tools.api.impl.JavaApiMemberWriter")
         val writerAdapter = writerClass.getMethod("adapter").invoke(null)
         val builder = extractorClass.getMethod("withWriter", writerAdapterClass).invoke(null, writerAdapter)
         val builderClass = builder.javaClass
-        val configuredBuilder = if (packages.isEmpty()) {
-            builderClass.getMethod("includePackagePrivateMembers").invoke(builder)
-        } else {
-            builderClass.getMethod("includePackagesMatching", Predicate::class.java)
-                .invoke(builder, Predicate<String> { it in packages })
-        }
+        val configuredBuilder = builderClass.getMethod("includePackagePrivateMembers").invoke(builder)
         return builderClass.getMethod("build").invoke(configuredBuilder)
     }
 
@@ -95,12 +88,12 @@ class IsolatedApiClassExtractor private constructor(
          * isolation check does on purpose. The extractor holds the class loader, so it stays inside
          * this scope.
          */
-        fun <T> runUsing(classpath: Iterable<File>, packages: Set<String>, block: (IsolatedApiClassExtractor) -> T): T =
+        fun <T> runUsing(classpath: Iterable<File>, block: (IsolatedApiClassExtractor) -> T): T =
             URLClassLoader(
                 classpath.map { it.toURI().toURL() }.toTypedArray(),
                 ClassLoader.getPlatformClassLoader()
             ).use { classLoader ->
-                block(IsolatedApiClassExtractor(classLoader, packages))
+                block(IsolatedApiClassExtractor(classLoader))
             }
     }
 }

--- a/build-logic/packaging/src/test/kotlin/gradlebuild/packaging/tasks/ContentFilterTest.kt
+++ b/build-logic/packaging/src/test/kotlin/gradlebuild/packaging/tasks/ContentFilterTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.packaging.tasks
+
+import gradlebuild.packaging.tasks.ContentFilter.API_ONLY
+import gradlebuild.packaging.tasks.ContentFilter.SKIP
+import gradlebuild.packaging.tasks.ContentFilter.VERBATIM
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+
+internal
+class ContentFilterTest {
+
+    @TempDir
+    lateinit var classDir: File
+
+    @Test
+    fun classifies_the_entries_of_a_classes_directory() {
+        val expectations = mapOf(
+            "org/gradle/api/Task.class" to API_ONLY,
+            // Extraction keeps the module and the package annotations, so these need no copy
+            "module-info.class" to API_ONLY,
+            "org/gradle/api/package-info.class" to API_ONLY,
+            "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule" to VERBATIM,
+            "META-INF/services/org.codehaus.groovy.transform.ASTTransformation" to VERBATIM,
+            "META-INF/org.gradle.core.kotlin_module" to VERBATIM,
+            "META-INF/MANIFEST.MF" to SKIP,
+            "META-INF/services/some.other.Service" to SKIP
+        )
+
+        assertAll(expectations.map { (relativePath, expected) ->
+            Executable {
+                assertEquals(expected, contentFilterFor(classDir, fileAt(relativePath)), relativePath)
+            }
+        })
+    }
+
+    @Test
+    fun classifies_the_entries_of_a_windows_classes_directory() {
+        assertEquals(
+            VERBATIM,
+            contentFilterFor("META-INF\\services\\org.codehaus.groovy.transform.ASTTransformation")
+        )
+    }
+
+    private
+    fun fileAt(relativePath: String): File =
+        classDir.resolve(relativePath).also {
+            it.parentFile.mkdirs()
+            it.writeText("")
+        }
+}

--- a/build-logic/packaging/src/test/kotlin/gradlebuild/packaging/tasks/ContentFilterTest.kt
+++ b/build-logic/packaging/src/test/kotlin/gradlebuild/packaging/tasks/ContentFilterTest.kt
@@ -23,15 +23,10 @@ import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
-import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 
 internal
 class ContentFilterTest {
-
-    @TempDir
-    lateinit var classDir: File
 
     @Test
     fun classifies_the_entries_of_a_classes_directory() {
@@ -49,23 +44,8 @@ class ContentFilterTest {
 
         assertAll(expectations.map { (relativePath, expected) ->
             Executable {
-                assertEquals(expected, contentFilterFor(classDir, fileAt(relativePath)), relativePath)
+                assertEquals(expected, contentFilterFor(relativePath), relativePath)
             }
         })
     }
-
-    @Test
-    fun classifies_the_entries_of_a_windows_classes_directory() {
-        assertEquals(
-            VERBATIM,
-            contentFilterFor("META-INF\\services\\org.codehaus.groovy.transform.ASTTransformation")
-        )
-    }
-
-    private
-    fun fileAt(relativePath: String): File =
-        classDir.resolve(relativePath).also {
-            it.parentFile.mkdirs()
-            it.writeText("")
-        }
 }

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/AnnotatableMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/AnnotatableMember.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 public abstract class AnnotatableMember extends AccessibleMember {
 
     private final SortedSet<AnnotationMember> annotations = new TreeSet<>();
+    private final SortedSet<AnnotationMember> typeAnnotations = new TreeSet<>();
     @Nullable
     private final String signature;
 
@@ -40,6 +41,14 @@ public abstract class AnnotatableMember extends AccessibleMember {
 
     public void addAnnotation(AnnotationMember annotationMember) {
         annotations.add(annotationMember);
+    }
+
+    public SortedSet<AnnotationMember> getTypeAnnotations() {
+        return ImmutableSortedSet.copyOf(typeAnnotations);
+    }
+
+    public void addTypeAnnotation(TypeAnnotationMember typeAnnotationMember) {
+        typeAnnotations.add(typeAnnotationMember);
     }
 
     @Nullable

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/AnnotationMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/AnnotationMember.java
@@ -49,9 +49,21 @@ public class AnnotationMember extends Member implements Comparable<AnnotationMem
         return visible;
     }
 
+    /**
+     * Orders the kinds of annotation member against each other.
+     *
+     * Subclasses compare fields that the other kinds do not have. Without a rank, such a
+     * comparison gives a different answer in each direction, which breaks the contract of
+     * {@link Comparable} and silently drops members of a {@link java.util.TreeSet}.
+     */
+    protected int kindRank() {
+        return 0;
+    }
+
     protected ComparisonChain compare(AnnotationMember o) {
         return super.compare(o)
-            .compareFalseFirst(visible, o.visible);
+            .compareFalseFirst(visible, o.visible)
+            .compare(kindRank(), o.kindRank());
     }
 
     @Override

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
@@ -94,6 +94,13 @@ public class ApiMemberSelector extends ClassVisitor {
         return new SortingAnnotationVisitor(ann, super.visitAnnotation(desc, visible));
     }
 
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String desc, boolean visible) {
+        TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
+        classMember.addTypeAnnotation(ann);
+        return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
+    }
+
     @Nullable
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, @Nullable String signature, @Nullable String[] exceptions) {
@@ -113,7 +120,7 @@ public class ApiMemberSelector extends ClassVisitor {
                 }
 
                 @Override
-                public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+                public AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String desc, boolean visible) {
                     TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
                     methodMember.addTypeAnnotation(ann);
                     return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
@@ -148,6 +155,13 @@ public class ApiMemberSelector extends ClassVisitor {
                     AnnotationMember ann = new AnnotationMember(desc, visible);
                     fieldMember.addAnnotation(ann);
                     return new SortingAnnotationVisitor(ann, super.visitAnnotation(desc, visible));
+                }
+
+                @Override
+                public AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String desc, boolean visible) {
+                    TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
+                    fieldMember.addTypeAnnotation(ann);
+                    return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
                 }
             };
         }

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
@@ -60,6 +60,7 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
             classMember.getVersion(), classMember.getAccess(), classMember.getName(), classMember.getSignature(),
             classMember.getSuperName(), classMember.getInterfaces());
         writeClassAnnotations(classMember.getAnnotations());
+        writeClassAnnotations(classMember.getTypeAnnotations());
         for (String permittedSubclass : classMember.getPermittedSubclasses()) {
             apiMemberAdapter.visitPermittedSubclass(permittedSubclass);
         }
@@ -74,6 +75,7 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
             FieldVisitor fieldVisitor = apiMemberAdapter.visitField(
                 field.getAccess(), field.getName(), field.getTypeDesc(), field.getSignature(), field.getValue());
             writeFieldAnnotations(fieldVisitor, field.getAnnotations());
+            writeFieldAnnotations(fieldVisitor, field.getTypeAnnotations());
             fieldVisitor.visitEnd();
         }
         for (InnerClassMember innerClass : innerClasses) {
@@ -130,8 +132,9 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
     @Override
     public void writeClassAnnotations(Set<AnnotationMember> annotationMembers) {
         for (AnnotationMember annotation : annotationMembers) {
-            AnnotationVisitor annotationVisitor =
-                apiMemberAdapter.visitAnnotation(annotation.getName(), annotation.isVisible());
+            AnnotationVisitor annotationVisitor = annotation instanceof TypeAnnotationMember
+                ? visitTypeAnnotation(apiMemberAdapter, (TypeAnnotationMember) annotation)
+                : apiMemberAdapter.visitAnnotation(annotation.getName(), annotation.isVisible());
             writeAnnotationValues(annotation, annotationVisitor);
         }
     }
@@ -145,10 +148,7 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
                     ((ParameterAnnotationMember) annotation).getParameter(), annotation.getName(),
                     annotation.isVisible());
             } else if (annotation instanceof TypeAnnotationMember) {
-                TypeAnnotationMember typeAnnotationMember = (TypeAnnotationMember) annotation;
-                annotationVisitor = mv.visitTypeAnnotation(
-                    typeAnnotationMember.getTypeRef(), typeAnnotationMember.getTypePath(),
-                    typeAnnotationMember.getName(), typeAnnotationMember.isVisible());
+                annotationVisitor = visitTypeAnnotation(mv, (TypeAnnotationMember) annotation);
             } else {
                 annotationVisitor = mv.visitAnnotation(annotation.getName(), annotation.isVisible());
             }
@@ -159,9 +159,23 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
     @Override
     public void writeFieldAnnotations(FieldVisitor fv, Set<AnnotationMember> annotationMembers) {
         for (AnnotationMember annotation : annotationMembers) {
-            AnnotationVisitor annotationVisitor = fv.visitAnnotation(annotation.getName(), annotation.isVisible());
+            AnnotationVisitor annotationVisitor = annotation instanceof TypeAnnotationMember
+                ? visitTypeAnnotation(fv, (TypeAnnotationMember) annotation)
+                : fv.visitAnnotation(annotation.getName(), annotation.isVisible());
             writeAnnotationValues(annotation, annotationVisitor);
         }
+    }
+
+    private static AnnotationVisitor visitTypeAnnotation(ClassVisitor target, TypeAnnotationMember annotation) {
+        return target.visitTypeAnnotation(annotation.getTypeRef(), annotation.getTypePath(), annotation.getName(), annotation.isVisible());
+    }
+
+    private static AnnotationVisitor visitTypeAnnotation(MethodVisitor target, TypeAnnotationMember annotation) {
+        return target.visitTypeAnnotation(annotation.getTypeRef(), annotation.getTypePath(), annotation.getName(), annotation.isVisible());
+    }
+
+    private static AnnotationVisitor visitTypeAnnotation(FieldVisitor target, TypeAnnotationMember annotation) {
+        return target.visitTypeAnnotation(annotation.getTypeRef(), annotation.getTypePath(), annotation.getName(), annotation.isVisible());
     }
 
     @Override

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
@@ -31,7 +31,6 @@ public class MethodMember extends TypedMember implements Comparable<MethodMember
     private static final Ordering<Iterable<String>> LEXICOGRAPHICAL_ORDERING = Ordering.<String>natural().lexicographical();
     private final SortedSet<String> exceptions = new TreeSet<>();
     private final SortedSet<AnnotationMember> parameterAnnotations = new TreeSet<>();
-    private final SortedSet<AnnotationMember> typeAnnotations = new TreeSet<>();
     @Nullable
     private AnnotationValue<?> annotationDefaultValue;
 
@@ -52,14 +51,6 @@ public class MethodMember extends TypedMember implements Comparable<MethodMember
 
     public void addParameterAnnotation(ParameterAnnotationMember parameterAnnotationMember) {
         parameterAnnotations.add(parameterAnnotationMember);
-    }
-
-    public SortedSet<AnnotationMember> getTypeAnnotations() {
-        return ImmutableSortedSet.copyOf(typeAnnotations);
-    }
-
-    public void addTypeAnnotation(TypeAnnotationMember typeAnnotationMember) {
-        typeAnnotations.add(typeAnnotationMember);
     }
 
     public Optional<@Nullable AnnotationValue<?>> getAnnotationDefaultValue() {

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ParameterAnnotationMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ParameterAnnotationMember.java
@@ -30,7 +30,16 @@ public class ParameterAnnotationMember extends AnnotationMember {
     }
 
     @Override
+    protected int kindRank() {
+        return 1;
+    }
+
+    @Override
     public int compareTo(AnnotationMember o) {
+        if (!(o instanceof ParameterAnnotationMember)) {
+            // The rank of the kinds decides, and it never leaves them equal
+            return super.compare(o).result();
+        }
         return super.compare(o)
             .compare(parameter, ((ParameterAnnotationMember) o).parameter)
             .result();

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/TypeAnnotationMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/TypeAnnotationMember.java
@@ -43,7 +43,16 @@ public class TypeAnnotationMember extends AnnotationMember {
     }
 
     @Override
+    protected int kindRank() {
+        return 2;
+    }
+
+    @Override
     public int compareTo(AnnotationMember o) {
+        if (!(o instanceof TypeAnnotationMember)) {
+            // The rank of the kinds decides, and it never leaves them equal
+            return super.compare(o).result();
+        }
         TypeAnnotationMember other = (TypeAnnotationMember) o;
         return super.compare(o)
             // The same annotation can appear on several types of the same member,

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/TypeAnnotationMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/TypeAnnotationMember.java
@@ -16,13 +16,15 @@
 
 package org.gradle.internal.tools.api.impl;
 
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.TypePath;
 
 public class TypeAnnotationMember extends AnnotationMember {
     private final int typeRef;
+    @Nullable
     private final TypePath typePath;
 
-    public TypeAnnotationMember(String desc, boolean visible, int typeRef, TypePath typePath) {
+    public TypeAnnotationMember(String desc, boolean visible, int typeRef, @Nullable TypePath typePath) {
         super(desc, visible);
         this.typeRef = typeRef;
         this.typePath = typePath;
@@ -32,7 +34,26 @@ public class TypeAnnotationMember extends AnnotationMember {
         return typeRef;
     }
 
+    /**
+     * The path to the annotated type, or {@code null} when the annotated type is the whole type.
+     */
+    @Nullable
     public TypePath getTypePath() {
         return typePath;
+    }
+
+    @Override
+    public int compareTo(AnnotationMember o) {
+        TypeAnnotationMember other = (TypeAnnotationMember) o;
+        return super.compare(o)
+            // The same annotation can appear on several types of the same member,
+            // so the target must be part of the identity
+            .compare(typeRef, other.typeRef)
+            .compare(typePathString(), other.typePathString())
+            .result();
+    }
+
+    private String typePathString() {
+        return typePath == null ? "" : typePath.toString();
     }
 }

--- a/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorAnnotationsTest.groovy
+++ b/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorAnnotationsTest.groovy
@@ -166,6 +166,158 @@ class ApiClassExtractorAnnotationsTest extends ApiClassExtractorTestSupport {
         extractedAnnotations[0].annotations[0].path() == 'somePath'
     }
 
+    void "type annotations on every method param are retained"() {
+        given:
+        def api = toApi([
+            A  : '''
+                public class A {
+                    public void foo(@Ann(path="first") String first, @Ann(path="second") String second) {}
+                }
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE_USE})
+                public @interface Ann {
+                    String path();
+                }
+            '''
+        ])
+
+        when:
+        def clazz = api.classes.A
+        def annotations = clazz.clazz.getDeclaredMethod('foo', String, String).annotatedParameterTypes
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extractedClass = api.extractAndLoadApiClassFrom(clazz)
+        def extractedAnnotations = extractedClass.getDeclaredMethod('foo', String, String).annotatedParameterTypes
+
+        then:
+        annotations.collect { it.annotations[0].path() } == ['first', 'second']
+        extractedAnnotations.collect { it.annotations[0].annotationType() } == [extractedAnn, extractedAnn]
+        extractedAnnotations.collect { it.annotations[0].path() } == ['first', 'second']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38792")
+    void "type annotations on class type parameter bounds are retained"() {
+        given:
+        def api = toApi([
+            A  : '''
+                public class A<OUT extends @Ann(path="out") Object, IN extends @Ann(path="in") Object> {}
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE_USE})
+                public @interface Ann {
+                    String path();
+                }
+            '''
+        ])
+
+        when:
+        def clazz = api.classes.A
+        def bounds = clazz.clazz.typeParameters.collect { it.annotatedBounds[0] }
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extractedClass = api.extractAndLoadApiClassFrom(clazz)
+        def extractedBounds = extractedClass.typeParameters.collect { it.annotatedBounds[0] }
+
+        then:
+        bounds.collect { it.annotations[0].path() } == ['out', 'in']
+        extractedBounds.collect { it.annotations[0].annotationType() } == [extractedAnn, extractedAnn]
+        extractedBounds.collect { it.annotations[0].path() } == ['out', 'in']
+    }
+
+    void "type annotations on implemented interfaces are retained"() {
+        given:
+        def api = toApi([
+            A  : '''
+                import java.util.concurrent.Callable;
+
+                public class A implements Callable<@Ann(path="somePath") String> {
+                    public String call() { return null; }
+                }
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE_USE})
+                public @interface Ann {
+                    String path();
+                }
+            '''
+        ])
+
+        when:
+        def clazz = api.classes.A
+        def typeArgument = clazz.clazz.annotatedInterfaces[0].annotatedActualTypeArguments[0]
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extractedClass = api.extractAndLoadApiClassFrom(clazz)
+        def extractedTypeArgument = extractedClass.annotatedInterfaces[0].annotatedActualTypeArguments[0]
+
+        then:
+        typeArgument.annotations.size() == 1
+        typeArgument.annotations[0].annotationType().name == 'Ann'
+        extractedTypeArgument.annotations.size() == 1
+        extractedTypeArgument.annotations[0].annotationType() == extractedAnn
+        extractedTypeArgument.annotations[0].path() == 'somePath'
+    }
+
+    void "type annotations on field are retained"() {
+        given:
+        def api = toApi([
+            A  : '''
+                import java.util.List;
+
+                public class A {
+                    public @Ann(path="onType") String foo;
+                    public List<@Ann(path="onTypeArgument") String> bar;
+                }
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE_USE})
+                public @interface Ann {
+                    String path();
+                }
+            '''
+        ])
+
+        when:
+        def clazz = api.classes.A
+        def annotations = clazz.clazz.getDeclaredField('foo').annotatedType.annotations
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extractedClass = api.extractAndLoadApiClassFrom(clazz)
+        def extractedAnnotations = extractedClass.getDeclaredField('foo').annotatedType.annotations
+        def extractedTypeArgumentAnnotations = extractedClass.getDeclaredField('bar').annotatedType.annotatedActualTypeArguments[0].annotations
+
+        then:
+        annotations.size() == 1
+        annotations[0].annotationType().name == 'Ann'
+        extractedAnnotations.size() == 1
+        extractedAnnotations[0].annotationType() == extractedAnn
+        extractedAnnotations[0].path() == 'onType'
+        extractedTypeArgumentAnnotations.size() == 1
+        extractedTypeArgumentAnnotations[0].annotationType() == extractedAnn
+        extractedTypeArgumentAnnotations[0].path() == 'onTypeArgument'
+    }
+
     void "mixed annotations on method params are retained"() {
         given:
         def api = toApi([

--- a/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/impl/AnnotationMemberTest.groovy
+++ b/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/impl/AnnotationMemberTest.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tools.api.impl
+
+import org.objectweb.asm.TypePath
+import spock.lang.Specification
+
+class AnnotationMemberTest extends Specification {
+
+    def "comparison of two kinds gives the opposite answer in each direction"() {
+        expect:
+        Integer.signum(a <=> b) == -Integer.signum(b <=> a)
+        (a <=> b) != 0
+
+        where:
+        a                                               | b
+        annotation()                                    | parameterAnnotation(0)
+        annotation()                                    | typeAnnotation(0, null)
+        parameterAnnotation(0)                          | typeAnnotation(0, null)
+    }
+
+    def "a set keeps one member of each kind"() {
+        given:
+        def members = new TreeSet<AnnotationMember>()
+
+        when:
+        members.add(annotation())
+        members.add(parameterAnnotation(0))
+        members.add(typeAnnotation(0, null))
+
+        then:
+        members.size() == 3
+    }
+
+    def "a set keeps the type annotations of the same name on different targets"() {
+        given:
+        def members = new TreeSet<AnnotationMember>()
+
+        when:
+        members.add(typeAnnotation(0, null))
+        members.add(typeAnnotation(1, null))
+        members.add(typeAnnotation(1, TypePath.fromString('[')))
+
+        then:
+        members.size() == 3
+    }
+
+    def "a set keeps one type annotation per target"() {
+        given:
+        def members = new TreeSet<AnnotationMember>()
+
+        when:
+        members.add(typeAnnotation(0, null))
+        members.add(typeAnnotation(0, null))
+
+        then:
+        members.size() == 1
+    }
+
+    def "a set keeps one parameter annotation per parameter"() {
+        given:
+        def members = new TreeSet<AnnotationMember>()
+
+        when:
+        members.add(parameterAnnotation(0))
+        members.add(parameterAnnotation(1))
+        members.add(parameterAnnotation(1))
+
+        then:
+        members.size() == 2
+    }
+
+    private static AnnotationMember annotation() {
+        new AnnotationMember('LAnn;', true)
+    }
+
+    private static ParameterAnnotationMember parameterAnnotation(int parameter) {
+        new ParameterAnnotationMember('LAnn;', true, parameter)
+    }
+
+    private static TypeAnnotationMember typeAnnotation(int typeRef, TypePath typePath) {
+        new TypeAnnotationMember('LAnn;', true, typeRef, typePath)
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslNullnessIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslNullnessIntegrationTest.kt
@@ -18,12 +18,29 @@ package org.gradle.kotlin.dsl.integration
 
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.junit.Test
+import spock.lang.Issue
 
 
 /**
  * Integration tests for API usage specific to Kotlin DSL nullness detection.
  */
 class KotlinDslNullnessIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/38792")
+    fun `Transformer can be implemented with a nullable OUT type argument in script`() {
+        withBuildScript(
+            """
+            class NullingTransformer : Transformer<String?, String> {
+                override fun transform(name: String): String? = null
+            }
+            tasks.register<Copy>("copyStuff") {
+                rename(NullingTransformer())
+            }
+            """
+        )
+        build("help")
+    }
 
     @Test
     fun `Provider#map works with a null return value in script`() {


### PR DESCRIPTION
* Follows up
    * #35658
    * #33846
* Fixes https://github.com/gradle/gradle/issues/38792

### Why

Gradle 9.7.0 compiles Kotlin DSL build scripts against a new ABI stub jar (`gradle-public-api-legacy`). That stub jar lost the type-use annotations of every class and every field. Kotlin therefore read the bound of `Transformer<OUT extends @Nullable Object, IN>` as non-null. A build script that declares `Transformer<String?, String>` failed with this error:

```
Type argument is not within its bounds: type parameter 'OUT (of interface Transformer<OUT : Any, IN : Any>' must be subtype of 'Any', but actual 'String?'
```

The real class keeps the annotation. Only the stub jar lost it, and the Kotlin compiler is correct about the stub it reads.

### What changes

- The API extractor keeps the type-use annotations of classes and fields. Before, it kept only the annotations of methods.
- The API extractor keeps two type-use annotations that have the same name on one member. Before, the second annotation replaced the first. For this reason the 9.7.0 stub of `DependencyFactory.create` kept one `@Nullable` mark of four.
- The build extracts the stubs with the API extractor of this source tree. Before, it used the extractor of the Gradle distribution that runs the build.

### Implementation

- `ApiMemberSelector` implements `visitTypeAnnotation` for the class visitor and for the field visitor. It implemented the method visitor only.
- `AnnotatableMember` holds the type-use annotations, so classes, fields and methods share one collection.
- `TypeAnnotationMember` compares `typeRef` and `typePath`. The name and the visibility gave an annotation its identity before, and the sorted set kept one annotation per name.
- `IsolatedApiClassExtractor` loads the extractor from `extractorClasspath` under the platform class loader. The package `org.gradle.internal.tools.api` resolves parent-first, and the class loader reads the distribution first. Only JDK types cross this boundary, therefore the calls are reflective.
- A check in the constructor stops the build when the extractor comes from another class loader. A broken isolation writes wrong output and reports no error, which is why the original `FIXME` survived a release.
- The worker process stays. It keeps extraction failures and heap out of the build process.

### How to review

1. Read `IsolatedApiClassExtractor` first. Without it, the two extractor fixes do not reach the stub jar.
2. To see the fault, get `lib/api/gradle-public-api-legacy-9.7.0.jar` from a 9.7.0 distribution. Run `javap -v -p org/gradle/api/Transformer.class` on it. The attribute `RuntimeVisibleTypeAnnotations` is absent. The same class in `gradle-base-services-9.7.0.jar` has it.
3. To prove that the isolation is necessary, replace `ClassLoader.getPlatformClassLoader()` with `IsolatedApiClassExtractor::class.java.classLoader`. Then run the integration test. It fails with the error of the issue.

Type-use annotations in the stub jar of the core distribution, for the 11628 classes that the 9.7.0 jar and this jar share:

| Target | 9.7.0 | This PR |
|---|---|---|
| `CLASS_TYPE_PARAMETER_BOUND` | 0 | 18 |
| `FIELD` | 0 | 27 |
| `METHOD_FORMAL_PARAMETER` | 1481 | 1863 |
| `METHOD_RETURN` | 1872 | 1872 |
| `METHOD_TYPE_PARAMETER_BOUND` | 49 | 50 |

No count decreases, so the stubs lose nothing. `METHOD_RETURN` does not change, so no public method gets a nullable return type. Only parameters and bounds accept more.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
