### PR TITLE
Reduce gradle memory usage: Realize configuration outgoing publications lazily

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
@@ -17,8 +17,10 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DependencyManagementInstanceIdentity;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -28,11 +30,13 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.typeconversion.NotationParser;
 
 /**
  * A bundle of services used by {@link Configuration}.
@@ -59,4 +63,7 @@ public interface ConfigurationServicesBundle {
     ProviderFactory getProviderFactory();
     ProjectLeaseRegistry getProjectLeaseRegistry();
     DependencyManagementInstanceIdentity getInstanceIdentity();
+    PublishArtifactNotationParser getArtifactNotationParser();
+    NotationParser<Object, Capability> getCapabilityNotationParser();
+    UserCodeApplicationContext getUserCodeApplicationContext();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.DomainObjectContext;
@@ -90,6 +91,18 @@ public interface ConfigurationInternal extends DeprecatableConfiguration, Config
      * Visits the variants of this configuration.
      */
     void collectVariants(VariantVisitor visitor);
+
+    /**
+     * The outgoing publications of this configuration, or {@code null} if they have not been
+     * realized yet.
+     *
+     * <p>Unlike {@link #getOutgoing()}, this does not realize the publications. Since any state
+     * of the publications (artifacts, variants, capabilities) can only be mutated through
+     * {@link #getOutgoing()}, a {@code null} result implies the publications are in their
+     * default, empty state.</p>
+     */
+    @Nullable
+    ConfigurationPublications getOutgoingIfInitialized();
 
     boolean isCanBeMutated();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -16,17 +16,28 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.capabilities.Capability;
 
 import java.util.Set;
 
 public class Configurations {
 
-    public static Set<Capability> collectCapabilities(Configuration configuration, Set<Capability> out, Set<Configuration> visited) {
+    /**
+     * Collects the capabilities declared by the given configuration and all configurations
+     * in its {@code extendsFrom} hierarchy.
+     *
+     * <p>Visiting a configuration does not realize its outgoing publications:
+     * to declare capability you would need to call {@link Configuration#getOutgoing()}, so no realized publications =  no capabilities.</p>
+     */
+    public static Set<Capability> collectCapabilities(ConfigurationInternal configuration, Set<Capability> out, Set<Configuration> visited) {
         if (visited.add(configuration)) {
-            out.addAll(configuration.getOutgoing().getCapabilities());
+            ConfigurationPublications outgoing = configuration.getOutgoingIfInitialized();
+            if (outgoing != null) {
+                out.addAll(outgoing.getCapabilities());
+            }
             for (Configuration parent : configuration.getExtendsFrom()) {
-                collectCapabilities(parent, out, visited);
+                collectCapabilities((ConfigurationInternal) parent, out, visited);
             }
         }
         return out;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -46,7 +46,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.ConfigurationServicesBundle;
@@ -62,7 +61,6 @@ import org.gradle.api.internal.artifacts.ExcludeRuleNotationConverter;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.api.internal.artifacts.ivyservice.ResolutionParameters;
 import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
@@ -165,7 +163,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     private final String name;
     private final boolean isDetached;
-    private final DefaultConfigurationPublications outgoing;
+
+    // Created lazily on first access: most configurations (resolvable or declarable ones) never
+    // publish anything, so their publications object is never realized. Anything that needs to
+    // observe mutation state without realizing the publications must use getOutgoingIfInitialized().
+    private volatile @Nullable DefaultConfigurationPublications outgoing;
 
     private boolean visible = true;
     private boolean transitive = true;
@@ -196,7 +198,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private @Nullable FileCollectionInternal intrinsicFiles;
 
     private final DisplayName displayName;
-    private final UserCodeApplicationContext userCodeApplicationContext;
 
     private final AtomicInteger copyCount = new AtomicInteger();
 
@@ -208,10 +209,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private @Nullable ConfigurationInternal consistentResolutionSource;
     private @Nullable String consistentResolutionReason;
 
-    /** This factory can't be extracted to the services bundle, as it would create a circular dependency between those two types. */
+    /**
+     * This factory can't be extracted to the services bundle, as it would create a circular dependency between those two types.
+     */
     private final DefaultConfigurationFactory defaultConfigurationFactory;
 
-    /** This factory has some unique usages during copy, so it can't be extracted to the services bundle. */
+    /**
+     * This factory has some unique usages during copy, so it can't be extracted to the services bundle.
+     */
     private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
     private @Nullable ResolutionStrategyInternal resolutionStrategy;
 
@@ -228,15 +233,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ConfigurationResolver resolver,
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-        PublishArtifactNotationParser artifactNotationParser,
-        NotationParser<Object, Capability> capabilityNotationParser,
-        UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ConfigurationRole roleAtCreation,
         boolean lockUsage
     ) {
         super(configurationServices.getTaskDependencyFactory());
-        this.userCodeApplicationContext = userCodeApplicationContext;
         this.identityPath = getIdentityPath(domainObjectContext, name);
         this.name = name;
         this.isDetached = isDetached;
@@ -264,7 +265,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         this.artifacts = new DefaultPublishArtifactSet(Describables.of(displayName, "artifacts"), ownArtifacts, configurationServices.getFileCollectionFactory(), taskDependencyFactory);
 
-        this.outgoing = configurationServices.getObjectFactory().newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, artifactNotationParser, capabilityNotationParser, configurationServices.getFileCollectionFactory(), configurationServices.getAttributesFactory(), configurationServices.getDomainObjectCollectionFactory(), taskDependencyFactory);
         this.currentResolveState = new DefaultCalculatedModelValue<>(domainObjectContext.getModel(), configurationServices.getProjectLeaseRegistry(), Optional.empty());
         this.defaultConfigurationFactory = defaultConfigurationFactory;
 
@@ -946,7 +946,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Override
     public Set<ExcludeRule> getAllExcludeRules() {
         Set<ExcludeRule> result = new LinkedHashSet<>(getExcludeRules());
-        extendsFrom.visitConfigurations(configuration -> result.addAll(((ConfigurationInternal)configuration.get()).getAllExcludeRules()));
+        extendsFrom.visitConfigurations(configuration -> {
+                ConfigurationInternal configurationInternal = (ConfigurationInternal) configuration.get();
+                result.addAll(configurationInternal.getAllExcludeRules());
+            }
+        );
         return result;
     }
 
@@ -988,12 +992,49 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public ConfigurationPublications getOutgoing() {
+        return getOrCreateOutgoing();
+    }
+
+    @Override
+    public @Nullable ConfigurationPublications getOutgoingIfInitialized() {
         return outgoing;
+    }
+
+    private DefaultConfigurationPublications getOrCreateOutgoing() {
+        if (outgoing == null) {
+            initOutgoing();
+        }
+        return outgoing;
+    }
+
+    private synchronized void initOutgoing() {
+        if (outgoing != null) {
+            return;
+        }
+
+        DefaultConfigurationPublications publications = configurationServices.getObjectFactory().newInstance(
+            DefaultConfigurationPublications.class,
+            displayName,
+            artifacts,
+            new AllArtifactsProvider(),
+            configurationAttributes,
+            configurationServices.getArtifactNotationParser(),
+            configurationServices.getCapabilityNotationParser(),
+            configurationServices.getFileCollectionFactory(),
+            configurationServices.getAttributesFactory(),
+            configurationServices.getDomainObjectCollectionFactory(),
+            taskDependencyFactory);
+        if (observationReason != null) {
+            // The configuration was already observed before the publications were
+            // realized, so they must start out immutable.
+            publications.preventFromFurtherMutation(observationReason);
+        }
+        outgoing = publications;
     }
 
     @Override
     public void collectVariants(VariantVisitor visitor) {
-        outgoing.collectVariants(visitor);
+        getOrCreateOutgoing().collectVariants(visitor);
     }
 
     @Override
@@ -1019,7 +1060,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 conf.observedState = InternalState.OBSERVED;
 
                 conf.configurationAttributes.freeze();
-                conf.outgoing.preventFromFurtherMutation(conf.observationReason);
+                if (conf.outgoing != null) {
+                    // Publications that were never realized have no mutable state to guard.
+                    // If they are realized later, initOutgoing() applies the observation.
+                    conf.outgoing.preventFromFurtherMutation(conf.observationReason);
+                }
                 conf.preventUsageMutation();
             }
         });
