### PR TITLE
Add release notes for lazy Copy/Sync destinationDirectory

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -139,7 +139,8 @@ See the [Looking up services in scripts](userguide/service_injection.html#lookin
 
 #### Lazy destination directory for `Copy` and `Sync`
 
-The [`Copy`](dsl/org.gradle.api.tasks.Copy.html) and [`Sync`](dsl/org.gradle.api.tasks.Sync.html) tasks only exposed `destinationDir`, a plain `File` property, so a destination derived from a provider had to be resolved eagerly at configuration time. Both tasks now expose a `destinationDirectory` [`DirectoryProperty`](javadoc/org/gradle/api/file/DirectoryProperty.html):
+The [`Copy`](dsl/org.gradle.api.tasks.Copy.html) and [`Sync`](dsl/org.gradle.api.tasks.Sync.html) tasks only exposed the destination as `destinationDir`, a plain `File` property, so a destination derived from a provider had to be resolved eagerly at configuration time.
+Both tasks now expose a `destinationDirectory` [`DirectoryProperty`](javadoc/org/gradle/api/file/DirectoryProperty.html):
 
 ```kotlin
 tasks.register<Copy>("copyFiles") {
@@ -148,9 +149,13 @@ tasks.register<Copy>("copyFiles") {
 }
 ```
 
-The property is the single source of truth for the destination. Assigning it is equivalent to calling `into(...)`, and it reflects whatever was configured through `into(...)` or `destinationDir`. `into(...)` in turn now wires a `Provider` destination into `destinationDirectory` instead of resolving its value, so provider-based destinations stay lazy; all other notations (`String`, `File`, `Closure`, `Callable`, ...) keep their existing lazy resolution. Since `destinationDirectory` is a task output property, other tasks can consume it directly and pick up the task dependency.
+The property is the single source of truth for the destination.
+Assigning it is equivalent to calling `into(...)`, and it reflects whatever was configured through `into(...)` or `destinationDir`.
 
-The new property is [incubating](userguide/feature_lifecycle.html#feature_preview). `destinationDir` keeps working and is planned for deprecation once `destinationDirectory` is promoted.
+`into(...)` now wires a `Provider` destination into `destinationDirectory` instead of resolving its value, so provider-based destinations stay lazy; all other notations (`String`, `File`, `Closure`, `Callable`, ...) keep their existing lazy resolution.
+Since `destinationDirectory` is a task output property, other tasks can consume it directly and pick up the task dependency.
+
+The new property is [incubating](userguide/feature_lifecycle.html#feature_preview). `destinationDir` continues to work and will be deprecated once `destinationDirectory` is promoted.
 
 See [`Copy.destinationDirectory`](dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:destinationDirectory) and [`Sync.destinationDirectory`](dsl/org.gradle.api.tasks.Sync.html#org.gradle.api.tasks.Sync:destinationDirectory) in the DSL Reference for more details.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -137,6 +137,23 @@ Precompiled script plugins that use `service<Type>()` require Gradle 9.8 or late
 
 See the [Looking up services in scripts](userguide/service_injection.html#looking_up_services) section in the Gradle User Manual for more details.
 
+#### Lazy destination directory for `Copy` and `Sync`
+
+The [`Copy`](dsl/org.gradle.api.tasks.Copy.html) and [`Sync`](dsl/org.gradle.api.tasks.Sync.html) tasks only exposed `destinationDir`, a plain `File` property, so a destination derived from a provider had to be resolved eagerly at configuration time. Both tasks now expose a `destinationDirectory` [`DirectoryProperty`](javadoc/org/gradle/api/file/DirectoryProperty.html):
+
+```kotlin
+tasks.register<Copy>("copyFiles") {
+    from("src")
+    destinationDirectory = layout.buildDirectory.dir("out")
+}
+```
+
+The property is the single source of truth for the destination. Assigning it is equivalent to calling `into(...)`, and it reflects whatever was configured through `into(...)` or `destinationDir`. `into(...)` in turn now wires a `Provider` destination into `destinationDirectory` instead of resolving its value, so provider-based destinations stay lazy; all other notations (`String`, `File`, `Closure`, `Callable`, ...) keep their existing lazy resolution. Since `destinationDirectory` is a task output property, other tasks can consume it directly and pick up the task dependency.
+
+The new property is [incubating](userguide/feature_lifecycle.html#feature_preview). `destinationDir` keeps working and is planned for deprecation once `destinationDirectory` is promoted.
+
+See [`Copy.destinationDirectory`](dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:destinationDirectory) and [`Sync.destinationDirectory`](dsl/org.gradle.api.tasks.Sync.html#org.gradle.api.tasks.Sync:destinationDirectory) in the DSL Reference for more details.
+
 ### Platform and toolchain management
 Gradle provides comprehensive support for [Native development](userguide/building_cpp_projects.html) and [JVM languages](userguide/building_java_projects.html), featuring automated [Toolchains](userguide/toolchains.html) for seamless JDK management.
 


### PR DESCRIPTION
Follow up for https://github.com/gradle/gradle/pull/38047

Fixes https://github.com/gradle/gradle/issues/25824
Fixes https://github.com/gradle/gradle/issues/13275