### PR TITLE
Fix OutputEventRendererTest flakiness by using a fixed clock

### DIFF
--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/OutputSpecification.groovy
@@ -38,7 +38,7 @@ abstract class OutputSpecification extends Specification {
     }
 
     /**
-     * Returns timestamp representing 10AM today in local time.
+     * Returns a fixed timestamp representing 10AM on 11 June 2012 in local time.
      */
     long getTenAm() {
         return getTenAmAsDate().getTimeInMillis()

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.internal.logging.events.LogLevelChangeEvent
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
 import org.gradle.internal.operations.BuildOperationCategory
-import org.gradle.internal.time.Time
+import org.gradle.internal.time.FixedClock
 import org.gradle.util.internal.RedirectStdOutAndErr
 import org.junit.Rule
 import spock.lang.TempDir
@@ -46,7 +46,11 @@ class OutputEventRendererTest extends OutputSpecification {
     private OutputEventRenderer renderer
 
     def setup() {
-        renderer = new OutputEventRenderer(Time.clock(), Stub(GlobalUserInputReceiver), TestFiles.tmpDirTemporaryFileProvider(tempDir))
+        // Use a clock fixed at the same instant as the timestamps of the events fed in by the tests below. Otherwise the
+        // periodic UpdateNowEvent emitted by ThrottlingOutputEventListener carries a real "now" that is years ahead of
+        // the event timestamps, which makes GroupingProgressLogEventGenerator consider its flush timeouts expired and
+        // flush grouped output early.
+        renderer = new OutputEventRenderer(FixedClock.createAt(tenAm), Stub(GlobalUserInputReceiver), TestFiles.tmpDirTemporaryFileProvider(tempDir))
         renderer.configure(LogLevel.INFO)
     }
 


### PR DESCRIPTION
### Context

`OutputEventRendererTest.rendersLogEventsWhenStdOutAndStdErrAreConsole` is a long-standing flaky test. Over the last two months Develocity recorded 4,940 runs of it: 4,927 passed, 4 failed and 9 flaky. The rate is low (~0.26%), but because it is a unit test in `:logging` it runs on nearly every pipeline, and a single failure is enough to dequeue a merge-queue build — it most recently knocked #38718 out of the merge queue (build scan `kusksduhhqr4m`).

`OutputEventRendererTest."renders log events when plain console is attached"` went flaky twice in the same window for the same reason; the fix below covers it too.

The failure always looks like this — the task header is emitted twice, once early without the status and again at the end with it:

```
expected: ['', '{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
actual:   ['{header}> description{normal}', 'info', '{error}error', '{normal}', '{header}> description{info} status{normal}']
```

### Root cause

The test drives the renderer with a **real** wall clock while feeding it events carrying a **fixed 2012** timestamp.

1. `OutputEventRendererTest.setup()` built the renderer with `Time.clock()`.
2. Every event the test feeds in is stamped with `OutputSpecification.getTenAm()`, which is a fixed `GregorianCalendar(2012, JUNE, 11, 10, 0, 0)`.
3. `ThrottlingOutputEventListener` (created in `OutputEventRenderer#onConsoleAttached`) schedules a fixed-rate task in its constructor that emits `new UpdateNowEvent(clock.getCurrentTime())` every 100ms (`org.gradle.internal.console.throttle`).
4. In `GroupingProgressLogEventGenerator`, `OperationGroup.lastUpdateTime` is seeded from the `ProgressStartEvent` timestamp (2012). `onUpdateNow` then calls `maybeFlushOutput(event.getTimestamp())`, and `timeoutExpired` computes `eventTimestamp - lastUpdateTime`, i.e. `now(2026) - tenAm(2012)` ≈ 4.4e11 ms. That trivially exceeds both `LOW_WATERMARK_FLUSH_TIMEOUT` (2s) and `HIGH_WATERMARK_FLUSH_TIMEOUT` (30s), so the group is flushed early.
5. That early flush renders the header while `status` is still empty. The subsequent `complete('status')` makes `statusHasChanged()` true, so the header is rendered a *second* time with the status appended at the end — exactly the observed output.

The test passes normally only because the four `onOutput` calls happen to complete inside a single 100ms throttle window. On a loaded agent (the #38718 failure was a Windows agent running 12 parallel test tasks) a scheduler tick lands in the middle of the test and the spurious flush fires.

### The fix

Give the test a clock that agrees with the timestamps of its own events: `FixedClock.createAt(tenAm)`.

`OutputEventRenderer` uses its `Clock` for exactly one thing — constructing the `ThrottlingOutputEventListener` — so this only changes the timestamp carried by `UpdateNowEvent`, which is precisely the value that has to match. With the fixed clock, `eventTimestamp - lastUpdateTime == 0` and neither watermark can expire spuriously, no matter how many scheduler ticks land mid-test. This makes the whole test class deterministic, not just the one method.

Also corrected the stale javadoc on `OutputSpecification.getTenAm()`, which claimed "10AM today" while returning a fixed 2012 date.

### Verification

- Reproduced the flake deterministically before the fix by setting `org.gradle.internal.console.throttle=1` and adding short sleeps between the `renderer.onOutput(...)` calls: the test failed with exactly the double-header output quoted above (scan `kwujxvczdfnze`).
- With the fix applied and that same aggressive-throttle scaffolding still in place, `OutputEventRendererTest` passes — the race is genuinely closed, not just made rarer.
- `./gradlew :logging:test` passes in full with the scaffolding removed.

The reproduction scaffolding is not part of this PR.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