@@ -1063,7 +1108,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public void outgoing(Action<? super ConfigurationPublications> action) {
-        action.execute(outgoing);
+        action.execute(getOrCreateOutgoing());
     }
 
     /**
@@ -1724,7 +1769,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public void beforeResolve(Action<? super ResolvableDependencies> action) {
-            configuration.dependencyResolutionListeners.add("beforeResolve", configuration.userCodeApplicationContext.reapplyCurrentLater(action));
+            UserCodeApplicationContext userCodeApplicationContext = configuration.configurationServices.getUserCodeApplicationContext();
+            configuration.dependencyResolutionListeners.add("beforeResolve", userCodeApplicationContext.reapplyCurrentLater(action));
         }
 
         @Override
@@ -1734,7 +1780,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public void afterResolve(Action<? super ResolvableDependencies> action) {
-            configuration.dependencyResolutionListeners.add("afterResolve", configuration.userCodeApplicationContext.reapplyCurrentLater(action));
+            UserCodeApplicationContext userCodeApplicationContext = configuration.configurationServices.getUserCodeApplicationContext();
+            configuration.dependencyResolutionListeners.add("afterResolve", userCodeApplicationContext.reapplyCurrentLater(action));
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -17,19 +17,14 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.DependencyResolutionListener;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.internal.Factory;
-import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -43,24 +38,16 @@ public class DefaultConfigurationFactory {
     private final ConfigurationServicesBundle configurationServices;
     private final ListenerManager listenerManager;
     private final DomainObjectContext domainObjectContext;
-    private final PublishArtifactNotationParser artifactNotationParser;
-    private final NotationParser<Object, Capability> capabilityNotationParser;
-    private final UserCodeApplicationContext userCodeApplicationContext;
 
     @Inject
     public DefaultConfigurationFactory(
         ConfigurationServicesBundle configurationServices,
         ListenerManager listenerManager,
-        DomainObjectContext domainObjectContext,
-        PublishArtifactNotationParser artifactNotationParserFactory,
-        UserCodeApplicationContext userCodeApplicationContext
+        DomainObjectContext domainObjectContext
     ) {
         this.configurationServices = configurationServices;
         this.listenerManager = listenerManager;
         this.domainObjectContext = domainObjectContext;
-        this.artifactNotationParser = artifactNotationParserFactory;
-        this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
-        this.userCodeApplicationContext = userCodeApplicationContext;
     }
 
     /**
@@ -84,9 +71,6 @@ public class DefaultConfigurationFactory {
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             this,
             role
         );
@@ -110,9 +94,6 @@ public class DefaultConfigurationFactory {
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             this
         );
     }
@@ -135,9 +116,6 @@ public class DefaultConfigurationFactory {
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             this
         );
     }
@@ -160,9 +138,6 @@ public class DefaultConfigurationFactory {
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             this
         );
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
@@ -16,10 +16,13 @@
 
 package org.gradle.api.internal.artifacts.configurations;
 
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.artifacts.DependencyManagementInstanceIdentity;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -29,9 +32,11 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.ProblemsInternal;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
+import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 
@@ -60,6 +65,9 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     private final ProviderFactory providerFactory;
     private final ProjectLeaseRegistry projectLeaseRegistry;
     private final DependencyManagementInstanceIdentity instanceIdentity;
+    private final PublishArtifactNotationParser artifactNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
+    private final UserCodeApplicationContext userCodeApplicationContext;
 
     @Inject
     public DefaultConfigurationServicesBundle(
@@ -77,7 +85,9 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         ResolveExceptionMapper exceptionMapper,
         ProviderFactory providerFactory,
         ProjectLeaseRegistry projectLeaseRegistry,
-        DependencyManagementInstanceIdentity instanceIdentity
+        DependencyManagementInstanceIdentity instanceIdentity,
+        PublishArtifactNotationParser artifactNotationParser,
+        UserCodeApplicationContext userCodeApplicationContext
     ) {
         this.buildOperationRunner = buildOperationRunner;
         this.projectStateRegistry = projectStateRegistry;
@@ -94,6 +104,9 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         this.providerFactory = providerFactory;
         this.projectLeaseRegistry = projectLeaseRegistry;
         this.instanceIdentity = instanceIdentity;
+        this.artifactNotationParser = artifactNotationParser;
+        this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
+        this.userCodeApplicationContext = userCodeApplicationContext;
     }
 
     @Override
@@ -171,4 +184,18 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         return instanceIdentity;
     }
 
+    @Override
+    public PublishArtifactNotationParser getArtifactNotationParser() {
+        return artifactNotationParser;
+    }
+
+    @Override
+    public NotationParser<Object, Capability> getCapabilityNotationParser() {
+        return capabilityNotationParser;
+    }
+
+    @Override
+    public UserCodeApplicationContext getUserCodeApplicationContext() {
+        return userCodeApplicationContext;
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -18,15 +18,11 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ConsumableConfiguration;
 import org.gradle.api.artifacts.DependencyResolutionListener;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.internal.Factory;
-import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 
@@ -43,9 +39,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         ConfigurationResolver resolver,
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-        PublishArtifactNotationParser artifactNotationParser,
-        NotationParser<Object, Capability> capabilityNotationParser,
-        UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
         super(
@@ -56,9 +49,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.CONSUMABLE,
             true

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -18,15 +18,11 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.DependencyScopeConfiguration;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.internal.Factory;
-import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 
@@ -43,9 +39,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         ConfigurationResolver resolver,
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-        PublishArtifactNotationParser artifactNotationParser,
-        NotationParser<Object, Capability> capabilityNotationParser,
-        UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
         super(
@@ -56,9 +49,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.DEPENDENCY_SCOPE,
             true

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
@@ -18,15 +18,11 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.LegacyConfiguration;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.internal.Factory;
-import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 
@@ -44,9 +40,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
         ConfigurationResolver resolver,
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-        PublishArtifactNotationParser artifactNotationParser,
-        NotationParser<Object, Capability> capabilityNotationParser,
-        UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ConfigurationRole roleAtCreation
     ) {
@@ -58,9 +51,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             defaultConfigurationFactory,
             roleAtCreation,
             false

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -18,15 +18,11 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.ResolvableConfiguration;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParser;
 import org.gradle.internal.Factory;
-import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 
@@ -43,9 +39,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         ConfigurationResolver resolver,
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-        PublishArtifactNotationParser artifactNotationParser,
-        NotationParser<Object, Capability> capabilityNotationParser,
-        UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
         super(
@@ -56,9 +49,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             resolver,
             dependencyResolutionListeners,
             resolutionStrategyFactory,
-            artifactNotationParser,
-            capabilityNotationParser,
-            userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.RESOLVABLE,
             true

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -147,7 +148,14 @@ public class VariantIdentityUniquenessVerifier {
         }
 
         public static VariantIdentity from(ConfigurationInternal configuration, ImmutableCapabilities defaultCapabilities) {
-            Collection<? extends Capability> declaredCapabilities = configuration.getOutgoing().getCapabilities();
+            ConfigurationPublications outgoing = configuration.getOutgoingIfInitialized();
+            if (outgoing == null) {
+                return new VariantIdentity(
+                    configuration.getAttributes().asImmutable(),
+                    defaultCapabilities
+                );
+            }
+            Collection<? extends Capability> declaredCapabilities = outgoing.getCapabilities();
             ImmutableCapabilities capabilities = !declaredCapabilities.isEmpty()
                 ? ImmutableCapabilities.of(declaredCapabilities)
                 : defaultCapabilities;

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -91,15 +91,15 @@ class DefaultConfigurationContainerSpec extends Specification {
         new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry()),
         TestUtil.providerFactory(),
         new TestWorkerLeaseService(),
-        instanceIdentity
+        instanceIdentity,
+        Stub(PublishArtifactNotationParser),
+        userCodeApplicationContext
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
         configurationServices,
         listenerManager,
-        domainObjectContext,
-        Stub(PublishArtifactNotationParser),
-        userCodeApplicationContext
+        domainObjectContext
     )
 
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -85,13 +85,7 @@ class DefaultConfigurationContainerTest extends Specification {
         new ResolveExceptionMapper(StandaloneDomainObjectContext.ANONYMOUS, new DocumentationRegistry()),
         TestUtil.providerFactory(),
         new TestWorkerLeaseService(),
-        new DependencyManagementInstanceIdentity(Describables.of("unknown"))
-    )
-
-    private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
-        configurationServices,
-        listenerManager,
-        StandaloneDomainObjectContext.ANONYMOUS,
+        new DependencyManagementInstanceIdentity(Describables.of("unknown")),
         new PublishArtifactNotationParserFactory(
                 objectFactory,
                 metaDataProvider,
@@ -99,6 +93,12 @@ class DefaultConfigurationContainerTest extends Specification {
                 TestFiles.taskDependencyFactory(),
         ).create(),
         userCodeApplicationContext
+    )
+
+    private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
+        configurationServices,
+        listenerManager,
+        StandaloneDomainObjectContext.ANONYMOUS
     )
 
     private DefaultConfigurationContainer configurationContainer = objectFactory.newInstance(DefaultConfigurationContainer.class,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -520,6 +520,56 @@ class DefaultConfigurationSpec extends Specification {
         configuration.artifacts.size() == 2
     }
 
+    def "outgoing publications are not realized until accessed"() {
+        given:
+        def configuration = conf()
+
+        expect:
+        configuration.outgoingIfInitialized == null
+
+        when:
+        def outgoing = configuration.outgoing
+
+        then:
+        configuration.outgoingIfInitialized.is(outgoing)
+    }
+
+    def "collecting capabilities does not realize outgoing publications"() {
+        given:
+        def configuration = conf()
+
+        when:
+        def capabilities = Configurations.collectCapabilities(configuration, new HashSet<>(), new HashSet<>())
+
+        then:
+        capabilities.empty
+        configuration.outgoingIfInitialized == null
+    }
+
+    def "collecting capabilities includes capabilities declared on outgoing publications"() {
+        given:
+        def configuration = conf()
+        configuration.outgoing.capability("group:capability:1.0")
+
+        when:
+        def capabilities = Configurations.collectCapabilities(configuration, new HashSet<>(), new HashSet<>())
+
+        then:
+        capabilities*.name == ["capability"]
+    }
+
+    def "observation forbids mutation of publications realized after observation"() {
+        given:
+        def configuration = conf()
+        configuration.markAsObserved("observed")
+
+        when:
+        configuration.outgoing.capability("group:capability:1.0")
+
+        then:
+        thrown(InvalidUserCodeException)
+    }
+
     def "build dependencies are calculated from the artifacts visited during graph resolution"() {
         def configuration = conf()
         def targetTask = Mock(Task)
@@ -1920,15 +1970,15 @@ This method is only meant to be called on configurations which allow the (non-de
             new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry()),
             TestUtil.providerFactory(),
             new TestWorkerLeaseService(),
-            instanceIdentity
+            instanceIdentity,
+            publishArtifactNotationParser,
+            userCodeApplicationContext
         )
 
         new DefaultConfigurationFactory(
             configurationServices,
             listenerManager,
-            domainObjectContext,
-            publishArtifactNotationParser,
-            userCodeApplicationContext
+            domainObjectContext
         )
     }
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
@@ -78,7 +78,7 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<? extends Capability> getCapabilities() {
         if (capabilities == null) {
-            this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities(configuration,
+            this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities((ConfigurationInternal) configuration,
                 new HashSet<>(),
                 new HashSet<>()));
         }


### PR DESCRIPTION
DefaultConfiguration eagerly created DefaultConfigurationPublications (including artifact and capability notation parsers) for every configuration, even though the vast majority of configurations are never published.

Create the publications on first access via getOrCreateOutgoing() and add ConfigurationInternal.getOutgoingIfInitialized() so read-only internal callers (such as capability collection during dependency graph resolution) do not force realization.

Also moved UserCodeApplicationContext and the notation parsers into ConfigurationServicesBundle, which is shared per project, instead of threading them through DefaultConfigurationFactory into per-configuration fields.



This saves ~145 mb of memory in a 3000 modules project. Here is the pipeline that measured this (it collected hprof files in a stable env of github runners - https://github.com/kroune/feature-module-3000/actions/runs/31731524085

Note: since project didn't fully finish the sync and not all of dependencies were realized, for the project overall it saves likely more than 145 mb


The issue this pr partially addresses - https://github.com/gradle/gradle/issues/38752


### Contributor Checklist
- [+] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [+] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [+] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [+] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [+] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [+] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [+] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [+] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [+] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
