### PR TITLE
Detect overlapping outputs between tasks in different builds

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -169,6 +169,17 @@ Whether the Build Cache is enabled is determined by the Gradle invocation (`--bu
 Enable or disable the Build Cache with the `org.gradle.caching` Gradle property instead.
 See <<build_cache.adoc#sec:build_cache_enable,Enable the Build Cache>> for details.
 
+[[deprecate_implicit_dependencies_between_builds]]
+==== Deprecation of implicit task dependencies between builds
+
+Gradle now detects overlapping task outputs across the builds of a composite build.
+Tasks in different builds that write to the same location no longer run in parallel, matching the behavior of tasks within a single build.
+
+As part of this change, a task consuming the outputs of a task in another build without declaring an explicit or implicit dependency is now deprecated.
+This will become an error in Gradle 10, matching the existing behavior for tasks in the same build.
+
+See <<validation_problems.adoc#implicit_dependency,Implicit dependencies between tasks>> for details and possible solutions.
+
 
 [[changes_9.7.0]]
 == Upgrading from 9.6.0 and earlier

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOverlappingOutputsIntegrationTest.groovy
@@ -41,7 +41,13 @@ class CompositeBuildOverlappingOutputsIntegrationTest extends AbstractCompositeB
 
         def buildB = singleProjectBuild("buildB") {
             buildFile << """
+                tasks.register("includedGate") {
+                    doLast {
+                        ${server.callFromBuild("includedGate")}
+                    }
+                }
                 tasks.register("includedPing") {
+                    dependsOn("includedGate")
                     outputs.dir(file("$sharedDir"))
                     doLast {
                         ${server.callFromBuild("includedPing")}
@@ -52,7 +58,13 @@ class CompositeBuildOverlappingOutputsIntegrationTest extends AbstractCompositeB
         includeBuild(buildB)
 
         buildA.buildFile << """
+            tasks.register("rootGate") {
+                doLast {
+                    ${server.callFromBuild("rootGate")}
+                }
+            }
             tasks.register("rootPing") {
+                dependsOn("rootGate")
                 outputs.file(file("$sharedDir/file.txt"))
                 doLast {
                     ${server.callFromBuild("rootPing")}
@@ -60,26 +72,89 @@ class CompositeBuildOverlappingOutputsIntegrationTest extends AbstractCompositeB
             }
         """
 
-        // With concurrent == 1, each call is held until explicitly released, and a second call
-        // arriving while another is held fails immediately as an unexpected request
-        def handle = server.expectConcurrentAndBlock(1, "rootPing", "includedPing")
+        // The gate tasks have no overlapping outputs, so both builds can reach their gate and be released together.
+        // This makes both builds attempt their overlapping task at the same moment.
+        def gates = server.expectConcurrentAndBlock(2, "rootGate", "includedGate")
+        // With concurrent == 1, each call is held until explicitly released, and a second call arriving while
+        // another is held fails immediately as an unexpected request. So if the mutual exclusion of overlapping
+        // outputs across builds were broken, this is where the test would fail.
+        def pings = server.expectConcurrentAndBlock(1, "rootPing", "includedPing")
 
         when:
         def build = executer.inDirectory(buildA)
             .withTasks(":buildB:includedPing", ":rootPing")
+            .withArgument("--max-workers=4")
             .start()
 
         then:
+        gates.waitForAllPendingCalls()
+        gates.releaseAll()
+
         // One of the two tasks is now frozen mid-action, holding its claim on the shared output location
-        handle.waitForAllPendingCalls()
-        // This is the detection window. If the mutual exclusion of overlapping outputs across builds
-        // were broken, the other task would start while the first is frozen, its call would arrive at
-        // the server, and the test would fail immediately with an unexpected request error.
-        Thread.sleep(500)
-        handle.release(1)
+        pings.waitForAllPendingCalls()
+        pings.release(1)
         // Now the second task is allowed to run and make its call
-        handle.waitForAllPendingCalls()
-        handle.release(1)
+        pings.waitForAllPendingCalls()
+        pings.release(1)
+        build.waitForFinish()
+    }
+
+    def "tasks destroying the same location in different builds do not run in parallel"() {
+        given:
+        def sharedDir = normaliseFileSeparators(file("shared-output").absolutePath)
+
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                tasks.register("includedGate") {
+                    doLast {
+                        ${server.callFromBuild("includedGate")}
+                    }
+                }
+                tasks.register("includedClean") {
+                    dependsOn("includedGate")
+                    destroyables.register(file("$sharedDir"))
+                    doLast {
+                        ${server.callFromBuild("includedClean")}
+                    }
+                }
+            """
+        }
+        includeBuild(buildB)
+
+        buildA.buildFile << """
+            tasks.register("rootGate") {
+                doLast {
+                    ${server.callFromBuild("rootGate")}
+                }
+            }
+            tasks.register("rootClean") {
+                dependsOn("rootGate")
+                destroyables.register(file("$sharedDir"))
+                doLast {
+                    ${server.callFromBuild("rootClean")}
+                }
+            }
+        """
+
+        def gates = server.expectConcurrentAndBlock(2, "rootGate", "includedGate")
+        def cleans = server.expectConcurrentAndBlock(1, "rootClean", "includedClean")
+
+        when:
+        def build = executer.inDirectory(buildA)
+            .withTasks(":buildB:includedClean", ":rootClean")
+            .withArgument("--max-workers=4")
+            .start()
+
+        then:
+        gates.waitForAllPendingCalls()
+        gates.releaseAll()
+
+        cleans.waitForAllPendingCalls()
+        cleans.release(1)
+
+        cleans.waitForAllPendingCalls()
+        cleans.release(1)
+
         build.waitForFinish()
     }
 
@@ -133,7 +208,7 @@ class CompositeBuildOverlappingOutputsIntegrationTest extends AbstractCompositeB
                 "For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.")
 
         when:
-        execute(buildA, [":buildB:producer", ":consumer"] as String[])
+        execute(buildA, [":buildB:producer", ":consumer"] as String[], ["--max-workers=4"])
 
         then:
         executed(":buildB:producer", ":consumer")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOverlappingOutputsIntegrationTest.groovy
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+
+import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
+
+/**
+ * Tests that the execution node access hierarchies are shared by all builds in a build tree,
+ * so that tasks with overlapping outputs or destroyables in different builds are
+ * subject to the same mutation ordering constraints as tasks within a single build.
+ */
+class CompositeBuildOverlappingOutputsIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.start()
+    }
+
+    def "tasks with overlapping outputs in different builds do not run in parallel"() {
+        given:
+        def sharedDir = normaliseFileSeparators(file("shared-output").absolutePath)
+
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                tasks.register("includedPing") {
+                    outputs.dir(file("$sharedDir"))
+                    doLast {
+                        ${server.callFromBuild("includedPing")}
+                    }
+                }
+            """
+        }
+        includeBuild(buildB)
+
+        buildA.buildFile << """
+            tasks.register("rootPing") {
+                outputs.file(file("$sharedDir/file.txt"))
+                doLast {
+                    ${server.callFromBuild("rootPing")}
+                }
+            }
+        """
+
+        // With concurrent == 1, each call is held until explicitly released, and a second call
+        // arriving while another is held fails immediately as an unexpected request
+        def handle = server.expectConcurrentAndBlock(1, "rootPing", "includedPing")
+
+        when:
+        def build = executer.inDirectory(buildA)
+            .withTasks(":buildB:includedPing", ":rootPing")
+            .start()
+
+        then:
+        // One of the two tasks is now frozen mid-action, holding its claim on the shared output location
+        handle.waitForAllPendingCalls()
+        // This is the detection window. If the mutual exclusion of overlapping outputs across builds
+        // were broken, the other task would start while the first is frozen, its call would arrive at
+        // the server, and the test would fail immediately with an unexpected request error.
+        Thread.sleep(500)
+        handle.release(1)
+        // Now the second task is allowed to run and make its call
+        handle.waitForAllPendingCalls()
+        handle.release(1)
+        build.waitForFinish()
+    }
+
+    def "task consuming the overlapping output location of a task in another build without a dependency emits a deprecation warning"() {
+        given:
+        enableProblemsApiCheck()
+        def sharedDir = normaliseFileSeparators(file("shared-output").absolutePath)
+
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                tasks.register("producer") {
+                    outputs.dir(file("$sharedDir"))
+                    def outputFile = file("$sharedDir/produced.txt")
+                    doLast {
+                        outputFile.text = "produced"
+                        ${server.callFromBuild("producer")}
+                    }
+                }
+            """
+        }
+        includedBuilds << buildB
+
+        buildA.buildFile << """
+            tasks.register("gate") {
+                doLast {
+                    ${server.callFromBuild("gate")}
+                }
+            }
+            tasks.register("consumer") {
+                dependsOn("gate")
+                inputs.dir(file("$sharedDir"))
+                def outputFile = file("consumer-out.txt")
+                outputs.file(outputFile)
+                doLast {
+                    outputFile.text = "consumed"
+                }
+            }
+        """
+
+        // Ensure the producer is executing (and thus its outputs are recorded in the shared hierarchy)
+        // before the gate task completes and the consumer starts, without introducing a dependency
+        // between the producer and the consumer
+        server.expectConcurrent("producer", "gate")
+
+        executer.expectDocumentedDeprecationWarning(
+            "Producing a file in one build and consuming it in another build without declaring an explicit dependency has been deprecated. " +
+                "This will fail with an error in Gradle 10. " +
+                "Gradle detected a problem with the following location: '${file("shared-output").absolutePath}'. " +
+                "Task ':consumer' uses this output of task ':buildB:producer' without declaring an explicit or implicit dependency. " +
+                "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
+                "For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.")
+
+        when:
+        execute(buildA, [":buildB:producer", ":consumer"] as String[])
+
+        then:
+        executed(":buildB:producer", ":consumer")
+        buildA.file("consumer-out.txt").text == "consumed"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'deprecation:implicit-dependency-between-tasks-in-different-builds'
+            definition.id.displayName == 'Implicit dependency between tasks in different builds'
+            contextualLabel == "Producing a file in one build and consuming it in another build without declaring an explicit dependency has been deprecated."
+            details == 'This will fail with an error in Gradle 10.'
+            solutions == [
+                "Gradle detected a problem with the following location: '${file("shared-output").absolutePath}'. " +
+                    "Task ':consumer' uses this output of task ':buildB:producer' without declaring an explicit or implicit dependency. " +
+                    "This can lead to incorrect results being produced, depending on what order the tasks are executed."
+            ]
+        }
+    }
+
+    def "task consuming the overlapping output location of a task in another build with a declared dependency does not emit a deprecation warning"() {
+        given:
+        def sharedDir = normaliseFileSeparators(file("shared-output").absolutePath)
+
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                tasks.register("producer") {
+                    outputs.dir(file("$sharedDir"))
+                    def outputFile = file("$sharedDir/produced.txt")
+                    doLast {
+                        outputFile.text = "produced"
+                    }
+                }
+            """
+        }
+        includedBuilds << buildB
+
+        buildA.buildFile << """
+            tasks.register("consumer") {
+                dependsOn(gradle.includedBuild("buildB").task(":producer"))
+                inputs.dir(file("$sharedDir"))
+                def outputFile = file("consumer-out.txt")
+                outputs.file(outputFile)
+                doLast {
+                    outputFile.text = "consumed"
+                }
+            }
+        """
+
+        expect:
+        execute(buildA, "consumer")
+        executed(":buildB:producer", ":consumer")
+        buildA.file("consumer-out.txt").text == "consumed"
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
+import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
@@ -84,6 +85,11 @@ public class ProjectExecutionServices implements ServiceRegistrationProvider {
     @Provides
     ReservedFileSystemLocationRegistry createReservedFileLocationRegistry(List<ReservedFileSystemLocation> reservedFileSystemLocations) {
         return new DefaultReservedFileSystemLocationRegistry(reservedFileSystemLocations);
+    }
+
+    @Provides
+    MissingTaskDependencyDetector createMissingTaskDependencyDetector(ExecutionNodeAccessHierarchies hierarchies) {
+        return new MissingTaskDependencyDetector(hierarchies.getOutputHierarchy(), hierarchies.createInputHierarchy());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
-import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
@@ -85,11 +84,6 @@ public class ProjectExecutionServices implements ServiceRegistrationProvider {
     @Provides
     ReservedFileSystemLocationRegistry createReservedFileLocationRegistry(List<ReservedFileSystemLocation> reservedFileSystemLocations) {
         return new DefaultReservedFileSystemLocationRegistry(reservedFileSystemLocations);
-    }
-
-    @Provides
-    MissingTaskDependencyDetector createMissingTaskDependencyDetector(ExecutionNodeAccessHierarchies hierarchies) {
-        return new MissingTaskDependencyDetector(hierarchies.getOutputHierarchy(), hierarchies.createInputHierarchy());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -104,6 +104,11 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
     }
 
     @Override
+    public boolean contains(Node node) {
+        return nodeMapping.contains(node);
+    }
+
+    @Override
     public void setScheduledWork(ScheduledWork work) {
         if (scheduledNodes != null) {
             throw new IllegalStateException("This execution plan already has nodes scheduled.");

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
@@ -85,9 +85,17 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
     private final OrdinalNodeAccess ordinalNodeAccess;
     private final Consumer<LocalTaskNode> completionHandler;
 
-    // When true, there may be nodes that are both ready and "selectable", which means their project and resources are able to be locked
-    // When false, there are definitely no nodes that are "selectable"
+    // When true, there may be nodes that are both ready and "selectable", which means their project and resources are able to be locked.
+    // When false, there are definitely no nodes that are "selectable", and some event that this plan can observe must happen before any
+    // node can become selectable: a node of this plan completing, a resource being unlocked, or a node being added to this plan.
+    // A selection scan must therefore leave this flag set when it rejected a node for a reason whose resolution this plan cannot
+    // observe, such as a mutation conflict with a node that belongs to another plan. See NodeStartResult.
     private boolean maybeNodesSelectable;
+
+    /**
+     * The pre- and post-execution nodes added to this plan while it is executing.
+     */
+    private final Set<Node> nodesAddedDuringExecution = new HashSet<>();
 
     private boolean buildCancelled;
 
@@ -151,6 +159,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         readyNodes.clear();
         runningNodes.clear();
         reachableCache.clear();
+        nodesAddedDuringExecution.clear();
     }
 
     private void resourceUnlocked(ResourceLock resourceLock) {
@@ -238,6 +247,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         }
 
         List<ResourceLock> resources = new ArrayList<>();
+        boolean nodeBlockedByConflictInOtherPlan = false;
         readyNodes.restart();
         while (readyNodes.hasNext()) {
             Node node = readyNodes.next();
@@ -276,11 +286,15 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
                 }
 
                 // Node is ready to execute and all dependencies and pre-execution nodes have completed
-                if (attemptToStart(node, resources)) {
+                NodeStartResult startResult = attemptToStart(node, resources);
+                if (startResult == NodeStartResult.STARTED) {
                     readyNodes.remove();
                     waitingToStartNodes.remove(node);
                     node.getConsumerState().started();
                     return Selection.of(node);
+                }
+                if (startResult == NodeStartResult.BLOCKED_BY_NODE_IN_ANOTHER_PLAN) {
+                    nodeBlockedByConflictInOtherPlan = true;
                 }
             }
             if (node.isComplete()) {
@@ -290,7 +304,11 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
             }
         }
 
-        maybeNodesSelectable = false;
+        // The plan must remain selectable while a node is blocked by a conflict with a node in another plan. The completion
+        // of the conflicting node does not reset maybeNodesSelectable. When the conflicting node holds no locks (for example,
+        // when its plan was loaded from CC) it also does not fire the resource unlock listener. So, no event observable by this
+        // plan would mark the end of the conflict. The blocked node is re-attempted on the next scan instead.
+        maybeNodesSelectable = nodeBlockedByConflictInOtherPlan;
         if (waitingToStartNodes.isEmpty()) {
             return Selection.noMoreWorkToStart();
         }
@@ -303,29 +321,57 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
     }
 
     private void addNodeToPlan(Node node) {
+        nodesAddedDuringExecution.add(node);
         maybeNodeReady(node);
         maybeWaitingForNewNode(node, "runtime");
     }
 
-    private boolean attemptToStart(Node node, List<ResourceLock> resources) {
+    private enum NodeStartResult {
+        /**
+         * The node was started.
+         */
+        STARTED,
+        /**
+         * The node cannot start yet. Some event that this plan can observe will make it startable, for example,
+         * a node of this plan completing or a resource lock being released.
+         */
+        BLOCKED,
+        /**
+         * The node cannot start because its mutations conflict with a node that belongs to another plan.
+         * No event that this plan can observe fires when that node completes.
+         */
+        BLOCKED_BY_NODE_IN_ANOTHER_PLAN
+    }
+
+    private NodeStartResult attemptToStart(Node node, List<ResourceLock> resources) {
         resources.clear();
         if (!tryAcquireLocksForNode(node, resources)) {
             releaseLocks(resources);
-            return false;
+            return NodeStartResult.BLOCKED;
         }
 
         MutationInfo mutations = node.getMutationInfo();
 
-        if (conflictsWithOtherNodes(node, mutations)) {
+        if (!canRunWithCurrentlyExecutedNodes(mutations)) {
+            LOGGER.debug("Node {} cannot run with currently running nodes {}", node, runningNodes);
             releaseLocks(resources);
-            return false;
+            return NodeStartResult.BLOCKED;
+        }
+
+        Node conflictingNode = findNodeConflictingWith(node, mutations);
+        if (conflictingNode != null) {
+            LOGGER.debug("Node {} cannot start, as it conflicts with {}", node, conflictingNode);
+            releaseLocks(resources);
+            return isPartOfThisPlan(conflictingNode)
+                ? NodeStartResult.BLOCKED
+                : NodeStartResult.BLOCKED_BY_NODE_IN_ANOTHER_PLAN;
         }
 
         node.startExecution(this::recordNodeExecutionStarted);
         if (mutations.hasValidationProblem()) {
             invalidNodeRunning = true;
         }
-        return true;
+        return NodeStartResult.STARTED;
     }
 
     private void releaseLocks(List<ResourceLock> resources) {
@@ -345,17 +391,20 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         return true;
     }
 
-    private boolean conflictsWithOtherNodes(Node node, MutationInfo mutations) {
-        if (!canRunWithCurrentlyExecutedNodes(mutations)) {
-            LOGGER.debug("Node {} cannot run with currently running nodes {}", node, runningNodes);
-            return true;
-        } else if (mutationConflictsWithOtherNodes(node, mutations)) {
-            return true;
-        } else if (destroysNotYetConsumedOutputOfAnotherNode(node, mutations.getDestroyablePaths())) {
-            LOGGER.debug("Node {} destroys not yet consumed output of another node", node);
-            return true;
+    /**
+     * Finds a node whose recorded mutations prevent the given node from starting, or null when there is none.
+     * The returned node may belong to another plan, as the node access hierarchies span all builds in the tree.
+     */
+    private @Nullable Node findNodeConflictingWith(Node node, MutationInfo mutations) {
+        Node conflictingNode = findMutationConflict(node, mutations);
+        if (conflictingNode != null) {
+            return conflictingNode;
         }
-        return false;
+        return findConsumerOfDestroyedOutput(node, mutations.getDestroyablePaths());
+    }
+
+    private boolean isPartOfThisPlan(Node node) {
+        return contents.contains(node) || nodesAddedDuringExecution.contains(node);
     }
 
     private void updateAllDependenciesCompleteForPredecessors(Node node) {
@@ -408,58 +457,80 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         }
     }
 
-    private boolean mutationConflictsWithOtherNodes(Node node, MutationInfo mutations) {
+    /**
+     * Finds the first node accessing the locations mutated by the given node that must complete
+     * before the given node can start, or null when there is none.
+     */
+    private @Nullable Node findMutationConflict(Node node, MutationInfo mutations) {
         Set<String> nodeOutputPaths = mutations.getOutputPaths();
         Set<String> nodeDestroysPaths = mutations.getDestroyablePaths();
         if (nodeOutputPaths.isEmpty() && nodeDestroysPaths.isEmpty()) {
-            return false;
+            return null;
         }
 
-        BiFunction<Boolean, Node, Boolean> conflictsWithRunning = (current, candidate) -> current || candidate.isExecuting();
+        BiFunction<@Nullable Node, Node, @Nullable Node> executingNode = (found, candidate) -> {
+            if (found != null) {
+                return found;
+            }
+            return candidate.isExecuting() ? candidate : null;
+        };
 
         OrdinalGroup nodeOrdinal = node.getOrdinal();
-        BiFunction<Boolean, Node, Boolean> conflictsWithNodeInEarlierOrdinal = (current, candidate) -> {
-            if (current || candidate.isComplete()) {
-                return current;
+        BiFunction<@Nullable Node, Node, @Nullable Node> nodeInEarlierOrdinal = (found, candidate) -> {
+            if (found != null) {
+                return found;
+            }
+            if (candidate.isComplete()) {
+                return null;
             }
             OrdinalGroup otherOrdinal = candidate.getOrdinal();
-            return otherOrdinal != null && otherOrdinal.getOrdinal() < nodeOrdinal.getOrdinal();
+            if (otherOrdinal != null && otherOrdinal.getOrdinal() < nodeOrdinal.getOrdinal()) {
+                return candidate;
+            }
+            return null;
         };
 
         for (String path : nodeOutputPaths) {
-            if (outputHierarchy.visitNodesAccessing(path, false, conflictsWithRunning)) {
-                return true;
+            Node conflict = outputHierarchy.visitNodesAccessing(path, null, executingNode);
+            if (conflict != null) {
+                return conflict;
             }
             if (nodeOrdinal != null) {
-                if (destroyableHierarchy.visitNodesAccessing(path, false, conflictsWithNodeInEarlierOrdinal)) {
-                    return true;
+                conflict = destroyableHierarchy.visitNodesAccessing(path, null, nodeInEarlierOrdinal);
+                if (conflict != null) {
+                    return conflict;
                 }
             }
         }
         for (String path : nodeDestroysPaths) {
-            if (destroyableHierarchy.visitNodesAccessing(path, false, conflictsWithRunning)) {
-                return true;
+            Node conflict = destroyableHierarchy.visitNodesAccessing(path, null, executingNode);
+            if (conflict != null) {
+                return conflict;
             }
             if (nodeOrdinal != null) {
-                if (outputHierarchy.visitNodesAccessing(path, false, conflictsWithNodeInEarlierOrdinal)) {
-                    return true;
+                conflict = outputHierarchy.visitNodesAccessing(path, null, nodeInEarlierOrdinal);
+                if (conflict != null) {
+                    return conflict;
                 }
             }
         }
-        return false;
+        return null;
     }
 
-    private boolean destroysNotYetConsumedOutputOfAnotherNode(Node destroyer, Set<String> destroyablePaths) {
+    /**
+     * Finds the first node that has not yet consumed an output that the given node destroys, or null when there is none.
+     */
+    private @Nullable Node findConsumerOfDestroyedOutput(Node destroyer, Set<String> destroyablePaths) {
         if (destroyablePaths.isEmpty()) {
-            return false;
+            return null;
         }
 
-        BiFunction<Boolean, Node, Boolean> conflicts = (current, producingNode) -> {
-            if (current) {
-                return current;
+        BiFunction<@Nullable Node, Node, @Nullable Node> conflictingConsumer = (found, producingNode) -> {
+            if (found != null) {
+                return found;
             }
             if (!producingNode.getConsumerState().isOutputProducedButNotYetConsumed()) {
-                return false;
+                return null;
             }
             ConsumerState producingNodeConsumerState = producingNode.getConsumerState();
             for (Node consumer : producingNodeConsumerState.getNodesYetToConsumeOutput()) {
@@ -468,18 +539,18 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
                     // then we accept that as the will of the user
                     continue;
                 }
-                LOGGER.debug("Node {} destroys output of consumer {}", destroyer, consumer);
-                return true;
+                return consumer;
             }
-            return false;
+            return null;
         };
 
         for (String destroyablePath : destroyablePaths) {
-            if (outputHierarchy.visitNodesAccessing(destroyablePath, false, conflicts)) {
-                return true;
+            Node conflict = outputHierarchy.visitNodesAccessing(destroyablePath, null, conflictingConsumer);
+            if (conflict != null) {
+                return conflict;
             }
         }
-        return false;
+        return null;
     }
 
     private boolean doesConsumerDependOnDestroyer(Node consumer, Node destroyer) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.CaseSensitivity;
 
-@ServiceScope(Scope.Build.class)
+@ServiceScope(Scope.BuildTree.class)
 public class ExecutionNodeAccessHierarchies implements HoldsProjectState {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
@@ -42,22 +42,23 @@ public class ExecutionNodeAccessHierarchies implements HoldsProjectState {
         destroyableHierarchy.clear();
     }
 
-    /**
-     * Create the input node access hierarchy.
-     *
-     * For performance reasons, we keep one input node access hierarchy per project,
-     * so we only have a factory method here and this is used to create the hierarchy in {@link org.gradle.execution.ProjectExecutionServices}.
-     */
-    public InputNodeAccessHierarchy createInputHierarchy() {
-        return new InputNodeAccessHierarchy(caseSensitivity, stat);
-    }
-
     public ExecutionNodeAccessHierarchy getOutputHierarchy() {
         return outputHierarchy;
     }
 
     public ExecutionNodeAccessHierarchy getDestroyableHierarchy() {
         return destroyableHierarchy;
+    }
+
+    /**
+     * Create the input node access hierarchy.
+     *
+     * <p>
+     * For performance reasons, we keep one input node access hierarchy per project, so we only have a factory method
+     * here and this is used to create the hierarchy in {@link org.gradle.execution.ProjectExecutionServices}.
+     */
+    public InputNodeAccessHierarchy createInputHierarchy() {
+        return new InputNodeAccessHierarchy(caseSensitivity, stat);
     }
 
     public static class InputNodeAccessHierarchy extends ExecutionNodeAccessHierarchy {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
@@ -114,7 +114,7 @@ public class ExecutionNodeAccessHierarchy {
         root = root.empty();
     }
 
-    private <T> T visitValues(String location, AbstractNodeAccessVisitor<T> visitor) {
+    private <T extends @Nullable Object> T visitValues(String location, AbstractNodeAccessVisitor<T> visitor) {
         root.visitValues(location, visitor);
         return visitor.getResult();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
@@ -24,6 +24,7 @@ import org.gradle.internal.collect.PersistentList;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.internal.snapshot.VfsRelativePath;
+import org.jspecify.annotations.Nullable;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
@@ -55,7 +56,7 @@ public class ExecutionNodeAccessHierarchy {
      *
      * That includes node which access ancestors or children of the location.
      */
-    public <T> T visitNodesAccessing(String location, T initialValue, BiFunction<T, ? super Node, T> visitor) {
+    public <T extends @Nullable Object> T visitNodesAccessing(String location, T initialValue, BiFunction<T, ? super Node, T> visitor) {
         return visitValues(location, new AbstractNodeAccessVisitor<T>() {
             T currentValue = initialValue;
 
@@ -118,7 +119,7 @@ public class ExecutionNodeAccessHierarchy {
         return visitor.getResult();
     }
 
-    private abstract static class AbstractNodeAccessVisitor<T> implements ValueVisitor<NodeAccess> {
+    private abstract static class AbstractNodeAccessVisitor<T extends @Nullable Object> implements ValueVisitor<NodeAccess> {
         @Override
         public void visitExact(NodeAccess value) {
             visit(value);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -18,13 +18,10 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;
@@ -54,7 +51,6 @@ import static org.gradle.internal.deprecation.Documentation.userManual;
  * consuming a parent directory of the produced output.
  * </p>
  */
-@ServiceScope(Scope.BuildTree.class)
 public class MissingTaskDependencyDetector {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy inputHierarchy;
@@ -89,35 +85,50 @@ public class MissingTaskDependencyDetector {
     }
 
     private static void collectValidationProblemsForConsumer(LocalTaskNode consumer, TypeValidationContext validationContext, String locationConsumedByThisTask, Collection<Node> producers) {
-        producers.stream()
-            .filter(producerNode -> hasNoSpecifiedOrder(producerNode, consumer))
-            .filter(MissingTaskDependencyDetector::isEnabled)
-            .forEach(producerWithoutDependency -> collectValidationProblem(
-                producerWithoutDependency,
-                consumer,
-                validationContext,
-                locationConsumedByThisTask
-            ));
+        for (Node producerNode : producers) {
+            if (!hasNoSpecifiedOrder(producerNode, consumer)) {
+                continue;
+            }
+            LocalTaskNode producerWithoutDependency = asEnabledTaskNode(producerNode);
+            if (producerWithoutDependency != null) {
+                collectValidationProblem(
+                    producerWithoutDependency,
+                    consumer,
+                    validationContext,
+                    locationConsumedByThisTask
+                );
+            }
+        }
     }
 
     private static void collectValidationProblemsForProducer(LocalTaskNode node, TypeValidationContext validationContext, String outputPath, Collection<Node> consumers) {
-        consumers.stream()
-            .filter(consumerNode -> hasNoSpecifiedOrder(node, consumerNode))
-            .filter(MissingTaskDependencyDetector::isEnabled)
-            .forEach(consumerWithoutDependency -> collectValidationProblem(
-                node,
-                consumerWithoutDependency,
-                validationContext,
-                outputPath)
-            );
+        for (Node consumerNode : consumers) {
+            if (!hasNoSpecifiedOrder(node, consumerNode)) {
+                continue;
+            }
+            LocalTaskNode consumerWithoutDependency = asEnabledTaskNode(consumerNode);
+            if (consumerWithoutDependency != null) {
+                collectValidationProblem(
+                    node,
+                    consumerWithoutDependency,
+                    validationContext,
+                    outputPath
+                );
+            }
+        }
     }
 
-    private static boolean isEnabled(Node node) {
-        if (node instanceof LocalTaskNode) {
-            TaskInternal task = ((LocalTaskNode) node).getTask();
-            return task.getOnlyIf().isSatisfiedBy(task);
+    /**
+     * Returns the given node as a task node, or null when it is not a task node, or it
+     * is not enabled.
+     */
+    private static @Nullable LocalTaskNode asEnabledTaskNode(Node node) {
+        if (!(node instanceof LocalTaskNode)) {
+            return null;
         }
-        return false;
+        LocalTaskNode taskNode = (LocalTaskNode) node;
+        TaskInternal task = taskNode.getTask();
+        return task.getOnlyIf().isSatisfiedBy(task) ? taskNode : null;
     }
 
     // In a perfect world, the consumer should depend on the producer.
@@ -174,8 +185,8 @@ public class MissingTaskDependencyDetector {
 
     private static final String IMPLICIT_DEPENDENCY = "IMPLICIT_DEPENDENCY";
 
-    private static void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext, String consumerProducerPath) {
-        if (mayBeDifferentBuilds(producer, consumer)) {
+    private static void collectValidationProblem(LocalTaskNode producer, LocalTaskNode consumer, TypeValidationContext validationContext, String consumerProducerPath) {
+        if (areInDifferentBuilds(producer, consumer)) {
             // Historically, we did not detect overlapping outputs between nodes in different builds.
             // Emit a deprecation warning instead of a failure until Gradle 10.
             // In Gradle 10, we can remove this branch entirely and fall back to the problem-emitting branch below.
@@ -209,29 +220,12 @@ public class MissingTaskDependencyDetector {
         );
     }
 
-    private static boolean mayBeDifferentBuilds(Node producer, Node consumer) {
-        Path producerBuild = buildPathOf(producer);
-        if (producerBuild == null) {
-            return true;
-        }
-        Path consumerBuild = buildPathOf(consumer);
-        if (consumerBuild == null) {
-            return true;
-        }
-        return !consumerBuild.equals(producerBuild);
+    private static boolean areInDifferentBuilds(LocalTaskNode producer, LocalTaskNode consumer) {
+        return !buildPathOf(producer).equals(buildPathOf(consumer));
     }
 
-    private static @Nullable Path buildPathOf(Node node) {
-        if (node instanceof TaskNode) {
-            return ((TaskNode) node).getTask().getTaskIdentity().getProjectIdentity().getBuildPath();
-        }
-
-        ProjectInternal owningProject = node.getOwningProject();
-        if (owningProject != null) {
-            return owningProject.getOwner().getOwner().getIdentityPath();
-        }
-
-        return null;
+    private static Path buildPathOf(LocalTaskNode node) {
+        return node.getTask().getTaskIdentity().getProjectIdentity().getBuildPath();
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -18,10 +18,16 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 import org.gradle.util.internal.TextUtil;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -48,6 +54,7 @@ import static org.gradle.internal.deprecation.Documentation.userManual;
  * consuming a parent directory of the produced output.
  * </p>
  */
+@ServiceScope(Scope.BuildTree.class)
 public class MissingTaskDependencyDetector {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy inputHierarchy;
@@ -149,7 +156,13 @@ public class MissingTaskDependencyDetector {
         node.getHardSuccessors().forEach(successor -> {
             // We are searching for dependencies between tasks, so we can skip everything which is not a task when searching.
             // For example, we can skip all the transform nodes between two task nodes.
-            if (successor instanceof TaskNode || successor instanceof OrdinalNode) {
+            if (successor instanceof TaskInAnotherBuild) {
+                // A reference to a task in another build is a proxy for the task node in the other build's work graph.
+                Node targetNode = ((TaskInAnotherBuild) successor).getTargetNode();
+                if (seenNodes.add(targetNode)) {
+                    queue.add(targetNode);
+                }
+            } else if (successor instanceof TaskNode || successor instanceof OrdinalNode) {
                 if (seenNodes.add(successor)) {
                     queue.add(successor);
                 }
@@ -162,6 +175,25 @@ public class MissingTaskDependencyDetector {
     private static final String IMPLICIT_DEPENDENCY = "IMPLICIT_DEPENDENCY";
 
     private static void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext, String consumerProducerPath) {
+        if (mayBeDifferentBuilds(producer, consumer)) {
+            // Historically, we did not detect overlapping outputs between nodes in different builds.
+            // Emit a deprecation warning instead of a failure until Gradle 10.
+            // In Gradle 10, we can remove this branch entirely and fall back to the problem-emitting branch below.
+            DeprecationLogger.deprecateAction("Producing a file in one build and consuming it in another build without declaring an explicit dependency")
+                .withContext(String.format(
+                    "Gradle detected a problem with the following location: '%s'. Task '%s' uses this output of task '%s' without declaring an explicit or implicit dependency. "
+                        + "This can lead to incorrect results being produced, depending on what order the tasks are executed.",
+                    consumerProducerPath,
+                    consumer,
+                    producer
+                ))
+                .withProblemIdDisplayName("Implicit dependency between tasks in different builds")
+                .withProblemId("implicit-dependency-between-tasks-in-different-builds")
+                .willBecomeAnErrorInGradle10()
+                .withUserManual("validation_problems", IMPLICIT_DEPENDENCY.toLowerCase(Locale.ROOT))
+                .nagUser();
+            return;
+        }
         validationContext.visitPropertyError(problem ->
             problem.id(TextUtil.screamingSnakeToKebabCase(IMPLICIT_DEPENDENCY), "Property has implicit dependency", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("Gradle detected a problem with the following location: '" + consumerProducerPath + "'")
@@ -176,4 +208,30 @@ public class MissingTaskDependencyDetector {
                 .solution("Declare an explicit dependency on '" + producer + "' from '" + consumer + "' using Task#mustRunAfter")
         );
     }
+
+    private static boolean mayBeDifferentBuilds(Node producer, Node consumer) {
+        Path producerBuild = buildPathOf(producer);
+        if (producerBuild == null) {
+            return true;
+        }
+        Path consumerBuild = buildPathOf(consumer);
+        if (consumerBuild == null) {
+            return true;
+        }
+        return !consumerBuild.equals(producerBuild);
+    }
+
+    private static @Nullable Path buildPathOf(Node node) {
+        if (node instanceof TaskNode) {
+            return ((TaskNode) node).getTask().getTaskIdentity().getProjectIdentity().getBuildPath();
+        }
+
+        ProjectInternal owningProject = node.getOwningProject();
+        if (owningProject != null) {
+            return owningProject.getOwner().getOwner().getIdentityPath();
+        }
+
+        return null;
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/NodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/NodeValidator.java
@@ -19,7 +19,7 @@ package org.gradle.execution.plan;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Build.class)
+@ServiceScope(Scope.BuildTree.class)
 public interface NodeValidator {
     boolean hasValidationProblems(LocalTaskNode node);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
@@ -59,4 +59,9 @@ public interface QueryableExecutionPlan {
      */
     int size();
 
+    /**
+     * Returns whether the given node was scheduled as part of this execution plan.
+     */
+    boolean contains(Node node);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -51,6 +51,10 @@ import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.TaskNameResolver;
 import org.gradle.execution.TaskPathProjectEvaluator;
 import org.gradle.execution.TaskSelector;
+import org.gradle.execution.plan.DefaultNodeValidator;
+import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
+import org.gradle.execution.plan.MissingTaskDependencyDetector;
+import org.gradle.execution.plan.NodeValidator;
 import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.execution.selection.DefaultBuildTaskSelector;
 import org.gradle.initialization.BuildOptionBuildOperationProgressEventsEmitter;
@@ -72,6 +76,7 @@ import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.exception.ExceptionAnalyser;
+import org.gradle.internal.file.Stat;
 import org.gradle.internal.id.ConfigurationCacheableIdFactory;
 import org.gradle.internal.initialization.layout.BuildTreeLocations;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -80,6 +85,7 @@ import org.gradle.internal.instrumentation.reporting.DefaultMethodInterceptionRe
 import org.gradle.internal.instrumentation.reporting.ErrorReportingMethodInterceptionReportCollector;
 import org.gradle.internal.instrumentation.reporting.MethodInterceptionReportCollector;
 import org.gradle.internal.instrumentation.reporting.PropertyUpgradeReportConfig;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.problems.DefaultProblemDiagnosticsFactory;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.service.PrivateService;
@@ -89,6 +95,7 @@ import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GradleModuleServices;
 import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory;
 import org.gradle.problems.buildtree.ProblemReporter;
 
@@ -137,6 +144,7 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
         registration.add(ConfigurationCacheableIdFactory.class);
         registration.add(TaskIdentityFactory.class);
         registration.add(BuildLogicBuildQueue.class, DefaultBuildLogicBuildQueue.class);
+        registration.add(NodeValidator.class, DefaultNodeValidator.class);
     }
 
     @Provides
@@ -176,6 +184,16 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
     @Provides
     FeatureFlags createFeatureFlags(FeatureFlagListener listener, StartParameterInternal startParameter) {
         return new DefaultFeatureFlags(listener, startParameter.getSystemPropertiesArgs());
+    }
+
+    @Provides
+    ExecutionNodeAccessHierarchies createExecutionNodeAccessHierarchies(FileSystem fileSystem, Stat stat) {
+        return new ExecutionNodeAccessHierarchies(fileSystem.isCaseSensitive() ? CaseSensitivity.CASE_SENSITIVE : CaseSensitivity.CASE_INSENSITIVE, stat);
+    }
+
+    @Provides
+    MissingTaskDependencyDetector createMissingTaskDependencyDetector(ExecutionNodeAccessHierarchies hierarchies) {
+        return new MissingTaskDependencyDetector(hierarchies.getOutputHierarchy(), hierarchies.createInputHierarchy());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -53,7 +53,6 @@ import org.gradle.execution.TaskPathProjectEvaluator;
 import org.gradle.execution.TaskSelector;
 import org.gradle.execution.plan.DefaultNodeValidator;
 import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
-import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.plan.NodeValidator;
 import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.execution.selection.DefaultBuildTaskSelector;
@@ -189,11 +188,6 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
     @Provides
     ExecutionNodeAccessHierarchies createExecutionNodeAccessHierarchies(FileSystem fileSystem, Stat stat) {
         return new ExecutionNodeAccessHierarchies(fileSystem.isCaseSensitive() ? CaseSensitivity.CASE_SENSITIVE : CaseSensitivity.CASE_INSENSITIVE, stat);
-    }
-
-    @Provides
-    MissingTaskDependencyDetector createMissingTaskDependencyDetector(ExecutionNodeAccessHierarchies hierarchies) {
-        return new MissingTaskDependencyDetector(hierarchies.getOutputHierarchy(), hierarchies.createInputHierarchy());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -126,10 +126,8 @@ import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.TaskNameResolvingBuildTaskScheduler;
 import org.gradle.execution.commandline.CommandLineTaskConfigurer;
 import org.gradle.execution.commandline.CommandLineTaskParser;
-import org.gradle.execution.plan.DefaultNodeValidator;
 import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.ExecutionPlanFactory;
-import org.gradle.execution.plan.NodeValidator;
 import org.gradle.execution.plan.OrdinalGroupFactory;
 import org.gradle.execution.plan.TaskDependencyResolver;
 import org.gradle.execution.plan.TaskNodeDependencyResolver;
@@ -213,7 +211,6 @@ import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.WorkExecutionTracker;
 import org.gradle.internal.file.RelativeFilePathResolver;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.managed.ManagedObjectRegistry;
@@ -242,7 +239,6 @@ import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.invocation.DefaultGradle;
 import org.gradle.plugin.management.internal.PluginHandler;
@@ -285,7 +281,6 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         registration.add(IProjectFactory.class, ProjectFactory.class);
         registration.add(SettingsPreparer.class, DefaultSettingsPreparer.class);
         registration.add(ResolvedBuildLayout.class);
-        registration.add(NodeValidator.class, DefaultNodeValidator.class);
         registration.add(TaskNodeFactory.class);
         registration.add(TaskNodeDependencyResolver.class);
         registration.add(WorkNodeDependencyResolver.class);
@@ -346,11 +341,6 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
             executionNodeAccessHierarchies.getDestroyableHierarchy(),
             lockCoordinationService
         );
-    }
-
-    @Provides
-    ExecutionNodeAccessHierarchies createExecutionNodeAccessHierarchies(FileSystem fileSystem, Stat stat) {
-        return new ExecutionNodeAccessHierarchies(fileSystem.isCaseSensitive() ? CaseSensitivity.CASE_SENSITIVE : CaseSensitivity.CASE_INSENSITIVE, stat);
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -56,8 +56,12 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService())
 
     def setup() {
+        executionPlan = newExecutionPlan()
+    }
+
+    private DefaultExecutionPlan newExecutionPlan() {
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator)
+        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator)
     }
 
     Node priorityNode(Map<String, ?> options = [:]) {
@@ -1215,6 +1219,68 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
         expect:
         tasksAreNotExecutedInParallel(a, b)
+    }
+
+    def "plan stays selectable while a node is blocked by a node in another plan"() {
+        given:
+        def sharedFile = file("output")
+
+        // A second plan, as if for another build of the same build tree. It shares the node access hierarchies, so
+        // its nodes are visible to the mutation conflict checks of the plan under test. The two tasks are in
+        // different projects, so only their outputs conflict, not their project locks.
+        def otherPlan = newExecutionPlan()
+        Task inOtherPlan = task("inOtherPlan", project: project(project, "a"), type: AsyncWithOutputFile)
+        _ * inOtherPlan.outputFile >> sharedFile
+        otherPlan.addEntryTask(inOtherPlan)
+        otherPlan.determineExecutionPlan()
+        WorkSource<?> otherFinalizedPlan = otherPlan.finalizePlan().asWorkSource()
+
+        Task inThisPlan = task("inThisPlan", project: project(project, "b"), type: AsyncWithOutputFile)
+        _ * inThisPlan.outputFile >> sharedFile
+        addToGraphAndPopulate(inThisPlan)
+
+        // Start the task of the other plan and leave it executing, so that its output location is recorded. The node
+        // that resolves its mutations is selected first, so run everything up to the task itself.
+        def nodeOfOtherPlan = null
+        coordinator.withStateLock {
+            while (nodeOfOtherPlan == null) {
+                def node = otherFinalizedPlan.selectNext().item
+                if (node instanceof LocalTaskNode) {
+                    nodeOfOtherPlan = node
+                } else {
+                    node.execute(null)
+                    otherFinalizedPlan.finishedExecuting(node, null)
+                }
+            }
+        }
+
+        expect:
+        // The task of this plan conflicts with the executing task of the other plan. Nothing this plan can observe
+        // happens when that task completes, so the plan has to stay selectable and re-attempt the blocked task on the
+        // next scan. Compare tasksAreNotExecutedInParallel(), where the same conflict within a single plan leaves the
+        // plan not selectable.
+        coordinator.withStateLock {
+            while (finalizedPlan.executionState() == WorkSource.State.MaybeWorkReadyToStart) {
+                def selection = finalizedPlan.selectNext()
+                if (selection.noWorkReadyToStart) {
+                    break
+                }
+                def node = selection.item
+                assert !(node instanceof LocalTaskNode)
+                node.execute(null)
+                finalizedPlan.finishedExecuting(node, null)
+            }
+            assert finalizedPlan.selectNext().noWorkReadyToStart
+            assert finalizedPlan.executionState() == WorkSource.State.MaybeWorkReadyToStart
+        }
+
+        when:
+        coordinator.withStateLock {
+            otherFinalizedPlan.finishedExecuting(nodeOfOtherPlan, null)
+        }
+
+        then:
+        selectNextTask() == inThisPlan
     }
 
     def "a task that destroys a directory that is an output of a currently running task is not started"() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -115,6 +115,7 @@ class KnownProblemIds {
         'dependency-version-catalog:too-many-import-files': [VersionCatalogProblemId.TOO_MANY_IMPORT_FILES.displayName],
         'dependency-version-catalog:too-many-import-invocation': [VersionCatalogProblemId.TOO_MANY_IMPORT_INVOCATION.displayName],
         'dependency-version-catalog:no-import-files': [VersionCatalogProblemId.NO_IMPORT_FILES.displayName],
+        'deprecation:implicit-dependency-between-tasks-in-different-builds': ['Implicit dependency between tasks in different builds'],
         'deprecation:implicit-lookup-of-methods-in-parent-projects': ['Implicit lookup of methods in parent projects has been deprecated.'],
         'deprecation:implicit-lookup-of-properties-in-parent-projects': ['Implicit lookup of properties in parent projects has been deprecated.'],
         'deprecation:buildsrc-script': ['BuildSrc script has been deprecated.'],


### PR DESCRIPTION
Previously, we did not detect overlapping outputs between tasks in different builds. By moving ExecutionNodeAccessHierarchies to the build tree scope, we can now detect these scenarios where we previously did not.
This means
- Tasks between builds with overlapping outputs will no longer run concurrently.
- Tasks that consume outputs from a task in another build will emit a deprecation warning if there is no declared dependency between those tasks.

Additionally, we also move NodeValidator to the build tree scope, as it only depends on ProblemsInternal, a build tree scoped service.

These two changes open the door to TaskNodeFactory becoming a build tree scoped service in an upcoming change set.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
