### PR TITLE
Fix PmdPluginVersionIntegrationTest against PMD 7.26.0

### DIFF
--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -36,7 +36,9 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
 
             ${mavenCentralRepository()}
 
-            testing.suites.test.useJUnit()
+            // The default rule set's WrongTestAnnotation rule (PMD 7.26.0+) assumes JUnit Jupiter,
+            // so the analyzed test sources must not use JUnit 4 annotations.
+            testing.suites.test.useJUnitJupiter()
 
             pmd {
                 toolVersion = '$version'
@@ -396,9 +398,9 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
             """
             package org.gradle;
 
-            import static org.junit.Assert.assertTrue;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
 
-            import org.junit.Test;
+            import org.junit.jupiter.api.Test;
 
             public class Class1Test {
                 @Test
@@ -420,9 +422,9 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
             """
             package org.gradle;
 
-            import static org.junit.Assert.assertTrue;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
 
-            import org.junit.Test;
+            import org.junit.jupiter.api.Test;
 
             public class Class1Test {
                 @Test


### PR DESCRIPTION
Fixes the 11 `PmdPluginVersionIntegrationTest` failures at PMD 7.26.0 seen in the flaky-quarantine `AllVersionsIntegMultiVersion` buckets, e.g. [_33 #556](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsIntegMultiVersion_33/116196844) and [_34 #496](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsIntegMultiVersion_34/116196862).

### Root cause

PMD 7.26.0 adds a new rule, [`WrongTestAnnotation`](https://docs.pmd-code.org/pmd-doc-7.26.0/pmd_rules_java_errorprone.html#wrongtestannotation), to `category/java/errorprone.xml` — the rule set the Pmd plugin applies by default (`PmdPlugin.ruleSetsConvention`).

The rule's `testFrameworks` property **defaults to `[JUnit Jupiter]`** and performs no classpath detection, so it flags *every* JUnit 4 `@Test` annotation at priority 1:

```
Class1Test.java:9:  WrongTestAnnotation:  The annotation org.junit.Test is from JUnit 4, your codebase is using JUnit Jupiter.
```

The analyzed fixture sources in this test use JUnit 4, so each gained one extra violation once `7.26.0` became `LATEST_PMD_VERSION`:

- `goodCode()` → 1 violation instead of 0, so `succeeds("check")` fails
- `badCode()` → 3 instead of 2, breaking every `"2 PMD rule violations were found"` assertion

### Fix

Switch the analyzed fixture sources to JUnit Jupiter (`useJUnitJupiter()`, `org.junit.jupiter.api.Test`, `org.junit.jupiter.api.Assertions.assertTrue`), so the violation counts again reflect only the two rules the tests actually target (`AvoidMultipleUnaryOperators` and `OverrideBothEqualsAndHashcode`).

### Verification

Run locally with `:code-quality:forkingIntegTest`, matching the CI executer:

| Run | Result |
| --- | --- |
| Before, PMD 7.26.0 | 20 tests, **11 failed** — the same 11 as CI |
| After, PMD 7.26.0 | 20 tests, **0 failed** |
| After, `-PtestVersions=all` (JDK 25) | 7.21.0 / 7.24.0 / 7.26.0 — 20/20 each |
| After, `-PtestVersions=all -PtestJavaVersion=17` | 6.37.0 / 7.0.0 / 7.21.0 / 7.24.0 / 7.26.0 — 20/20 each |

### Notes

- `PmdPluginDependenciesIntegrationTest` uses the same JUnit 4 fixture but only asserts *that* `:pmdTest` fails, never a violation count, so it is unaffected and will not break when `DEFAULT_PMD_VERSION` moves past 7.26.0. `PmdRelocationIntegrationTest` has JUnit 4 sources with no JUnit on the classpath, so the annotation type cannot resolve and the rule does not fire. Neither is changed here.
- Worth knowing before `DEFAULT_PMD_VERSION` is bumped to 7.26.0+: users with JUnit 4 codebases will start seeing this rule too. That is PMD's intended design — they would configure the rule's `testFrameworks` property — but it is a visible behaviour change.
