### PR TITLE
Accept the classloader-revert regression for ReadyForRelease too

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.7.1-commit-ff0c023bffc
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.7.0-commit-8943fa5e8c4
+defaultRfrPerformanceBaselines=9.7.1-commit-ff0c023bffc
 systemProp.dependency.analysis.test.analysis=false
 
 # Informs BuildCommitDistribution task that the current commit can be built with CC enabled


### PR DESCRIPTION
The `release` ReadyForRelease nightly has been red on performance since the minimal app classloader revert landed, because only one of the two performance baselines was moved.

#38793 reverted the minimal app classloader change, and commit 3de26b9db22f explicitly accepted the resulting regression:

> https://github.com/gradle/gradle/pull/37286 improved performance by 1-6% based depending on the scenario. Due to #38788 and #38791, we had to revert. We accept the performance regression, caused by the revert

That commit moved `defaultRfnPerformanceBaselines` to `9.7.1-commit-ff0c023bffc` (the revert commit), but left `defaultRfrPerformanceBaselines` at `9.7.0-commit-8943fa5e8c4`, which predates the revert. `PerformanceTestSlow` runs in ReadyForRelease and compares against the latter, so every scenario #37286 had sped up is now measured against a baseline that still includes the speedup — and reported as a regression.

This moves the ReadyForRelease baseline to the same post-revert commit the ReadyForNightly baseline already uses.

## Evidence

Nightly [ReadyForRelease #1804](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_Stage_ReadyforRelease_Trigger/116232932) — 11 `PerformanceTestSlow` buckets failed, all against `9.7.0-commit-8943fa5e8c4`:

| Scenario | Build |
|---|---|
| largeJavaMultiProject (buckets 1–5) | [1](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket1/116232700), [2](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket2/116232701), [3](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket3/116232702), [4](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket4/116232703), [5](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket5/116232704) |
| largeMonolithicJavaProject (bucket 3) | [link](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket8/116232707) |
| largeJavaMultiProjectKotlinDsl (buckets 2–3) | [2](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket11/116232710), [3](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket12/116232711) |
| nowInAndroidBuild | [link](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket15/116232714) |
| largeJavaMultiProjectNoBuildSrc | [link](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket19/116232718) |
| largeEmptyMultiProjectDeclarativeDsl | [link](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket21/116232720) |

Representative failure, from `JavaFirstUsePerformanceTest.first use`:

```
java.lang.AssertionError: Speed Results for test project 'largeJavaMultiProject' with tasks tasks:
we're slower than 9.7.0-commit-8943fa5e8c4 with 99% confidence.
Difference: 1.044 s slower (1043.5 ms), 2.92%
```

The magnitudes (~1–3%) sit inside the 1–6% band #37286 originally gained, which is consistent with the revert rather than a new regression.

The preceding nightly [#1803](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_Stage_ReadyforRelease_Trigger/116197339), which ran before the revert landed, had **no** performance failures — e.g. bucket 5 was [green](https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket5/116197111). Build parameters are identical between the two runs, so the comparison is like-for-like.

## Notes for the reviewer

- I have **not** verified that all 11 scenarios are exactly the set #37286 sped up. The inference rests on the timing, the baseline string in the assertions, and the accepted-regression commit message. Worth a sanity check by someone who knows #37286's scope.
- `master` carries the same stale `defaultRfrPerformanceBaselines=9.7.0-commit-8943fa5e8c4`, but does **not** contain the revert, so it is deliberately left alone here. `master` did show two isolated perf bucket failures (0.81% and 1.82%, different bucket each night) which look unrelated to this and are not addressed by this PR.

Found during daily CI triage.
