### PR TITLE
Lower Guava version range in docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
@@ -399,7 +399,7 @@ include::sample[dir="snippets/dependencyManagement/richVersionsDirectDependencie
 include::sample[dir="snippets/dependencyManagement/richVersionsDirectDependencies/groovy",files="build.gradle[tags=reject-multiple-versions]"]
 ====
 
-This resolves to the highest available version in the `[33.0, 34.0[` range that is neither `33.4.4-jre` nor `33.5.0-jre`.
+This resolves to the highest available version in the `[32.0, 33.0[` range that is neither `32.1.1-jre` nor `32.1.2-jre`.
 
 [[sec:strictly-in-constraints]]
 ==== Use `strictly` in dependency constraints to actually constrain

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/groovy/build.gradle
@@ -46,8 +46,8 @@ dependencies {
 dependencies {
     implementation('com.google.guava:guava') {
         version {
-            require '[33.0, 34.0['
-            reject '33.4.4-jre', '33.5.0-jre'
+            require '[32.0, 33.0['
+            reject '32.1.1-jre', '32.1.2-jre'
         }
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/kotlin/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
 dependencies {
     implementation("com.google.guava:guava") {
         version {
-            require("[33.0, 34.0[")
-            reject("33.4.4-jre", "33.5.0-jre")
+            require("[32.0, 33.0[")
+            reject("32.1.1-jre", "32.1.2-jre")
         }
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/tests/richVersionsDirectDependencies.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/richVersionsDirectDependencies/tests/richVersionsDirectDependencies.out
@@ -3,4 +3,4 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 +--- org.apache.httpcomponents:httpclient:4.5.4
 +--- commons-io:commons-io:{require [1.0, 2.0[; reject 1.4} -> 1.3.2
 +--- org.slf4j:slf4j-api:{strictly [1.0, 2.0[; prefer 1.7.25} -> 1.7.25
-\--- com.google.guava:guava:{require [33.0, 34.0[; reject 33.4.4-jre & 33.5.0-jre} -> 33.6.0-jre
+\--- com.google.guava:guava:{require [32.0, 33.0[; reject 32.1.1-jre & 32.1.2-jre} -> 32.1.3-jre


### PR DESCRIPTION
This is unlikely to break as Guava doesn't tend to release new versions for older major versions. A slightly stronger version of #38867.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
