### PR TITLE
Make dsl-meta-data.bin reproducible across JVM runs

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/model/ClassMetaData.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/model/ClassMetaData.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,14 @@ public class ClassMetaData extends AbstractLanguageElement implements Serializab
     private final List<String> imports = new ArrayList<String>();
     private final List<String> interfaceNames = new ArrayList<String>();
     private final Map<String, PropertyMetaData> declaredProperties = new HashMap<String, PropertyMetaData>();
-    private final Set<MethodMetaData> declaredMethods = new HashSet<MethodMetaData>();
+    /**
+     * Must preserve a deterministic iteration order: this set is serialized as part of the
+     * {@code dsl-meta-data.bin} repository, and {@link MethodMetaData#hashCode()} mixes in the
+     * identity hash code of its owner {@link ClassMetaData} (which does not override
+     * {@code hashCode()}). With a plain {@code HashSet} the serialized order therefore varies
+     * between JVM runs, making the task output non-reproducible for identical inputs.
+     */
+    private final Set<MethodMetaData> declaredMethods = new LinkedHashSet<MethodMetaData>();
     private final List<String> innerClassNames = new ArrayList<String>();
     private String outerClassName;
     private transient ClassMetaDataRepository<ClassMetaData> metaDataRepository;


### PR DESCRIPTION
## Problem

`:distributions-full:dslMetaData` (`ExtractDslMetaDataTask`) is not reproducible: for identical inputs it produces different `dsl-meta-data.bin` bytes on different JVM runs.

The task is `@CacheableTask`, so the same cache key can map to *different* outputs in different caches. Everything derived from that file then diverges as well:

```
dsl-meta-data.bin
  └─ api-mapping.txt, default-imports.txt
       └─ gradle-runtime-api-info-<version>.jar
            └─ bin distribution / lib/*.jar and the distribution zips
                 └─ integTest / smokeTest tasks that consume the distribution
```

On `ge.gradle.org` this shows up as a diverging `CLASSPATH`-normalized input on the integration-test tasks. Two builds at the **same commit** (`1aa7f0c58f5938ce9ab8cee52214a4ff8706d18d`), same branch, same OS and same JVM:

- cache miss: [`lfbvyalghlbxc`](https://ge.gradle.org/s/lfbvyalghlbxc)
- comparison: [`ptcw4vaobmec4`](https://ge.gradle.org/s/ptcw4vaobmec4)

Both ran `:distributions-full:dslMetaData` with the **identical cache key** `d16806a98ae9c6f704ae463cac852aa2` — one hit the local cache, the other the remote cache — yet the downstream `:distributions-full:apiMapping` keys diverged (`26a5b8cd…` vs `a9a57970…`). Same key, different bytes, which is the signature of a non-reproducible cacheable task.

## Root cause

`ClassMetaData.declaredMethods` was a `HashSet<MethodMetaData>`:

- `MethodMetaData.hashCode()` is `Objects.hash(super.hashCode(), name, ownerClass, parameters, returnType)`
- `ownerClass` is a `ClassMetaData`, which does **not** override `hashCode()`

So every `MethodMetaData` hash code derives from an identity hash code, the `HashSet`'s bucket order varies per JVM run, and Java serialization writes the set — and the surrounding object graph's back-references — in that order.

## Fix

Use a `LinkedHashSet`, so the serialized order follows source parse order. One-line change plus a comment explaining the constraint.

## Validation

`:distributions-full:dslMetaData` run repeatedly with `--no-build-cache`, outputs deleted between runs, SHA-1 of `dsl-meta-data.bin`:

| | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| **before** | `a032d1ad` | `4a1e771b` | `08d53652` | `a032d1ad` |
| **after** | `c0a45dc2` | `c0a45dc2` | `c0a45dc2` | `c0a45dc2` |

Runs 3 and 4 in each row used a freshly started daemon (`./gradlew --stop` first) and were verified to have actually executed the task (`Parsed 1749 classes`, `3 executed`), so the stable "after" result is not an up-to-date or cache artifact.

`:build-logic:documentation:test` passes.

## Impact

Develocity attributes roughly **950 CI hours per week** of avoidable cache misses to this one diverging jar and the distribution zips embedding it, across 10 tasks — `:configuration-cache:noDaemonIntegTest` (157.8h), `:dependency-management:forkingIntegTest` (145.2h), `:dependency-management:noDaemonIntegTest` (120.8h), `:configuration-cache:forkingIntegTest` (117.0h), `:core:forkingIntegTest` (90.2h), `:dependency-management:embeddedIntegTest` (76.1h), `:smoke-test:gradleBuildSmokeTest` (66.6h), `:smoke-test:configCacheSmokeTest` (65.5h), `:smoke-test:smokeTest` (57.7h), `:core:test` (52.8h).

## Honest caveat — this may not be the whole story

The non-reproducibility above is confirmed and eliminated. But I could not fully account for one detail, and it should be checked before assuming the misses are gone:

Locally, two byte-different `dsl-meta-data.bin` files still produced **identical** `api-mapping.txt` and `default-imports.txt` — both generators iterate the repository's `TreeMap` and are order-insensitive. On CI, Develocity reports those two `.txt` files as having different *contents*. Ordering-only divergence in the `.bin` does not explain that, which suggests a second, content-level divergence in `dslMetaData` may also exist.

I ruled out the most likely candidate: duplicate public-API source paths colliding in the repository under the task's `@PathSensitive(NAME_ONLY)` normalization. The only duplicates in the tree are integration-test fixtures (not in `gradleApiSources`) and byte-identical `package-info.java` files.

Worth watching after this merges: if `gradle-runtime-api-info.jar` still diverges, the next things to look at are the `lenient(true)` artifact view feeding `gradleApiSources` and the `NAME_ONLY` path sensitivity on `ExtractDslMetaDataTask.getSource()`, which together make the input fingerprint blind to where a source file came from.

Separately, and out of scope here: `:distributions-full:runtimeApiInfoJar` reports `OUTPUT_CACHING_NOT_ENABLED` in both scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
