### PR TITLE
Update dynamic version after guava release

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/tests/richVersionsDirectDependencies.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/tests/richVersionsDirectDependencies.out
@@ -3,4 +3,4 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 +--- org.apache.httpcomponents:httpclient:4.5.4
 +--- commons-io:commons-io:{require [1.0, 2.0[; reject 1.4} -> 1.3.2
 +--- org.slf4j:slf4j-api:{strictly [1.0, 2.0[; prefer 1.7.25} -> 1.7.25
-\--- com.google.guava:guava:{require [33.0, 34.0[; reject 33.4.4-jre & 33.5.0-jre} -> 33.6.0-jre
+\--- com.google.guava:guava:{require [33.0, 34.0[; reject 33.4.4-jre & 33.5.0-jre} -> 33.7.0-jre


### PR DESCRIPTION
Guava released a new version. Our samples test tests for a specific version being selected, which may change as new guava versions are released.

We should probably make this version stable/reproducible using dependency locking, but in the mean time update the expected version until we make this sample reproducible


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
