### PR TITLE
Fix the Kotlin version warning of embedded-kotlin

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
@@ -16,9 +16,13 @@
 
 package org.gradle.kotlin.dsl.plugins.embedded
 
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.gradle.util.internal.VersionNumber
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
@@ -47,6 +51,83 @@ class EmbeddedKotlinPluginIntegTest : AbstractKotlinIntegrationTest() {
         val result = build("assemble")
 
         result.assertOutputContains(":compileKotlin NO-SOURCE")
+    }
+
+    @Test
+    fun `warns when the Kotlin compiler version differs from the embedded Kotlin version`() {
+
+        withBuildScript(
+            """
+            import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+            import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
+            plugins {
+                `embedded-kotlin`
+            }
+
+            $repositoriesBlock
+
+            @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+            fun useDifferentCompiler() = kotlin {
+                compilerVersion.set("2.3.21")
+            }
+            useDifferentCompiler()
+
+            """
+        )
+
+        val result = build("classes")
+
+        assertThat(result.output, containsString("Unsupported Kotlin compiler version"))
+    }
+
+    @Test
+    @Requires(
+        TestExecutionPreconditions.NotEmbeddedExecutor::class,
+        reason = "Class path isolation, needed for the forced Kotlin Gradle Plugin version"
+    )
+    fun `does not warn when the Kotlin compiler version is the embedded Kotlin version`() {
+
+        val olderKgpVersion = KotlinGradlePluginVersions().latestsStable
+            .last { VersionNumber.parse(it) < VersionNumber.parse(embeddedKotlinVersion) }
+
+        withBuildScript(
+            """
+            import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+            import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+            import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
+            buildscript {
+                configurations.classpath {
+                    resolutionStrategy.eachDependency {
+                        if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-gradle-plugin")) {
+                            useVersion("$olderKgpVersion")
+                        }
+                    }
+                }
+            }
+
+            plugins {
+                `embedded-kotlin`
+            }
+
+            $repositoriesBlock
+
+            @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+            fun useEmbeddedCompiler() = kotlin {
+                compilerVersion.set("$embeddedKotlinVersion")
+            }
+            useEmbeddedCompiler()
+
+            println("applied Kotlin plugin version: " + project.getKotlinPluginVersion())
+
+            """
+        )
+
+        val result = build("classes")
+
+        assertThat(result.output, containsString("applied Kotlin plugin version: $olderKgpVersion"))
+        assertThat(result.output, not(containsString("Unsupported Kotlin")))
     }
 
     @Test

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
@@ -82,6 +82,38 @@ class EmbeddedKotlinPluginIntegTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
+    fun `does not read the compiler version while the project configures`() {
+
+        withBuildScript(
+            """
+            import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+            import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+            import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+            plugins {
+                `embedded-kotlin`
+            }
+
+            $repositoriesBlock
+
+            // Some plugins realize the Kotlin compile tasks while the project configures
+            tasks.withType<KotlinCompile>().all { }
+
+            @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+            fun useDifferentCompiler() = kotlin {
+                compilerVersion.set("2.3.21")
+            }
+            useDifferentCompiler()
+
+            """
+        )
+
+        val result = build("classes")
+
+        assertThat(result.output, containsString("Unsupported Kotlin compiler version"))
+    }
+
+    @Test
     fun `does not warn when the Build Tools API is off and the plugin version is the embedded one`() {
 
         withFile("gradle.properties", "kotlin.compiler.runViaBuildToolsApi=false")

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
@@ -82,6 +82,39 @@ class EmbeddedKotlinPluginIntegTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
+    fun `does not warn when the Build Tools API is off and the plugin version is the embedded one`() {
+
+        withFile("gradle.properties", "kotlin.compiler.runViaBuildToolsApi=false")
+
+        // The Kotlin Gradle Plugin deprecated this property, and it reports that on each build
+        executer.noDeprecationChecks()
+
+        withBuildScript(
+            """
+            import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+            import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
+            plugins {
+                `embedded-kotlin`
+            }
+
+            $repositoriesBlock
+
+            @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+            fun useDifferentCompiler() = kotlin {
+                compilerVersion.set("2.3.21")
+            }
+            useDifferentCompiler()
+
+            """
+        )
+
+        val result = build("classes")
+
+        assertThat(result.output, not(containsString("Unsupported Kotlin")))
+    }
+
+    @Test
     @Requires(
         TestExecutionPreconditions.NotEmbeddedExecutor::class,
         reason = "Class path isolation, needed for the forced Kotlin Gradle Plugin version"

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     compileOnly(projects.serviceLookup)
     compileOnly(projects.stdlibJavaExtensions)
 
+    compileOnly(libs.kotlinBuildToolsApi.relaxRestriction())
     compileOnly(libs.slf4jApi)
     compileOnly(libs.inject)
     compileOnly(libs.jspecify)

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/CheckKotlinCompilerVersion.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/CheckKotlinCompilerVersion.kt
@@ -75,6 +75,9 @@ internal abstract class CheckKotlinCompilerVersion : DefaultTask() {
     /**
      * The Kotlin Gradle Plugin runs the compilation through the Build Tools API since version 2.3.20.
      * Older versions need the Gradle property, and every version accepts it.
+     *
+     * This reads the Gradle properties only. The Kotlin Gradle Plugin also accepts the property from
+     * the extra properties of the project, and from the `local.properties` file of the root project.
      */
     private fun Project.runsCompilerViaBuildToolsApi(kotlinPluginVersion: String): Provider<Boolean> =
         providers.gradleProperty(RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY)

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/CheckKotlinCompilerVersion.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/CheckKotlinCompilerVersion.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl.plugins.embedded
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Console
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.util.internal.VersionNumber
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
+
+/**
+ * Compares the Kotlin compiler version of a project with the Kotlin version embedded in Gradle.
+ *
+ * The Kotlin compile tasks depend on this task, and the comparison then happens after the
+ * configuration of the project. A read of the compiler version finalizes that value, and an earlier
+ * read breaks every build that configures the value.
+ */
+@UntrackedTask(because = "Produces only console output")
+internal abstract class CheckKotlinCompilerVersion : DefaultTask() {
+
+    companion object {
+        private const val RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY = "kotlin.compiler.runViaBuildToolsApi"
+        private val FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT = VersionNumber.parse("2.3.20")
+    }
+
+    @get:Console
+    abstract val kotlinCompilerVersion: Property<String>
+
+    init {
+        kotlinCompilerVersion.set(project.effectiveKotlinCompilerVersion())
+        kotlinCompilerVersion.finalizeValueOnRead()
+    }
+
+    @TaskAction
+    fun checkKotlinCompilerVersion() {
+        logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion.get())
+    }
+
+    /**
+     * The `compilerVersion` property selects the compiler only when the compilation runs through the
+     * Build Tools API. The legacy path always compiles with the compiler of the plugin version.
+     *
+     * The result stays a provider, because a read of `compilerVersion` finalizes that value.
+     */
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+    private fun Project.effectiveKotlinCompilerVersion(): Provider<String> =
+        getKotlinPluginVersion().let { kotlinPluginVersion ->
+            runsCompilerViaBuildToolsApi(kotlinPluginVersion)
+                .zip(kotlinExtension.compilerVersion.orElse(kotlinPluginVersion)) { viaBuildToolsApi, compilerVersion ->
+                    if (viaBuildToolsApi) compilerVersion else kotlinPluginVersion
+                }
+        }
+
+    /**
+     * The Kotlin Gradle Plugin runs the compilation through the Build Tools API since version 2.3.20.
+     * Older versions need the Gradle property, and every version accepts it.
+     */
+    private fun Project.runsCompilerViaBuildToolsApi(kotlinPluginVersion: String): Provider<Boolean> =
+        providers.gradleProperty(RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY)
+            .map { it.toBoolean() }
+            .orElse(VersionNumber.parse(kotlinPluginVersion).baseVersion >= FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT)
+}

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -95,11 +95,11 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
 }
 
 
-fun Logger.warnOnDifferentKotlinVersion(kotlinVersion: String?) {
-    if (kotlinVersion != embeddedKotlinVersion) {
+fun Logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion: String?) {
+    if (kotlinCompilerVersion != embeddedKotlinVersion) {
         val warning =
             """|WARNING: Unsupported Kotlin compiler version.
-               |The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `$embeddedKotlinVersion` that might work differently than in the compiler version `$kotlinVersion`.
+               |The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `$embeddedKotlinVersion` that might work differently than in the compiler version `$kotlinCompilerVersion`.
                |Using the `kotlin-dsl` plugin together with a different Kotlin version (for example, by using the Kotlin Gradle plugin (`kotlin(jvm)`)) in the same project is not recommended.
                |
                |See https://docs.gradle.org/${GradleVersion.current().version}/userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin for more details on how the `kotlin-dsl` plugin works (same applies to `embedded-kotlin`).

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -22,12 +22,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 import org.gradle.util.GradleVersion
-import org.gradle.util.internal.VersionNumber
-import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import javax.inject.Inject
 
@@ -64,42 +59,12 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
         }
     }
 
-    /**
-     * A read of `compilerVersion` finalizes the value, so the read waits for the task configuration.
-     * A project can have several Kotlin compile tasks, and the warning appears one time.
-     */
     private fun Project.warnOnDifferentKotlinCompilerVersion() {
-        var warned = false
-        tasks.withType<KotlinCompile>().configureEach {
-            if (!warned) {
-                warned = true
-                logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion())
-            }
+        val checkKotlinCompilerVersion = tasks.register<CheckKotlinCompilerVersion>("checkKotlinCompilerVersion")
+        tasks.withType<KotlinCompile>().configureEach { kotlinCompile ->
+            kotlinCompile.dependsOn(checkKotlinCompilerVersion)
         }
     }
-
-    /**
-     * The `compilerVersion` property selects the compiler only when the compilation runs through the
-     * Build Tools API. The legacy path always compiles with the compiler of the plugin version.
-     */
-    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
-    private fun Project.kotlinCompilerVersion(): String {
-        val kotlinPluginVersion = getKotlinPluginVersion()
-        if (!runsCompilerViaBuildToolsApi(kotlinPluginVersion)) {
-            return kotlinPluginVersion
-        }
-        return kotlinExtension.compilerVersion.orNull ?: kotlinPluginVersion
-    }
-
-    /**
-     * The Kotlin Gradle Plugin runs the compilation through the Build Tools API since version 2.3.20.
-     * Older versions need the Gradle property, and every version accepts it.
-     */
-    private fun Project.runsCompilerViaBuildToolsApi(kotlinPluginVersion: String): Boolean =
-        providers.gradleProperty(RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY)
-            .map { it.toBoolean() }
-            .orElse(VersionNumber.parse(kotlinPluginVersion).baseVersion >= FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT)
-            .get()
 
     // See https://github.com/gradle/gradle/issues/35309
     // TODO remove once https://youtrack.jetbrains.com/issue/KT-81706/ is fixed
@@ -130,14 +95,6 @@ fun Logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion: String?) {
         warn(warning)
     }
 }
-
-
-private
-const val RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY = "kotlin.compiler.runViaBuildToolsApi"
-
-
-private
-val FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT = VersionNumber.parse("2.3.20")
 
 
 internal

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 import org.gradle.util.GradleVersion
+import org.gradle.util.internal.VersionNumber
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
@@ -77,9 +78,28 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
         }
     }
 
+    /**
+     * The `compilerVersion` property selects the compiler only when the compilation runs through the
+     * Build Tools API. The legacy path always compiles with the compiler of the plugin version.
+     */
     @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
-    private fun Project.kotlinCompilerVersion(): String =
-        kotlinExtension.compilerVersion.orNull ?: getKotlinPluginVersion()
+    private fun Project.kotlinCompilerVersion(): String {
+        val kotlinPluginVersion = getKotlinPluginVersion()
+        if (!runsCompilerViaBuildToolsApi(kotlinPluginVersion)) {
+            return kotlinPluginVersion
+        }
+        return kotlinExtension.compilerVersion.orNull ?: kotlinPluginVersion
+    }
+
+    /**
+     * The Kotlin Gradle Plugin runs the compilation through the Build Tools API since version 2.3.20.
+     * Older versions need the Gradle property, and every version accepts it.
+     */
+    private fun Project.runsCompilerViaBuildToolsApi(kotlinPluginVersion: String): Boolean =
+        providers.gradleProperty(RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY)
+            .map { it.toBoolean() }
+            .orElse(VersionNumber.parse(kotlinPluginVersion).baseVersion >= FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT)
+            .get()
 
     // See https://github.com/gradle/gradle/issues/35309
     // TODO remove once https://youtrack.jetbrains.com/issue/KT-81706/ is fixed
@@ -110,6 +130,14 @@ fun Logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion: String?) {
         warn(warning)
     }
 }
+
+
+private
+const val RUN_COMPILER_VIA_BUILD_TOOLS_API_PROPERTY = "kotlin.compiler.runViaBuildToolsApi"
+
+
+private
+val FIRST_VERSION_WITH_BUILD_TOOLS_API_BY_DEFAULT = VersionNumber.parse("2.3.20")
 
 
 internal

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -22,8 +22,12 @@ import org.gradle.api.logging.Logger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import javax.inject.Inject
 
 
@@ -42,7 +46,7 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
 
             plugins.apply(KotlinPluginWrapper::class.java)
 
-            logger.warnOnDifferentKotlinVersion(getKotlinPluginVersion())
+            warnOnDifferentKotlinCompilerVersion()
 
             val embeddedKotlinConfiguration = configurations.create("embeddedKotlin")
             embeddedKotlin.addDependenciesTo(
@@ -58,6 +62,24 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
             workAroundKgpEagerConfigurations()
         }
     }
+
+    /**
+     * A read of `compilerVersion` finalizes the value, so the read waits for the task configuration.
+     * A project can have several Kotlin compile tasks, and the warning appears one time.
+     */
+    private fun Project.warnOnDifferentKotlinCompilerVersion() {
+        var warned = false
+        tasks.withType<KotlinCompile>().configureEach {
+            if (!warned) {
+                warned = true
+                logger.warnOnDifferentKotlinVersion(kotlinCompilerVersion())
+            }
+        }
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
+    private fun Project.kotlinCompilerVersion(): String =
+        kotlinExtension.compilerVersion.orNull ?: getKotlinPluginVersion()
 
     // See https://github.com/gradle/gradle/issues/35309
     // TODO remove once https://youtrack.jetbrains.com/issue/KT-81706/ is fixed
@@ -76,8 +98,8 @@ abstract class EmbeddedKotlinPlugin @Inject internal constructor(
 fun Logger.warnOnDifferentKotlinVersion(kotlinVersion: String?) {
     if (kotlinVersion != embeddedKotlinVersion) {
         val warning =
-            """|WARNING: Unsupported Kotlin plugin version.
-               |The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `$embeddedKotlinVersion` that might work differently than in the requested version `$kotlinVersion`.
+            """|WARNING: Unsupported Kotlin compiler version.
+               |The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `$embeddedKotlinVersion` that might work differently than in the compiler version `$kotlinVersion`.
                |Using the `kotlin-dsl` plugin together with a different Kotlin version (for example, by using the Kotlin Gradle plugin (`kotlin(jvm)`)) in the same project is not recommended.
                |
                |See https://docs.gradle.org/${GradleVersion.current().version}/userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin for more details on how the `kotlin-dsl` plugin works (same applies to `embedded-kotlin`).

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/KotlinDslPluginRelatedToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/KotlinDslPluginRelatedToolingApiSpecification.groovy
@@ -36,7 +36,7 @@ class KotlinDslPluginRelatedToolingApiSpecification extends ToolingApiSpecificat
     }
 
     private boolean disableJdkWarningCheck() {
-        // Doing this to avoid "The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `X` that might work differently than in the requested version `Y`." errors
+        // Doing this to avoid "The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `X` that might work differently than in the compiler version `Y`." errors
         // on embedded Kotlin version bumps. Proper solution would be to make these tests use a version of `kotlin-dsl` plugin that's generated from current sources.
         withJdkWarningsCheckDisabled()
     }


### PR DESCRIPTION
* Fixes #38809

### Why

The `embedded-kotlin` plugin warns when the Kotlin version of a build differs from the Kotlin version
embedded in Gradle. The check reads the version of the applied Kotlin Gradle Plugin. That version is
not the version of the compiler that compiles the code, because a build selects the compiler with
`kotlinExtension.compilerVersion`.

The warning is wrong in both directions:

- Gradle logs no warning when the compiler version differs. The build then fails with a
  `NoSuchFieldError` from the compiler, and the user gets no explanation.
- Gradle logs the warning when the compiler version is the embedded one. The message is noise. This
  is the case that JetBrains reported.

### What changes

- The check compares `kotlinExtension.compilerVersion` with `embeddedKotlinVersion`.
- The first line of the message reads `WARNING: Unsupported Kotlin compiler version.`, and the text
  names the compiler version.
- The warning comes from the Kotlin compile tasks. A build that configures no Kotlin compile task
  gets no warning.

### Implementation

- A read of `compilerVersion` finalizes the value. A read at plugin apply time breaks every build
  that sets the property, so the check runs at the configuration of the compile tasks.
- A project can have several Kotlin compile tasks. A flag keeps the warning to one message.
- The code has no version check for old plugins. Gradle supports Kotlin Gradle Plugin 2.0.0 and
  newer, and every version in that range has the property.
- `compilerVersion` needs two opt-in annotations, so `kotlin-build-tools-api` gets a `compileOnly`
  declaration.

### How to review

1. Read `EmbeddedKotlinPlugin.kt`. The whole behavior change is there.
2. Read the two tests in `EmbeddedKotlinPluginIntegTest`. The first test covers the missed warning.
   The second test covers the false warning.
3. The second test forces an older Kotlin Gradle Plugin version with a `resolutionStrategy` rule. A
   `plugins` block cannot lower that version, because the distribution puts the embedded version on
   the same classpath and conflict resolution selects the higher one. The rule must cover every
   module with the `kotlin-gradle-plugin` prefix, or the plugin apply fails.
4. Both tests run `classes` on a project without Kotlin sources. The compile task is then
   `NO-SOURCE`, so the build needs no compiler artifact.

To see the change in a real build, publish the plugins and use the attached reproducer of the issue:

    ./gradlew :kotlin-dsl-plugins:publishToMavenLocal
    ./gradlew :distributions-full:install -Pgradle_installPath=/tmp/gradle-9.8-fix

The `kotlin-dsl` plugins are not part of a distribution, so the reproducer needs `mavenLocal()` in
its `pluginManagement` repositories and a rule that selects the version of the local build.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
