### PR TITLE
Asodja/provider api perf

### DIFF
--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationOwner;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks the query hot paths of properties whose values are constants.
+ *
+ * <p>These are the shapes that dominate a real build: a property assigned a constant in a build
+ * script, and the same property read through a user {@code map {}} chain. Run with {@code -prof gc}
+ * to see the per-read allocation, which is what most of these cases are really measuring.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class ProviderHotPathBenchmark {
+
+    private static final int LIST_SIZE = 10;
+
+    private final PropertyHost host = producer -> null;
+
+    private Property<String> fixedProperty;
+    private Provider<String> mappedFixedProperty;
+    private ListProperty<String> listProperty;
+    private Provider<Integer> mappedListProperty;
+    private MapProperty<String, String> mapProperty;
+    private EvaluationOwner scopeOwner;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        fixedProperty = new DefaultProperty<>(host, String.class);
+        fixedProperty.set("explicit-value");
+        mappedFixedProperty = fixedProperty.map(v -> v);
+
+        listProperty = new DefaultListProperty<>(host, String.class);
+        for (int i = 0; i < LIST_SIZE; i++) {
+            listProperty.add("element-" + i);
+        }
+        mappedListProperty = listProperty.map(List::size);
+
+        scopeOwner = (EvaluationOwner) fixedProperty;
+
+        mapProperty = new DefaultMapProperty<>(host, String.class, String.class);
+        for (int i = 0; i < LIST_SIZE; i++) {
+            mapProperty.put("key-" + i, "value-" + i);
+        }
+    }
+
+    /**
+     * The simplest possible read: one {@code EvaluationContext} scope, one {@code Value} allocation.
+     */
+    @Benchmark
+    public void getFixedProperty(Blackhole bh) {
+        bh.consume(fixedProperty.get());
+    }
+
+    /**
+     * Adds {@code TransformBackedProvider.beforeRead}, which walks the upstream producer graph.
+     */
+    @Benchmark
+    public void getMappedFixedProperty(Blackhole bh) {
+        bh.consume(mappedFixedProperty.get());
+    }
+
+    @Benchmark
+    public void isPresentFixedProperty(Blackhole bh) {
+        bh.consume(fixedProperty.isPresent());
+    }
+
+    @Benchmark
+    public void getListProperty(Blackhole bh) {
+        bh.consume(listProperty.get());
+    }
+
+    /**
+     * The expensive shape: {@code beforeRead} rebuilds a {@code ValueProducer} per collector on
+     * every single read.
+     */
+    @Benchmark
+    public void getMappedListProperty(Blackhole bh) {
+        bh.consume(mappedListProperty.get());
+    }
+
+    @Benchmark
+    public void isPresentListProperty(Blackhole bh) {
+        bh.consume(listProperty.isPresent());
+    }
+
+    @Benchmark
+    public void getMapProperty(Blackhole bh) {
+        bh.consume(mapProperty.get());
+    }
+
+    /**
+     * Isolates the cycle-detection scope that {@code AbstractProperty} opens on every read. This is
+     * the ceiling on what skipping the scope for constant-valued properties can save.
+     */
+    @Benchmark
+    public void evaluationScopeOpenClose(Blackhole bh) {
+        try (EvaluationScopeContext context = EvaluationContext.current().open(scopeOwner)) {
+            bh.consume(context);
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
@@ -62,6 +62,9 @@ public class ProviderHotPathBenchmark {
     private ListProperty<String> listProperty;
     private Provider<Integer> mappedListProperty;
     private MapProperty<String, String> mapProperty;
+    private Property<String> propertyBackedByProperty;
+    private Property<String> propertyChainWithinLookahead;
+    private Property<String> propertyChainBeyondLookahead;
     private ListProperty<String> listPropertyOfProviders;
     private MapProperty<String, String> mapPropertyOfProviders;
     private EvaluationOwner scopeOwner;
@@ -77,6 +80,15 @@ public class ProviderHotPathBenchmark {
             listProperty.add("element-" + i);
         }
         mappedListProperty = listProperty.map(List::size);
+
+        // b.set(a) where a holds a constant: property-to-property wiring, very common in real builds.
+        propertyBackedByProperty = new DefaultProperty<>(host, String.class);
+        propertyBackedByProperty.set(fixedProperty);
+
+        // Chains of properties: the first stays within the lookahead bound, the second runs past it so
+        // the outer links pay the walk and open a scope anyway.
+        propertyChainWithinLookahead = chainOfLength(2);
+        propertyChainBeyondLookahead = chainOfLength(8);
 
         scopeOwner = (EvaluationOwner) fixedProperty;
 
@@ -109,6 +121,36 @@ public class ProviderHotPathBenchmark {
     @Benchmark
     public void getMappedFixedProperty(Blackhole bh) {
         bh.consume(mappedFixedProperty.get());
+    }
+
+    private Property<String> chainOfLength(int links) {
+        Property<String> head = new DefaultProperty<>(host, String.class);
+        head.set("explicit-value");
+        for (int i = 0; i < links; i++) {
+            Property<String> next = new DefaultProperty<>(host, String.class);
+            next.set(head);
+            head = next;
+        }
+        return head;
+    }
+
+    @Benchmark
+    public void getPropertyChainWithinLookahead(Blackhole bh) {
+        bh.consume(propertyChainWithinLookahead.get());
+    }
+
+    @Benchmark
+    public void getPropertyChainBeyondLookahead(Blackhole bh) {
+        bh.consume(propertyChainBeyondLookahead.get());
+    }
+
+    /**
+     * {@code b.set(a)} where {@code a} holds a constant. {@code a} is a property, not a value, so
+     * {@code b}'s supplier is not self-contained and {@code b} still opens a scope.
+     */
+    @Benchmark
+    public void getPropertyBackedByProperty(Blackhole bh) {
+        bh.consume(propertyBackedByProperty.get());
     }
 
     @Benchmark

--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ProviderHotPathBenchmark.java
@@ -62,6 +62,8 @@ public class ProviderHotPathBenchmark {
     private ListProperty<String> listProperty;
     private Provider<Integer> mappedListProperty;
     private MapProperty<String, String> mapProperty;
+    private ListProperty<String> listPropertyOfProviders;
+    private MapProperty<String, String> mapPropertyOfProviders;
     private EvaluationOwner scopeOwner;
 
     @Setup(Level.Trial)
@@ -81,6 +83,15 @@ public class ProviderHotPathBenchmark {
         mapProperty = new DefaultMapProperty<>(host, String.class, String.class);
         for (int i = 0; i < LIST_SIZE; i++) {
             mapProperty.put("key-" + i, "value-" + i);
+        }
+
+        // Elements contributed by providers: these cannot report a cheap size, so they exercise the
+        // path where the builder gets little or no size hint.
+        listPropertyOfProviders = new DefaultListProperty<>(host, String.class);
+        mapPropertyOfProviders = new DefaultMapProperty<>(host, String.class, String.class);
+        for (int i = 0; i < LIST_SIZE; i++) {
+            listPropertyOfProviders.add(Providers.of("element-" + i));
+            mapPropertyOfProviders.put("key-" + i, Providers.of("value-" + i));
         }
     }
 
@@ -127,6 +138,16 @@ public class ProviderHotPathBenchmark {
     @Benchmark
     public void getMapProperty(Blackhole bh) {
         bh.consume(mapProperty.get());
+    }
+
+    @Benchmark
+    public void getListPropertyOfProviders(Blackhole bh) {
+        bh.consume(listPropertyOfProviders.get());
+    }
+
+    @Benchmark
+    public void getMapPropertyOfProviders(Blackhole bh) {
+        bh.consume(mapPropertyOfProviders.get());
     }
 
     /**

--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ScalarPropertyGetBenchmark.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ScalarPropertyGetBenchmark.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.evaluation.EvaluationOwner;
 import org.gradle.internal.evaluation.EvaluationScopeContext;

--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ScalarPropertyGetBenchmark.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/api/internal/provider/ScalarPropertyGetBenchmark.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationOwner;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Decomposes the cost of a scalar {@code Property.get()} into its parts, so the remaining ~5ns can be
+ * attributed rather than guessed at.
+ *
+ * <p>The layers, cheapest first: a raw ThreadLocal lookup, the whole evaluation scope, a bare
+ * provider read with no property around it, and finally the property read itself.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+public class ScalarPropertyGetBenchmark {
+
+    private final PropertyHost host = producer -> null;
+
+    private final ThreadLocal<Object> threadLocal = ThreadLocal.withInitial(Object::new);
+
+    private Property<String> property;
+    private Property<String> finalizedProperty;
+    private Property<String> conventionProperty;
+    private ProviderInternal<String> bareFixedProvider;
+    private EvaluationOwner scopeOwner;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        property = new DefaultProperty<>(host, String.class);
+        property.set("explicit-value");
+
+        finalizedProperty = new DefaultProperty<>(host, String.class);
+        finalizedProperty.set("explicit-value");
+        finalizedProperty.finalizeValue();
+
+        conventionProperty = new DefaultProperty<>(host, String.class);
+        conventionProperty.convention("convention-value");
+
+        bareFixedProvider = Providers.of("explicit-value");
+        scopeOwner = (EvaluationOwner) property;
+    }
+
+    // ---- layer 0: the primitives the scope is built from ----
+
+    @Benchmark
+    public void threadLocalGet(Blackhole bh) {
+        bh.consume(threadLocal.get());
+    }
+
+    @Benchmark
+    public void evaluationScopeOpenClose(Blackhole bh) {
+        try (EvaluationScopeContext context = EvaluationContext.current().open(scopeOwner)) {
+            bh.consume(context);
+        }
+    }
+
+    // ---- layer 1: a provider with no property wrapper and no scope ----
+
+    @Benchmark
+    public void bareFixedProviderGet(Blackhole bh) {
+        bh.consume(bareFixedProvider.get());
+    }
+
+    /**
+     * Same as above but through {@code calculateValue}, which adds the
+     * {@code pushWhenMissing(getDeclaredDisplayName())} pair that does nothing for a present value.
+     */
+    @Benchmark
+    public void bareFixedProviderCalculateValue(Blackhole bh) {
+        bh.consume(bareFixedProvider.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead));
+    }
+
+    // ---- layer 2: the full property read ----
+
+    @Benchmark
+    public void propertyGet(Blackhole bh) {
+        bh.consume(property.get());
+    }
+
+    @Benchmark
+    public void finalizedPropertyGet(Blackhole bh) {
+        bh.consume(finalizedProperty.get());
+    }
+
+    @Benchmark
+    public void conventionPropertyGet(Blackhole bh) {
+        bh.consume(conventionProperty.get());
+    }
+
+    @Benchmark
+    public void propertyGetOrNull(Blackhole bh) {
+        bh.consume(property.getOrNull());
+    }
+
+    @Benchmark
+    public void propertyIsPresent(Blackhole bh) {
+        bh.consume(property.isPresent());
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectingSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectingSupplier.java
@@ -67,6 +67,13 @@ abstract class AbstractCollectingSupplier<COLLECTOR extends ValueSupplier, TYPE>
     }
 
     @Override
+    public void visitContentProducerTasks(Action<? super Task> visitor) {
+        for (COLLECTOR collector : collectors) {
+            collector.visitContentProducerTasks(visitor);
+        }
+    }
+
+    @Override
     public final boolean calculatePresence(ValueConsumer consumer) {
         for (COLLECTOR collector : collectors) {
             if (!collector.calculatePresence(consumer)) {
@@ -82,16 +89,24 @@ abstract class AbstractCollectingSupplier<COLLECTOR extends ValueSupplier, TYPE>
         BUILDER builder,
         Function<BUILDER, ENTRIES> buildEntries
     ) {
-        SideEffectBuilder<ENTRIES> sideEffects = SideEffect.builder();
+        // Side effects are rare, so the builder (and its backing list) is only created once one shows up.
+        SideEffectBuilder<ENTRIES> sideEffects = null;
         for (COLLECTOR collector : collectors) {
             Value<Void> result = collectEntriesForCollector.apply(builder, collector);
             if (result.isMissing()) {
                 // When any contributor is missing, the whole property is missing.
                 return result.asType();
             }
-            sideEffects.add(SideEffect.fixedFrom(result));
+            SideEffect<ENTRIES> sideEffect = SideEffect.fixedFrom(result);
+            if (sideEffect != null) {
+                if (sideEffects == null) {
+                    sideEffects = SideEffect.builder();
+                }
+                sideEffects.add(sideEffect);
+            }
         }
-        return Value.of(buildEntries.apply(builder)).withSideEffect(sideEffects.build());
+        Value<ENTRIES> value = Value.of(buildEntries.apply(builder));
+        return sideEffects == null ? value : value.withSideEffect(sideEffects.build());
     }
 
     protected ExecutionTimeValue<? extends TYPE> calculateExecutionTimeValue(

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Supplier;
+import java.util.function.IntFunction;
 
 import static org.gradle.api.internal.provider.AppendOnceList.toAppendOnceList;
 
@@ -80,6 +80,12 @@ import static org.gradle.api.internal.provider.AppendOnceList.toAppendOnceList;
  */
 public abstract class AbstractCollectionProperty<T, C extends Collection<T>> extends AbstractProperty<C, CollectionSupplier<T, C>>
     implements CollectionPropertyInternal<T, C> {
+
+    /**
+     * Matches {@code ImmutableCollection.Builder.DEFAULT_INITIAL_CAPACITY}, which is what a builder created
+     * without a size hint starts with.
+     */
+    private static final int DEFAULT_BUILDER_CAPACITY = 4;
 
     private final Class<T> elementType;
     private final ValueCollector<T> valueCollector;
@@ -481,7 +487,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
     }
 
-    protected abstract Supplier<ImmutableCollection.Builder<T>> getCollectionFactory();
+    protected abstract IntFunction<ImmutableCollection.Builder<T>> getCollectionFactory();
 
     private CollectingSupplier<T, C> newSupplierOf(Collector<T> value) {
         return new CollectingSupplier<>(getType(), getCollectionFactory(), valueCollector, value);
@@ -489,17 +495,17 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
     private static class CollectingSupplier<T, C extends Collection<T>> extends AbstractCollectingSupplier<Collector<T>, C> implements CollectionSupplier<T, C> {
         private final Class<C> type;
-        private final Supplier<ImmutableCollection.Builder<T>> collectionFactory;
+        private final IntFunction<ImmutableCollection.Builder<T>> collectionFactory;
         private final ValueCollector<T> valueCollector;
 
-        public CollectingSupplier(Class<C> type, Supplier<ImmutableCollection.Builder<T>> collectionFactory, ValueCollector<T> valueCollector, Collector<T> value) {
+        public CollectingSupplier(Class<C> type, IntFunction<ImmutableCollection.Builder<T>> collectionFactory, ValueCollector<T> valueCollector, Collector<T> value) {
             this(type, collectionFactory, valueCollector, AppendOnceList.of(value));
         }
 
         // A constructor for sharing.
         private CollectingSupplier(
             Class<C> type,
-            Supplier<ImmutableCollection.Builder<T>> collectionFactory,
+            IntFunction<ImmutableCollection.Builder<T>> collectionFactory,
             ValueCollector<T> valueCollector,
             AppendOnceList<Collector<T>> collectors
         ) {
@@ -520,9 +526,24 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             // TODO - don't make a copy when the collector already produces an immutable collection
             return calculateValue(
                 (builder, collector) -> collector.collectEntries(consumer, valueCollector, builder),
-                collectionFactory.get(),
+                collectionFactory.apply(sizeHint()),
                 builder -> Cast.uncheckedNonnullCast(builder.build())
             );
+        }
+
+        /**
+         * A lower bound on the element count, used to presize the builder so it does not grow from its
+         * default capacity. Never evaluates a collector, so an unknown contributor just means a smaller hint.
+         * <p>
+         * Floored at the capacity the builder would have started with anyway: contributors of unknown size
+         * hint zero, and presizing to that is worse than not presizing at all.
+         */
+        private int sizeHint() {
+            int hint = 0;
+            for (Collector<T> collector : collectors) {
+                hint += collector.sizeHint();
+            }
+            return Math.max(hint, DEFAULT_BUILDER_CAPACITY);
         }
 
         @Override
@@ -556,7 +577,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         private ExecutionTimeValue<? extends C> calculateFixedExecutionTimeValue(
             List<ExecutionTimeValue<? extends C>> executionTimeValues, SideEffectBuilder<C> sideEffectBuilder
         ) {
-            ImmutableCollection.Builder<T> entries = collectionFactory.get();
+            ImmutableCollection.Builder<T> entries = collectionFactory.apply(Math.max(executionTimeValues.size(), DEFAULT_BUILDER_CAPACITY));
             for (ExecutionTimeValue<? extends C> value : executionTimeValues) {
                 valueCollector.addAll(value.getFixedValue(), entries);
                 sideEffectBuilder.add(SideEffect.fixedFrom(value));

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -309,7 +309,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected Value<? extends C> calculateValueFrom(EvaluationScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
+    protected Value<? extends C> calculateValueFrom(CollectionSupplier<T, C> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
@@ -371,6 +371,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
+        public boolean isSelfContained() {
+            return true;
+        }
+
+        @Override
         public CollectionSupplier<T, C> plus(Collector<T> collector) {
             // No value + something = no value.
             return this;
@@ -402,6 +407,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public Value<? extends C> calculateValue(ValueConsumer consumer) {
             return Value.of(emptyCollection());
+        }
+
+        @Override
+        public boolean isSelfContained() {
+            return true;
         }
 
         @Override
@@ -443,6 +453,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public Value<? extends C> calculateValue(ValueConsumer consumer) {
             return Value.of(value).withSideEffect(sideEffect);
+        }
+
+        @Override
+        public boolean isSelfContained() {
+            return true;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -326,7 +326,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(EvaluationScopeContext context, CollectionSupplier<T, C> value) {
+    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(CollectionSupplier<T, C> value) {
         return value.calculateExecutionTimeValue();
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -53,23 +53,29 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     private DisplayName displayName;
     private ValueState<S> state;
     private S value;
-    // Kept in sync with value by setValue(), so that reads test a field instead of the supplier.
-    private boolean valueIsSelfContained;
 
     public AbstractProperty(PropertyHost host) {
         state = ValueState.newState(host);
     }
 
     /**
-     * The only place {@link #value} is assigned, so {@link #valueIsSelfContained} cannot drift out of sync.
+     * Always false: a property never lets a consumer skip cycle detection.
+     * <p>
+     * Deliberately does not answer from the supplier. A property can be reachable from its own supplier -
+     * {@code p.set(p)} is enough, and {@code a.set(b)} with {@code b.set(a)} does it indirectly - so
+     * delegating would not terminate, and the self-reference the scope exists to report would instead
+     * arrive as a StackOverflowError.
+     * <p>
+     * This costs the fast path for a property wired to another property. Reading such a property still
+     * reaches the inner property's fast path once the scope is open.
      */
-    private void setValue(S newValue) {
-        this.value = newValue;
-        this.valueIsSelfContained = newValue.isSelfContained();
+    @Override
+    public boolean isSelfContained() {
+        return false;
     }
 
     protected void init(S initialValue, S convention) {
-        setValue(initialValue);
+        this.value = initialValue;
         this.state.setConvention(convention);
     }
 
@@ -126,7 +132,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      * again, so the host would see two calls per read.
      */
     private boolean canReadWithoutScope(ValueConsumer consumer) {
-        return valueIsSelfContained && !state.needsReadPreparation(consumer);
+        return value.isSelfContained() && !state.needsReadPreparation(consumer);
     }
 
     @Override
@@ -239,7 +245,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        if (valueIsSelfContained) {
+        if (value.isSelfContained()) {
             return withChangingContentIfProducedByTask(calculateOwnExecutionTimeValue(this.value));
         }
         try (EvaluationScopeContext ignored = openScope()) {
@@ -274,7 +280,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         if (task != null) {
             return ValueProducer.task(task);
         }
-        if (valueIsSelfContained) {
+        if (value.isSelfContained()) {
             return value.getProducer();
         }
         try (EvaluationScopeContext context = openScope()) {
@@ -289,7 +295,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
             visitor.execute(task);
             return;
         }
-        if (valueIsSelfContained) {
+        if (value.isSelfContained()) {
             value.visitContentProducerTasks(visitor);
             return;
         }
@@ -342,12 +348,12 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     protected void setSupplier(S supplier) {
         assertCanMutate();
-        setValue(state.explicitValue(supplier));
+        this.value = state.explicitValue(supplier);
     }
 
     protected void setConvention(S convention) {
         assertCanMutate();
-        setValue(state.applyConvention(value, convention));
+        this.value = state.applyConvention(value, convention);
     }
 
     /**
@@ -367,7 +373,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     private void finalizeNow(EvaluationScopeContext context, ValueConsumer consumer) {
         try {
-            setValue(finalValue(context, value, state.forUpstream(consumer)));
+            value = finalValue(context, value, state.forUpstream(consumer));
         } catch (Exception e) {
             if (displayName != null) {
                 throw new PropertyQueryException(String.format("Failed to calculate the value of %s.", displayName), e);
@@ -393,10 +399,10 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         if (isDefaultConvention()) {
             // special case: discarding value without a convention restores the initial state
             state.implicitValue(getDefaultConvention());
-            setValue(getDefaultValue());
+            value = getDefaultValue();
         } else {
             // otherwise, the convention will become the new value
-            setValue(state.implicitValue(state.convention()));
+            value = state.implicitValue(state.convention());
         }
     }
 
@@ -405,7 +411,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      */
     protected void discardConvention() {
         assertCanMutate();
-        setValue(state.applyConvention(value, getDefaultConvention()));
+        value = state.applyConvention(value, getDefaultConvention());
     }
 
     @Override
@@ -428,7 +434,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      */
     protected SupportsConvention setToConvention() {
         assertCanMutate();
-        setValue(state.setToConvention());
+        this.value = state.setToConvention();
         return this;
     }
 
@@ -442,7 +448,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     protected SupportsConvention setToConventionIfUnset() {
         assertCanMutate();
         if (!isDefaultConvention()) {
-            setValue(state.setToConventionIfUnset(value));
+            this.value = state.setToConventionIfUnset(value);
         }
         return this;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Describables;
@@ -236,6 +237,18 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         } else {
             try (EvaluationScopeContext context = openScope()) {
                 return getSupplier(context).getProducer();
+            }
+        }
+    }
+
+    @Override
+    public void visitContentProducerTasks(Action<? super Task> visitor) {
+        Task task = getProducerTask();
+        if (task != null) {
+            visitor.execute(task);
+        } else {
+            try (EvaluationScopeContext context = openScope()) {
+                getSupplier(context).visitContentProducerTasks(visitor);
             }
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -239,17 +239,19 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (EvaluationScopeContext context = openScope()) {
-            ExecutionTimeValue<? extends T> value = calculateOwnExecutionTimeValue(context, this.value);
-            if (getProducerTask() == null) {
-                return value;
-            } else {
-                return value.withChangingContent();
-            }
+        if (valueIsSelfContained) {
+            return withChangingContentIfProducedByTask(calculateOwnExecutionTimeValue(this.value));
+        }
+        try (EvaluationScopeContext ignored = openScope()) {
+            return withChangingContentIfProducedByTask(calculateOwnExecutionTimeValue(this.value));
         }
     }
 
-    protected abstract ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(EvaluationScopeContext context, S value);
+    private ExecutionTimeValue<? extends T> withChangingContentIfProducedByTask(ExecutionTimeValue<? extends T> value) {
+        return getProducerTask() == null ? value : value.withChangingContent();
+    }
+
+    protected abstract ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(S value);
 
     /**
      * Returns a diagnostic string describing the current source of value of this property. Should not realize the value.
@@ -271,10 +273,12 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         Task task = getProducerTask();
         if (task != null) {
             return ValueProducer.task(task);
-        } else {
-            try (EvaluationScopeContext context = openScope()) {
-                return getSupplier(context).getProducer();
-            }
+        }
+        if (valueIsSelfContained) {
+            return value.getProducer();
+        }
+        try (EvaluationScopeContext context = openScope()) {
+            return getSupplier(context).getProducer();
         }
     }
 
@@ -283,10 +287,14 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         Task task = getProducerTask();
         if (task != null) {
             visitor.execute(task);
-        } else {
-            try (EvaluationScopeContext context = openScope()) {
-                getSupplier(context).visitContentProducerTasks(visitor);
-            }
+            return;
+        }
+        if (valueIsSelfContained) {
+            value.visitContentProducerTasks(visitor);
+            return;
+        }
+        try (EvaluationScopeContext context = openScope()) {
+            getSupplier(context).visitContentProducerTasks(visitor);
         }
     }
 
@@ -529,7 +537,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         @Override
         public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
             try (EvaluationScopeContext context = openScope()) {
-                return calculateOwnExecutionTimeValue(context, copiedValue);
+                return calculateOwnExecutionTimeValue(copiedValue);
             }
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -53,13 +53,23 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     private DisplayName displayName;
     private ValueState<S> state;
     private S value;
+    // Kept in sync with value by setValue(), so that reads test a field instead of the supplier.
+    private boolean valueIsSelfContained;
 
     public AbstractProperty(PropertyHost host) {
         state = ValueState.newState(host);
     }
 
+    /**
+     * The only place {@link #value} is assigned, so {@link #valueIsSelfContained} cannot drift out of sync.
+     */
+    private void setValue(S newValue) {
+        this.value = newValue;
+        this.valueIsSelfContained = newValue.isSelfContained();
+    }
+
     protected void init(S initialValue, S convention) {
-        this.value = initialValue;
+        setValue(initialValue);
         this.state.setConvention(convention);
     }
 
@@ -82,18 +92,41 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
+        if (canReadWithoutScope(consumer)) {
+            return doCalculatePresence(consumer);
+        }
         try (EvaluationScopeContext context = openScope()) {
             beforeRead(context, consumer); // may throw its own exception, which should not be wrapped.
-            try {
-                return getSupplier(context).calculatePresence(consumer);
-            } catch (Exception e) {
-                if (displayName != null) {
-                    throw new PropertyQueryException(String.format("Failed to query the value of %s.", displayName), e);
-                } else {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
+            return doCalculatePresence(consumer);
+        }
+    }
+
+    private boolean doCalculatePresence(ValueConsumer consumer) {
+        try {
+            return value.calculatePresence(consumer);
+        } catch (Exception e) {
+            if (displayName != null) {
+                throw new PropertyQueryException(String.format("Failed to query the value of %s.", displayName), e);
+            } else {
+                throw UncheckedException.throwAsUncheckedException(e);
             }
         }
+    }
+
+    /**
+     * Whether this read can skip the cycle-detection scope.
+     * <p>
+     * Safe only when the supplier {@link ValueSupplier#isSelfContained() evaluates nothing else}, so
+     * nothing can re-enter this property, and when the read has nothing to prepare - consulting the host
+     * or finalizing both have to happen inside a scope, the latter because {@link #finalValue} may
+     * evaluate upstream providers.
+     * <p>
+     * Deliberately asks {@link ValueState#needsReadPreparation} rather than calling
+     * {@code maybeFinalizeOnRead} here: that would consult the host, and the slow path consults it
+     * again, so the host would see two calls per read.
+     */
+    private boolean canReadWithoutScope(ValueConsumer consumer) {
+        return valueIsSelfContained && !state.needsReadPreparation(consumer);
     }
 
     @Override
@@ -157,24 +190,28 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     }
 
     protected Value<? extends T> calculateOwnValueNoProducer(ValueConsumer consumer) {
-        try (EvaluationScopeContext context = openScope()) {
-            beforeReadNoProducer(context, consumer);
-            return doCalculateValue(context, consumer);
-        }
+        return calculateOwnValue(null, consumer);
     }
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        return calculateOwnValue(producer, consumer);
+    }
+
+    private Value<? extends T> calculateOwnValue(@Nullable ModelObject effectiveProducer, ValueConsumer consumer) {
+        if (canReadWithoutScope(consumer)) {
+            return doCalculateValue(consumer);
+        }
         try (EvaluationScopeContext context = openScope()) {
-            beforeRead(context, consumer);
-            return doCalculateValue(context, consumer);
+            beforeRead(context, effectiveProducer, consumer);
+            return doCalculateValue(consumer);
         }
     }
 
     @NonNull
-    private Value<? extends T> doCalculateValue(EvaluationScopeContext context, ValueConsumer consumer) {
+    private Value<? extends T> doCalculateValue(ValueConsumer consumer) {
         try {
-            return calculateValueFrom(context, value, consumer);
+            return calculateValueFrom(value, consumer);
         } catch (Exception e) {
             if (displayName != null) {
                 throw new PropertyQueryException(String.format("Failed to query the value of %s.", displayName), e);
@@ -198,7 +235,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         );
     }
 
-    protected abstract Value<? extends T> calculateValueFrom(EvaluationScopeContext context, S value, ValueConsumer consumer);
+    protected abstract Value<? extends T> calculateValueFrom(S value, ValueConsumer consumer);
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
@@ -297,12 +334,12 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     protected void setSupplier(S supplier) {
         assertCanMutate();
-        this.value = state.explicitValue(supplier);
+        setValue(state.explicitValue(supplier));
     }
 
     protected void setConvention(S convention) {
         assertCanMutate();
-        this.value = state.applyConvention(value, convention);
+        setValue(state.applyConvention(value, convention));
     }
 
     /**
@@ -322,7 +359,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     private void finalizeNow(EvaluationScopeContext context, ValueConsumer consumer) {
         try {
-            value = finalValue(context, value, state.forUpstream(consumer));
+            setValue(finalValue(context, value, state.forUpstream(consumer)));
         } catch (Exception e) {
             if (displayName != null) {
                 throw new PropertyQueryException(String.format("Failed to calculate the value of %s.", displayName), e);
@@ -348,10 +385,10 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         if (isDefaultConvention()) {
             // special case: discarding value without a convention restores the initial state
             state.implicitValue(getDefaultConvention());
-            value = getDefaultValue();
+            setValue(getDefaultValue());
         } else {
             // otherwise, the convention will become the new value
-            value = state.implicitValue(state.convention());
+            setValue(state.implicitValue(state.convention()));
         }
     }
 
@@ -360,7 +397,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      */
     protected void discardConvention() {
         assertCanMutate();
-        value = state.applyConvention(value, getDefaultConvention());
+        setValue(state.applyConvention(value, getDefaultConvention()));
     }
 
     @Override
@@ -383,7 +420,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      */
     protected SupportsConvention setToConvention() {
         assertCanMutate();
-        this.value = state.setToConvention();
+        setValue(state.setToConvention());
         return this;
     }
 
@@ -397,7 +434,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     protected SupportsConvention setToConventionIfUnset() {
         assertCanMutate();
         if (!isDefaultConvention()) {
-            this.value = state.setToConventionIfUnset(value);
+            setValue(state.setToConventionIfUnset(value));
         }
         return this;
     }
@@ -499,7 +536,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         @Override
         protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
             try (EvaluationScopeContext context = openScope()) {
-                return calculateValueFrom(context, copiedValue, consumer);
+                return calculateValueFrom(copiedValue, consumer);
             }
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AppendOnceList.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AppendOnceList.java
@@ -17,12 +17,12 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 
 import javax.annotation.CheckReturnValue;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -119,7 +119,25 @@ class AppendOnceList<E> implements Iterable<E> {
      */
     @Override
     public Iterator<E> iterator() {
-        return Iterators.unmodifiableIterator(getItems().iterator());
+        // Deliberately not getItems().iterator(): this is iterated on every read of a collection
+        // property, and the subList + its iterator + the unmodifiable wrapper are three allocations
+        // where an index cursor over the shared buffer needs one.
+        return new Iterator<E>() {
+            private int index;
+
+            @Override
+            public boolean hasNext() {
+                return index < size;
+            }
+
+            @Override
+            public E next() {
+                if (index >= size) {
+                    throw new NoSuchElementException();
+                }
+                return buffer.get(index++);
+            }
+        };
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -30,5 +30,16 @@ public interface Collector<T> extends ValueSupplier {
 
     int size();
 
+    /**
+     * A lower bound on {@link #size()} that is cheap to compute.
+     * <p>
+     * Unlike {@code size()}, this never evaluates a provider - {@code ElementsFromCollectionProvider.size()}
+     * realises the whole upstream value, which would defeat the point of asking. Used only to presize the
+     * builder, so an underestimate costs a resize and nothing else.
+     */
+    default int sizeHint() {
+        return 0;
+    }
+
     ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -20,6 +20,8 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
@@ -125,6 +127,11 @@ public class Collectors {
         @Override
         public ValueProducer getProducer() {
             return provider.getProducer();
+        }
+
+        @Override
+        public void visitContentProducerTasks(Action<? super Task> visitor) {
+            provider.visitContentProducerTasks(visitor);
         }
 
         @Override
@@ -260,6 +267,11 @@ public class Collectors {
         }
 
         @Override
+        public void visitContentProducerTasks(Action<? super Task> visitor) {
+            provider.visitContentProducerTasks(visitor);
+        }
+
+        @Override
         public boolean isProvidedBy(Provider<?> provider) {
             return Objects.equal(this.provider, provider);
         }
@@ -380,6 +392,11 @@ public class Collectors {
         @Override
         public ValueProducer getProducer() {
             return delegate.getProducer();
+        }
+
+        @Override
+        public void visitContentProducerTasks(Action<? super Task> visitor) {
+            delegate.visitContentProducerTasks(visitor);
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -26,6 +26,7 @@ import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
 
@@ -77,6 +78,11 @@ public class Collectors {
         @Override
         public int hashCode() {
             return Objects.hashCode(element);
+        }
+
+        @Override
+        public int sizeHint() {
+            return 1;
         }
 
         @Override
@@ -152,6 +158,12 @@ public class Collectors {
         }
 
         @Override
+        public int sizeHint() {
+            // Exactly one element, and knowing that does not require evaluating the provider.
+            return 1;
+        }
+
+        @Override
         public int size() {
             return 1;
         }
@@ -216,6 +228,12 @@ public class Collectors {
         @Override
         public int hashCode() {
             return Objects.hashCode(value);
+        }
+
+        @Override
+        public int sizeHint() {
+            // Only when it is O(1); a general Iterable would have to be traversed.
+            return value instanceof Collection ? ((Collection<?>) value).size() : 0;
         }
 
         @Override
@@ -339,6 +357,11 @@ public class Collectors {
         }
 
         @Override
+        public int sizeHint() {
+            return value.length;
+        }
+
+        @Override
         public int size() {
             return value.length;
         }
@@ -397,6 +420,11 @@ public class Collectors {
         @Override
         public void visitContentProducerTasks(Action<? super Task> visitor) {
             delegate.visitContentProducerTasks(visitor);
+        }
+
+        @Override
+        public int sizeHint() {
+            return delegate.sizeHint();
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ContentProducerCheck.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ContentProducerCheck.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.jspecify.annotations.Nullable;
+
+final class ContentProducerCheck {
+
+    private static final Action<Task> FAIL_ON_UNEXECUTED = task -> {
+        if (!task.getState().getExecuted()) {
+            throw new UnexecutedProducerException(task);
+        }
+    };
+
+    /**
+     * Returns the first task producing the content of {@code provider} that has not executed yet, or
+     * {@code null} when there is none.
+     * <p>
+     * The task is carried out by unwinding rather than captured by the visitor for two reasons. The
+     * visitor stays a constant, so this costs nothing on the path where every producer has executed -
+     * which is every read of every mapped provider. And the caller gets to describe the provider once
+     * the evaluation scopes opened by the visit have closed; describing it during the visit would
+     * render it as {@code <CIRCULAR REFERENCE>}.
+     */
+    @Nullable
+    static Task findUnexecutedContentProducer(ProviderInternal<?> provider) {
+        try {
+            provider.visitContentProducerTasks(FAIL_ON_UNEXECUTED);
+            return null;
+        } catch (UnexecutedProducerException e) {
+            return e.task;
+        }
+    }
+
+    private ContentProducerCheck() {
+    }
+
+    private static final class UnexecutedProducerException extends RuntimeException {
+        private final Task task;
+
+        UnexecutedProducerException(Task task) {
+            // Used for control flow only, so no message, no stack trace.
+            super(null, null, false, false);
+            this.task = task;
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,19 +18,19 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.internal.lambdas.SerializableLambdas.SerializableSupplier;
+import org.gradle.api.internal.lambdas.SerializableLambdas.SerializableIntFunction;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
-import java.util.function.Supplier;
+import java.util.function.IntFunction;
 
 import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T>> implements ListProperty<T> {
-    private static final SerializableSupplier<ImmutableCollection.Builder<Object>> FACTORY = ImmutableList::builder;
+    private static final SerializableIntFunction<ImmutableCollection.Builder<Object>> FACTORY = ImmutableList::builderWithExpectedSize;
 
     public DefaultListProperty(PropertyHost host, Class<T> elementType) {
         super(host, new ValidatingValueCollector<>(List.class, elementType, ValueSanitizers.forType(elementType)), elementType);
@@ -42,7 +42,7 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     }
 
     @Override
-    protected final Supplier<ImmutableCollection.Builder<T>> getCollectionFactory() {
+    protected final IntFunction<ImmutableCollection.Builder<T>> getCollectionFactory() {
         return Cast.uncheckedNonnullCast(FACTORY);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -362,7 +362,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(EvaluationScopeContext context, MapSupplier<K, V> value) {
+    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(MapSupplier<K, V> value) {
         return value.calculateExecutionTimeValue();
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -31,7 +31,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.jspecify.annotations.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +57,11 @@ import static org.gradle.internal.Cast.uncheckedNonnullCast;
 public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSupplier<K, V>> implements MapProperty<K, V>, MapProviderInternal<K, V>, MapPropertyInternal<K, V> {
     private static final String NULL_KEY_FORBIDDEN_MESSAGE = String.format("Cannot add an entry with a null key to a property of type %s.", Map.class.getSimpleName());
     private static final String NULL_VALUE_FORBIDDEN_MESSAGE = String.format("Cannot add an entry with a null value to a property of type %s.", Map.class.getSimpleName());
+
+    /**
+     * See AbstractCollectionProperty.DEFAULT_BUILDER_CAPACITY.
+     */
+    private static final int DEFAULT_BUILDER_CAPACITY = 4;
 
     private final Class<K> keyType;
     private final Class<V> valueType;
@@ -611,7 +615,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
                 // buildKeepingLast() gives the same last-wins semantics as putting into a LinkedHashMap,
                 // which is what MapProperty needs because a provider may override entries of earlier ones.
                 // Building straight into the ImmutableMap.Builder avoids materialising the map twice.
-                ImmutableMap.<K, V>builderWithExpectedSize(collectors.size()),
+                ImmutableMap.<K, V>builderWithExpectedSize(Math.max(collectors.size(), DEFAULT_BUILDER_CAPACITY)),
                 ImmutableMap.Builder::buildKeepingLast
             );
         }
@@ -636,7 +640,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             SideEffectBuilder<Map<K, V>> sideEffectBuilder
         ) {
             // See calculateOwnValue for why buildKeepingLast().
-            ImmutableMap.Builder<K, V> entries = ImmutableMap.builderWithExpectedSize(values.size());
+            ImmutableMap.Builder<K, V> entries = ImmutableMap.builderWithExpectedSize(Math.max(values.size(), DEFAULT_BUILDER_CAPACITY));
             for (ExecutionTimeValue<? extends Map<K, V>> value : values) {
                 entryCollector.addAll(value.getFixedValue().entrySet(), entries);
                 sideEffectBuilder.add(SideEffect.fixedFrom(value));

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -345,7 +345,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected Value<? extends Map<K, V>> calculateValueFrom(EvaluationScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
+    protected Value<? extends Map<K, V>> calculateValueFrom(MapSupplier<K, V> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
@@ -441,6 +441,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
+        public boolean isSelfContained() {
+            return true;
+        }
+
+        @Override
         public MapSupplier<K, V> plus(MapCollector<K, V> collector) {
             // nothing + something = nothing.
             return this;
@@ -476,6 +481,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public Value<? extends Set<K>> calculateKeys(ValueConsumer consumer) {
             return Value.of(ImmutableSet.of());
+        }
+
+        @Override
+        public boolean isSelfContained() {
+            return true;
         }
 
         @Override
@@ -522,6 +532,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public Value<? extends Set<K>> calculateKeys(ValueConsumer consumer) {
             return Value.of(entries.keySet());
+        }
+
+        @Override
+        public boolean isSelfContained() {
+            return true;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -608,11 +608,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             // TODO - don't make a copy when the collector already produces an immutable collection
             return calculateValue(
                 (builder, collector) -> collector.collectEntries(consumer, entryCollector, builder),
-                // Cannot use ImmutableMap.Builder here, as it does not allow multiple entries with the same key, however the contract
-                // for MapProperty allows a provider to override the entries of earlier providers and so there can be multiple entries
-                // with the same key
-                new LinkedHashMap<K, V>(),
-                ImmutableMap::copyOf
+                // buildKeepingLast() gives the same last-wins semantics as putting into a LinkedHashMap,
+                // which is what MapProperty needs because a provider may override entries of earlier ones.
+                // Building straight into the ImmutableMap.Builder avoids materialising the map twice.
+                ImmutableMap.<K, V>builderWithExpectedSize(collectors.size()),
+                ImmutableMap.Builder::buildKeepingLast
             );
         }
 
@@ -635,15 +635,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             List<ExecutionTimeValue<? extends Map<K, V>>> values,
             SideEffectBuilder<Map<K, V>> sideEffectBuilder
         ) {
-            // Cannot use ImmutableMap.Builder here, as it does not allow multiple entries with the same key, however the contract
-            // for MapProperty allows a provider to override the entries of earlier providers and so there can be multiple entries
-            // with the same key.
-            Map<K, V> entries = new LinkedHashMap<>();
+            // See calculateOwnValue for why buildKeepingLast().
+            ImmutableMap.Builder<K, V> entries = ImmutableMap.builderWithExpectedSize(values.size());
             for (ExecutionTimeValue<? extends Map<K, V>> value : values) {
                 entryCollector.addAll(value.getFixedValue().entrySet(), entries);
                 sideEffectBuilder.add(SideEffect.fixedFrom(value));
             }
-            return ExecutionTimeValue.fixedValue(ImmutableMap.copyOf(entries));
+            return ExecutionTimeValue.fixedValue(entries.buildKeepingLast());
         }
 
         private ExecutionTimeValue<? extends Map<K, V>> calculateChangingExecutionTimeValue(
@@ -679,7 +677,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest) {
             collector.addAll(entries.entrySet(), dest);
             return sideEffect != null
                 ? Value.present().withSideEffect(SideEffect.fixed(entries, sideEffect))

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -148,7 +148,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(EvaluationScopeContext context, ProviderInternal<? extends T> value) {
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ProviderInternal<? extends T> value) {
         // Discard this property from a provider chain, as it does not contribute anything to the calculation.
         return value.calculateExecutionTimeValue();
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -154,7 +154,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected Value<? extends T> calculateValueFrom(EvaluationScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
+    protected Value<? extends T> calculateValueFrom(ProviderInternal<? extends T> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.internal.lambdas.SerializableLambdas.SerializableSupplier;
+import org.gradle.api.internal.lambdas.SerializableLambdas.SerializableIntFunction;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.Cast;
@@ -26,12 +26,12 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.IntFunction;
 
 import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>> implements SetProperty<T> {
-    private static final SerializableSupplier<ImmutableCollection.Builder<Object>> FACTORY = ImmutableSet::builder;
+    private static final SerializableIntFunction<ImmutableCollection.Builder<Object>> FACTORY = ImmutableSet::builderWithExpectedSize;
 
     /**
      * Convenience method to add a possibly-missing provider to a set property without clearing the set.
@@ -55,7 +55,7 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     }
 
     @Override
-    protected final Supplier<ImmutableCollection.Builder<T>> getCollectionFactory() {
+    protected final IntFunction<ImmutableCollection.Builder<T>> getCollectionFactory() {
         return Cast.uncheckedNonnullCast(FACTORY);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.jspecify.annotations.NonNull;
@@ -48,6 +50,13 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
     public ValueProducer getProducer() {
         try (EvaluationScopeContext ignored = openScope()) {
             return provider.getProducer();
+        }
+    }
+
+    @Override
+    public void visitContentProducerTasks(Action<? super Task> visitor) {
+        try (EvaluationScopeContext ignored = openScope()) {
+            provider.visitContentProducerTasks(visitor);
         }
     }
 
@@ -91,13 +100,12 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     protected void beforeRead(EvaluationScopeContext ignored) {
-        provider.getProducer().visitContentProducerTasks(producer -> {
-            if (!producer.getState().getExecuted()) {
-                throw new InvalidUserCodeException(
-                    String.format("Querying the filtered value of %s before %s has completed is not supported", provider, producer)
-                );
-            }
-        });
+        Task producer = ContentProducerCheck.findUnexecutedContentProducer(provider);
+        if (producer != null) {
+            throw new InvalidUserCodeException(
+                String.format("Querying the filtered value of %s before %s has completed is not supported", provider, producer)
+            );
+        }
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -29,7 +30,7 @@ import java.util.Map;
  */
 public interface MapCollector<K, V> extends ValueSupplier {
 
-    Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest);
+    Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest);
 
     Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest);
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -41,7 +41,7 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest) {
             collector.add(key, value, dest);
             return Value.present();
         }
@@ -100,7 +100,7 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest) {
             Value<? extends V> value = providerOfValue.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
@@ -158,7 +158,7 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest) {
             collector.addAll(entries.entrySet(), dest);
             return Value.present();
         }
@@ -199,7 +199,7 @@ public class MapCollectors {
         }
 
         @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, ImmutableMap.Builder<K, V> dest) {
             Value<? extends Map<? extends K, ? extends V>> value = providerOfEntries.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapEntryCollector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapEntryCollector.java
@@ -16,11 +16,13 @@
 
 package org.gradle.api.internal.provider;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 public interface MapEntryCollector<K, V> {
 
-    void add(K key, V value, Map<K, V> dest);
+    void add(K key, V value, ImmutableMap.Builder<K, V> dest);
 
-    void addAll(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Map<K, V> dest);
+    void addAll(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, ImmutableMap.Builder<K, V> dest);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -206,6 +206,11 @@ public class Providers {
         }
 
         @Override
+        public boolean isSelfContained() {
+            return true;
+        }
+
+        @Override
         public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
             return ExecutionTimeValue.fixedValue(value);
         }
@@ -258,6 +263,11 @@ public class Providers {
 
         @Override
         public boolean isImmutable() {
+            return true;
+        }
+
+        @Override
+        public boolean isSelfContained() {
             return true;
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.jspecify.annotations.NonNull;
@@ -61,6 +63,13 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
     }
 
     @Override
+    public void visitContentProducerTasks(Action<? super Task> visitor) {
+        try (EvaluationScopeContext ignored = openScope()) {
+            provider.visitContentProducerTasks(visitor);
+        }
+    }
+
+    @Override
     public ExecutionTimeValue<? extends OUT> calculateExecutionTimeValue() {
         try (EvaluationScopeContext context = openScope()) {
             ExecutionTimeValue<? extends IN> value = provider.calculateExecutionTimeValue();
@@ -92,13 +101,12 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
     }
 
     protected void beforeRead(EvaluationScopeContext context) {
-        provider.getProducer().visitContentProducerTasks(producer -> {
-            if (!producer.getState().getExecuted()) {
-                throw new InvalidUserCodeException(
-                    String.format("Querying the mapped value of %s before %s has completed is not supported", provider, producer)
-                );
-            }
-        });
+        Task producer = ContentProducerCheck.findUnexecutedContentProducer(provider);
+        if (producer != null) {
+            throw new InvalidUserCodeException(
+                String.format("Querying the mapped value of %s before %s has completed is not supported", provider, producer)
+            );
+        }
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -35,7 +36,7 @@ class ValidatingMapEntryCollector<K, V> implements MapEntryCollector<K, V> {
     }
 
     @Override
-    public void add(K key, V value, Map<K, V> dest) {
+    public void add(K key, V value, ImmutableMap.Builder<K, V> dest) {
         Preconditions.checkNotNull(
             key,
             "Cannot get the value of a property of type %s with key type %s as the source contains a null key.",
@@ -63,7 +64,7 @@ class ValidatingMapEntryCollector<K, V> implements MapEntryCollector<K, V> {
     }
 
     @Override
-    public void addAll(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, Map<K, V> dest) {
+    public void addAll(Iterable<? extends Map.Entry<? extends K, ? extends V>> entries, ImmutableMap.Builder<K, V> dest) {
         for (Map.Entry<? extends K, ? extends V> entry : entries) {
             add(entry.getKey(), entry.getValue(), dest);
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -124,6 +124,15 @@ public abstract class ValueState<S> {
 
     public abstract boolean maybeFinalizeOnRead(Describable displayName, @Nullable ModelObject producer, ValueSupplier.ValueConsumer consumer);
 
+    /**
+     * Whether a read has to do anything before the value can be produced - consult the host, or finalize.
+     * <p>
+     * When false, {@link #maybeFinalizeOnRead} would do nothing but return false, so a read holding a
+     * self-contained value can skip it entirely. Deliberately a pure test of the flags: it must not
+     * consult the host, because the point is to decide whether the host needs consulting at all.
+     */
+    public abstract boolean needsReadPreparation(ValueSupplier.ValueConsumer consumer);
+
     public abstract void beforeMutate(Describable displayName);
 
     public abstract ValueSupplier.ValueConsumer forUpstream(ValueSupplier.ValueConsumer consumer);
@@ -220,6 +229,12 @@ public abstract class ValueState<S> {
         @Override
         public ValueState<S> finalState() {
             return Cast.uncheckedCast(FINALIZED_VALUE);
+        }
+
+        @Override
+        public boolean needsReadPreparation(ValueSupplier.ValueConsumer consumer) {
+            return (flags & (DISALLOW_UNSAFE_READ | FINALIZE_ON_NEXT_GET)) != 0
+                || consumer == ValueSupplier.ValueConsumer.DisallowUnsafeRead;
         }
 
         @Override
@@ -424,6 +439,12 @@ public abstract class ValueState<S> {
         @Override
         public void disallowUnsafeRead() {
             // Finalized already so read is safe
+        }
+
+        @Override
+        public boolean needsReadPreparation(ValueSupplier.ValueConsumer consumer) {
+            // Already finalized, and the host was consulted when it was
+            return false;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -45,6 +45,22 @@ public interface ValueSupplier {
     ValueProducer getProducer();
 
     /**
+     * Whether obtaining this supplier's value evaluates nothing else.
+     * <p>
+     * True only for suppliers that already hold their value: computing it consults no other provider
+     * and runs no user code, so it cannot re-enter whatever is asking for it. A property backed by
+     * such a supplier can therefore be read without the {@link org.gradle.internal.evaluation.EvaluationContext}
+     * cycle-detection scope, which is around 60% of the cost of reading a property that holds a constant.
+     * <p>
+     * Defaults to false, and must stay false for anything that can reach user code. Note that
+     * finalization is <em>not</em> sufficient grounds to return true: a finalized property can still be
+     * backed by a supplier that instantiates something on read, such as a build service.
+     */
+    default boolean isSelfContained() {
+        return false;
+    }
+
+    /**
      * Visits the tasks that produce the content of this supplier's value.
      * <p>
      * Equivalent to {@code getProducer().visitContentProducerTasks(visitor)}, but implementations can

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -44,6 +44,18 @@ public interface ValueSupplier {
      */
     ValueProducer getProducer();
 
+    /**
+     * Visits the tasks that produce the content of this supplier's value.
+     * <p>
+     * Equivalent to {@code getProducer().visitContentProducerTasks(visitor)}, but implementations can
+     * override this to walk their inputs directly. That matters because this runs on every read of a
+     * mapped or filtered provider, where materializing the whole {@link ValueProducer} graph just to
+     * discover there is no producer task is pure overhead.
+     */
+    default void visitContentProducerTasks(Action<? super Task> visitor) {
+        getProducer().visitContentProducerTasks(visitor);
+    }
+
     boolean calculatePresence(ValueConsumer consumer);
 
     enum ValueConsumer {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
@@ -50,6 +50,13 @@ public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
+    public boolean isSelfContained() {
+        // The side effect is attached to the Value here and executed later by Value.get(), by which
+        // point the evaluation scope has already closed, so it does not affect re-entrance.
+        return provider.isSelfContained();
+    }
+
+    @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
         return provider.calculateValue(consumer).withSideEffect(sideEffect);
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/lambdas/SerializableLambdas.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 /**
@@ -105,6 +106,9 @@ public class SerializableLambdas {
     /**
      * A {@link Serializable} version of {@link Supplier}.
      */
+    public interface SerializableIntFunction<T> extends IntFunction<T>, Serializable {
+    }
+
     public interface SerializableSupplier<T> extends Supplier<T>, Serializable {
     }
 


### PR DESCRIPTION
## Reduce the cost of reading a Property

  Six optimisations to the read path of `Property`, `ListProperty`, `SetProperty` and `MapProperty`. No public API or behaviour change.

  ### What changed

  1. Cycle detection ran on every read. `AbstractProperty` opened an `EvaluationContext` scope for every `get()`, `isPresent()`, `calculateExecutionTimeValue()`, `getProducer()`
  and `visitContentProducerTasks()` — 3.4ns of a 5.1ns scalar read. A supplier that already holds its value evaluates nothing and runs no user code, so it cannot re-enter the property
  and the scope can never fire.

  2. `map {}` rebuilt the producer graph on every read. `TransformBackedProvider.beforeRead` called `getProducer()`, which for a collection property allocated a `ValueProducer`
  per collector plus a stream pipeline, only to find there was no producer task. Suppliers now walk their inputs directly.

  3. Map values were materialised twice. `MapProperty` built a `LinkedHashMap` and copied it into an `ImmutableMap`. It now builds straight into an `ImmutableMap.Builder` and
  finishes with `buildKeepingLast()`, which has the same last-wins semantics.

  4. Collection builders grew from their default capacity, now presized from a cheap `Collector.sizeHint()`.

  ### Which reads get faster

  The scope is skipped when the property's supplier already holds its value: an explicit or convention **constant**, **any finalized property** (`withFinalValue()` collapses almost
  every provider to a fixed value, so finalized task inputs qualify), and **a property wired to another such property** (`b.set(a)`).

  It is not skipped for a non-finalized provider-backed property, a collection property that still has collectors, or a build service provider — `RegisteredBuildServiceProvider`
  survives finalization and instantiates the service on read, so "finalized" alone is not sufficient grounds to skip cycle detection.

  Changes 2–4 are not limited to constants and speed up mapped and collection reads generally.

  ### Measurements

  JMH, JDK 25, 5 forks × (5 warmup + 5 measurement) × 1s, `-prof gc`. Percentages rounded down.

  ```
  Operation                 Property value                  before             after             time  alloc
  ────────────────────────  ──────────────────────────────  ─────────────────  ────────────────  ────  ─────
  property.isPresent()      set("value")                    4.835 ns / 0 B     0.978 ns / 0 B    -79%      —
  property.get()            set("value")                    5.083 ns / 0 B     1.212 ns / 0 B    -76%      —
  property.get()            convention("value")             5.294 ns / 0 B     1.199 ns / 0 B    -77%      —
  property.get()            set("value") + finalizeValue()  4.96 ns / 0 B      1.104 ns / 0 B    -77%      —
  property.get()            set(other), other.set("value")  19.86 ns / 24 B    6.119 ns / 24 B   -69%     0%
  property.get()            chain of 3 properties           24.873 ns / 24 B   12.194 ns / 24 B  -50%     0%
  property.get()            chain of 9 properties           78.669 ns / 24 B   64.763 ns / 24 B  -17%     0%
  property.map{}.get()      set("value")                    45.776 ns / 48 B   5.84 ns / ~0 B    -87%  -100%
  listProperty.get()        add("e") x10                    155 ns / 296 B     77.42 ns / 115 B  -50%   -61%
  listProperty.get()        add(provider) x10               204 ns / 512 B     111.9 ns / 336 B  -45%   -34%
  listProperty.map{}.get()  add("e") x10                    238.1 ns / 627 B   117.4 ns / 125 B  -50%   -80%
  listProperty.isPresent()  add("e") x10                    11.047 ns / 0 B    10.021 ns / 0 B    -9%      —
  mapProperty.get()         put("k","v") x10                309 ns / 1070 B    276.2 ns / 490 B  -10%   -54%
  mapProperty.get()         put("k", provider) x10          377.7 ns / 1288 B  193 ns / 704 B    -48%   -45%
  ```

  Notes:

  - Property-to-property wiring keeps its 24 B: the `Present` produced by the inner property escapes into the outer one's return value, so escape analysis cannot remove it. Only the
  scope cost goes away.
  - `chain of 9 properties` runs past the lookahead bound, so its outer links walk four suppliers, answer false, and open a scope anyway. It is still faster, because the inner links
  skip theirs.
  - `mapProperty.get()` with constant entries is the noisiest row (±37 ns); its allocation drop is the solid result. Isolating the map build step: 144.7 → 71.0 ns, 2× faster, 55% less
  allocation.
  - `—` in the `alloc` column means the operation allocated nothing before or after.

  Benchmarks included: `ProviderHotPathBenchmark`, `ScalarPropertyGetBenchmark`. Retained heap per property is unchanged.

  ### Notes for reviewers

  - `ValueSupplier.isSelfContained(int)` is a correctness surface: it must stay `false` for anything that can reach user code. The `int` is a lookahead bound, and any implementation
  that delegates must spend a link — a property can be reachable from its own supplier (`p.set(p)`, or `a.set(b)` with `b.set(a)`), so unbounded delegation would not terminate.
  Answering `false` is always safe.
  - `calculateValueFrom` and `calculateOwnExecutionTimeValue` lost their `EvaluationScopeContext` parameter — a token asserting a scope was open, which the fast path deliberately does
  not do. No implementation used it.
  - `MapCollector` / `MapEntryCollector` take an `ImmutableMap.Builder` instead of a `Map`. Internal, no usages outside the package.
  - `sizeHint()` deliberately does not reuse `Collector.size()`, which for a provider-backed collector realizes the whole upstream value. It is floored at the builder's default
  capacity, since presizing to an unknown contributor's hint of zero is worse than not presizing at all.