### PR TITLE
Make printed problem locations clickable

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslPluginCustomKotlinOptionsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslPluginCustomKotlinOptionsIntegrationTest.kt
@@ -50,7 +50,7 @@ class KotlinDslPluginCustomKotlinOptionsIntegrationTest : AbstractKotlinIntegrat
         withBuildScript("println(MyDataObject.other)")
         executer.expectExternalDeprecatedMessage("    Language version 2.1 is deprecated and its support will be removed in a future version of Kotlin. Update the version to 2.2.")
         buildAndFail("help").apply {
-            assertOutputContainsPattern("""The feature "multi dollar interpolation" is only available since language version 2.2\s+Location: .*?MyDataObject.kt line 3""")
+            assertOutputContainsPattern("""The feature "multi dollar interpolation" is only available since language version 2.2\s+Location: .*?MyDataObject.kt:3""")
         }
 
         buildSrcBuildScript.appendText("""

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginVersionCatalogIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginVersionCatalogIntegrationTest.kt
@@ -77,8 +77,8 @@ class PrecompiledScriptPluginVersionCatalogIntegrationTest : AbstractKotlinInteg
 
         buildAndFail(":help").apply {
             assertHasFailure("Execution failed for task ':buildSrc:compileKotlin' (registered by plugin class 'org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper').") {
-                assertOutputContainsPattern("""Unresolved reference 'libs'\.\s+Location: .*?plugin-without-plugins\.gradle\.kts line 1""")
-                assertOutputContainsPattern("""Unresolved reference 'libs'\.\s+Location: .*?plugin-with-plugins\.gradle\.kts line 3""")
+                assertOutputContainsPattern("""Unresolved reference 'libs'\.\s+Location: .*?plugin-without-plugins\.gradle\.kts:1""")
+                assertOutputContainsPattern("""Unresolved reference 'libs'\.\s+Location: .*?plugin-with-plugins\.gradle\.kts:3""")
             }
         }
     }

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -106,7 +106,7 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
 
         buildAndFail("compileKotlin").apply {
             assertHasCause("Compilation error.")
-            assertOutputContainsPattern("""Unresolved reference 'after'\.\s+Location: .*?consumer\.plugin\.gradle\.kts line 4""")
+            assertOutputContainsPattern("""Unresolved reference 'after'\.\s+Location: .*?consumer\.plugin\.gradle\.kts:4""")
         }
     }
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -461,7 +461,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
                 "Execution failed for task ':compileKotlin' (registered by plugin class 'org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper')."
             )
             assertOutputContainsPattern(
-                """'fun Project\.plugins\(block: PluginDependenciesSpec\.\(\) -> Unit\): Nothing' is deprecated\. The plugins \{\} block must not be used here\. If you need to apply a plugin imperatively, please use apply<PluginType>\(\) or apply\(plugin = "id"\) instead\.\s+Location: .*?my-project-plugin\.gradle\.kts line 3"""
+                """'fun Project\.plugins\(block: PluginDependenciesSpec\.\(\) -> Unit\): Nothing' is deprecated\. The plugins \{\} block must not be used here\. If you need to apply a plugin imperatively, please use apply<PluginType>\(\) or apply\(plugin = "id"\) instead\.\s+Location: .*?my-project-plugin\.gradle\.kts:3"""
             )
         }
     }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -15,7 +15,7 @@ We are excited to announce Gradle @version@ (released [@releaseDate@](https://gr
 This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
-[jkrannich](https://github.com/jkrannich).
+[Julian Krannich](https://github.com/jkrannich).
 
 <!-- 
 Include only their name, impactful features should be called out separately below.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -15,6 +15,7 @@ We are excited to announce Gradle @version@ (released [@releaseDate@](https://gr
 This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
+[jkrannich](https://github.com/jkrannich).
 
 <!-- 
 Include only their name, impactful features should be called out separately below.

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -501,7 +501,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
   This is a prototype and not a guideline for modeling real-life projects
     Complex build logic like the Problems API usage should be integrated into plugins
     For more information, please refer to https://example.com/some-problem.
-    Location: /path/to/script line 20
+    Location: /path/to/script:20
     Possible solution: Look up the samples index for real-life examples.
         """
         verifyAll(receivedProblem) {

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
@@ -77,7 +77,7 @@ class ProblemBodyWriter implements PartialProblemWriter {
             indent(output, "Location: " + location.getPath(), LEVEL_2_INDENT);
             if (location instanceof LineInFileLocation) {
                 LineInFileLocation lineLocation = (LineInFileLocation) location;
-                output.printf(" line " + lineLocation.getLine());
+                output.print(":" + lineLocation.getLine());
             }
         }
 

--- a/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
+++ b/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
@@ -168,7 +168,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
 Problem found: Project is a prototype (id: sample-problems:prototype-project)
   This is a prototype and not a guideline for modeling real-life projects
     Complex build logic like the Problems API usage should integrated into plugins
-    Location: /path/to/script line 20
+    Location: /path/to/script:20
     Possible solution: Look up the samples index for real-life examples.
         ''')
     }
@@ -192,7 +192,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
         then:
         renderedProblem == denormalizeAndStrip('''
 Problem found: Project is a prototype (id: sample-problems:prototype-project)
-    Location: /path/to/script line 20
+    Location: /path/to/script:20
         ''')
     }
 
@@ -217,8 +217,8 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
 Problem found: Project is a prototype (id: sample-problems:prototype-project)
   This is a prototype and not a guideline for modeling real-life projects
     Complex build logic like the Problems API usage should integrated into plugins
-    Location: /path/to/script line 20
-    Location: /path/to/alternative line 30
+    Location: /path/to/script:20
+    Location: /path/to/alternative:30
     Possible solutions:
       1. Look up the samples index for real-life examples.
       2. Or read the documentation on the Gradle website.

--- a/platforms/ide/problems-reporting/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemReporterTest.groovy
+++ b/platforms/ide/problems-reporting/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemReporterTest.groovy
@@ -83,7 +83,7 @@ class DefaultProblemReporterTest extends Specification {
         expect:
         with(DefaultProblemReporter.discardedProblemMessage(problem)) {
             it.contains("/path/to/build.gradle")
-            it.contains("line 14")
+            it.contains(":14")
         }
     }
 


### PR DESCRIPTION
Fixes #38808 

### Context

The Kotlin compilation errors from Gradle currently produce output that includes a file location + "line " + number of line, however it needs to be in the ":line" format in order to be clickable by the IDE.

Before:

<img width="706" height="207" alt="image" src="https://github.com/user-attachments/assets/c827e39c-7fd0-4f39-8d49-4990622fa2fc" />

After:

<img width="706" height="207" alt="image" src="https://github.com/user-attachments/assets/b1de76e4-5007-4759-9fa0-65209ffda587" />


### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
