### PR TITLE
Intern repository content filtering rules

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.repositories;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
@@ -43,6 +45,15 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorInternal {
+    /**
+     * Rules are commonly declared identically on every repository of every project, which without
+     * sharing costs one {@code ContentSpec} per rule per repository. Since a spec is an immutable
+     * value, one instance can serve every descriptor declaring that rule. The interner is weak, so
+     * an entry is collected once the last descriptor referencing it is gone and nothing accumulates
+     * across builds in the daemon.
+     */
+    private static final Interner<ContentSpec> SPEC_INTERNER = Interners.newWeakInterner();
+
     private enum MatcherKind {
         SIMPLE,
         REGEX,
@@ -91,7 +102,10 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
             // no filtering in place
             return Actions.doNothing();
         }
-        cachedAction = new RepositoryFilterAction(createSpecMatchers(includeSpecs), createSpecMatchers(excludeSpecs));
+        cachedAction = new RepositoryFilterAction(
+            createSpecMatchers(includeSpecs, versionSelectorScheme, versionSelectors),
+            createSpecMatchers(excludeSpecs, versionSelectorScheme, versionSelectors)
+        );
         return cachedAction;
     }
 
@@ -117,12 +131,16 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     }
 
     @Nullable
-    private static ImmutableList<SpecMatcher> createSpecMatchers(@Nullable Set<ContentSpec> specs) {
+    private static ImmutableList<SpecMatcher> createSpecMatchers(
+        @Nullable Set<ContentSpec> specs,
+        VersionSelectorScheme versionSelectorScheme,
+        ConcurrentHashMap<String, VersionSelector> versionSelectors
+    ) {
         ImmutableList<SpecMatcher> matchers = null;
         if (specs != null) {
             ImmutableList.Builder<SpecMatcher> builder = ImmutableList.builderWithExpectedSize(specs.size());
             for (ContentSpec spec : specs) {
-                builder.add(spec.toMatcher());
+                builder.add(spec.toMatcher(versionSelectorScheme, versionSelectors));
             }
             matchers = builder.build();
         }
@@ -188,7 +206,7 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         if (includeSpecs == null) {
             includeSpecs = new HashSet<>();
         }
-        includeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, true));
+        includeSpecs.add(SPEC_INTERNER.intern(new ContentSpec(matcherKind, group, moduleName, version, true)));
     }
 
     @Override
@@ -244,7 +262,7 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         if (excludeSpecs == null) {
             excludeSpecs = new HashSet<>();
         }
-        excludeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, false));
+        excludeSpecs.add(SPEC_INTERNER.intern(new ContentSpec(matcherKind, group, moduleName, version, false)));
     }
 
     @Override
@@ -328,23 +346,25 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         this.requiredAttributes = requiredAttributes;
     }
 
