### PR TITLE
Handle overrides of getters upgraded to the Provider API

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
@@ -68,4 +68,40 @@ class UpgradedPropertyLegacyGetterIntegrationTest extends AbstractIntegrationSpe
         "ListProperty<String>"       | "List<String>"   | "[]"
         "ConfigurableFileCollection" | "FileCollection" | "null"
     }
+
+    def "the legacy getter reads through the upgraded property instead of its own body"() {
+        given:
+        // Groovy cannot dispatch between two same-named getters, so each is selected by return type.
+        buildFile """
+            import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty
+
+            interface UpgradedProp {
+                @ReplacesEagerProperty
+                @Internal
+                Property<String> getProp()
+            }
+
+            abstract class LegacyBase extends DefaultTask {
+                String getProp() { return "from legacy body" }
+            }
+
+            abstract class SomeTask extends LegacyBase implements UpgradedProp {
+                private accessor(Class<?> returnType) {
+                    getClass().methods.find { it.name == "getProp" && it.returnType == returnType }
+                }
+
+                @TaskAction
+                void go() {
+                    accessor(Property).invoke(this).set("from lazy property")
+                    println("eager getter returned: " + accessor(String).invoke(this))
+                }
+            }
+
+            tasks.register("thing", SomeTask)
+        """
+
+        expect:
+        succeeds("thing")
+        outputContains("eager getter returned: from lazy property")
+    }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * A type compiled against an older Gradle keeps declaring the eager accessor of a property that
+ * has since been upgraded with {@code @ReplacesEagerProperty}, so the decorated type ends up with
+ * both a concrete eager getter and an abstract lazy getter for the same property.
+ *
+ * That shape cannot be produced by a single compilation of a subclass — both javac and groovyc
+ * reject an override that only differs in return type. It is reproduced here by inheriting the two
+ * getters from different branches of the hierarchy, which groovyc does accept and which leaves the
+ * class generator in the same state.
+ */
+@Issue("https://github.com/gradle/gradle/issues/25421")
+class UpgradedPropertyLegacyGetterIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can generate a task type that has both an upgraded #lazyType getter and a legacy #eagerType getter"() {
+        given:
+        buildFile """
+            import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty
+
+            interface UpgradedProp {
+                @ReplacesEagerProperty
+                @Internal
+                $lazyType getProp()
+            }
+
+            abstract class LegacyBase extends DefaultTask {
+                $eagerType getProp() { return $eagerValue }
+            }
+
+            abstract class SomeTask extends LegacyBase implements UpgradedProp {
+                @TaskAction
+                void go() {
+                    println("task ran")
+                }
+            }
+
+            tasks.register("thing", SomeTask)
+        """
+
+        expect:
+        succeeds("thing")
+        outputContains("task ran")
+
+        where:
+        lazyType                     | eagerType        | eagerValue
+        "Property<String>"           | "String"         | '"legacy"'
+        "Property<Integer>"          | "int"            | "42"
+        "ListProperty<String>"       | "List<String>"   | "[]"
+        "ConfigurableFileCollection" | "FileCollection" | "null"
+    }
+}

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/UpgradedPropertyLegacyGetterIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.ExpectedDeprecationWarning
 import spock.lang.Issue
 
 /**
@@ -32,8 +33,20 @@ import spock.lang.Issue
 @Issue("https://github.com/gradle/gradle/issues/25421")
 class UpgradedPropertyLegacyGetterIntegrationTest extends AbstractIntegrationSpec {
 
+    /**
+     * These types cannot delegate to super — LegacyBase extends DefaultTask, which has no such accessor —
+     * so every legacy getter here is a non-delegating body and is expected to be reported. The
+     * delegating-body case, which must stay silent, is covered by FreefairAspectJPluginSmokeTest.
+     */
+    private static final String OVERRIDE_DEPRECATION =
+        "Overriding LegacyBase.getProp() on a property upgraded to the Provider API has been deprecated. " +
+            "This will fail with an error in Gradle 11. " +
+            "Gradle reads 'prop' through the upgraded accessor, so this override is no longer called. " +
+            "Remove the override and configure the 'prop' property instead."
+
     def "can generate a task type that has both an upgraded #lazyType getter and a legacy #eagerType getter"() {
         given:
+        executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(OVERRIDE_DEPRECATION))
         buildFile """
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty
 
@@ -69,8 +82,48 @@ class UpgradedPropertyLegacyGetterIntegrationTest extends AbstractIntegrationSpe
         "ConfigurableFileCollection" | "FileCollection" | "null"
     }
 
+    def "the legacy primitive getter reads through the upgraded property, defaulting like the eager adapters"() {
+        given:
+        executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(OVERRIDE_DEPRECATION))
+        buildFile """
+            import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty
+
+            interface UpgradedProp {
+                @ReplacesEagerProperty
+                @Internal
+                Property<Integer> getProp()
+            }
+
+            abstract class LegacyBase extends DefaultTask {
+                int getProp() { return -1 }
+            }
+
+            abstract class SomeTask extends LegacyBase implements UpgradedProp {
+                private accessor(Class<?> returnType) {
+                    getClass().methods.find { it.name == "getProp" && it.returnType == returnType }
+                }
+
+                @TaskAction
+                void go() {
+                    println("unset: " + accessor(Integer.TYPE).invoke(this))
+                    accessor(Property).invoke(this).set(7)
+                    println("set: " + accessor(Integer.TYPE).invoke(this))
+                }
+            }
+
+            tasks.register("thing", SomeTask)
+        """
+
+        expect:
+        succeeds("thing")
+        // getOrElse(0), matching what the generated eager adapters return for an unset property
+        outputContains("unset: 0")
+        outputContains("set: 7")
+    }
+
     def "the legacy getter reads through the upgraded property instead of its own body"() {
         given:
+        executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(OVERRIDE_DEPRECATION))
         // Groovy cannot dispatch between two same-named getters, so each is selected by return type.
         buildFile """
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -1249,6 +1249,25 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 && property.setters.stream().anyMatch(setter -> !Modifier.isAbstract(setter.getModifiers()));
         }
 
