### PR TITLE
Reduce gradle memory usage: Transformed artifact files only

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenArtifacts;
@@ -85,6 +86,10 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
         return FileCollectionStructureVisitor.VisitType.Visit;
     }
 
+    /**
+     * A transform chain execution for a single artifact. Thread safe: the result is computed at most once,
+     * regardless of how many threads call {@link #startFinalization}, {@link #run} or {@link #visit} concurrently.
+     */
     public static class TransformedArtifact implements ResolvedArtifactSet.Artifacts, RunnableBuildOperation {
         private final DisplayName artifactSetName;
         private final ImmutableCapabilities capabilities;
@@ -92,7 +97,10 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
         private final ResolvableArtifact artifact;
         private final ImmutableAttributes target;
         private final List<BoundTransformStep> transformSteps;
-        private @Nullable Try<ImmutableList<File>> transformedFiles;
+
+        // The terminal result, set at most once via setResult(). Volatile, so an available result is read without synchronization.
+        private volatile @Nullable Try<ImmutableList<File>> transformedFiles;
+        // The pending invocation, created at most once and released when the result is set. Guarded by this instance's monitor.
         private @Nullable Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles;
 
         public TransformedArtifact(
@@ -135,6 +143,13 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
             return transformSteps;
         }
 
+        @VisibleForTesting
+        boolean hasPendingInvocation() {
+            synchronized (this) {
+                return deferredTransformedFiles != null;
+            }
+        }
+
         @Override
         public void prepareForVisitingIfNotAlready() {
             // The parameters of the transforms should already be isolated prior to visiting this set.
@@ -166,73 +181,88 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
          * Returns true if this artifact should be queued for execution, false when a value is already available.
          */
         private boolean prepareInvocation() {
-            synchronized (this) {
-                if (transformedFiles != null) {
-                    // Already have a result, no need to execute
-                    return false;
-                }
+            if (transformedFiles != null) {
+                // Already have a result, no need to execute
+                return false;
             }
             if (!artifact.getFileSource().isFinalized()) {
                 // No input artifact yet, should execute
                 return true;
             }
-            Try<File> inputFile = artifact.getFileSource().getValue();
-            Optional<Throwable> inputFailure = inputFile.getFailure();
+            Optional<Throwable> inputFailure = artifact.getFileSource().getValue().getFailure();
             if (inputFailure.isPresent()) {
-                synchronized (this) {
-                    // Failed to resolve input artifact, no need to execute
-                    transformedFiles = Try.failure(inputFailure.get());
-                    return false;
-                }
+                // Failed to resolve the input artifact, no need to execute
+                setResult(Try.failure(inputFailure.get()));
+                return false;
             }
 
-            Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles = createDeferredTransformedFiles();
-            synchronized (this) {
-                if (deferredTransformedFiles.getCompleted().isPresent()) {
-                    // Have already executed the transform, no need to execute
-                    transformedFiles = deferredTransformedFiles.getCompleted().get();
-                    this.deferredTransformedFiles = null;
-                    return false;
-                } else {
-                    // Have not executed the transform, should execute
-                    this.deferredTransformedFiles = deferredTransformedFiles;
-                    return true;
-                }
+            Deferrable<Try<ImmutableList<File>>> invocation = invocationForExecution();
+            if (invocation == null) {
+                // A result became available concurrently, no need to execute
+                return false;
             }
+            Optional<Try<ImmutableList<File>>> completed = invocation.getCompleted();
+            if (completed.isPresent()) {
+                // Have already executed the transform, no need to execute
+                setResult(completed.get());
+                return false;
+            }
+            // Have not executed the transform, should execute
+            return true;
         }
 
         private Try<ImmutableList<File>> finalizeValue() {
-            synchronized (this) {
-                if (transformedFiles != null) {
-                    return transformedFiles;
-                }
+            Try<ImmutableList<File>> result = transformedFiles;
+            if (result != null) {
+                return result;
             }
 
             artifact.getFileSource().finalizeIfNotAlready();
-            Try<File> inputFile = artifact.getFileSource().getValue();
-            Optional<Throwable> inputFailure = inputFile.getFailure();
+            Optional<Throwable> inputFailure = artifact.getFileSource().getValue().getFailure();
             if (inputFailure.isPresent()) {
-                synchronized (this) {
-                    // Failed to resolve input artifact
-                    transformedFiles = Try.failure(inputFailure.get());
-                    return transformedFiles;
+                // Failed to resolve the input artifact
+                return setResult(Try.failure(inputFailure.get()));
+            }
+
+            Deferrable<Try<ImmutableList<File>>> invocation = invocationForExecution();
+            if (invocation != null) {
+                return setResult(invocation.completeAndGet());
+            }
+            // A concurrent invocation has already set the result
+            return Objects.requireNonNull(transformedFiles);
+        }
+
+        /**
+         * Returns the invocation of the transform chain, creating it on first use, or null when the result is already available.
+         * The invocation is created at most once, since its creation is expensive and has side effects. Creation deliberately
+         * runs under the monitor; this is safe because it never calls back into this instance.
+         */
+        private @Nullable Deferrable<Try<ImmutableList<File>>> invocationForExecution() {
+            synchronized (this) {
+                if (transformedFiles != null) {
+                    return null;
                 }
+                Deferrable<Try<ImmutableList<File>>> currentDeferred = deferredTransformedFiles;
+                if (currentDeferred == null) {
+                    currentDeferred = createDeferredTransformedFiles();
+                    deferredTransformedFiles = currentDeferred;
+                }
+                return currentDeferred;
             }
+        }
 
-            Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles;
+        /**
+         * Sets the terminal result unless already set and releases the invocation machinery.
+         */
+        private Try<ImmutableList<File>> setResult(Try<ImmutableList<File>> result) {
             synchronized (this) {
-                deferredTransformedFiles = this.deferredTransformedFiles;
-            }
-
-            if (deferredTransformedFiles == null) {
-                deferredTransformedFiles = createDeferredTransformedFiles();
-            }
-            Try<ImmutableList<File>> result = deferredTransformedFiles.completeAndGet();
-            synchronized (this) {
-                transformedFiles = result;
-                // Only the files are needed from now on, release the invocation machinery
-                this.deferredTransformedFiles = null;
-                return result;
+                Try<ImmutableList<File>> currentTransformedFiles = transformedFiles;
+                if (currentTransformedFiles == null) {
+                    currentTransformedFiles = result;
+                    transformedFiles = result;
+                }
+                deferredTransformedFiles = null;
+                return currentTransformedFiles;
             }
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenArtifacts;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -29,6 +28,7 @@ import org.gradle.internal.Deferrable;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Try;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -37,6 +37,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Visitor {
     private final List<BoundTransformStep> transformSteps;
@@ -90,8 +92,8 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
         private final ResolvableArtifact artifact;
         private final ImmutableAttributes target;
         private final List<BoundTransformStep> transformSteps;
-        private Try<TransformStepSubject> transformedSubject;
-        private Deferrable<Try<TransformStepSubject>> invocation;
+        private @Nullable Try<ImmutableList<File>> transformedFiles;
+        private @Nullable Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles;
 
         public TransformedArtifact(
             DisplayName artifactSetName,
@@ -165,7 +167,7 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
          */
         private boolean prepareInvocation() {
             synchronized (this) {
-                if (transformedSubject != null) {
+                if (transformedFiles != null) {
                     // Already have a result, no need to execute
                     return false;
                 }
@@ -174,80 +176,93 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
                 // No input artifact yet, should execute
                 return true;
             }
-            if (!artifact.getFileSource().getValue().isSuccessful()) {
+            Try<File> inputFile = artifact.getFileSource().getValue();
+            Optional<Throwable> inputFailure = inputFile.getFailure();
+            if (inputFailure.isPresent()) {
                 synchronized (this) {
                     // Failed to resolve input artifact, no need to execute
-                    transformedSubject = Try.failure(artifact.getFileSource().getValue().getFailure().get());
+                    transformedFiles = Try.failure(inputFailure.get());
                     return false;
                 }
             }
 
-            Deferrable<Try<TransformStepSubject>> invocation = createInvocation();
+            Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles = createDeferredTransformedFiles();
             synchronized (this) {
-                this.invocation = invocation;
-                if (invocation.getCompleted().isPresent()) {
+                if (deferredTransformedFiles.getCompleted().isPresent()) {
                     // Have already executed the transform, no need to execute
-                    transformedSubject = invocation.getCompleted().get();
+                    transformedFiles = deferredTransformedFiles.getCompleted().get();
+                    this.deferredTransformedFiles = null;
                     return false;
                 } else {
                     // Have not executed the transform, should execute
+                    this.deferredTransformedFiles = deferredTransformedFiles;
                     return true;
                 }
             }
         }
 
-        private Try<TransformStepSubject> finalizeValue() {
+        private Try<ImmutableList<File>> finalizeValue() {
             synchronized (this) {
-                if (transformedSubject != null) {
-                    return transformedSubject;
+                if (transformedFiles != null) {
+                    return transformedFiles;
                 }
             }
 
             artifact.getFileSource().finalizeIfNotAlready();
-            if (!artifact.getFileSource().getValue().isSuccessful()) {
+            Try<File> inputFile = artifact.getFileSource().getValue();
+            Optional<Throwable> inputFailure = inputFile.getFailure();
+            if (inputFailure.isPresent()) {
                 synchronized (this) {
-                    transformedSubject = Try.failure(artifact.getFileSource().getValue().getFailure().get());
-                    return transformedSubject;
+                    // Failed to resolve input artifact
+                    transformedFiles = Try.failure(inputFailure.get());
+                    return transformedFiles;
                 }
             }
 
-            Deferrable<Try<TransformStepSubject>> invocation;
+            Deferrable<Try<ImmutableList<File>>> deferredTransformedFiles;
             synchronized (this) {
-                invocation = this.invocation;
+                deferredTransformedFiles = this.deferredTransformedFiles;
             }
 
-            if (invocation == null) {
-                invocation = createInvocation();
+            if (deferredTransformedFiles == null) {
+                deferredTransformedFiles = createDeferredTransformedFiles();
             }
-            Try<TransformStepSubject> result = invocation.completeAndGet();
+            Try<ImmutableList<File>> result = deferredTransformedFiles.completeAndGet();
             synchronized (this) {
-                transformedSubject = result;
+                transformedFiles = result;
+                // Only the files are needed from now on, release the invocation machinery
+                this.deferredTransformedFiles = null;
                 return result;
             }
         }
 
-        private Deferrable<Try<TransformStepSubject>> createInvocation() {
+        private Deferrable<Try<ImmutableList<File>>> createDeferredTransformedFiles() {
             TransformStepSubject initialSubject = TransformStepSubject.initial(artifact);
             BoundTransformStep initialStep = transformSteps.get(0);
             Deferrable<Try<TransformStepSubject>> invocation = initialStep.getTransformStep()
                 .createInvocation(initialSubject, initialStep.getUpstreamDependencies(), null);
             for (int i = 1; i < transformSteps.size(); i++) {
                 BoundTransformStep nextStep = transformSteps.get(i);
-                invocation = invocation
-                    .flatMap(intermediateResult -> intermediateResult
-                        .map(intermediateSubject -> nextStep.getTransformStep()
-                            .createInvocation(intermediateSubject, nextStep.getUpstreamDependencies(), null))
-                        .getOrMapFailure(failure -> Deferrable.completed(Try.failure(failure))));
+                invocation = invocation.flatMap(previousResult -> {
+                    if (previousResult.isSuccessful()) {
+                        // The subject of a successful invocation is never null
+                        TransformStepSubject previousSubject = Objects.requireNonNull(previousResult.get());
+                        return nextStep.getTransformStep().createInvocation(previousSubject, nextStep.getUpstreamDependencies(), null);
+                    }
+                    // Propagate the failure
+                    return Deferrable.completed(previousResult);
+                });
             }
-            return invocation;
+            // Keep only the files, so that the subject chain can be collected once the invocation completes
+            return invocation.map(result -> result.map(TransformStepSubject::getFiles));
         }
 
         @Override
         public void visit(ArtifactVisitor visitor) {
-            Try<TransformStepSubject> transformedSubject = finalizeValue();
-            transformedSubject.ifSuccessfulOrElse(
-                subject -> {
-                    for (File output : subject.getFiles()) {
+            Try<ImmutableList<File>> result = finalizeValue();
+            result.ifSuccessfulOrElse(
+                files -> {
+                    for (File output : files) {
                         ResolvableArtifact resolvedArtifact = artifact.transformedTo(output);
                         visitor.visitArtifact(artifactSetName, sourceVariantId, target, capabilities, resolvedArtifact);
                     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -35,7 +35,6 @@ class TransformingAsyncArtifactListenerTest extends Specification {
     def transformStep = Mock(TransformStep)
     def targetAttributes = Mock(ImmutableAttributes)
     def result = ImmutableList.<ResolvedArtifactSet.Artifacts>builder()
-    def invocation = Mock(Deferrable<TransformStepSubject>)
     def operationQueue = Mock(BuildOperationQueue)
     def listener = new TransformingAsyncArtifactListener([new BoundTransformStep(transformStep, Stub(TransformUpstreamDependencies))], targetAttributes, ImmutableCapabilities.EMPTY, result)
     def file = new File("foo")
@@ -54,6 +53,9 @@ class TransformingAsyncArtifactListenerTest extends Specification {
     def artifacts = Mock(ResolvedArtifactSet.Artifacts)
 
     def "adds expensive artifact transformations to the build operation queue"() {
+        given:
+        def pendingInvocation = Deferrable.deferred { throw new AssertionError("The invocation should be queued, not executed") }
+
         when:
         listener.visitArtifacts(artifacts)
         def artifacts = result.build()
@@ -67,12 +69,14 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         artifacts[0].startFinalization(operationQueue, true)
 
         then:
-        1 * transformStep.createInvocation(_, _, _) >> invocation
-        1 * invocation.getCompleted() >> Optional.empty()
+        1 * transformStep.createInvocation(_, _, _) >> pendingInvocation
         1 * operationQueue.add(_ as BuildOperation)
     }
 
     def "runs cheap artifact transformations immediately when not scheduled"() {
+        given:
+        def completedInvocation = Deferrable.completed(Try.successful(TransformStepSubject.initial(artifact)))
+
         when:
         listener.visitArtifacts(artifacts)
         def artifacts = result.build()
@@ -86,8 +90,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         artifacts[0].startFinalization(operationQueue, true)
 
         then:
-        1 * transformStep.createInvocation({ it.files == [this.artifactFile] }, _ as TransformUpstreamDependencies, _) >> invocation
-        2 * invocation.getCompleted() >> Optional.of(Try.successful(TransformStepSubject.initial(artifact)))
+        1 * transformStep.createInvocation({ it.files == [this.artifactFile] }, _ as TransformUpstreamDependencies, _) >> completedInvocation
         0 * operationQueue._
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -31,6 +31,8 @@ import org.gradle.internal.operations.BuildOperation
 import org.gradle.internal.operations.BuildOperationQueue
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class TransformingAsyncArtifactListenerTest extends Specification {
     def transformStep = Mock(TransformStep)
     def targetAttributes = Mock(ImmutableAttributes)
@@ -92,5 +94,93 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         then:
         1 * transformStep.createInvocation({ it.files == [this.artifactFile] }, _ as TransformUpstreamDependencies, _) >> completedInvocation
         0 * operationQueue._
+        !artifacts[0].hasPendingInvocation()
+    }
+
+    def "propagates the input artifact failure without queueing the transformation"() {
+        given:
+        def failure = new RuntimeException("broken")
+        def failedSource = Stub(CalculatedValue) {
+            isFinalized() >> true
+            getValue() >> Try.failure(failure)
+        }
+        def failedArtifact = Stub(ResolvableArtifact) {
+            getId() >> artifactId
+            getFileSource() >> failedSource
+        }
+        def visitor = Mock(ArtifactVisitor)
+
+        when:
+        listener.visitArtifacts(artifacts)
+        def transformed = result.build()
+
+        then:
+        transformed.size() == 1
+        1 * artifacts.visit(_) >> { ArtifactVisitor v -> v.visitArtifact(null, sourceVariantId, null, ImmutableCapabilities.EMPTY, failedArtifact) }
+        0 * _
+
+        when:
+        transformed[0].startFinalization(operationQueue, true)
+
+        then:
+        0 * transformStep._
+        0 * operationQueue._
+
+        when:
+        transformed[0].visit(visitor)
+
+        then:
+        1 * visitor.visitFailure({ it instanceof TransformException && it.cause == failure })
+        0 * _
+    }
+
+    def "creates the invocation only once under concurrent finalization"() {
+        given:
+        def outputArtifact = Stub(ResolvableArtifact)
+        def artifact = Stub(ResolvableArtifact) {
+            getId() >> artifactId
+            getFileSource() >> source
+            getFile() >> artifactFile
+            transformedTo(_) >> outputArtifact
+        }
+        def invocationCreations = new AtomicInteger()
+        def invocationExecutions = new AtomicInteger()
+        def visitor = Mock(ArtifactVisitor)
+        transformStep.createInvocation(_, _, _) >> {
+            invocationCreations.incrementAndGet()
+            // Give racing threads a chance to attempt a duplicate creation
+            Thread.sleep(10)
+            Deferrable.deferred {
+                invocationExecutions.incrementAndGet()
+                Try.successful(TransformStepSubject.initial(artifact))
+            }
+        }
+
+        when:
+        listener.visitArtifacts(artifacts)
+        def transformed = result.build()
+
+        then:
+        transformed.size() == 1
+        1 * artifacts.visit(_) >> { ArtifactVisitor v -> v.visitArtifact(null, sourceVariantId, null, ImmutableCapabilities.EMPTY, artifact) }
+        0 * _
+
+        when:
+        def threads = (1..8).collect {
+            Thread.start {
+                transformed[0].startFinalization(operationQueue, true)
+                transformed[0].run(null)
+                transformed[0].visit(visitor)
+            }
+        }
+        threads*.join(30_000)
+
+        then:
+        threads.every { !it.alive }
+        invocationCreations.get() == 1
+        invocationExecutions.get() == 1
+        8 * visitor.visitArtifact(null, sourceVariantId, targetAttributes, ImmutableCapabilities.EMPTY, outputArtifact)
+        0 * visitor.visitFailure(_)
+        !transformed[0].hasPendingInvocation()
     }
 }


### PR DESCRIPTION
Retain only transformed files in TransformedArtifact after execution
Once the transform chain for an artifact completes, only the resulting
files are needed for subsequent visits. Previously the calculated
invocation (Deferrable chain, lambdas, ImmutableTransformExecution) and
the TransformStepSubject chain stayed referenced for as long as the
artifact set itself, which is pinned by the scoped
DefaultTransformedVariantFactory cache for the lifetime of the build.

Store the result as Try<ImmutableList<File>> and release the invocation
at every completion point, so the execution machinery becomes garbage
immediately after finalization.

I also noticed that there were some race conditions and hard to read code (old createInvocation), so I refactored it a bit. This way heavy work is always executed at most once and code is more readable (in my opinion)

This saves ~308 mb of memory in a 3000 modules project. Here is the pipeline that measured this (it collected hprof files in a stable env of github runners - https://github.com/kroune/feature-module-3000/actions/runs/31890607981)

Note: since project didn't fully finish the sync and not all of dependencies were realized, for the project overall it saves likely more than 308 mb

The issue this pr partially addresses - https://github.com/gradle/gradle/issues/38752

### Contributor Checklist
- [+] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [+] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [+] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [+] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [+] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [+] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [+] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [+] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [+] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
