### PR TITLE
Add an opt-out from configuration cache input tracking

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheInputTrackingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheInputTrackingIntegrationTest.groovy
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import org.gradle.process.ShellScript
+import spock.lang.Issue
+
+class ConfigurationCacheInputTrackingIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def configurationCache = new ConfigurationCacheFixture(this)
+
+    @Issue("https://github.com/gradle/gradle/issues/24203")
+    def "build cache service can refresh untracked credentials after configuration cache reuse"() {
+        given:
+        def credentialsProvider = ShellScript.builder().printEnvironmentVariable("CREDENTIALS").writeTo(testDirectory, "credentials-provider")
+        def profile = file("credentials.profile")
+        profile.text = credentialsProvider.commandLine.join(System.lineSeparator())
+
+        settingsFile << """
+            import org.gradle.api.configuration.ConfigurationCacheInputTracking
+            import org.gradle.api.provider.ProviderFactory
+            import org.gradle.caching.BuildCacheException
+            import org.gradle.caching.BuildCacheKey
+            import org.gradle.caching.BuildCacheService
+            import org.gradle.caching.BuildCacheServiceFactory
+            import org.gradle.caching.configuration.AbstractBuildCache
+
+            import javax.inject.Inject
+
+            interface CredentialsProviderFactory extends Serializable {
+                CredentialsProvider create()
+            }
+
+            class ProfileCredentialsProviderFactory implements CredentialsProviderFactory {
+                private final String profilePath
+
+                ProfileCredentialsProviderFactory(String profilePath) {
+                    this.profilePath = profilePath
+                }
+
+                @Override
+                CredentialsProvider create() {
+                    return new CredentialsProvider(profilePath)
+                }
+            }
+
+            class CredentialsProvider {
+                private final List<String> commandLine
+                private final Object nonSerializableState = new Object()
+
+                CredentialsProvider(String profilePath) {
+                    commandLine = new File(profilePath).readLines()
+                }
+
+                String resolveCredentials() {
+                    def standardOutput = new ByteArrayOutputStream()
+                    def process = commandLine.execute()
+                    process.waitForProcessOutput(standardOutput, System.err)
+                    if (process.exitValue() != 0) {
+                        throw new IllegalStateException("Credentials process failed")
+                    }
+                    return standardOutput.toString().trim()
+                }
+            }
+
+            class UntrackedCredentialsProvider {
+                private final CredentialsProvider delegate
+                private final ConfigurationCacheInputTracking inputTracking
+
+                UntrackedCredentialsProvider(CredentialsProvider delegate, ConfigurationCacheInputTracking inputTracking) {
+                    this.delegate = delegate
+                    this.inputTracking = inputTracking
+                }
+
+                String resolveCredentials() {
+                    return inputTracking.withInputTrackingDisabledUnsafe(delegate::resolveCredentials)
+                }
+            }
+
+            class CustomBuildCache extends AbstractBuildCache {
+                CredentialsProviderFactory credentialsProviderFactory
+            }
+
+            class CustomBuildCacheServiceFactory implements BuildCacheServiceFactory<CustomBuildCache> {
+                private final ConfigurationCacheInputTracking inputTracking
+                private final ProviderFactory providers
+
+                @Inject
+                CustomBuildCacheServiceFactory(ConfigurationCacheInputTracking inputTracking, ProviderFactory providers) {
+                    this.inputTracking = inputTracking
+                    this.providers = providers
+                }
+
+                @Override
+                BuildCacheService createBuildCacheService(CustomBuildCache configuration, Describer describer) {
+                    def credentialsProperty = inputTracking.withInputTrackingDisabledUnsafe(
+                        providers.gradleProperty("credentialsProperty")::get
+                    )
+                    def credentialsProvider = inputTracking.withInputTrackingDisabledUnsafe(
+                        configuration.credentialsProviderFactory::create
+                    )
+                    def untrackedCredentialsProvider = new UntrackedCredentialsProvider(credentialsProvider, inputTracking)
+                    println "credentials property during service creation = " + credentialsProperty
+                    println "credentials during service creation = " + untrackedCredentialsProvider.resolveCredentials()
+                    return new CustomBuildCacheService(untrackedCredentialsProvider)
+                }
+            }
+
+            class CustomBuildCacheService implements BuildCacheService {
+                private final UntrackedCredentialsProvider credentialsProvider
+
+                CustomBuildCacheService(UntrackedCredentialsProvider credentialsProvider) {
+                    this.credentialsProvider = credentialsProvider
+                }
+
+                @Override
+                boolean load(BuildCacheKey key, BuildCacheEntryReader reader) throws BuildCacheException {
+                    println "credentials during cache load = " + credentialsProvider.resolveCredentials()
+                    return false
+                }
+
+                @Override
+                void store(BuildCacheKey key, BuildCacheEntryWriter writer) throws BuildCacheException {
+                }
+
+                @Override
+                void close() throws IOException {
+                }
+            }
+
+            buildCache {
+                registerBuildCacheService(CustomBuildCache, CustomBuildCacheServiceFactory)
+                local {
+                    enabled = false
+                }
+                remote(CustomBuildCache) {
+                    push = true
+                    credentialsProviderFactory = new ProfileCredentialsProviderFactory(
+                        new File(settingsDir, "credentials.profile").absolutePath
+                    )
+                }
+            }
+        """
+        buildFile << """
+            plugins {
+                id("java")
+            }
+        """
+        file("src/main/java/Main.java") << "class Main {}"
+
+        when:
+        executer.withEnvironmentVars(
+            CREDENTIALS: "first-credentials",
+            ORG_GRADLE_PROJECT_credentialsProperty: "first-property"
+        )
+        configurationCacheRun("compileJava", "--build-cache")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("credentials property during service creation = first-property")
+        outputContains("credentials during service creation = CREDENTIALS=first-credentials")
+        outputContains("credentials during cache load = CREDENTIALS=first-credentials")
+
+        when:
+        executer.withEnvironmentVars(
+            CREDENTIALS: "second-credentials",
+            ORG_GRADLE_PROJECT_credentialsProperty: "second-property"
+        )
+        file("build").deleteDir()
+        configurationCacheRun("compileJava", "--build-cache")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("credentials property during service creation = second-property")
+        outputContains("credentials during service creation = CREDENTIALS=second-credentials")
+        outputContains("credentials during cache load = CREDENTIALS=second-credentials")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/java/org/gradle/internal/cc/impl/DefaultConfigurationCacheInputTracking.java
+++ b/platforms/core-configuration/configuration-cache/src/main/java/org/gradle/internal/cc/impl/DefaultConfigurationCacheInputTracking.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl;
+
+import org.gradle.api.configuration.ConfigurationCacheInputTracking;
+import org.gradle.internal.UncheckedException;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.concurrent.Callable;
+
+@NullMarked
+public final class DefaultConfigurationCacheInputTracking implements ConfigurationCacheInputTracking {
+
+    private final InputTrackingState inputTrackingState;
+
+    public DefaultConfigurationCacheInputTracking(InputTrackingState inputTrackingState) {
+        this.inputTrackingState = inputTrackingState;
+    }
+
+    @Override
+    public <T> T withInputTrackingDisabledUnsafe(Callable<? extends T> action) {
+        inputTrackingState.disableForCurrentThread();
+        try {
+            return action.call();
+        } catch (Exception ex) {
+            throw UncheckedException.throwAsUncheckedException(ex);
+        } finally {
+            inputTrackingState.restoreForCurrentThread();
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
+import org.gradle.api.configuration.ConfigurationCacheInputTracking
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentCache
@@ -95,6 +96,7 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
         // This was originally only for the configuration cache, but now used for configuration cache and problems reporting
         add(ProblemFactory::class.java, DefaultProblemFactory::class.java)
         add(InputTrackingState::class.java)
+        add(ConfigurationCacheInputTracking::class.java, DefaultConfigurationCacheInputTracking::class.java)
         add(InstrumentedExecutionAccessListener::class.java)
         add(ConfigurationCacheProblemsListener::class.java, DefaultConfigurationCacheProblemsListener::class.java)
         if (modelParameters.isIsolatedProjects) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -1004,7 +1004,8 @@ class ConfigurationCacheFingerprintWriter(
         propertyName: String,
         propertyValue: Any?
     ) {
-        if (!Workarounds.isIgnoredStartParameterProperty(propertyName)
+        if (!isInputTrackingDisabled()
+            && !Workarounds.isIgnoredStartParameterProperty(propertyName)
             && propertyTracking.shouldTrackPropertyAccess(propertyScope, propertyName)
         ) {
             // TODO:isolated could tracking per project

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheInputTrackingTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheInputTrackingTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+
+class DefaultConfigurationCacheInputTrackingTest {
+
+    private val inputTrackingState = InputTrackingState()
+    private val inputTracking = DefaultConfigurationCacheInputTracking(inputTrackingState)
+
+    @Test
+    fun `disables input tracking while action runs and restores it afterward`() {
+        val result = inputTracking.withInputTrackingDisabledUnsafe {
+            assertFalse(inputTrackingState.isEnabledForCurrentThread())
+            "result"
+        }
+
+        assertEquals("result", result)
+        assertTrue(inputTrackingState.isEnabledForCurrentThread())
+    }
+
+    @Test
+    fun `restores input tracking after action fails`() {
+        val failure = RuntimeException("broken")
+
+        try {
+            inputTracking.withInputTrackingDisabledUnsafe<String> {
+                assertFalse(inputTrackingState.isEnabledForCurrentThread())
+                throw failure
+            }
+            fail("Expected the action to fail")
+        } catch (ex: RuntimeException) {
+            assertSame(failure, ex)
+        }
+
+        assertTrue(inputTrackingState.isEnabledForCurrentThread())
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -101,6 +101,9 @@ The following services are available for injection in both project and settings 
 | <<buildfeatures,`BuildFeatures`>>
 | Reports whether features such as Configuration Cache and Isolated Projects are requested and active. Use it to branch plugin logic on whether the Configuration Cache or Isolated Projects is active.
 
+| <<configurationcacheinputtracking,`ConfigurationCacheInputTracking`>> incubating-label:[]
+| Suppresses automatic Configuration Cache input tracking for a narrow action. Use it only for volatile runtime state that cannot affect build configuration or the work Gradle executes.
+
 | <<flow_services,`FlowScope` and `FlowProviders`>> incubating-label:[]
 | Register dataflow actions that run on build lifecycle events such as build completion. Use them to run cleanup, notification, or reporting work at the end of every build.
 
@@ -490,6 +493,18 @@ include::{snippetsPath}/reference/plugin-development/reactingToBuildFeatures/gro
 <3> Use `getActive()` to read whether the feature is actually active in the current build, returning a non-empty `Provider<Boolean>`.
 
 You can learn more in the <<implementing_gradle_plugins_binary.adoc#sec:reacting_to_build_features,Implementing Binary Plugins guide>>.
+
+[[configurationcacheinputtracking]]
+== `ConfigurationCacheInputTracking` incubating-label:[]
+
+link:{javadocPath}/org/gradle/api/configuration/ConfigurationCacheInputTracking.html[`ConfigurationCacheInputTracking`] is a service that allows plugin infrastructure to run a narrow action without automatically recording the files, system properties, environment variables, or external processes it accesses as Configuration Cache inputs.
+
+This service is intended for volatile runtime state that cannot affect build configuration or the work Gradle executes.
+For example, a custom build cache implementation can use it to create and refresh a credentials provider that belongs to its non-serialized `BuildCacheService`.
+
+Calling `withInputTrackingDisabledUnsafe()` is unsafe when the observed value influences configuration.
+In that case, Gradle can reuse a Configuration Cache entry containing an incorrect task graph or other stale state.
+The scope affects only the current thread and does not disable instrumentation, file system watching, task input tracking, build cache key calculation, or serialization of returned values.
 
 [[flow_services]]
 == `FlowScope` and `FlowProviders` incubating-label:[]

--- a/platforms/enterprise/enterprise/build.gradle.kts
+++ b/platforms/enterprise/enterprise/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     api(projects.baseServices)
     api(projects.buildOperations)
     api(projects.enterpriseOperations)
-    api(projects.configurationCache)
     api(projects.core)
     api(projects.coreApi)
     api(projects.daemonServices)
@@ -37,12 +36,15 @@ dependencies {
     implementation(projects.serialization)
     implementation(projects.testingBase)
 
+    runtimeOnly(projects.configurationCache)
+
     implementation(libs.guava)
 
     compileOnly(libs.groovy) {
         because("some used APIs (e.g. FileTree.visit) provide methods taking Groovy closures which causes compile errors")
     }
 
+    testImplementation(projects.configurationCache)
     testImplementation(projects.resources)
     testImplementation(testFixtures(projects.core))
 

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultDevelocityPluginUnsafeConfigurationService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultDevelocityPluginUnsafeConfigurationService.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.enterprise.impl;
 
-import org.gradle.internal.cc.impl.InputTrackingState;
+import org.gradle.api.configuration.ConfigurationCacheInputTracking;
 import org.gradle.internal.enterprise.DevelocityPluginUnsafeConfigurationService;
 
 import javax.inject.Inject;
@@ -24,20 +24,15 @@ import java.util.function.Supplier;
 
 public class DefaultDevelocityPluginUnsafeConfigurationService implements DevelocityPluginUnsafeConfigurationService {
 
-    private final InputTrackingState inputTrackingState;
+    private final ConfigurationCacheInputTracking inputTracking;
 
     @Inject
-    public DefaultDevelocityPluginUnsafeConfigurationService(InputTrackingState inputTrackingState) {
-        this.inputTrackingState = inputTrackingState;
+    public DefaultDevelocityPluginUnsafeConfigurationService(ConfigurationCacheInputTracking inputTracking) {
+        this.inputTracking = inputTracking;
     }
 
     @Override
     public <T> T withConfigurationInputTrackingDisabled(Supplier<T> supplier) {
-        inputTrackingState.disableForCurrentThread();
-        try {
-            return supplier.get();
-        } finally {
-            inputTrackingState.restoreForCurrentThread();
-        }
+        return inputTracking.withInputTrackingDisabledUnsafe(supplier::get);
     }
 }

--- a/platforms/enterprise/enterprise/src/test/groovy/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutorsTest.groovy
+++ b/platforms/enterprise/enterprise/src/test/groovy/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutorsTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.enterprise.impl
 
+import org.gradle.internal.cc.impl.DefaultConfigurationCacheInputTracking
 import org.gradle.internal.cc.impl.InputTrackingState
 import spock.lang.Specification
 
@@ -26,7 +27,8 @@ class DefaultGradleEnterprisePluginBackgroundJobExecutorsTest extends Specificat
     DefaultGradleEnterprisePluginBackgroundJobExecutors jobExecutors
 
     void setup() {
-        jobExecutors = new DefaultGradleEnterprisePluginBackgroundJobExecutors(new DefaultDevelocityPluginUnsafeConfigurationService(new InputTrackingState()))
+        def inputTracking = new DefaultConfigurationCacheInputTracking(new InputTrackingState())
+        jobExecutors = new DefaultGradleEnterprisePluginBackgroundJobExecutors(new DefaultDevelocityPluginUnsafeConfigurationService(inputTracking))
     }
 
     void cleanup() {

--- a/subprojects/core-api/src/main/java/org/gradle/api/configuration/ConfigurationCacheInputTracking.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/configuration/ConfigurationCacheInputTracking.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.configuration;
+
+import org.gradle.api.Incubating;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Controls the automatic tracking of Configuration Cache inputs.
+ * <p>
+ * An instance of this type can be injected into a plugin or other object by annotating a public constructor or
+ * property getter method with {@code javax.inject.Inject}.
+ * <p>
+ * This service is intended for narrow infrastructure code that reads volatile runtime state which does not affect
+ * build configuration or the work Gradle executes. For example, a custom build cache implementation can use it when
+ * creating and refreshing a credentials provider that belongs to the non-serialized build cache service.
+ *
+ * @since 9.8.0
+ */
+@Incubating
+@ServiceScope(Scope.BuildTree.class)
+public interface ConfigurationCacheInputTracking {
+
+    /**
+     * Runs an action without recording the inputs that it reads as Configuration Cache inputs.
+     * <p>
+     * The scope applies to the current thread only and can be nested. Input tracking is restored when the action
+     * completes or throws an exception.
+     * <p>
+     * For example, calling {@link System#getenv(String)} from the action does not make the environment variable a
+     * Configuration Cache input. Obtaining a {@link org.gradle.api.provider.Provider Provider} backed by a
+     * {@link org.gradle.api.provider.ValueSource ValueSource}, such as one returned by
+     * {@link org.gradle.api.provider.ProviderFactory#environmentVariable(String)}, still records its value as a
+     * Configuration Cache input. The returned value is also subject to the usual Configuration Cache serialization
+     * rules if it is retained in serialized build state.
+     * <p>
+     * This method is unsafe. If an input read by the action affects build configuration or the work Gradle executes,
+     * suppressing it can cause Gradle to reuse an incorrect Configuration Cache entry.
+     *
+     * @param action the action to run without automatic Configuration Cache input tracking
+     * @return the value returned by the action
+     * @since 9.8.0
+     */
+    <T> T withInputTrackingDisabledUnsafe(Callable<? extends T> action);
+}


### PR DESCRIPTION
Adds a new injectable `ConfigurationCacheInputTracking` which provides a `withInputTrackingDisabledUnsafe` wrapper that temporarily disables Configuration Cache input tracking for the action inside the block.

This is based on the code that exists specifically for the Develocity plugin, but makes that mechanism available as a public API.

### Context
Our build cache auth for developer users fetches temporary AWS keys from an internal REST API. Because configuration cache does not instrument http requests, this is invisible to input tracking and we have been getting configuration cache hits on these builds for years now with no issues.

On CI, the authentication is provided by a commandline tool that also returns temporary credentials. Since `ProcessBuilder` is instrumented by configuration cache, those inputs are tracked, and invalidate the configuration cache that could otherwise be reused between builds. We can work around this by using static credentials, or by rewriting the auth tool to use a mechanism that is invisible to input tracking. The former is obviously not ideal security, and the latter relies on internal gradle details that can change at any time.

Some other related issues:

* https://github.com/gradle/gradle/issues/20873
* https://github.com/gradle/gradle/issues/24203
* https://github.com/gradle/gradle/issues/20673

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