+        /**
+         * The generated subclass overrides the eager accessor, so whatever the declaring type put in its
+         * body stops running. That is invisible when the body only delegated to super, and a silent
+         * behaviour change otherwise — so report the second case.
+         */
+        private void applyLegacyEagerGetter(ClassGenerationVisitor visitor, PropertyMetadata property, MethodMetadata getter) {
+            Method legacyGetter = getter.method;
+            if (!SuperDelegatingAccessors.isPureSuperDelegation(legacyGetter)) {
+                Class<?> declaringClass = legacyGetter.getDeclaringClass();
+                DeprecationLogger.deprecateAction("Overriding " + declaringClass.getCanonicalName() + "." + legacyGetter.getName() + "() on a property upgraded to the Provider API")
+                    .withContext("Gradle reads '" + property.getName() + "' through the upgraded accessor, so this override is no longer called.")
+                    .withAdvice("Remove the override and configure the '" + property.getName() + "' property instead.")
+                    .willBecomeAnErrorInGradle11()
+                    .undocumented()
+                    .nagUser();
+            }
+            visitor.applyEagerShimToLegacyGetter(property, legacyGetter);
+        }
+
         @Override
         void applyTo(ClassInspectionVisitor visitor) {
             if (!hasFields) {
@@ -1279,7 +1298,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 for (MethodMetadata getter : property.getters) {
                     if (property.isLegacyEagerGetter(getter)) {
                         // Its return type is the replaced eager type, so it cannot read the managed field
-                        visitor.applyEagerShimToLegacyGetter(property, getter.method);
+                        applyLegacyEagerGetter(visitor, property, getter);
                         continue;
                     }
                     visitor.applyManagedStateToGetter(property, getter.method);
@@ -1293,7 +1312,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 boolean applyRole = isRoleType(property);
                 for (MethodMetadata getter : property.getters) {
                     if (property.isLegacyEagerGetter(getter)) {
-                        visitor.applyEagerShimToLegacyGetter(property, getter.method);
+                        applyLegacyEagerGetter(visitor, property, getter);
                         continue;
                     }
                     visitor.applyReadOnlyManagedStateToGetter(property, getter.method, applyRole);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -1279,6 +1279,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 for (MethodMetadata getter : property.getters) {
                     if (property.isLegacyEagerGetter(getter)) {
                         // Its return type is the replaced eager type, so it cannot read the managed field
+                        visitor.applyEagerShimToLegacyGetter(property, getter.method);
                         continue;
                     }
                     visitor.applyManagedStateToGetter(property, getter.method);
@@ -1292,6 +1293,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 boolean applyRole = isRoleType(property);
                 for (MethodMetadata getter : property.getters) {
                     if (property.isLegacyEagerGetter(getter)) {
+                        visitor.applyEagerShimToLegacyGetter(property, getter.method);
                         continue;
                     }
                     visitor.applyReadOnlyManagedStateToGetter(property, getter.method, applyRole);
@@ -1657,6 +1659,12 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         void applyManagedStateToProperty(PropertyMetadata property);
 
         void applyManagedStateToGetter(PropertyMetadata property, Method getter);
+
+        /**
+         * Implements the eager accessor a type compiled against an older Gradle still declares, by reading
+         * through the upgraded lazy property. Does nothing if the value cannot be unwrapped to the eager type.
+         */
+        void applyEagerShimToLegacyGetter(PropertyMetadata property, Method legacyGetter);
 
         void applyManagedStateToSetter(PropertyMetadata property, Method setter);
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -668,6 +668,15 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             return !method.isBridge();
         }
 
+        /**
+         * Is this the lazy accessor of a property upgraded to the Provider API? A type compiled against
+         * an older Gradle may still declare the eager accessor this one replaced, under the same name
+         * but with a different descriptor.
+         */
+        boolean isUpgradedLazyAccessor() {
+            return method.isAnnotationPresent(ReplacesEagerProperty.class);
+        }
+
         public Class<?> getReturnType() {
             return method.getReturnType();
         }
@@ -789,11 +798,33 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             } else if (mainGetter.getReturnType().isAssignableFrom(metadata.getReturnType())) {
                 // Prefer the most specialized type
                 mainGetter = metadata;
+            } else if (metadata.isUpgradedLazyAccessor() && !mainGetter.isUpgradedLazyAccessor()) {
+                // Neither return type is assignable to the other, so the rules above cannot choose. One of them is
+                // the eager accessor an upgraded property replaced (e.g. String against Property<String>), and
+                // picking it would stop the property being recognised as managed.
+                mainGetter = metadata;
             }
         }
 
         public void addGetterDeclaration(Method method) {
             getterDeclarations.add(method);
+        }
+
+        /**
+         * The eager accessor an upgraded property replaced, still declared by a type compiled against an older
+         * Gradle. Identified by return type rather than by carrying the annotation: an override does not inherit
+         * it, and a covariant override of the lazy getter is still the lazy getter, not the accessor it replaced.
+         */
+        public boolean isLegacyEagerGetter(MethodMetadata getter) {
+            if (!getter.shouldImplement()) {
+                // A bridge is not a declaration of its own; the method it delegates to is handled instead
+                return false;
+            }
+            List<Method> lazyDeclarations = getterDeclarations.stream()
+                .filter(declaration -> declaration.isAnnotationPresent(ReplacesEagerProperty.class))
+                .collect(Collectors.toList());
+            return !lazyDeclarations.isEmpty()
+                && lazyDeclarations.stream().noneMatch(declaration -> declaration.getReturnType().isAssignableFrom(getter.getReturnType()));
         }
 
         public void addSetter(Method method) {
@@ -1158,6 +1189,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     // A bridge getter cannot manage state: its compiler-generated body only delegates to the real getter
                     continue;
                 }
+                if (property.isLegacyEagerGetter(getter)) {
+                    // The eager accessor a type compiled against an older Gradle still declares. We implement it as a
+                    // shim over the upgraded property, so its body is not user-managed state either.
+                    continue;
+                }
                 if (!getter.isAbstract()) {
                     // A concrete real getter reads user-managed state (e.g. a handwritten field), so the property is not ours to claim
                     return false;
@@ -1241,6 +1277,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             for (PropertyMetadata property : mutableProperties) {
                 visitor.applyManagedStateToProperty(property);
                 for (MethodMetadata getter : property.getters) {
+                    if (property.isLegacyEagerGetter(getter)) {
+                        // Its return type is the replaced eager type, so it cannot read the managed field
+                        continue;
+                    }
                     visitor.applyManagedStateToGetter(property, getter.method);
                 }
                 for (Method setter : property.setters) {
@@ -1251,6 +1291,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 visitor.applyManagedStateToProperty(property);
                 boolean applyRole = isRoleType(property);
                 for (MethodMetadata getter : property.getters) {
+                    if (property.isLegacyEagerGetter(getter)) {
+                        continue;
+                    }
                     visitor.applyReadOnlyManagedStateToGetter(property, getter.method, applyRole);
                 }
             }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.instantiation.generator;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
@@ -35,6 +36,7 @@ import org.gradle.api.internal.provider.support.LazyGroovySupport;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.cache.Cache;
 import org.gradle.cache.internal.ClassCacheFactory;
@@ -88,6 +90,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -496,6 +499,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private static final String RETURN_VOID_FROM_CONVENTION_AWARE_CONVENTION = getMethodDescriptor(Type.VOID_TYPE, CONVENTION_AWARE_TYPE);
         private static final String RETURN_CONVENTION_MAPPING = getMethodDescriptor(CONVENTION_MAPPING_TYPE);
         private static final String RETURN_OBJECT = getMethodDescriptor(OBJECT_TYPE);
+        private static final Type PROVIDER_TYPE = getType(Provider.class);
         private static final String RETURN_OBJECT_FROM_STRING = getMethodDescriptor(OBJECT_TYPE, STRING_TYPE);
         private static final String RETURN_OBJECT_FROM_STRING_OBJECT = getMethodDescriptor(OBJECT_TYPE, STRING_TYPE, OBJECT_TYPE);
         private static final String RETURN_VOID_FROM_STRING_OBJECT = getMethodDescriptor(Type.VOID_TYPE, STRING_TYPE, OBJECT_TYPE);
@@ -533,6 +537,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private final AsmClassGenerator classGenerator;
         private final int factoryId;
         private boolean hasMappingField;
+        private final Set<String> generatedLegacyShims = new HashSet<>();
         private final boolean conventionAware;
         private final boolean mixInDsl;
         private final boolean extensible;
@@ -1363,6 +1368,51 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         }
 
         @Override
+        public void applyEagerShimToLegacyGetter(PropertyMetadata property, Method legacyGetter) {
+            Class<?> eagerRawType = legacyGetter.getReturnType();
+            if (eagerRawType.isPrimitive()) {
+                // Would need the same default-value semantics as the generated eager adapters
+                // (getOrElse(0), getOrElse(false), ...), which is not settled yet.
+                return;
+            }
+            Class<?> lazyRawType = property.getType();
+            boolean lazyValueIsAlreadyEagerType = eagerRawType.isAssignableFrom(lazyRawType);
+            if (!lazyValueIsAlreadyEagerType) {
+                if (!Provider.class.isAssignableFrom(lazyRawType)) {
+                    return;
+                }
+                Class<?> valueType = TypeToken.of(property.getGenericType())
+                    .resolveType(Provider.class.getTypeParameters()[0])
+                    .getRawType();
+                if (!eagerRawType.isAssignableFrom(valueType)) {
+                    // e.g. DirectoryProperty is a Provider<Directory>, but the accessor it replaced returned a File
+                    return;
+                }
+            }
+
+            Type eagerType = getType(eagerRawType);
+            String descriptor = getMethodDescriptor(eagerType);
+            if (!generatedLegacyShims.add(legacyGetter.getName() + descriptor)) {
+                // The same accessor is declared more than once in the hierarchy
+                return;
+            }
+
+            // GENERATE public <eagerType> <getter>() { return <lazyGetter>()[.getOrNull()]; }
+            String lazyGetterName = property.getMainGetter().getName();
+            String lazyDescriptor = getMethodDescriptor(getType(lazyRawType));
+            addGetter(legacyGetter.getName(), eagerType, descriptor, methodVisitor -> new MethodVisitorScope(methodVisitor) {{
+                _ALOAD(0);
+                _INVOKEVIRTUAL(generatedType, lazyGetterName, lazyDescriptor);
+                if (!lazyValueIsAlreadyEagerType) {
+                    _CHECKCAST(PROVIDER_TYPE);
+                    _INVOKEINTERFACE(PROVIDER_TYPE, "getOrNull", RETURN_OBJECT);
+                    _CHECKCAST(eagerType);
+                }
+                _ARETURN();
+            }});
+        }
+
+        @Override
         public void applyManagedStateToSetter(PropertyMetadata property, Method setter) {
             addSetterForProperty(property, setter);
         }
@@ -2059,6 +2109,10 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
         @Override
         public void applyManagedStateToGetter(PropertyMetadata property, Method getter) {
+        }
+
+        @Override
+        public void applyEagerShimToLegacyGetter(PropertyMetadata property, Method legacyGetter) {
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -72,6 +72,7 @@ import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import javax.inject.Inject;
@@ -95,6 +96,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static groovy.lang.MetaProperty.getSetterName;
+import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.getWrapperTypeForPrimitiveType;
 import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.getterSignature;
 import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.signature;
 import static org.gradle.util.internal.CollectionUtils.collectArray;
@@ -499,6 +501,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private static final String RETURN_VOID_FROM_CONVENTION_AWARE_CONVENTION = getMethodDescriptor(Type.VOID_TYPE, CONVENTION_AWARE_TYPE);
         private static final String RETURN_CONVENTION_MAPPING = getMethodDescriptor(CONVENTION_MAPPING_TYPE);
         private static final String RETURN_OBJECT = getMethodDescriptor(OBJECT_TYPE);
+        private static final String RETURN_OBJECT_FROM_OBJECT = getMethodDescriptor(OBJECT_TYPE, OBJECT_TYPE);
         private static final Type PROVIDER_TYPE = getType(Provider.class);
         private static final String RETURN_OBJECT_FROM_STRING = getMethodDescriptor(OBJECT_TYPE, STRING_TYPE);
         private static final String RETURN_OBJECT_FROM_STRING_OBJECT = getMethodDescriptor(OBJECT_TYPE, STRING_TYPE, OBJECT_TYPE);
@@ -1370,13 +1373,8 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         @Override
         public void applyEagerShimToLegacyGetter(PropertyMetadata property, Method legacyGetter) {
             Class<?> eagerRawType = legacyGetter.getReturnType();
-            if (eagerRawType.isPrimitive()) {
-                // Would need the same default-value semantics as the generated eager adapters
-                // (getOrElse(0), getOrElse(false), ...), which is not settled yet.
-                return;
-            }
             Class<?> lazyRawType = property.getType();
-            boolean lazyValueIsAlreadyEagerType = eagerRawType.isAssignableFrom(lazyRawType);
+            boolean lazyValueIsAlreadyEagerType = !eagerRawType.isPrimitive() && eagerRawType.isAssignableFrom(lazyRawType);
             if (!lazyValueIsAlreadyEagerType) {
                 if (!Provider.class.isAssignableFrom(lazyRawType)) {
                     return;
@@ -1384,7 +1382,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 Class<?> valueType = TypeToken.of(property.getGenericType())
                     .resolveType(Provider.class.getTypeParameters()[0])
                     .getRawType();
-                if (!eagerRawType.isAssignableFrom(valueType)) {
+                if (!boxed(eagerRawType).isAssignableFrom(boxed(valueType))) {
                     // e.g. DirectoryProperty is a Provider<Directory>, but the accessor it replaced returned a File
                     return;
                 }
@@ -1397,7 +1395,9 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
-            // GENERATE public <eagerType> <getter>() { return <lazyGetter>()[.getOrNull()]; }
+            // GENERATE public <eagerType> <getter>() { return <lazyGetter>()[.getOrElse(<default>)]; }
+            // The default must match the generated eager adapters, so a rewritten call site and a virtual
+            // call landing here agree on the value of an unset property.
             String lazyGetterName = property.getMainGetter().getName();
             String lazyDescriptor = getMethodDescriptor(getType(lazyRawType));
             addGetter(legacyGetter.getName(), eagerType, descriptor, methodVisitor -> new MethodVisitorScope(methodVisitor) {{
@@ -1405,11 +1405,38 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 _INVOKEVIRTUAL(generatedType, lazyGetterName, lazyDescriptor);
                 if (!lazyValueIsAlreadyEagerType) {
                     _CHECKCAST(PROVIDER_TYPE);
-                    _INVOKEINTERFACE(PROVIDER_TYPE, "getOrNull", RETURN_OBJECT);
-                    _CHECKCAST(eagerType);
+                    if (eagerRawType.isPrimitive()) {
+                        pushDefaultValue(this, eagerType);
+                        _AUTOBOX(eagerRawType, eagerType);
+                        _INVOKEINTERFACE(PROVIDER_TYPE, "getOrElse", RETURN_OBJECT_FROM_OBJECT);
+                    } else {
+                        _INVOKEINTERFACE(PROVIDER_TYPE, "getOrNull", RETURN_OBJECT);
+                    }
+                    _UNBOX(eagerType);
                 }
-                _ARETURN();
+                _IRETURN_OF(eagerType);
             }});
+        }
+
+        private static void pushDefaultValue(MethodVisitorScope mv, Type primitiveType) {
+            switch (primitiveType.getSort()) {
+                case Type.LONG:
+                    mv.visitInsn(Opcodes.LCONST_0);
+                    break;
+                case Type.FLOAT:
+                    mv.visitInsn(Opcodes.FCONST_0);
+                    break;
+                case Type.DOUBLE:
+                    mv.visitInsn(Opcodes.DCONST_0);
+                    break;
+                default:
+                    mv._ICONST_0();
+                    break;
+            }
+        }
+
+        private static Class<?> boxed(Class<?> type) {
+            return type.isPrimitive() ? getWrapperTypeForPrimitiveType(type) : type;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/SuperDelegatingAccessors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/SuperDelegatingAccessors.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation.generator;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+import static org.gradle.model.internal.asm.AsmConstants.ASM_LEVEL;
+
+/**
+ * Recognises accessors whose body does nothing but {@code return super.getX()}.
+ *
+ * <p>When a property is upgraded to the Provider API, a type compiled against an older Gradle keeps
+ * declaring the eager accessor it replaced. The generated subclass overrides that accessor, so the
+ * original body no longer runs — harmless when it only delegated to super, a silent behaviour change
+ * otherwise. This tells the two apart so only the second case is reported.
+ *
+ * <p>Deliberately strict: anything not positively recognised is reported as non-delegating, so an
+ * unreadable or unusual body produces a warning rather than silence.
+ */
+@NullMarked
+final class SuperDelegatingAccessors {
+
+    private static final String SCRIPT_BYTECODE_ADAPTER = "org/codehaus/groovy/runtime/ScriptBytecodeAdapter";
+    private static final String KOTLIN_INTRINSICS = "kotlin/jvm/internal/Intrinsics";
+    private static final String GROOVY_TYPE_TRANSFORMATION = "org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation";
+
+    private SuperDelegatingAccessors() {
+    }
+
+    static boolean isPureSuperDelegation(Method method) {
+        Class<?> owner = method.getDeclaringClass();
+        ClassLoader loader = owner.getClassLoader();
+        if (loader == null) {
+            return false;
+        }
+        String resource = owner.getName().replace('.', '/') + ".class";
+        try (InputStream in = loader.getResourceAsStream(resource)) {
+            if (in == null) {
+                return false;
+            }
+            BodyVisitor visitor = new BodyVisitor(method.getName(), Type.getMethodDescriptor(method));
+            new ClassReader(in).accept(visitor, ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+            return visitor.isPureSuperDelegation();
+        } catch (IOException | RuntimeException e) {
+            // Can't read it, so can't claim the body is safe to discard
+            return false;
+        }
+    }
+
+    private static class BodyVisitor extends ClassVisitor {
+        private final String methodName;
+        private final String methodDescriptor;
+        private @Nullable String superName;
+        private boolean visited;
+        private int superCalls;
+        private boolean disqualified;
+
+        BodyVisitor(String methodName, String methodDescriptor) {
+            super(ASM_LEVEL);
+            this.methodName = methodName;
+            this.methodDescriptor = methodDescriptor;
+        }
+
+        boolean isPureSuperDelegation() {
+            return visited && superCalls == 1 && !disqualified;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            this.superName = superName;
+        }
+
+        @Override
+        public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            if (!name.equals(methodName) || !descriptor.equals(methodDescriptor)) {
+                return null;
+            }
+            visited = true;
+            return new InstructionVisitor();
+        }
+
+        private void disqualify() {
+            disqualified = true;
+        }
+
+        private class InstructionVisitor extends MethodVisitor {
+            InstructionVisitor() {
+                super(ASM_LEVEL);
+            }
+
+            @Override
+            public void visitVarInsn(int opcode, int var) {
+                // `this` only — these accessors take no arguments
+                if (opcode != Opcodes.ALOAD || var != 0) {
+                    disqualify();
+                }
+            }
+
+            @Override
+            public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                if (opcode == Opcodes.INVOKESPECIAL && owner.equals(superName) && name.equals(methodName)) {
+                    superCalls++;
+                } else if (opcode == Opcodes.INVOKESTATIC && owner.equals(SCRIPT_BYTECODE_ADAPTER) && name.equals("invokeMethodOnSuper0")) {
+                    // Groovy compiles `super.getX()` to a reflective dispatch rather than INVOKESPECIAL
+                    superCalls++;
+                } else if (!isValuePreservingCall(opcode, owner, name)) {
+                    // Anything beyond the casting, boxing and null-assertion noise the compilers add
+                    // around the super call could change the value
+                    disqualify();
+                }
+            }
+
+            private boolean isValuePreservingCall(int opcode, String owner, String name) {
+                if (owner.equals(KOTLIN_INTRINSICS) || owner.equals(GROOVY_TYPE_TRANSFORMATION)) {
+                    return true;
+                }
+                if (owner.equals(SCRIPT_BYTECODE_ADAPTER)) {
+                    return name.equals("castToType");
+                }
+                if (owner.startsWith("java/lang/")) {
+                    return (opcode == Opcodes.INVOKESTATIC && name.equals("valueOf"))
+                        || (opcode == Opcodes.INVOKEVIRTUAL && name.endsWith("Value"));
+                }
+                return false;
+            }
+
+            @Override
+            public void visitInsn(int opcode) {
+                if (opcode < Opcodes.IRETURN || opcode > Opcodes.RETURN) {
+                    disqualify();
+                }
+            }
+
+            @Override
+            public void visitInvokeDynamicInsn(String name, String descriptor, Handle handle, Object... args) {
+                // Groovy's indy cast is fine; an indy-dispatched super call is not something we can read
+                if (!name.equals("cast")) {
+                    disqualify();
+                }
+            }
+
+            @Override
+            public void visitTypeInsn(int opcode, String type) {
+                if (opcode != Opcodes.CHECKCAST) {
+                    disqualify();
+                }
+            }
+
+            @Override
+            public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+                disqualify();
+            }
+
+            @Override
+            public void visitJumpInsn(int opcode, Label label) {
+                disqualify();
+            }
+
+            @Override
+            public void visitIincInsn(int var, int increment) {
+                disqualify();
+            }
+
+            @Override
+            public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
+                disqualify();
+            }
+
+            @Override
+            public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+                disqualify();
+            }
+
+            @Override
+            public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
+                disqualify();
+            }
+
+            @Override
+            public void visitIntInsn(int opcode, int operand) {
+                disqualify();
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/SuperDelegatingAccessorsTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/SuperDelegatingAccessorsTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation.generator
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * These fixtures are compiled by groovyc, so they exercise the dynamic-Groovy shape, where
+ * {@code super.getX()} becomes a reflective {@code ScriptBytecodeAdapter.invokeMethodOnSuper0}
+ * call rather than an INVOKESPECIAL. The javac shape is covered by FreefairAspectJPluginSmokeTest,
+ * whose plugin delegates to super and must not be reported.
+ */
+@Issue("https://github.com/gradle/gradle/issues/25421")
+class SuperDelegatingAccessorsTest extends Specification {
+
+    static class Base {
+        String getThing() { return "base" }
+    }
+
+    static class Delegating extends Base {
+        @Override
+        String getThing() { return super.getThing() }
+    }
+
+    static class AddsLogic extends Base {
+        @Override
+        String getThing() { return super.getThing() + "!" }
+    }
+
+    static class IgnoresSuper extends Base {
+        @Override
+        String getThing() { return "own" }
+    }
+
+    static class ReadsField extends Base {
+        private String other = "x"
+
+        @Override
+        String getThing() { return other }
+    }
+
+    static class Branches extends Base {
+        @Override
+        String getThing() { return System.getProperty("x") == null ? super.getThing() : "other" }
+    }
+
+    def "recognises a body that only delegates to super"() {
+        expect:
+        SuperDelegatingAccessors.isPureSuperDelegation(Delegating.getDeclaredMethod("getThing"))
+    }
+
+    def "does not recognise #type.simpleName"() {
+        expect:
+        !SuperDelegatingAccessors.isPureSuperDelegation(type.getDeclaredMethod("getThing"))
+
+        where:
+        type << [AddsLogic, IgnoresSuper, ReadsField, Branches]
+    }
+
+    def "does not recognise a method whose bytecode cannot be read"() {
+        given:
+        // Array classes have no class file to load
+        def method = Object.getDeclaredMethod("toString")
+
+        expect:
+        !SuperDelegatingAccessors.isPureSuperDelegation(method)
+    }
+}


### PR DESCRIPTION
<!-- Fixes #25421 -->

> [!NOTE]
> Stacked on #38829 — review that first, and merge it first. The diff here is only the getter-side change.

### Context

When a property is upgraded to the Provider API with `@ReplacesEagerProperty`, a type compiled against an older Gradle keeps declaring the eager accessor it replaced. The two share a name but differ in return type, and class generation fails:

```
Cannot have abstract method AbstractCompile.getClasspath(): ConfigurableFileCollection.
```

Fixes https://github.com/gradle/gradle/issues/25421.

Two earlier attempts (#37592, #38138) tried to solve this in `InstrumentingClassTransform`, pattern-matching `return super.getX()` in bytecode and rewriting the override to abstract. That needs the shape recognised across javac, dynamic Groovy, `@CompileStatic` Groovy and Kotlin, and it silently does nothing when the match fails. Here the load-bearing work happens in the class generator, where the accessors are visible through reflection; bytecode analysis is used **only** to decide whether to warn, so a miss costs a warning rather than a broken build.

### The shape this handles

```java
// Gradle, after the upgrade
public abstract class AbstractCompile extends SourceTask {
    @ReplacesEagerProperty
    public abstract ConfigurableFileCollection getClasspath();

    public void setClasspath(FileCollection files) { getClasspath().setFrom(files); }
}

// Plugin, compiled against an older Gradle, where getClasspath() returned FileCollection
public abstract class AspectjCompile extends AbstractCompile {
    @Override @Classpath
    public FileCollection getClasspath() { return super.getClasspath(); }
}
```

`AspectjCompile` now declares one accessor and inherits another, same name, different return type. That is legal in bytecode but the class generator refused it. The decorated class it produces afterwards is, in pseudo-Java (the two overloads differ only in return type, so this cannot be written in Java source):

```java
class AspectjCompile_Decorated extends AspectjCompile {
    private ConfigurableFileCollection classpath;                   // managed state

    ConfigurableFileCollection getClasspath() { /* managed */ }     // the upgraded accessor
    FileCollection             getClasspath() { return getClasspath(); }  // shim over it
}
```

The plugin's own `getClasspath()` body is now unreachable — which is what makes it safe that its `super.getClasspath()` call targets a method that no longer exists.

### What this does

**1. Picks the upgraded accessor as the property type.** Only as a last resort, when neither return type is assignable to the other:

| lazy accessor | eager accessor it replaced | previously |
|---|---|---|
| `ConfigurableFileCollection` | `FileCollection` | already correct — assignable |
| `Property<String>` | `String` | **wrong** — decided by visit order |
| `Property<Integer>` | `int` | **wrong** |
| `ListProperty<String>` | `List<String>` | **wrong** |

Picking the eager one makes `getType()` return e.g. `String`, so the property stops being recognised as managed and never gets a body.

A covariant override is *not* an eager accessor and still wins on specificity:

```java
interface BeanWithAnnotatedProviderProp {
    @ReplacesEagerProperty Provider<String> getProp();
}
abstract class Bean implements BeanWithAnnotatedProviderProp {
    @Override public abstract Property<String> getProp();   // still the lazy getter
}
```

Worked through, for a reference type — `AntlrTask.maxHeapSize`, upgraded from `String`:

```java
// Gradle
@Internal @ReplacesEagerProperty
public abstract Property<String> getMaxHeapSize();

// Plugin, compiled when it returned String
public abstract class MyAntlrTask extends AntlrTask {
    @Override public String getMaxHeapSize() { return super.getMaxHeapSize(); }
}
```

`String` and `Property<String>` are unrelated, so neither "prefer the most specialized type" nor anything else in `addGetter` could choose, and `MyAntlrTask`'s declaration won purely by being visited first. `getType()` then returned `String`, which is not `@ManagedType`, so `maxHeapSize` was never given a body. Now the annotated accessor wins and the generated class gets:

```java
Property<String> getMaxHeapSize() { /* managed */ }
String           getMaxHeapSize() { return getMaxHeapSize().getOrNull(); }
```

And for a primitive — `Checkstyle.maxErrors`, upgraded from `int`:

```java
// Gradle
@Input @ReplacesEagerProperty(originalType = int.class)
public abstract Property<Integer> getMaxErrors();

// Plugin, compiled when it returned int
public abstract class MyCheckstyle extends Checkstyle {
    @Override public int getMaxErrors() { return super.getMaxErrors(); }
}
```

```java
Property<Integer> getMaxErrors() { /* managed */ }
int               getMaxErrors() { return getMaxErrors().getOrElse(0); }
```

`getOrElse(0)` rather than `getOrNull()` for two reasons: unboxing `null` would throw, and the generated eager adapter for `maxErrors` uses `getOrElse(0)` — an old call site rewritten to the adapter and a virtual call landing on this shim have to return the same thing when the property is unset.

**2. Stops the legacy accessor blocking the claim.** A concrete getter normally means "the user manages this state, hands off". An eager accessor left over from an upgrade does not, so it is skipped — identified by return type, since an override does not inherit the annotation.

**3. Implements the legacy accessor over the lazy property.** What gets generated depends on the pair:

```java
ConfigurableFileCollection -> FileCollection   return getClasspath();                    // already is one
Property<String>           -> String           return getProp().getOrNull();
Property<Integer>          -> int              return getProp().getOrElse(0);            // matches the eager adapters
ListProperty<String>       -> List<String>     return getProp().getOrNull();
Provider<Directory>        -> File             // no shim: the value is a Directory, not a File
```

The primitive default matters: a call site rewritten to the generated eager adapter and a virtual call landing on this shim must agree on an unset property, and the adapter uses `getOrElse(0)`.

**4. Reports overrides whose body did more than delegate.** The shim replaces the plugin's body, so anything it did stops happening:

```java
// silent — the shim is equivalent
public FileCollection getClasspath() { return super.getClasspath(); }

// reported — this logic no longer runs
public FileCollection getClasspath() { return super.getClasspath().plus(extraJars); }
public FileCollection getClasspath() { return this.ownField; }
```

> Overriding AspectjCompile.getClasspath() on a property upgraded to the Provider API has been deprecated. This will fail with an error in Gradle 11. Gradle reads 'classpath' through the upgraded accessor, so this override is no longer called. Remove the override and configure the 'classpath' property instead.

Both the javac/Kotlin `INVOKESPECIAL` shape and Groovy's reflective `invokeMethodOnSuper0` count as delegation. Anything unrecognised is reported rather than silently discarded, so a miss costs a warning, not a broken build.

### Testing

- `UpgradedPropertyLegacyGetterIntegrationTest` — `Property<String>`/`String`, `Property<Integer>`/`int`, `ListProperty<String>`/`List<String>`, `ConfigurableFileCollection`/`FileCollection`; that the eager accessor reads the lazy value; and the `getOrElse(0)` default. It produces the shape by inheriting the two getters from different branches of the hierarchy — javac and groovyc both reject an override differing only in return type, so a plain subclass cannot express it in one compilation.
- `SuperDelegatingAccessorsTest` — delegating vs. adds-logic / ignores-super / reads-field / branches / unreadable.
- `:model-core:test` 3880 tests, 0 failures.
- Verified end to end on the Provider API migration branch, where `AbstractCompile.getClasspath()` is actually upgraded: `FreefairAspectJPluginSmokeTest` passes and emits **no** deprecation, since freefair's override is a pure `super` delegation. That was against an earlier revision of the base; worth re-running once this settles.

### Known gaps

- The javac super-delegation shape is covered only by that smoke test: `SuperDelegatingAccessorsTest`'s fixtures are groovyc-compiled, and the integ fixtures extend `DefaultTask` so they cannot call super. A Java fixture under `src/test/java` would close this.
- `addGetter` runs during `assembleProperties`, before `getterDeclarations` is populated, so it reads the annotation off the single declaration `ClassDetails` kept — the fragility `hasAnnotationOnAnyGetter` exists to avoid. Narrow, since the tie-breaker only fires for unrelated return types, but a proper fix means deferring main-getter selection until after assembly.
- The new deprecation is `.undocumented()` and needs an upgrade guide section before release.
- Setter overrides are out of scope: upgraded types keep a concrete setter forwarding into the lazy property, so those still compose.