+    /**
+     * A rule declared on a descriptor. This is a pure value: it carries no state belonging to the
+     * descriptor that created it, so equal specs are interchangeable and a single instance can be
+     * shared by every descriptor declaring that rule. The version selector scheme and the selector
+     * cache are supplied by the owning descriptor when the matcher is created.
+     */
     private static class ContentSpec {
         private final MatcherKind matcherKind;
         private final String group;
         private final String module;
         private final String version;
-        private final VersionSelectorScheme versionSelectorScheme;
-        private final ConcurrentHashMap<String, VersionSelector> versionSelectors;
         private final boolean inclusive;
         private final int hashCode;
 
-        private ContentSpec(MatcherKind matcherKind, String group, @Nullable String module, @Nullable String version, VersionSelectorScheme versionSelectorScheme, ConcurrentHashMap<String, VersionSelector> versionSelectors, boolean inclusive) {
+        private ContentSpec(MatcherKind matcherKind, String group, @Nullable String module, @Nullable String version, boolean inclusive) {
             this.matcherKind = matcherKind;
             this.group = group;
             this.module = module;
             this.version = version;
-            this.versionSelectorScheme = versionSelectorScheme;
-            this.versionSelectors = versionSelectors;
             this.inclusive = inclusive;
             this.hashCode = Objects.hashCode(matcherKind, group, module, version, inclusive);
         }
@@ -371,7 +391,7 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
             return hashCode;
         }
 
-        SpecMatcher toMatcher() {
+        SpecMatcher toMatcher(VersionSelectorScheme versionSelectorScheme, ConcurrentHashMap<String, VersionSelector> versionSelectors) {
             switch (matcherKind) {
                 case SIMPLE:
                 case SUB_GROUP:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
@@ -486,4 +486,112 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
         0 * details.notFound()
     }
 
+    def "the same rule declared on independent descriptors is a single spec instance"() {
+        given:
+        def first = new DefaultRepositoryContentDescriptor({ "first" }, new VersionParser())
+        def second = new DefaultRepositoryContentDescriptor({ "second" }, new VersionParser())
+
+        when:
+        first.includeGroup("org")
+        second.includeGroup("org")
+        second.includeGroup("other")
+
+        then:
+        first.includeSpecs.size() == 1
+        second.includeSpecs.size() == 2
+        second.includeSpecs.any { it.is(first.includeSpecs.first()) }
+        !second.includeSpecs.every { it.is(first.includeSpecs.first()) }
+    }
+
+    def "an include and an exclude of the same coordinates are not the same spec"() {
+        given:
+        def including = new DefaultRepositoryContentDescriptor({ "including" }, new VersionParser())
+        def excluding = new DefaultRepositoryContentDescriptor({ "excluding" }, new VersionParser())
+
+        when:
+        including.includeGroup("org")
+        excluding.excludeGroup("org")
+
+        then:
+        !excluding.excludeSpecs.first().is(including.includeSpecs.first())
+    }
+
+    def "descriptors sharing a spec filter independently, including dynamic versions"() {
+        def fooMod = DefaultModuleIdentifier.newId('org', 'foo')
+        def firstDetails = Mock(ArtifactResolutionDetails)
+        def secondDetails = Mock(ArtifactResolutionDetails)
+
+        given:
+        def first = new DefaultRepositoryContentDescriptor({ "first" }, new VersionParser())
+        def second = new DefaultRepositoryContentDescriptor({ "second" }, new VersionParser())
+        first.excludeVersion("org", "foo", "[1.0,1.2]")
+        second.excludeVersion("org", "foo", "[1.0,1.2]")
+
+        expect: "the rule is declared once and both descriptors see the same spec"
+        first.excludeSpecs.first().is(second.excludeSpecs.first())
+
+        when: "each descriptor resolves the shared spec through its own selector scheme"
+        def firstAction = first.toContentFilter()
+        def secondAction = second.toContentFilter()
+        firstDetails.moduleId >> fooMod
+        firstDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.1')
+        secondDetails.moduleId >> fooMod
+        secondDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.1')
+        firstAction.execute(firstDetails)
+        secondAction.execute(secondDetails)
+
+        then: "a version inside the range is excluded by both"
+        1 * firstDetails.notFound()
+        1 * secondDetails.notFound()
+
+        when:
+        firstDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.3')
+        secondDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.3')
+        firstAction.execute(firstDetails)
+        secondAction.execute(secondDetails)
+
+        then: "a version outside it is excluded by neither"
+        0 * firstDetails.notFound()
+        0 * secondDetails.notFound()
+    }
+
+    def "a mutable copy of a descriptor holding shared specs can take further rules"() {
+        def fooMod = DefaultModuleIdentifier.newId('org', 'foo')
+        def barMod = DefaultModuleIdentifier.newId('org', 'bar')
+        def originalDetails = Mock(ArtifactResolutionDetails)
+        def copyDetails = Mock(ArtifactResolutionDetails)
+
+        given: "another descriptor already declared the rule, so the spec is shared"
+        new DefaultRepositoryContentDescriptor({ "other" }, new VersionParser()).excludeModule("org", "foo")
+        descriptor.excludeModule("org", "foo")
+
+        when:
+        def copy = descriptor.asMutableCopy()
+        copy.excludeModule("org", "bar")
+        def originalAction = descriptor.toContentFilter()
+        def copyAction = copy.toContentFilter()
+        originalDetails.moduleId >> barMod
+        originalDetails.componentId >> DefaultModuleComponentIdentifier.newId(barMod, '1.0')
+        copyDetails.moduleId >> barMod
+        copyDetails.componentId >> DefaultModuleComponentIdentifier.newId(barMod, '1.0')
+        originalAction.execute(originalDetails)
+        copyAction.execute(copyDetails)
+
+        then: "the rule added to the copy does not reach the original"
+        0 * originalDetails.notFound()
+        1 * copyDetails.notFound()
+
+        when:
+        originalDetails.moduleId >> fooMod
+        originalDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.0')
+        copyDetails.moduleId >> fooMod
+        copyDetails.componentId >> DefaultModuleComponentIdentifier.newId(fooMod, '1.0')
+        originalAction.execute(originalDetails)
+        copyAction.execute(copyDetails)
+
+        then: "and the shared rule still applies to both"
+        1 * originalDetails.notFound()
+        1 * copyDetails.notFound()
+    }
+
 }


### PR DESCRIPTION
addInclude() and addExclude() allocated a fresh ContentSpec per rule per descriptor and retained it in that descriptor's own set, so the retained cost of content filtering was projects x repositories x rules with nothing shared between descriptors. Large multi-project builds usually declare repositories and their filtering rules from a convention plugin, so every project gets every rule.

On a 500-project build with 4 filtered repositories each and 697 rules, ContentSpec was the largest class in the heap: 1,396,788 instances holding 63.9 MiB of a 205.6 MiB configuration-time live set, all representing those 697 distinct rules. Interning them takes the class to 697 instances and the live set to 152.1 MiB.
Fixes #38816

### Context

`DefaultRepositoryContentDescriptor.addInclude`/`addExclude` allocate a fresh `ContentSpec` for every
rule and retain it in that descriptor's own `HashSet`. Nothing is shared between descriptors, so the
retained cost of repository content filtering is `projects x repositories x rules`.

That product grows fast in the setup this pattern is designed for. Content filtering is recommended
precisely so that builds with several repositories stop hitting all of them for every module, and the
natural way to apply it is a convention plugin that declares the same rule set on every repository of
every project. Each project then pays for its own private copy of a rule set that is identical
everywhere.

Measured on the reproducer below (500 projects, 4 repositories each, 697 rules, `-Xmx2g`, compressed
oops on), from `jcmd GC.class_histogram` after configuration:

| | objects | retained | live set |
|---|---|---|---|
| rules declared | 1,396,788 `ContentSpec` | 63.9 MiB | 205.6 MiB |
| same repositories, no rules | 0 | 0 | 90.3 MiB |
| every spec canonicalized after the fact | 697 `ContentSpec` | 0.03 MiB | 152.1 MiB |

`ContentSpec` is the single largest class in the heap, and those 1,396,788 objects represent 697
distinct rules, a duplication factor of 2,004. Content filtering accounts for 115.3 MiB of the
205.6 MiB live set, and roughly half of that is pure duplication. A real build with 519 projects shows
the same shape at 1,473,703 instances and 101.2 MiB, higher per instance because a heap above the
compressed oops threshold widens every reference.

A spec is an immutable value, so one instance can serve every descriptor that declares that rule.
This PR canonicalizes them through a weak interner, which makes the retained cost proportional to the
number of distinct rules instead of to rules times repositories.

Centralizing repositories in `dependencyResolutionManagement` is not a substitute here. The default
`RepositoriesMode.PREFER_PROJECT` leaves project repositories in charge wherever a project declares
any, plugins routinely add repositories to individual projects for their own resolution needs, and
`buildscript` repositories are outside `dependencyResolutionManagement` entirely. A build cannot
generally guarantee that no project or plugin declares a repository, so the per-project cost stays.

### Implementation

Two things happen in one commit, because the first is what makes the second safe.

**`ContentSpec` becomes a pure value.** It held `versionSelectorScheme` and a `versionSelectors` memo
belonging to the descriptor that created it, only so `toMatcher()` could pass them to
`SimpleSpecMatcher`'s constructor. `equals` already ignored both. Since `createSpecMatchers` is static
and is called from the instance method `toContentFilter()`, the owning descriptor can pass both down
as parameters instead. After that the spec carries no descriptor-scoped state at all, so equal specs
are genuinely interchangeable and each descriptor keeps using its own scheme and its own memo even
when the spec objects are shared. This is worth having on its own: it drops the object from six
reference fields to four, 48 bytes to 40 with compressed oops and 72 to 56 without.

**The specs are interned.** A `static final Interner<ContentSpec>` from `Interners.newWeakInterner()`,
wrapped around the two `new ContentSpec(...)` call sites. Weak means an entry goes away once the last
descriptor referencing it does, so nothing accumulates across builds in the daemon, and Guava's weak
interner is concurrent, so it is safe under parallel project configuration. This mirrors
`IncludeWithSimpleExpression` in `language-native`, which interns the same way for the same reason.

Sharing `ContentSpec` across descriptors is already how this code works:
`DefaultMavenRepositoryContentDescriptor.asMutableCopy()` does `Sets.newHashSet(getIncludeSpecs())`,
copying the set and sharing the elements by reference. No public API changes, no change to
`equals`/`hashCode`, no build file changes, and one production file touched.

An alternative worth mentioning: `InMemoryInterner` threaded through
`AbstractArtifactRepository.createRepositoryDescriptor` would scope the pool to the build rather than
the daemon, which is arguably tidier, at the cost of plumbing through a constructor that already
carries a `this-escape` suppression. Happy to switch to that if you prefer it.

### Verification

Four unit tests in `DefaultRepositoryContentDescriptorTest`:

- the same rule declared on two independently constructed descriptors yields one instance, and a
  different rule on the same descriptor does not collide with it
- an include and an exclude of the same coordinates stay distinct, which is the assertion that
  covers the `inclusive` flag in `equals`
- two descriptors sharing a spec still filter independently and correctly, including for a version
  range, built with separate `VersionParser` instances. This is the regression guard for the field
  removal: without it, one descriptor's scheme would leak into the other
- `asMutableCopy()` on a descriptor holding shared specs can still take further rules without
  disturbing the original

Checked that these tests are not vacuous: with the interner removed and everything else unchanged,
exactly the two interning-dependent tests fail.

Existing coverage is unchanged, including `RepositoryContentFilteringIntegrationTest`,
`BuildscriptRepositoryContentFilteringIntegrationTest`, and
`ExclusiveRepositoryContentFilteringIntegrationTest`. No new integration test: the change is invisible
from the build script level by design.

### AI involvement

I used Claude Code while working on this. It helped build the reproducer, run and cross-check the heap
measurements, and draft the tests and this description. The design, in particular removing the two
descriptor-scoped fields so that interning is behavior-neutral by construction rather than by
argument, and every claim above, I reviewed and verified myself, and I can explain and defend the
change in review.

### Reproducer

https://github.com/rpalcolea/gradle-contentspec-repro

Fully offline: `help` resolves nothing and every repository URL points at `https://example.invalid/`.
`./measure.sh` runs three configurations on fresh daemons and prints the table above. Project count,
repository count, rule count, and group count are all `-P` knobs.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
