### PR TITLE
Fix ABI extraction defects that miss recompiles

### DIFF
--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiClassExtractor.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiClassExtractor.java
@@ -98,7 +98,9 @@ public class ApiClassExtractor {
         ApiMemberSelector visitor;
         try {
             visitor = new ApiMemberSelector(originalClassReader.getClassName(), apiMemberWriterFactory.makeApiMemberWriter(apiClassWriter), apiIncludesPackagePrivateMembers);
-            originalClassReader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+            // SKIP_CODE discards method bodies and all the debug information they contain, but
+            // unlike SKIP_DEBUG it keeps the MethodParameters attribute, which is part of the API.
+            originalClassReader.accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
         } catch (ApiClassExtractionException e) {
             throw e.withClass(originalClassReader.getClassName());
         }

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
@@ -22,6 +22,7 @@ import org.gradle.internal.tools.api.impl.ClassMember;
 import org.gradle.internal.tools.api.impl.FieldMember;
 import org.gradle.internal.tools.api.impl.InnerClassMember;
 import org.gradle.internal.tools.api.impl.MethodMember;
+import org.gradle.internal.tools.api.impl.RecordComponentMember;
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -40,6 +41,8 @@ public interface ApiMemberWriter {
     ModuleVisitor writeModule(String name, int access, @Nullable String version);
 
     void writeClass(ClassMember classMember, Set<MethodMember> methods, Set<FieldMember> fields, Set<InnerClassMember> innerClasses);
+
+    void writeRecordComponent(RecordComponentMember recordComponent);
 
     void writeMethod(ClassMember classMember, @Nullable InnerClassMember declaringInnerClass, MethodMember method);
 

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.ModuleVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.TypePath;
 
 import java.util.LinkedHashSet;
@@ -123,6 +124,12 @@ public class ApiMemberSelector extends ClassVisitor {
             methods.add(methodMember);
             return new MethodVisitor(Opcodes.ASM9) {
                 @Override
+                public void visitParameter(@Nullable String name, int access) {
+                    methodMember.addParameter(new ParameterMember(name, access));
+                    super.visitParameter(name, access);
+                }
+
+                @Override
                 public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                     AnnotationMember ann = new AnnotationMember(desc, visible);
                     methodMember.addAnnotation(ann);
@@ -131,7 +138,10 @@ public class ApiMemberSelector extends ClassVisitor {
 
                 @Override
                 public AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String desc, boolean visible) {
-                    TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
+                    // The extracted class writes the thrown exceptions sorted, so a THROWS type
+                    // reference of the original class points at the wrong exception.
+                    int writtenTypeRef = methodMember.mapTypeReferenceToWrittenExceptionOrder(typeRef);
+                    TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, writtenTypeRef, typePath);
                     methodMember.addTypeAnnotation(ann);
                     return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
                 }
@@ -176,6 +186,29 @@ public class ApiMemberSelector extends ClassVisitor {
             };
         }
         return null;
+    }
+
+    @Override
+    public RecordComponentVisitor visitRecordComponent(String name, String descriptor, @Nullable String signature) {
+        // Record components are always part of the API: their order determines the parameter order
+        // of the canonical constructor and the binding order of a record pattern.
+        RecordComponentMember recordComponent = new RecordComponentMember(name, descriptor, signature);
+        classMember.getRecordComponents().add(recordComponent);
+        return new RecordComponentVisitor(Opcodes.ASM9) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                AnnotationMember ann = new AnnotationMember(desc, visible);
+                recordComponent.addAnnotation(ann);
+                return new SortingAnnotationVisitor(ann, super.visitAnnotation(desc, visible));
+            }
+
+            @Override
+            public AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String desc, boolean visible) {
+                TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
+                recordComponent.addTypeAnnotation(ann);
+                return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
+            }
+        };
     }
 
     @Override

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ClassMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ClassMember.java
@@ -30,6 +30,7 @@ public class ClassMember extends AnnotatableMember {
     private final String[] interfaces;
 
     private final List<String> permittedSubclasses = new ArrayList<>();
+    private final List<RecordComponentMember> recordComponents = new ArrayList<>();
 
     public ClassMember(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
         super(access, name, signature);
@@ -57,5 +58,12 @@ public class ClassMember extends AnnotatableMember {
 
     public List<String> getPermittedSubclasses() {
         return permittedSubclasses;
+    }
+
+    /**
+     * The components of this record, in declaration order.
+     */
+    public List<RecordComponentMember> getRecordComponents() {
+        return recordComponents;
     }
 }

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.Type;
 
 import java.util.Optional;
@@ -64,6 +65,9 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
         for (String permittedSubclass : classMember.getPermittedSubclasses()) {
             apiMemberAdapter.visitPermittedSubclass(permittedSubclass);
         }
+        for (RecordComponentMember recordComponent : classMember.getRecordComponents()) {
+            writeRecordComponent(recordComponent);
+        }
         InnerClassMember declaringInnerClass = innerClasses.stream()
             .filter(innerClass -> innerClass.getName().equals(classMember.getName()))
             .findFirst()
@@ -86,10 +90,27 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
     }
 
     @Override
+    public void writeRecordComponent(RecordComponentMember recordComponent) {
+        RecordComponentVisitor rcv = apiMemberAdapter.visitRecordComponent(
+            recordComponent.getName(), recordComponent.getTypeDesc(), recordComponent.getSignature());
+        for (AnnotationMember annotation : recordComponent.getAnnotations()) {
+            writeAnnotationValues(annotation, rcv.visitAnnotation(annotation.getName(), annotation.isVisible()));
+        }
+        for (AnnotationMember annotation : recordComponent.getTypeAnnotations()) {
+            writeAnnotationValues(annotation, visitTypeAnnotation(rcv, (TypeAnnotationMember) annotation));
+        }
+        rcv.visitEnd();
+    }
+
+    @Override
     public void writeMethod(ClassMember classMember, @Nullable InnerClassMember declaringInnerClass, MethodMember method) {
         MethodVisitor mv = apiMemberAdapter.visitMethod(
             method.getAccess(), method.getName(), method.getTypeDesc(), method.getSignature(),
             method.getExceptions().toArray(new String[0]));
+        // Parameters must be visited before any annotation, see the MethodVisitor contract.
+        for (ParameterMember parameter : method.getParameters()) {
+            mv.visitParameter(parameter.getName(), parameter.getAccess());
+        }
         writeMethodAnnotations(mv, method.getAnnotations());
         writeMethodAnnotations(mv, method.getTypeAnnotations());
         writeMethodAnnotations(mv, method.getParameterAnnotations());
@@ -175,6 +196,10 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
     }
 
     private static AnnotationVisitor visitTypeAnnotation(FieldVisitor target, TypeAnnotationMember annotation) {
+        return target.visitTypeAnnotation(annotation.getTypeRef(), annotation.getTypePath(), annotation.getName(), annotation.isVisible());
+    }
+
+    private static AnnotationVisitor visitTypeAnnotation(RecordComponentVisitor target, TypeAnnotationMember annotation) {
         return target.visitTypeAnnotation(annotation.getTypeRef(), annotation.getTypePath(), annotation.getName(), annotation.isVisible());
     }
 

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
@@ -16,13 +16,18 @@
 
 package org.gradle.internal.tools.api.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.TypeReference;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -30,19 +35,53 @@ import java.util.TreeSet;
 public class MethodMember extends TypedMember implements Comparable<MethodMember> {
     private static final Ordering<Iterable<String>> LEXICOGRAPHICAL_ORDERING = Ordering.<String>natural().lexicographical();
     private final SortedSet<String> exceptions = new TreeSet<>();
+    private final List<String> declaredExceptions;
+    private final List<ParameterMember> parameters = new ArrayList<>();
     private final SortedSet<AnnotationMember> parameterAnnotations = new TreeSet<>();
     @Nullable
     private AnnotationValue<?> annotationDefaultValue;
 
     public MethodMember(int access, String name, String typeDesc, @Nullable String signature, String @Nullable [] exceptions) {
         super(access, name, signature, typeDesc);
-        if (exceptions != null && exceptions.length > 0) {
-            this.exceptions.addAll(Arrays.asList(exceptions));
-        }
+        this.declaredExceptions = exceptions == null ? Collections.emptyList() : Arrays.asList(exceptions);
+        this.exceptions.addAll(declaredExceptions);
     }
 
     public SortedSet<String> getExceptions() {
         return ImmutableSortedSet.copyOf(exceptions);
+    }
+
+    /**
+     * The entries of the {@code MethodParameters} attribute, in declaration order.
+     */
+    public List<ParameterMember> getParameters() {
+        return ImmutableList.copyOf(parameters);
+    }
+
+    public void addParameter(ParameterMember parameter) {
+        parameters.add(parameter);
+    }
+
+    /**
+     * Maps a type reference from the declaration order of the thrown exceptions to the sorted
+     * order in which this member writes them.
+     *
+     * <p>The {@code type_index} of a {@code THROWS} type annotation points into the
+     * {@code Exceptions} attribute. Since the extracted class writes the exceptions sorted, the
+     * index of the original class file no longer identifies the annotated exception. Type
+     * references of any other sort are returned unchanged.</p>
+     */
+    public int mapTypeReferenceToWrittenExceptionOrder(int typeRef) {
+        TypeReference typeReference = new TypeReference(typeRef);
+        if (typeReference.getSort() != TypeReference.THROWS) {
+            return typeRef;
+        }
+        int declaredIndex = typeReference.getExceptionIndex();
+        if (declaredIndex < 0 || declaredIndex >= declaredExceptions.size()) {
+            return typeRef;
+        }
+        String exception = declaredExceptions.get(declaredIndex);
+        return TypeReference.newExceptionReference(exceptions.headSet(exception).size()).getValue();
     }
 
     public SortedSet<AnnotationMember> getParameterAnnotations() {

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ParameterMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ParameterMember.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tools.api.impl;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single entry of the {@code MethodParameters} attribute of a method.
+ *
+ * <p>Parameter names are part of the API, because annotation processors read them via
+ * {@code VariableElement.getSimpleName()}. Unlike other members, parameters keep their
+ * declaration order, since that order determines which parameter a name belongs to.</p>
+ */
+public class ParameterMember {
+
+    @Nullable
+    private final String name;
+    private final int access;
+
+    public ParameterMember(@Nullable String name, int access) {
+        this.name = name;
+        this.access = access;
+    }
+
+    /**
+     * The parameter name, or {@code null} when the class file records no name for it.
+     */
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public int getAccess() {
+        return access;
+    }
+
+    @Override
+    public String toString() {
+        return name == null ? "<unnamed>" : name;
+    }
+}

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/RecordComponentMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/RecordComponentMember.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tools.api.impl;
+
+import com.google.common.collect.ImmutableSortedSet;
+import org.jspecify.annotations.Nullable;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * A single component of a record, as recorded in the {@code Record} attribute of a class file.
+ *
+ * <p>Record components keep their declaration order, since that order is part of the API: it
+ * determines the parameter order of the canonical constructor and the binding order of a record
+ * pattern.</p>
+ */
+public class RecordComponentMember extends Member {
+
+    private final String typeDesc;
+    @Nullable
+    private final String signature;
+    private final SortedSet<AnnotationMember> annotations = new TreeSet<>();
+    private final SortedSet<AnnotationMember> typeAnnotations = new TreeSet<>();
+
+    public RecordComponentMember(String name, String typeDesc, @Nullable String signature) {
+        super(name);
+        this.typeDesc = typeDesc;
+        this.signature = signature;
+    }
+
+    public String getTypeDesc() {
+        return typeDesc;
+    }
+
+    @Nullable
+    public String getSignature() {
+        return signature;
+    }
+
+    public SortedSet<AnnotationMember> getAnnotations() {
+        return ImmutableSortedSet.copyOf(annotations);
+    }
+
+    public void addAnnotation(AnnotationMember annotationMember) {
+        annotations.add(annotationMember);
+    }
+
+    public SortedSet<AnnotationMember> getTypeAnnotations() {
+        return ImmutableSortedSet.copyOf(typeAnnotations);
+    }
+
+    public void addTypeAnnotation(TypeAnnotationMember typeAnnotationMember) {
+        typeAnnotations.add(typeAnnotationMember);
+    }
+}

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/SortingAnnotationVisitor.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/SortingAnnotationVisitor.java
@@ -61,7 +61,7 @@ public class SortingAnnotationVisitor extends AnnotationVisitor {
     @Override
     public AnnotationVisitor visitArray(@Nullable String name) {
         SortingAnnotationVisitor visitor = new SortingAnnotationVisitor(annotation, super.visitArray(name));
-        visitor.arrayValueName = name;
+        visitor.arrayValueName = nameOrValue(name);
         return visitor;
     }
 
@@ -73,17 +73,22 @@ public class SortingAnnotationVisitor extends AnnotationVisitor {
 
     @Override
     public void visitEnd() {
-        if (annotationValueName != null) {
-            AnnotationAnnotationValue value = new AnnotationAnnotationValue(annotationValueName, annotation);
-            requireNonNull(parentVisitor).annotationValues.add(value);
-            annotationValueName = null;
-        } else if (arrayValueName != null) {
+        if (arrayValueName != null) {
+            // The collected values are the elements of the array, not members of the annotation.
+            // They must not be added to the annotation, since an array element carries no name of
+            // its own and would therefore masquerade as the "value" member of the annotation.
             ArrayAnnotationValue value = new ArrayAnnotationValue(
                 arrayValueName, annotationValues.toArray(new AnnotationValue<?>[0]));
             annotation.addValue(value);
             arrayValueName = null;
+        } else {
+            if (annotationValueName != null) {
+                AnnotationAnnotationValue value = new AnnotationAnnotationValue(annotationValueName, annotation);
+                requireNonNull(parentVisitor).annotationValues.add(value);
+                annotationValueName = null;
+            }
+            annotation.addValues(annotationValues);
         }
-        annotation.addValues(annotationValues);
         annotationValues.clear();
         super.visitEnd();
     }

--- a/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorAnnotationsTest.groovy
+++ b/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorAnnotationsTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.tools.api
 
+import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
@@ -752,6 +753,93 @@ class ApiClassExtractorAnnotationsTest extends ApiClassExtractorTestSupport {
         consumer.classes.Main.clazz.name == "Main"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/38828")
+    void "annotation value member is retained next to an array member"() {
+        given:
+        def api = toApi([
+            A  : '''
+                @Ann(value = "v", names = {"x", "y"})
+                public class A {}
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE})
+                public @interface Ann {
+                    String value();
+                    String[] names();
+                }
+            '''
+        ])
+
+        when:
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extractedClass = api.extractAndLoadApiClassFrom(api.classes.A)
+        def extractedAnnotations = extractedClass.annotations
+
+        then:
+        extractedAnnotations.size() == 1
+        def annotation = extractedAnnotations[0]
+        annotation.annotationType() == extractedAnn
+        annotation.value() == 'v'
+        annotation.names() == ['x', 'y']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38828")
+    void "an array member does not add a value member to the extracted annotation"() {
+        given:
+        def api = toApi([
+            A  : '''
+                @Ann(names = {"x", "y"})
+                public class A {}
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE})
+                public @interface Ann {
+                    String[] names();
+                }
+            '''
+        ])
+
+        expect:
+        classAnnotationMemberNames(api.extractApiClassFrom(api.classes.A)) == ['names']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38828")
+    void "extracted class changes when an annotation value member changes"() {
+        given:
+        def annotation = [Ann: '''
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.TYPE})
+            public @interface Ann {
+                String value();
+                String[] names();
+            }
+        ''']
+        def before = toApi(annotation + [A: '@Ann(value = "v", names = {"x", "y"}) public class A {}'])
+        def beforeBytes = before.extractApiClassFrom(before.classes.A)
+        def after = toApi(annotation + [A: '@Ann(value = "w", names = {"x", "y"}) public class A {}'])
+        def afterBytes = after.extractApiClassFrom(after.classes.A)
+
+        expect:
+        beforeBytes != afterBytes
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/38873")
     def "annotation members keep their declaration order"() {
         given:
@@ -770,6 +858,42 @@ class ApiClassExtractorAnnotationsTest extends ApiClassExtractorTestSupport {
 
         then:
         methodNamesInOrder(extractedBytes) == ['option', 'description', 'alpha']
+    }
+
+    /**
+     * The names of the members of every annotation on the given class, in the order they are written.
+     */
+    private static List<String> classAnnotationMemberNames(byte[] apiClassBytes) {
+        List<String> names = []
+        new ClassReader(apiClassBytes).accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                return new AnnotationVisitor(Opcodes.ASM9) {
+                    @Override
+                    void visit(String name, Object value) {
+                        names << name
+                    }
+
+                    @Override
+                    void visitEnum(String name, String desc, String value) {
+                        names << name
+                    }
+
+                    @Override
+                    AnnotationVisitor visitAnnotation(String name, String desc) {
+                        names << name
+                        return null
+                    }
+
+                    @Override
+                    AnnotationVisitor visitArray(String name) {
+                        names << name
+                        return null
+                    }
+                }
+            }
+        }, 0)
+        return names
     }
 
     private static List<String> methodNamesInOrder(byte[] classBytes) {

--- a/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTest.groovy
+++ b/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTest.groovy
@@ -22,10 +22,14 @@ import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
+import spock.lang.Issue
 
 import java.lang.reflect.Modifier
 
 class ApiClassExtractorTest extends ApiClassExtractorTestSupport {
+
+    // Records require Java 16, and the tests always run on a newer JVM than that
+    private static final String RECORD_TARGET_VERSION = '17'
 
     def "should not remove public method"() {
         given:
@@ -540,5 +544,127 @@ class ApiClassExtractorTest extends ApiClassExtractorTestSupport {
 
         then:
         !api.isApiClassExtractedFrom(clazz)
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38827")
+    def "method parameter names are retained"() {
+        given:
+        additionalCompilerArgs = ['-parameters']
+        def api = toApi([A: '''
+            public class A {
+                public void greet(String firstName, int repeatCount) {}
+            }
+        '''])
+
+        when:
+        def extracted = api.extractAndLoadApiClassFrom(api.classes.A)
+        def parameters = extracted.getDeclaredMethod('greet', String, int).parameters
+
+        then:
+        parameters*.namePresent == [true, true]
+        parameters*.name == ['firstName', 'repeatCount']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38827")
+    def "extracted class changes when a method parameter is renamed"() {
+        given:
+        additionalCompilerArgs = ['-parameters']
+        def before = toApi([A: 'public class A { public void greet(String firstName, int repeatCount) {} }'])
+        def beforeBytes = before.extractApiClassFrom(before.classes.A)
+        def after = toApi([A: 'public class A { public void greet(String givenName, int times) {} }'])
+        def afterBytes = after.extractApiClassFrom(after.classes.A)
+
+        expect:
+        beforeBytes != afterBytes
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38823")
+    def "record components are retained in declaration order"() {
+        given:
+        def api = toApi(RECORD_TARGET_VERSION, [Point: 'public record Point(int x, int y) {}'])
+
+        when:
+        def extracted = api.extractAndLoadApiClassFrom(api.classes.Point)
+
+        then:
+        extracted.recordComponents*.name == ['x', 'y']
+        extracted.recordComponents*.type == [int, int]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38823")
+    def "extracted class changes when the record component order changes"() {
+        given:
+        def before = toApi(RECORD_TARGET_VERSION, [Point: 'public record Point(int x, int y) {}'])
+        def beforeBytes = before.extractApiClassFrom(before.classes.Point)
+        def after = toApi(RECORD_TARGET_VERSION, [Point: 'public record Point(int y, int x) {}'])
+        def afterBytes = after.extractApiClassFrom(after.classes.Point)
+
+        expect:
+        beforeBytes != afterBytes
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38825")
+    def "type annotations in a throws clause stay on the exception they annotate"() {
+        given:
+        def api = toApi([
+            A  : '''
+                import java.io.IOException;
+
+                public class A {
+                    public void foo() throws @Ann ArithmeticException, IOException {}
+                }
+            ''',
+            Ann: '''
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target({ElementType.TYPE_USE})
+                public @interface Ann {}
+            '''
+        ])
+
+        when:
+        def extractedAnn = api.extractAndLoadApiClassFrom(api.classes.Ann)
+        def extracted = api.extractAndLoadApiClassFrom(api.classes.A)
+        // The extractor writes the exceptions sorted, so IOException comes first
+        def annotatedExceptionTypes = extracted.getDeclaredMethod('foo').annotatedExceptionTypes
+
+        then:
+        annotatedExceptionTypes*.type == [IOException, ArithmeticException]
+        annotatedExceptionTypes[0].annotations.length == 0
+        annotatedExceptionTypes[1].annotations*.annotationType() == [extractedAnn]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38825")
+    def "extracted class changes when a type annotation moves to another exception"() {
+        given:
+        def annotation = [Ann: '''
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.TYPE_USE})
+            public @interface Ann {}
+        ''']
+        // Both variants annotate the first declared exception, and both extract to the same sorted
+        // throws clause, so only a mapped type_index tells them apart
+        def before = toApi(annotation + [A: '''
+            import java.io.IOException;
+            public class A { public void foo() throws @Ann ArithmeticException, IOException {} }
+        '''])
+        def beforeBytes = before.extractApiClassFrom(before.classes.A)
+        def after = toApi(annotation + [A: '''
+            import java.io.IOException;
+            public class A { public void foo() throws @Ann IOException, ArithmeticException {} }
+        '''])
+        def afterBytes = after.extractApiClassFrom(after.classes.A)
+
+        expect:
+        beforeBytes != afterBytes
     }
 }

--- a/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTestSupport.groovy
+++ b/platforms/core-configuration/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTestSupport.groovy
@@ -113,6 +113,11 @@ class ApiClassExtractorTestSupport extends Specification {
     @TempDir
     File temporaryFolder
 
+    /**
+     * Compiler options to add to every compilation of this specification, e.g. {@code -parameters}.
+     */
+    protected List<String> additionalCompilerArgs = []
+
     // The default target version can be updated to a new version when necessary, as long as
     // you also update `ApiClassExtractorTest#target binary compatibility is maintained` with new assumptions.
     private static final String DEFAULT_TARGET_VERSION = '8'
@@ -146,7 +151,7 @@ class ApiClassExtractorTestSupport extends Specification {
             null,
             fileManager,
             diagnostics,
-            ['-d', dir.absolutePath, '-source', targetVersion, '-target', targetVersion],
+            ['-d', dir.absolutePath, '-source', targetVersion, '-target', targetVersion] + additionalCompilerArgs,
             [],
             sources.collect { fqn, src -> new JavaSourceFromString(fqn, src) })
         fileManager.close()

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
@@ -482,4 +482,193 @@ sealed interface Foo {
         then:
         executedAndNotSkipped(":b:${language.compileTaskName}")
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/38823")
+    @Requires(JdkVersionTestPreconditions.Jdk16OrLater)
+    @ToBeFixedForIsolatedProjects(because = "Configure projects from root")
+    def "recompiles when record component order changes"() {
+        given:
+        buildFile << """
+            project(':b') {
+                dependencies {
+                    implementation project(':a')
+                }
+            }
+        """
+
+        def sourceFile = file("a/src/main/${language.name}/Point.${language.name}")
+        sourceFile << 'public record Point(int x, int y) {}'
+        file("b/src/main/${language.name}/Main.${language.name}") << 'public class Main { Point p = new Point(1, 2); }'
+
+        when:
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+
+        when:
+        // Swapping the components keeps every accessor, the canonical constructor and every field
+        sourceFile.text = 'public record Point(int y, int x) {}'
+
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38827")
+    @ToBeFixedForIsolatedProjects(because = "Configure projects from root")
+    def "recompiles when a method parameter is renamed"() {
+        given:
+        buildFile << """
+            project(':a') {
+                tasks.named('${language.compileTaskName}') {
+                    options.compilerArgs << '-parameters'
+                }
+            }
+            project(':b') {
+                dependencies {
+                    implementation project(':a')
+                }
+            }
+        """
+
+        def sourceFile = file("a/src/main/${language.name}/ToolImpl.${language.name}")
+        sourceFile << """
+            public class ToolImpl {
+                public void greet(String firstName, int repeatCount) { }
+            }
+        """
+        file("b/src/main/${language.name}/Main.${language.name}") << """
+            public class Main { ToolImpl t = new ToolImpl(); }
+        """
+
+        when:
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+
+        when:
+        // Parameter names are an input of annotation processing, so they are part of the API
+        sourceFile.text = """
+            public class ToolImpl {
+                public void greet(String givenName, int times) { }
+            }
+        """
+
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38828")
+    @ToBeFixedForIsolatedProjects(because = "Configure projects from root")
+    def "recompiles when an annotation value member changes next to an array member"() {
+        given:
+        buildFile << """
+            project(':b') {
+                dependencies {
+                    implementation project(':a')
+                }
+            }
+        """
+
+        file("a/src/main/${language.name}/Ann.${language.name}") << """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.TYPE})
+            public @interface Ann {
+                String value();
+                String[] names();
+            }
+        """
+        def sourceFile = file("a/src/main/${language.name}/ToolImpl.${language.name}")
+        sourceFile << """
+            @Ann(value = "v", names = {"x", "y"})
+            public class ToolImpl { }
+        """
+        file("b/src/main/${language.name}/Main.${language.name}") << """
+            public class Main { ToolImpl t = new ToolImpl(); }
+        """
+
+        when:
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+
+        when:
+        sourceFile.text = """
+            @Ann(value = "w", names = {"x", "y"})
+            public class ToolImpl { }
+        """
+
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38825")
+    @ToBeFixedForIsolatedProjects(because = "Configure projects from root")
+    def "recompiles when a type annotation in a throws clause moves to another exception"() {
+        given:
+        buildFile << """
+            project(':b') {
+                dependencies {
+                    implementation project(':a')
+                }
+            }
+        """
+
+        file("a/src/main/${language.name}/Ann.${language.name}") << """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ElementType.TYPE_USE})
+            public @interface Ann { }
+        """
+        def sourceFile = file("a/src/main/${language.name}/ToolImpl.${language.name}")
+        sourceFile << """
+            import java.io.IOException;
+
+            public class ToolImpl {
+                public void execute() throws @Ann ArithmeticException, IOException { }
+            }
+        """
+        file("b/src/main/${language.name}/Main.${language.name}") << """
+            public class Main { ToolImpl t = new ToolImpl(); }
+        """
+
+        when:
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+
+        when:
+        // The extractor writes the exceptions sorted while it keeps the type_index of the
+        // declaration order, so both variants used to extract to the same bytes
+        sourceFile.text = """
+            import java.io.IOException;
+
+            public class ToolImpl {
+                public void execute() throws @Ann IOException, ArithmeticException { }
+            }
+        """
+
+        succeeds ":b:${language.compileTaskName}"
+
+        then:
+        executedAndNotSkipped(":b:${language.compileTaskName}")
+    }
 }

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -39,7 +39,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 249
+        return 250
     }
 
     @Requires(TestEnvironmentPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class BinDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 144
+        return 145
     }
 
     def binZipContents() {

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -38,7 +38,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 144
+        return 145
     }
 
     /**


### PR DESCRIPTION
Fixes #38823
Fixes #38825
Fixes #38827
Fixes #38828

### Context

Gradle compares the extracted ABI of each compile classpath entry to decide whether a consumer has to be recompiled. Four kinds of API change left the extracted bytes unchanged, so Gradle kept the consumer up to date and an incremental build produced a different result than a clean build — with no error and no warning. All four were reported by the same contributor while working on #38810, on top of which this builds.

**Annotation members displaced by array elements (#38828).** The array branch of `SortingAnnotationVisitor.visitEnd` wrapped the collected elements in an `ArrayAnnotationValue` and then fell through to `annotation.addValues(annotationValues)`, adding every element to the annotation as a member. An array element carries no name of its own, so each one arrived as `value` and displaced the real `value` member in the `TreeSet`. This also writes wrong bytes into the ABI jar of the distribution: in 9.7.0, `InputArtifact` carries an `InjectionPointQualifier(value=FileSystemLocation)` that its source never declares.

**Parameter names dropped (#38827).** `ApiMemberSelector` never implemented `visitParameter`, so `(String firstName, int repeatCount)` and `(String givenName, int times)` extracted to the same bytes. Two things were needed: collecting the parameters, and reading the class with `SKIP_CODE` instead of `SKIP_DEBUG` — ASM gates the `MethodParameters` attribute behind the latter. `SKIP_CODE` still discards method bodies and all the debug information inside them, and skips more work than before.

**Record components dropped (#38823).** `ApiMemberSelector` never implemented `visitRecordComponent`. Swapping the components of `record Point(int x, int y)` keeps every accessor, the canonical constructor and every private field, so both orders extracted to the same bytes — while a record pattern in the consumer binds by position and silently produced a wrong result.

**`THROWS` type annotation on the wrong exception (#38825).** The `type_index` of a `THROWS` type annotation points into the `Exceptions` attribute in declaration order, but the extractor writes the exceptions sorted and kept the original index. The annotation therefore moved to another exception, which is a defect on its own beyond the hash. `MethodMember` now maps the index onto the written order.

Parameter names, record components and type annotations in a `throws` clause are all real inputs of the consumer's compilation, since the compile task also runs annotation processors, which read them via `VariableElement.getSimpleName()`, `RecordComponentElement` and `ExecutableElement.getThrownTypes()`. This is the same reasoning that kept type annotations in #35658 and #38810.

Note that the extracted ABI of every classpath entry changes, so the first build after this change recompiles everything.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally.

### Testing

8 unit tests in `ApiClassExtractorTest` / `ApiClassExtractorAnnotationsTest`, and 4 integration tests in `AbstractJavaCompileAvoidanceIntegrationSpec`, which run across all three subclasses (incremental/non-incremental × jar/classes-dir).

Every test was verified against a stashed fix: all 8 unit tests and all 8 jar-variant integration tests fail without it.

Green locally: `sanityCheck`, `:java-api-extractor:test`, `:normalization-java:test`, `:kotlin-dsl:test`, and all compile-avoidance integration tests in `plugins-java`, `plugins-groovy`, `language-java` and `kotlin-dsl`.
