### PR TITLE
Allow adding setters for upgraded lazy properties

### DIFF
--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(projects.baseServicesGroovy)
     implementation(projects.baseAsm)
     implementation(projects.classloaders)
+    implementation(projects.internalInstrumentationApi)
     implementation(projects.logging)
     implementation(projects.serviceRegistryBuilder)
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -357,9 +357,26 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 propertyMetaData.field(property.getBackingField());
             }
         }
-        // ClassDetails keeps a single declaration per getter signature, preferring the most concrete one, so a
-        // supertype getter that a subtype re-declares (directly, or via the bridge of a covariant override) is
-        // dropped. Record every declaration separately, so that annotations on the dropped ones remain visible.
+        recordGetterDeclarations(classDetails, classMetaData);
+        for (Method method : classDetails.getInstanceMethods()) {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            if (parameterTypes.length == 1) {
+                PropertyMetadata propertyMetaData = classMetaData.getProperty(method.getName());
+                if (propertyMetaData != null) {
+                    propertyMetaData.addSetMethod(method);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@link ClassDetails} keeps a single declaration per getter signature, preferring the most concrete one, so a
+     * supertype getter that a subtype re-declares — directly, or via the bridge of a covariant override — is dropped.
+     * Record every declaration too, so that annotations on the dropped ones remain visible.
+     *
+     * <p>Mirrors how {@link ClassInspector} classifies methods into properties.
+     */
+    private void recordGetterDeclarations(ClassDetails classDetails, ClassMetadata classMetaData) {
         for (Method method : classDetails.getAllMethods()) {
             if (Modifier.isPrivate(method.getModifiers()) || Modifier.isStatic(method.getModifiers())) {
                 continue;
@@ -369,15 +386,6 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 PropertyMetadata propertyMetaData = classMetaData.getProperty(accessorType.propertyNameFor(method));
                 if (propertyMetaData != null) {
                     propertyMetaData.addGetterDeclaration(method);
-                }
-            }
-        }
-        for (Method method : classDetails.getInstanceMethods()) {
-            Class<?>[] parameterTypes = method.getParameterTypes();
-            if (parameterTypes.length == 1) {
-                PropertyMetadata propertyMetaData = classMetaData.getProperty(method.getName());
-                if (propertyMetaData != null) {
-                    propertyMetaData.addSetMethod(method);
                 }
             }
         }
@@ -394,13 +402,60 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         // Else, ignore abstract methods on non-abstract classes as some other tooling (e.g. the Groovy compiler) has decided this is ok
     }
 
+    /**
+     * Readable, has no setter of the property type, and the type is one we can create.
+     */
     private static boolean isManagedProperty(PropertyMetadata property) {
-        // Property is readable and without a setter of property type and the type can be created
         return property.isReadableWithoutSetterOfPropertyType() && isManagedPropertyType(property);
     }
 
+    /**
+     * The property type is one we can create, e.g. {@code Property} or {@code ConfigurableFileCollection}.
+     */
     private static boolean isManagedPropertyType(PropertyMetadata property) {
         return property.getType().isAnnotationPresent(ManagedType.class) || hasNestedAnnotation(property::hasAnnotation);
+    }
+
+    /**
+     * A getter with a body reads state the author manages, so the property is not ours to implement. Bridge getters
+     * don't count: their compiler-generated body only delegates to the real getter.
+     */
+    private static boolean hasConcreteGetter(PropertyMetadata property) {
+        for (MethodMetadata getter : property.getters) {
+            if (getter.shouldImplement() && !getter.isAbstract()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAbstractGetter(PropertyMetadata property) {
+        for (MethodMetadata getter : property.getters) {
+            if (getter.shouldImplement() && getter.isAbstract()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasConcreteSetter(PropertyMetadata property) {
+        for (Method setter : property.setters) {
+            if (!Modifier.isAbstract(setter.getModifiers())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A property upgraded to the Provider API that still declares the eager setter it replaced. Every getter being
+     * abstract is what makes the setter safe to keep: there is no backing field for it to manage, so it can only be
+     * writing through the getter.
+     */
+    private static boolean isUpgradedPropertyWithEagerSetter(PropertyMetadata property) {
+        return hasAbstractGetter(property)
+            && property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class)
+            && hasConcreteSetter(property);
     }
 
     private static boolean hasNestedAnnotation(Predicate<Class<? extends Annotation>> hasAnnotation) {
@@ -680,6 +735,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     protected static class PropertyMetadata {
         private final String name;
         private final List<MethodMetadata> getters = new ArrayList<>();
+        // Every declaration of every getter, including those ClassDetails discarded as duplicates of one another
         private final List<Method> getterDeclarations = new ArrayList<>();
         private final List<MethodMetadata> overridableGetters = new ArrayList<>();
         private final List<Method> overridableSetters = new ArrayList<>();
@@ -726,7 +782,12 @@ abstract class AbstractClassGenerator implements ClassGenerator {
          * declaration of this getter in the type hierarchy, not just on {@link #getMainGetter()}.
          */
         public boolean hasAnnotationOnAnyGetter(Class<? extends Annotation> type) {
-            return getterDeclarations.stream().anyMatch(getter -> getter.isAnnotationPresent(type));
+            for (Method getter : getterDeclarations) {
+                if (getter.isAnnotationPresent(type)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Nullable
@@ -1152,36 +1213,24 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
         @Override
         boolean claimPropertyImplementation(PropertyMetadata property) {
-            boolean hasAbstractGetter = false;
-            for (MethodMetadata getter : property.getters) {
-                if (!getter.shouldImplement()) {
-                    // A bridge getter cannot manage state: its compiler-generated body only delegates to the real getter
-                    continue;
-                }
-                if (!getter.isAbstract()) {
-                    // A concrete real getter reads user-managed state (e.g. a handwritten field), so the property is not ours to claim
-                    return false;
-                }
-                hasAbstractGetter = true;
-            }
-
-            if (isForwarderSetterProperty(property, hasAbstractGetter)) {
-                // The setter can only forward into the property, so we must give the property a managed body without
-                // touching the setter. Only the read-only treatment leaves setters alone, so require a type we can
-                // create — regardless of the setter's parameter type, which is what isManagedProperty would test.
-                if (isManagedPropertyType(property)) {
-                    readOnlyProperties.add(property);
-                    return true;
-                }
-                // We cannot create the property, so a managed body would have to replace the setter's own. Leave both.
+            if (hasConcreteGetter(property)) {
                 return false;
             }
 
-            for (Method setter : property.setters) {
-                if (!Modifier.isAbstract(setter.getModifiers())) {
-                    // A concrete setter manages its own state, so the property is not ours to claim
+            if (isUpgradedPropertyWithEagerSetter(property)) {
+                // The eager setter must keep its own body, and only the read-only treatment leaves setters alone.
+                // So the property is ours only if we can create it — whatever the setter's parameter type, which is
+                // the part isManagedProperty would additionally test.
+                if (!isManagedPropertyType(property)) {
                     return false;
                 }
+                readOnlyProperties.add(property);
+                return true;
+            }
+
+            if (hasConcreteSetter(property)) {
+                // The setter manages its own state, including for a write-only property such as Task.setOnlyIf
+                return false;
             }
 
             // Property has no user-managed state
@@ -1197,20 +1246,6 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // Read only but unrecognized type
                 return false;
             }
-        }
-
-        /**
-         * A property migrated to the Provider API that kept the eager setter it replaced, as a forwarder into the
-         * lazy property. Every getter being abstract is what makes that safe to assume: there is no backing field
-         * for the setter to manage, so it can only be writing through the getter.
-         *
-         * <p>Without an abstract getter the property is write-only (e.g. {@code Task.setOnlyIf}) — a concrete getter
-         * would already have disqualified the property — so a concrete setter there has nothing to forward into.
-         */
-        private boolean isForwarderSetterProperty(PropertyMetadata property, boolean hasAbstractGetter) {
-            return hasAbstractGetter
-                && property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class)
-                && property.setters.stream().anyMatch(setter -> !Modifier.isAbstract(setter.getModifiers()));
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -655,6 +655,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         public Type getGenericReturnType() {
             return returnType;
         }
+
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return method.isAnnotationPresent(annotationType);
+        }
     }
 
     protected static class PropertyMetadata {
@@ -1125,7 +1129,15 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     return false;
                 }
             }
+            boolean allAbstract = allGettersAreAbstract(property);
             for (Method setter : property.setters) {
+                // When every getter is abstract, the user cannot be managing a backing field
+                // themselves (an abstract getter has no body to read it from). Any concrete
+                // setter must then be a forwarder (e.g. setX(value) { getX().set(value); }),
+                // so it shouldn't prevent the property from being claimed and given a managed body.
+                if (allAbstract) {
+                    continue;
+                }
                 if (!Modifier.isAbstract(setter.getModifiers())) {
                     return false;
                 }
@@ -1144,6 +1156,18 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // Read only but unrecognized type
                 return false;
             }
+        }
+
+        private boolean allGettersAreAbstract(PropertyMetadata property) {
+            if (property.getters.isEmpty()) {
+                return false;
+            }
+            for (MethodMetadata getter : property.getters) {
+                if (!getter.isAbstract()) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -1123,27 +1123,32 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
         @Override
         boolean claimPropertyImplementation(PropertyMetadata property) {
-            // Skip properties with non-abstract getter or setter implementations
+            boolean hasAbstractGetter = false;
             for (MethodMetadata getter : property.getters) {
-                if (getter.shouldImplement() && !getter.isAbstract()) {
-                    return false;
-                }
-            }
-            boolean allAbstract = allGettersAreAbstract(property);
-            for (Method setter : property.setters) {
-                // When every getter is abstract, the user cannot be managing a backing field
-                // themselves (an abstract getter has no body to read it from). Any concrete
-                // setter must then be a forwarder (e.g. setX(value) { getX().set(value); }),
-                // so it shouldn't prevent the property from being claimed and given a managed body.
-                if (allAbstract) {
+                if (!getter.shouldImplement()) {
+                    // A bridge getter cannot manage state: its compiler-generated body only delegates to the real getter
                     continue;
                 }
-                if (!Modifier.isAbstract(setter.getModifiers())) {
+                if (!getter.isAbstract()) {
+                    // A concrete real getter reads user-managed state (e.g. a handwritten field), so the property is not ours to claim
                     return false;
+                }
+                hasAbstractGetter = true;
+            }
+
+            if (!hasAbstractGetter) {
+                for (Method setter : property.setters) {
+                    if (!Modifier.isAbstract(setter.getModifiers())) {
+                        // At this point we know that:
+                        //  - The property has no getter at all (write-only, e.g. Task.setOnlyIf): a concrete getter would have returned above, an abstract one would have set the flag.
+                        //  - This setter is concrete, and with no getter to work through, it can only be managing its own state.
+                        // So the property is not ours to claim.
+                        return false;
+                    }
                 }
             }
 
-            // Property is readable and all getters and setters are abstract
+            // Property has no user-managed state
             if (isManagedProperty(property)) {
                 // Abstract read-only property with managed type
                 readOnlyProperties.add(property);
@@ -1156,18 +1161,6 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // Read only but unrecognized type
                 return false;
             }
-        }
-
-        private boolean allGettersAreAbstract(PropertyMetadata property) {
-            if (property.getters.isEmpty()) {
-                return false;
-            }
-            for (MethodMetadata getter : property.getters) {
-                if (!getter.isAbstract()) {
-                    return false;
-                }
-            }
-            return true;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -54,6 +54,7 @@ import org.gradle.internal.instantiation.ClassGenerationException;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler;
+import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.reflect.ClassDetails;
 import org.gradle.internal.reflect.ClassInspector;
@@ -356,6 +357,21 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 propertyMetaData.field(property.getBackingField());
             }
         }
+        // ClassDetails keeps a single declaration per getter signature, preferring the most concrete one, so a
+        // supertype getter that a subtype re-declares (directly, or via the bridge of a covariant override) is
+        // dropped. Record every declaration separately, so that annotations on the dropped ones remain visible.
+        for (Method method : classDetails.getAllMethods()) {
+            if (Modifier.isPrivate(method.getModifiers()) || Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
+            PropertyAccessorType accessorType = PropertyAccessorType.of(method);
+            if (accessorType == PropertyAccessorType.GET_GETTER || accessorType == PropertyAccessorType.IS_GETTER) {
+                PropertyMetadata propertyMetaData = classMetaData.getProperty(accessorType.propertyNameFor(method));
+                if (propertyMetaData != null) {
+                    propertyMetaData.addGetterDeclaration(method);
+                }
+            }
+        }
         for (Method method : classDetails.getInstanceMethods()) {
             Class<?>[] parameterTypes = method.getParameterTypes();
             if (parameterTypes.length == 1) {
@@ -655,15 +671,12 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         public Type getGenericReturnType() {
             return returnType;
         }
-
-        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
-            return method.isAnnotationPresent(annotationType);
-        }
     }
 
     protected static class PropertyMetadata {
         private final String name;
         private final List<MethodMetadata> getters = new ArrayList<>();
+        private final List<Method> getterDeclarations = new ArrayList<>();
         private final List<MethodMetadata> overridableGetters = new ArrayList<>();
         private final List<Method> overridableSetters = new ArrayList<>();
         private final List<Method> setters = new ArrayList<>();
@@ -702,6 +715,14 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
         public boolean hasAnnotation(Class<? extends Annotation> type) {
             return findAnnotation(type) != null;
+        }
+
+        /**
+         * A method annotation is not inherited by an override, so the annotation may sit on any
+         * declaration of this getter in the type hierarchy, not just on {@link #getMainGetter()}.
+         */
+        public boolean hasAnnotationOnAnyGetter(Class<? extends Annotation> type) {
+            return getterDeclarations.stream().anyMatch(getter -> getter.isAnnotationPresent(type));
         }
 
         @Nullable
@@ -765,6 +786,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // Prefer the most specialized type
                 mainGetter = metadata;
             }
+        }
+
+        public void addGetterDeclaration(Method method) {
+            getterDeclarations.add(method);
         }
 
         public void addSetter(Method method) {
@@ -1136,13 +1161,14 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 hasAbstractGetter = true;
             }
 
-            if (!hasAbstractGetter) {
+            // A concrete setter means the property is not ours to claim, unless it can only be a forwarder into a
+            // property we manage. That takes an abstract getter, leaving the setter no backing field to manage, plus
+            // @ReplacesEagerProperty, which marks the getters migrated to the Provider API; anywhere else a concrete
+            // setter still means "hands off". Without an abstract getter the property is write-only (e.g.
+            // Task.setOnlyIf) — a concrete getter would have returned above — so there is nothing to forward into.
+            if (!hasAbstractGetter || !property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class)) {
                 for (Method setter : property.setters) {
                     if (!Modifier.isAbstract(setter.getModifiers())) {
-                        // At this point we know that:
-                        //  - The property has no getter at all (write-only, e.g. Task.setOnlyIf): a concrete getter would have returned above, an abstract one would have set the flag.
-                        //  - This setter is concrete, and with no getter to work through, it can only be managing its own state.
-                        // So the property is not ours to claim.
                         return false;
                     }
                 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -396,7 +396,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     private static boolean isManagedProperty(PropertyMetadata property) {
         // Property is readable and without a setter of property type and the type can be created
-        return property.isReadableWithoutSetterOfPropertyType() && (property.getType().isAnnotationPresent(ManagedType.class) || hasNestedAnnotation(property::hasAnnotation));
+        return property.isReadableWithoutSetterOfPropertyType() && isManagedPropertyType(property);
+    }
+
+    private static boolean isManagedPropertyType(PropertyMetadata property) {
+        return property.getType().isAnnotationPresent(ManagedType.class) || hasNestedAnnotation(property::hasAnnotation);
     }
 
     private static boolean hasNestedAnnotation(Predicate<Class<? extends Annotation>> hasAnnotation) {
@@ -1161,16 +1165,22 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 hasAbstractGetter = true;
             }
 
-            // A concrete setter means the property is not ours to claim, unless it can only be a forwarder into a
-            // property we manage. That takes an abstract getter, leaving the setter no backing field to manage, plus
-            // @ReplacesEagerProperty, which marks the getters migrated to the Provider API; anywhere else a concrete
-            // setter still means "hands off". Without an abstract getter the property is write-only (e.g.
-            // Task.setOnlyIf) — a concrete getter would have returned above — so there is nothing to forward into.
-            if (!hasAbstractGetter || !property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class)) {
-                for (Method setter : property.setters) {
-                    if (!Modifier.isAbstract(setter.getModifiers())) {
-                        return false;
-                    }
+            if (isForwarderSetterProperty(property, hasAbstractGetter)) {
+                // The setter can only forward into the property, so we must give the property a managed body without
+                // touching the setter. Only the read-only treatment leaves setters alone, so require a type we can
+                // create — regardless of the setter's parameter type, which is what isManagedProperty would test.
+                if (isManagedPropertyType(property)) {
+                    readOnlyProperties.add(property);
+                    return true;
+                }
+                // We cannot create the property, so a managed body would have to replace the setter's own. Leave both.
+                return false;
+            }
+
+            for (Method setter : property.setters) {
+                if (!Modifier.isAbstract(setter.getModifiers())) {
+                    // A concrete setter manages its own state, so the property is not ours to claim
+                    return false;
                 }
             }
 
@@ -1187,6 +1197,20 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // Read only but unrecognized type
                 return false;
             }
+        }
+
+        /**
+         * A property migrated to the Provider API that kept the eager setter it replaced, as a forwarder into the
+         * lazy property. Every getter being abstract is what makes that safe to assume: there is no backing field
+         * for the setter to manage, so it can only be writing through the getter.
+         *
+         * <p>Without an abstract getter the property is write-only (e.g. {@code Task.setOnlyIf}) — a concrete getter
+         * would already have disqualified the property — so a concrete setter there has nothing to forward into.
+         */
+        private boolean isForwarderSetterProperty(PropertyMetadata property, boolean hasAbstractGetter) {
+            return hasAbstractGetter
+                && property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class)
+                && property.setters.stream().anyMatch(setter -> !Modifier.isAbstract(setter.getModifiers()));
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -815,6 +815,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             return overridableSetters;
         }
 
+        public List<Method> getSetters() {
+            return setters;
+        }
+
         @Nullable
         public Field getBackingField() {
             return backingField;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -937,6 +937,17 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
+            // If the type already declares a set<Name>(Object) (e.g. an eager-style migration setter
+            // forwarding into the lazy container, or one synthesised by @ReplacesEagerProperty when the
+            // original type erases to Object), our setFromAnyValue-backed set<Name>(Object) would be a
+            // duplicate. Skip generation in that case.
+            if (property.getOverridableSetters().stream().anyMatch(setter ->
+                setter.getParameterCount() == 1
+                    && setter.getParameterTypes()[0].equals(Object.class)
+                    && setter.getReturnType().equals(Void.TYPE))) {
+                return;
+            }
+
             // GENERATE public void set<Name>(Object p) {
             //    ((LazyGroovySupport)<getter>()).setFromAnyValue(p);
             // }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -48,6 +48,7 @@ import org.gradle.internal.instantiation.ClassGenerationException;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler;
+import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.BeanDynamicObject;
@@ -937,7 +938,8 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
-            if (declaresSetterTakingObject(property)) {
+            // Limited to upgraded properties: elsewhere a type declaring its own set<Name>(Object) alongside a lazy property fails to generate
+            if (property.hasAnnotationOnAnyGetter(ReplacesEagerProperty.class) && implementsSetterTakingObject(property)) {
                 return;
             }
 
@@ -954,13 +956,18 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         }
 
         /**
-         * Does the type already declare a {@code set<Name>(Object)}? It may be an eager-style migration setter
+         * Does the type already implement a {@code set<Name>(Object)}? It may be an eager-style migration setter
          * forwarding into the lazy container, or one synthesised by {@code @ReplacesEagerProperty} when the original
-         * type erases to Object. Either way our {@code setFromAnyValue}-backed overload would duplicate it.
+         * type erases to Object. Either way our {@code setFromAnyValue}-backed overload would be a second method with
+         * the same signature, which the JVM rejects when the class is defined.
+         *
+         * <p>An abstract one is not an implementation: our overload is what implements it, so it must still be
+         * generated. Final ones count, which is why this looks at every setter rather than the overridable ones.
          */
-        private static boolean declaresSetterTakingObject(PropertyMetadata property) {
-            for (Method setter : property.getOverridableSetters()) {
-                if (setter.getParameterCount() == 1
+        private static boolean implementsSetterTakingObject(PropertyMetadata property) {
+            for (Method setter : property.getSetters()) {
+                if (!Modifier.isAbstract(setter.getModifiers())
+                    && setter.getParameterCount() == 1
                     && setter.getParameterTypes()[0].equals(Object.class)
                     && setter.getReturnType().equals(Void.TYPE)) {
                     return true;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -937,14 +937,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
-            // If the type already declares a set<Name>(Object) (e.g. an eager-style migration setter
-            // forwarding into the lazy container, or one synthesised by @ReplacesEagerProperty when the
-            // original type erases to Object), our setFromAnyValue-backed set<Name>(Object) would be a
-            // duplicate. Skip generation in that case.
-            if (property.getOverridableSetters().stream().anyMatch(setter ->
-                setter.getParameterCount() == 1
-                    && setter.getParameterTypes()[0].equals(Object.class)
-                    && setter.getReturnType().equals(Void.TYPE))) {
+            if (declaresSetterTakingObject(property)) {
                 return;
             }
 
@@ -958,6 +951,22 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 _ALOAD(1);
                 _INVOKEINTERFACE(LAZY_GROOVY_SUPPORT_TYPE, "setFromAnyValue", ClassBuilderImpl.RETURN_VOID_FROM_OBJECT);
             }});
+        }
+
+        /**
+         * Does the type already declare a {@code set<Name>(Object)}? It may be an eager-style migration setter
+         * forwarding into the lazy container, or one synthesised by {@code @ReplacesEagerProperty} when the original
+         * type erases to Object. Either way our {@code setFromAnyValue}-backed overload would duplicate it.
+         */
+        private static boolean declaresSetterTakingObject(PropertyMetadata property) {
+            for (Method setter : property.getOverridableSetters()) {
+                if (setter.getParameterCount() == 1
+                    && setter.getParameterTypes()[0].equals(Object.class)
+                    && setter.getReturnType().equals(Void.TYPE)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /**

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -29,6 +29,7 @@ import static org.gradle.internal.instantiation.generator.AsmBackedClassGenerato
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BrokenConstructor
@@ -62,9 +63,22 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         def bean = create(BeanWithAbstractProperty)
 
         expect:
+        bean instanceof Managed
         bean.name == null
         bean.setName("name")
         bean.name == "name"
+    }
+
+    def canConstructInstanceOfAbstractClassWithAbstractPropertyGetterAndConcreteForwarderSetter() {
+        def bean = create(AbstractPropertyBeanWithForwarderSetter)
+
+        expect:
+        bean instanceof Managed
+        bean.prop.toString() == "property 'prop'"
+        !bean.prop.present
+
+        bean.setProp("value")
+        bean.prop.get() == "value"
     }
 
     def canUnpackAndRecreateAbstractClassWithAbstractPropertyGetterAndSetter() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -32,6 +32,8 @@ import static org.gradle.internal.instantiation.generator.AsmBackedClassGenerato
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithInheritedAnnotation
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractFileCollectionBeanWithPropertyTypedForwarderSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractProviderPropBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanRedeclaringAnnotatedGetter
@@ -98,6 +100,29 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
         bean.setProp("value")
         bean.prop.get() == "value"
+    }
+
+    def "claims property with a forwarder setter that takes the property type"() {
+        def bean = create(AbstractFileCollectionBeanWithPropertyTypedForwarderSetter)
+        def file = tmpDir.file("some-file")
+
+        expect:
+        bean instanceof Managed
+        bean.files.toString() == "property 'files'"
+        bean.files.files.empty
+
+        // the setter's own body runs, rather than being replaced by managed state
+        bean.setFiles(TestUtil.objectFactory().fileCollection().from(file))
+        bean.files.files == [file] as Set
+    }
+
+    def "does not claim property with a forwarder setter when the property type cannot be created"() {
+        when:
+        create(AbstractProviderPropBeanWithForwarderSetter)
+
+        then:
+        def e = thrown(ClassGenerationException)
+        e.cause.message.contains("Cannot have abstract method AbstractProviderPropBeanWithForwarderSetter.getProp()")
     }
 
     def "claims property when @ReplacesEagerProperty is inherited from a super-interface getter"() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -29,17 +29,17 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithForwarderSetter
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithInheritedAnnotation
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantUpgradedPropertyBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantUpgradedPropertyBeanWithInheritedAnnotation
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractFileCollectionBeanWithPropertyTypedForwarderSetter
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractProviderPropBeanWithForwarderSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractUpgradedFileCollectionBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractUpgradedProviderPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBean
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetter
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanRedeclaringAnnotatedGetter
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetterInSubclass
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithUnannotatedForwarderSetter
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractUpgradedPropertyBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractUpgradedPropertyBeanRedeclaringGetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractUpgradedPropertyBeanWithEagerSetterInSubclass
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractLazyPropertyBeanWithEagerSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractLazyPropertyBeanWithEagerSetterInSubclass
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BrokenConstructor
@@ -79,8 +79,8 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         bean.name == "name"
     }
 
-    def canConstructInstanceOfAbstractClassWithAbstractPropertyGetterAndConcreteForwarderSetter() {
-        def bean = create(AbstractPropertyBeanWithForwarderSetter)
+    def canConstructInstanceOfAbstractClassWithUpgradedPropertyAndEagerSetter() {
+        def bean = create(AbstractUpgradedPropertyBean)
 
         expect:
         bean instanceof Managed
@@ -91,8 +91,8 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         bean.prop.get() == "value"
     }
 
-    def canConstructInstanceOfAbstractClassWithCovariantAbstractPropertyGetterAndConcreteForwarderSetter() {
-        def bean = create(AbstractCovariantPropertyBeanWithForwarderSetter)
+    def canConstructInstanceOfAbstractClassWithCovariantUpgradedPropertyAndEagerSetter() {
+        def bean = create(AbstractCovariantUpgradedPropertyBean)
 
         expect:
         bean instanceof Managed
@@ -103,7 +103,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
     }
 
     def "claims property with a forwarder setter that takes the property type"() {
-        def bean = create(AbstractFileCollectionBeanWithPropertyTypedForwarderSetter)
+        def bean = create(AbstractUpgradedFileCollectionBean)
         def file = tmpDir.file("some-file")
 
         expect:
@@ -118,11 +118,11 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
     def "does not claim property with a forwarder setter when the property type cannot be created"() {
         when:
-        create(AbstractProviderPropBeanWithForwarderSetter)
+        create(AbstractUpgradedProviderPropertyBean)
 
         then:
         def e = thrown(ClassGenerationException)
-        e.cause.message.contains("Cannot have abstract method AbstractProviderPropBeanWithForwarderSetter.getProp()")
+        e.cause.message.contains("Cannot have abstract method AbstractUpgradedProviderPropertyBean.getProp()")
     }
 
     def "claims property when @ReplacesEagerProperty is inherited from a super-interface getter"() {
@@ -136,11 +136,11 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         bean.prop.get() == "value"
 
         where:
-        type << [AbstractCovariantPropertyBeanWithInheritedAnnotation, AbstractPropertyBeanRedeclaringAnnotatedGetter]
+        type << [AbstractCovariantUpgradedPropertyBeanWithInheritedAnnotation, AbstractUpgradedPropertyBeanRedeclaringGetter]
     }
 
     def "claims property when @ReplacesEagerProperty is on a superclass getter and the forwarder setter is in a subclass"() {
-        def bean = create(AbstractPropertyBeanWithForwarderSetterInSubclass)
+        def bean = create(AbstractUpgradedPropertyBeanWithEagerSetterInSubclass)
 
         expect:
         bean instanceof Managed
@@ -160,8 +160,8 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
         where:
         type                                                          | declaringType
-        AbstractPropertyBeanWithUnannotatedForwarderSetter            | AbstractPropertyBeanWithUnannotatedForwarderSetter
-        AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass  | AbstractPropertyBean
+        AbstractLazyPropertyBeanWithEagerSetter            | AbstractLazyPropertyBeanWithEagerSetter
+        AbstractLazyPropertyBeanWithEagerSetterInSubclass  | AbstractPropertyBean
     }
 
     def canUnpackAndRecreateAbstractClassWithAbstractPropertyGetterAndSetter() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.instantiation.generator
 
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.Describables
+import org.gradle.internal.instantiation.ClassGenerationException
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
 import org.gradle.internal.state.DefaultManagedFactoryRegistry
 import org.gradle.internal.state.Managed
@@ -29,8 +30,14 @@ import static org.gradle.internal.instantiation.generator.AsmBackedClassGenerato
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithForwarderSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithInheritedAnnotation
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanRedeclaringAnnotatedGetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetterInSubclass
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithUnannotatedForwarderSetter
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BrokenConstructor
@@ -91,6 +98,45 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
 
         bean.setProp("value")
         bean.prop.get() == "value"
+    }
+
+    def "claims property when @ReplacesEagerProperty is inherited from a super-interface getter"() {
+        def bean = create(type)
+
+        expect:
+        bean instanceof Managed
+        !bean.prop.present
+
+        bean.setProp("value")
+        bean.prop.get() == "value"
+
+        where:
+        type << [AbstractCovariantPropertyBeanWithInheritedAnnotation, AbstractPropertyBeanRedeclaringAnnotatedGetter]
+    }
+
+    def "claims property when @ReplacesEagerProperty is on a superclass getter and the forwarder setter is in a subclass"() {
+        def bean = create(AbstractPropertyBeanWithForwarderSetterInSubclass)
+
+        expect:
+        bean instanceof Managed
+        !bean.prop.present
+
+        bean.setProp("value")
+        bean.prop.get() == "value"
+    }
+
+    def "does not claim property with a concrete forwarder setter when the getter is not annotated with @ReplacesEagerProperty"() {
+        when:
+        create(type)
+
+        then:
+        def e = thrown(ClassGenerationException)
+        e.cause.message.contains("Cannot have abstract method ${declaringType.simpleName}.getProp()")
+
+        where:
+        type                                                          | declaringType
+        AbstractPropertyBeanWithUnannotatedForwarderSetter            | AbstractPropertyBeanWithUnannotatedForwarderSetter
+        AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass  | AbstractPropertyBean
     }
 
     def canUnpackAndRecreateAbstractClassWithAbstractPropertyGetterAndSetter() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantPropertyBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractPropertyBeanWithForwarderSetter
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
@@ -75,6 +76,17 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         expect:
         bean instanceof Managed
         bean.prop.toString() == "property 'prop'"
+        !bean.prop.present
+
+        bean.setProp("value")
+        bean.prop.get() == "value"
+    }
+
+    def canConstructInstanceOfAbstractClassWithCovariantAbstractPropertyGetterAndConcreteForwarderSetter() {
+        def bean = create(AbstractCovariantPropertyBeanWithForwarderSetter)
+
+        expect:
+        bean instanceof Managed
         !bean.prop.present
 
         bean.setProp("value")

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.provider.Property
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
 import org.gradle.internal.Describables
+import org.gradle.internal.instantiation.ClassGenerationException
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
@@ -58,6 +59,41 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
 
     @Rule
     final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    def "does not generate a set(Object) overload for an upgraded property that already declares one"() {
+        def bean = create(AsmBackedClassGeneratorTest.AbstractUpgradedPropertyBeanWithObjectSetter)
+
+        when:
+        bean.getClass().getDeclaredMethod("setProp", Object)
+
+        then:
+        thrown(NoSuchMethodException)
+    }
+
+    // Pre-existing behaviour, unchanged here: convention mapping and the lazy Groovy support each generate a
+    // set(Object), and the JVM rejects the duplicate. Only upgraded properties skip the generated overload.
+    def "fails to generate a lazy property that is not upgraded and declares its own set(Object)"() {
+        when:
+        create(AsmBackedClassGeneratorTest.BeanWithLazyPropertyAndObjectSetter)
+
+        then:
+        def e = thrown(ClassGenerationException)
+        e.cause.message.contains('Duplicate method name "setProp"')
+    }
+
+    def "implements an abstract set(Object) declared for a lazy property"() {
+        def bean = create(type)
+
+        expect:
+        bean.setProp("x")
+        bean.prop.get() == "x"
+
+        where:
+        type << [
+            AsmBackedClassGeneratorTest.BeanWithLazyPropertyAndAbstractObjectSetter,
+            AsmBackedClassGeneratorTest.UpgradedPropertyBeanWithAbstractObjectSetter
+        ]
+    }
 
     def "mixes in toString() implementation for class"() {
         given:

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -2092,6 +2092,16 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
+    public static abstract class AbstractPropertyBeanWithForwarderSetter {
+        public abstract Property<String> getProp();
+
+        // A concrete setter that forwards into the lazy property. There is no backing field
+        // for the abstract getter to read, so this setter cannot be managing one itself.
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
     interface InterfaceWithTypeParameter<T> {
         @Inject
         T getThing();

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -2164,6 +2164,26 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
+    public static abstract class AbstractUpgradedPropertyBeanWithObjectSetter {
+        @ReplacesEagerProperty
+        public abstract Property<String> getProp();
+
+        // The eager accessor of an upgraded property whose original type erases to Object
+        public void setProp(Object value) {
+        }
+    }
+
+    // Not upgraded, so the generated set(Object) overload is a second method with the same signature and the JVM
+    // rejects the decorated class. Pre-existing on master and deliberately left alone, see the test for this bean.
+    public static class BeanWithLazyPropertyAndObjectSetter {
+        public Property<String> getProp() {
+            return null;
+        }
+
+        public void setProp(Object value) {
+        }
+    }
+
     public interface BeanWithAnnotatedProperty {
         @ReplacesEagerProperty
         Property<String> getProp();
@@ -2199,6 +2219,20 @@ public class AsmBackedClassGeneratorTest {
         public void setProp(String value) {
             getProp().set(value);
         }
+    }
+
+    // An abstract set(Object) has no body of its own, so the generated overload is its only implementation
+    public interface BeanWithLazyPropertyAndAbstractObjectSetter {
+        Property<String> getProp();
+
+        void setProp(Object value);
+    }
+
+    public interface UpgradedPropertyBeanWithAbstractObjectSetter {
+        @ReplacesEagerProperty
+        Property<String> getProp();
+
+        void setProp(Object value);
     }
 
     interface InterfaceWithTypeParameter<T> {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -2093,7 +2093,7 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
-    public static abstract class AbstractPropertyBeanWithForwarderSetter {
+    public static abstract class AbstractUpgradedPropertyBean {
         @ReplacesEagerProperty
         public abstract Property<String> getProp();
 
@@ -2104,7 +2104,7 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
-    public static abstract class AbstractPropertyBeanWithUnannotatedForwarderSetter {
+    public static abstract class AbstractLazyPropertyBeanWithEagerSetter {
         public abstract Property<String> getProp();
 
         public void setProp(String value) {
@@ -2116,7 +2116,7 @@ public class AsmBackedClassGeneratorTest {
         Provider<String> getProp();
     }
 
-    public static abstract class AbstractCovariantPropertyBeanWithForwarderSetter implements BeanWithProviderProp {
+    public static abstract class AbstractCovariantUpgradedPropertyBean implements BeanWithProviderProp {
         // The covariant override makes javac emit a concrete bridge getter.
         // The bridge only delegates here, so it cannot be managing a backing field either.
         @Override
@@ -2134,7 +2134,7 @@ public class AsmBackedClassGeneratorTest {
     }
 
     // The annotation is only on the super-interface getter: an override does not inherit it.
-    public static abstract class AbstractCovariantPropertyBeanWithInheritedAnnotation implements BeanWithAnnotatedProviderProp {
+    public static abstract class AbstractCovariantUpgradedPropertyBeanWithInheritedAnnotation implements BeanWithAnnotatedProviderProp {
         @Override
         public abstract Property<String> getProp();
 
@@ -2143,7 +2143,7 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
-    public static abstract class AbstractFileCollectionBeanWithPropertyTypedForwarderSetter {
+    public static abstract class AbstractUpgradedFileCollectionBean {
         @ReplacesEagerProperty
         public abstract ConfigurableFileCollection getFiles();
 
@@ -2154,7 +2154,7 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
-    public static abstract class AbstractProviderPropBeanWithForwarderSetter {
+    public static abstract class AbstractUpgradedProviderPropertyBean {
         // Provider cannot be created as managed state, so there is no lazy property to forward into
         @ReplacesEagerProperty
         public abstract Provider<String> getProp();
@@ -2170,7 +2170,7 @@ public class AsmBackedClassGeneratorTest {
     }
 
     // The re-declared getter has the same signature as the annotated one, so it hides it from ClassDetails.
-    public static abstract class AbstractPropertyBeanRedeclaringAnnotatedGetter implements BeanWithAnnotatedProperty {
+    public static abstract class AbstractUpgradedPropertyBeanRedeclaringGetter implements BeanWithAnnotatedProperty {
         @Override
         public abstract Property<String> getProp();
 
@@ -2185,7 +2185,7 @@ public class AsmBackedClassGeneratorTest {
     }
 
     // The annotation is on the superclass getter, the forwarder setter is added further down the hierarchy.
-    public static abstract class AbstractPropertyBeanWithForwarderSetterInSubclass extends AbstractAnnotatedPropertyBean {
+    public static abstract class AbstractUpgradedPropertyBeanWithEagerSetterInSubclass extends AbstractAnnotatedPropertyBean {
         public void setProp(String value) {
             getProp().set(value);
         }
@@ -2195,7 +2195,7 @@ public class AsmBackedClassGeneratorTest {
         public abstract Property<String> getProp();
     }
 
-    public static abstract class AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass extends AbstractPropertyBean {
+    public static abstract class AbstractLazyPropertyBeanWithEagerSetterInSubclass extends AbstractPropertyBean {
         public void setProp(String value) {
             getProp().set(value);
         }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -55,6 +55,7 @@ import org.gradle.internal.extensibility.NoConventionMapping;
 import org.gradle.internal.instantiation.ClassGenerationException;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.PropertyRoleAnnotationHandler;
+import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -2093,10 +2094,19 @@ public class AsmBackedClassGeneratorTest {
     }
 
     public static abstract class AbstractPropertyBeanWithForwarderSetter {
+        @ReplacesEagerProperty
         public abstract Property<String> getProp();
 
         // A concrete setter that forwards into the lazy property. There is no backing field
         // for the abstract getter to read, so this setter cannot be managing one itself.
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
+    public static abstract class AbstractPropertyBeanWithUnannotatedForwarderSetter {
+        public abstract Property<String> getProp();
+
         public void setProp(String value) {
             getProp().set(value);
         }
@@ -2110,8 +2120,61 @@ public class AsmBackedClassGeneratorTest {
         // The covariant override makes javac emit a concrete bridge getter.
         // The bridge only delegates here, so it cannot be managing a backing field either.
         @Override
+        @ReplacesEagerProperty
         public abstract Property<String> getProp();
 
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
+    public interface BeanWithAnnotatedProviderProp {
+        @ReplacesEagerProperty
+        Provider<String> getProp();
+    }
+
+    // The annotation is only on the super-interface getter: an override does not inherit it.
+    public static abstract class AbstractCovariantPropertyBeanWithInheritedAnnotation implements BeanWithAnnotatedProviderProp {
+        @Override
+        public abstract Property<String> getProp();
+
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
+    public interface BeanWithAnnotatedProperty {
+        @ReplacesEagerProperty
+        Property<String> getProp();
+    }
+
+    // The re-declared getter has the same signature as the annotated one, so it hides it from ClassDetails.
+    public static abstract class AbstractPropertyBeanRedeclaringAnnotatedGetter implements BeanWithAnnotatedProperty {
+        @Override
+        public abstract Property<String> getProp();
+
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
+    public static abstract class AbstractAnnotatedPropertyBean {
+        @ReplacesEagerProperty
+        public abstract Property<String> getProp();
+    }
+
+    // The annotation is on the superclass getter, the forwarder setter is added further down the hierarchy.
+    public static abstract class AbstractPropertyBeanWithForwarderSetterInSubclass extends AbstractAnnotatedPropertyBean {
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
+    public static abstract class AbstractPropertyBean {
+        public abstract Property<String> getProp();
+    }
+
+    public static abstract class AbstractPropertyBeanWithUnannotatedForwarderSetterInSubclass extends AbstractPropertyBean {
         public void setProp(String value) {
             getProp().set(value);
         }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -2102,6 +2102,21 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
+    public interface BeanWithProviderProp {
+        Provider<String> getProp();
+    }
+
+    public static abstract class AbstractCovariantPropertyBeanWithForwarderSetter implements BeanWithProviderProp {
+        // The covariant override makes javac emit a concrete bridge getter.
+        // The bridge only delegates here, so it cannot be managing a backing field either.
+        @Override
+        public abstract Property<String> getProp();
+
+        public void setProp(String value) {
+            getProp().set(value);
+        }
+    }
+
     interface InterfaceWithTypeParameter<T> {
         @Inject
         T getThing();

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -2143,6 +2143,27 @@ public class AsmBackedClassGeneratorTest {
         }
     }
 
+    public static abstract class AbstractFileCollectionBeanWithPropertyTypedForwarderSetter {
+        @ReplacesEagerProperty
+        public abstract ConfigurableFileCollection getFiles();
+
+        // Takes the property type rather than the value type, so this is not a plain mutable property:
+        // the forwarder still writes through the lazy property.
+        public void setFiles(ConfigurableFileCollection files) {
+            getFiles().setFrom(files);
+        }
+    }
+
+    public static abstract class AbstractProviderPropBeanWithForwarderSetter {
+        // Provider cannot be created as managed state, so there is no lazy property to forward into
+        @ReplacesEagerProperty
+        public abstract Provider<String> getProp();
+
+        public void setProp(String value) {
+            throw new UnsupportedOperationException("should not be reachable");
+        }
+    }
+
     public interface BeanWithAnnotatedProperty {
         @ReplacesEagerProperty
         Property<String> getProp();


### PR DESCRIPTION
This continues work of https://github.com/gradle/gradle/pull/38196.

The main change is that we allow setters only for `@ReplacesEagerProperty` getters while for the rest we have the old behavior.

### What is handled, and how

**The annotation may sit anywhere on the getter in the hierarchy.** A method annotation is not
inherited by an override, and `ClassDetails` keeps only the most concrete declaration per name and
return type — so an annotated supertype getter disappears as soon as a subtype re-declares it. Both
shapes below are common in the migration and both are handled, by looking the annotation up over every
getter declaration rather than the one that survived:

```java
// annotation on the super-interface, re-declared with the same signature
public interface HasProp {
    @ReplacesEagerProperty
    Property<String> getProp();
}

public abstract class Bean implements HasProp {
    @Override
    public abstract Property<String> getProp();          // annotation not inherited

    public void setProp(String value) {
        getProp().set(value);
    }
}
```

```java
// covariant override: javac emits a concrete bridge getter, which is not user-managed state
public interface HasProp {
    @ReplacesEagerProperty
    Provider<String> getProp();
}

public abstract class Bean implements HasProp {
    @Override
    public abstract Property<String> getProp();

    public void setProp(String value) {
        getProp().set(value);
    }
}
```

**The setter may be declared below the getter.**

```java
public abstract class Base {
    @ReplacesEagerProperty
    public abstract Property<String> getProp();
}

public abstract class Bean extends Base {
    public void setProp(String value) {
        getProp().set(value);
    }
}
```

**The setter may take the property type rather than the value type.** This used to make the property
look like a plain mutable one: a setter was generated over the hand-written body and the property was
never created, so the getter returned `null`.

```java
@ReplacesEagerProperty
public abstract ConfigurableFileCollection getFiles();

public void setFiles(ConfigurableFileCollection files) {
    getFiles().setFrom(files);       // runs; not replaced by generated state
}
```

**A type that already declares `set<Name>(Object)`** no longer also gets the generated
`setFromAnyValue`-backed overload, which would be a duplicate method. This replaces the old
`Property<URI>` special case.

### What is deliberately not handled

**No annotation, no relaxation.** A concrete setter still means "hands off", so this is rejected
exactly as on `master`:

```java
public abstract class Bean {
    public abstract Property<String> getProp();          // no @ReplacesEagerProperty

    public void setProp(String value) {
        getProp().set(value);
    }
}
```

**A property type that cannot be created.** `Provider` is not a `@ManagedType`, so there is no lazy
property to forward into. Rather than generate over the setter, the property stays unclaimed and you
get the `Cannot have abstract method` error at generation time:

```java
@ReplacesEagerProperty
public abstract Provider<String> getProp();

public void setProp(String value) { ... }
```

**A concrete getter**, annotated or not. A getter with a body reads state the author manages, so the
property is not ours to implement.

Fixes https://github.com/gradle/gradle-private/issues/5282
Also fixes https://github.com/gradle/gradle/issues/38038