### PR TITLE
Make printed problem locations clickable

### DIFF
--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
@@ -75,7 +75,7 @@ class ProblemBodyWriter implements PartialProblemWriter {
             indent(output, "Location: " + location.getPath(), 4);
             if (location instanceof LineInFileLocation) {
                 LineInFileLocation lineLocation = (LineInFileLocation) location;
-                output.printf(" line " + lineLocation.getLine());
+                output.printf(":" + lineLocation.getLine());
             }
         }
     }

--- a/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
+++ b/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
@@ -164,7 +164,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
   This is a prototype and not a guideline for modeling real-life projects
     Complex build logic like the Problems API usage should integrated into plugins
     Solution: Look up the samples index for real-life examples
-    Location: /path/to/script line 20
+    Location: /path/to/script:20
         ''')
     }
 
@@ -191,8 +191,8 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
     Complex build logic like the Problems API usage should integrated into plugins
     Solution: Look up the samples index for real-life examples
     Solution: Or read the documentation on the Gradle website
-    Location: /path/to/script line 20
-    Location: /path/to/alternative line 30
+    Location: /path/to/script:20
+    Location: /path/to/alternative:30
         ''')
     }
 


### PR DESCRIPTION
Fixes #38808 

### Context

The Kotlin compilation errors from Gradle currently produce output that includes a file location + "line " + number of line, however it needs to be in the ":line" format in order to be clickable by the IDE.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
