### PR TITLE
Compute the build timestamp once per build

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -59,6 +59,39 @@ fun Project.currentGitCommitViaFileSystemQuery(): Provider<String> = getBuildEnv
 fun Project.scriptTemplateCommitIdViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtensionOrNull()?.scriptTemplateCommitId ?: objects.property(String::class.java)
 
 
+/**
+ * The build timestamp, computed once per build and identical in every project.
+ *
+ * Do not compute this per project: on the `install`, `:docs:docsTest` and CI paths the timestamp is
+ * the current instant, so every project computing its own would build a distribution whose projects
+ * disagree about its version.
+ *
+ * @see gradlebuild.basics.BuildEnvironmentService.buildTimestamp
+ */
+fun Project.buildTimestamp(): Provider<String> =
+    getBuildEnvironmentExtensionOrNull()?.buildTimestamp ?: localMidnightBuildTimestamp()
+
+
+/**
+ * The timestamp to use where `gradlebuild.build-environment` is not applied, which is the case for the
+ * `build-logic`/`build-logic-commons` builds and for the synthetic projects that
+ * `generatePrecompiledScriptPluginAccessors` configures. Those still resolve
+ * `gradleModule.identity.version`, which is derived from the build timestamp, so a value must be present.
+ *
+ * None of them produce a distribution, so the exact instant does not matter — but it must be the same in
+ * every project of the build. Local midnight is stable by construction, so per-project value sources agree.
+ */
+private
+fun Project.localMidnightBuildTimestamp(): Provider<String> =
+    providers.of(BuildTimestampValueSource::class) {
+        parameters {
+            runningOnCi.set(false)
+            runningInstallTask.set(false)
+            runningDocsTestTask.set(false)
+        }
+    }
+
+
 // gh-readonly-queue/master/pr-1234-5678abcdef -> master
 fun toMergeQueueBaseBranch(actualBranch: String): String = when {
     actualBranch.startsWith("gh-readonly-queue/") -> actualBranch.substringAfter("/").substringBefore("/")

--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -17,18 +17,13 @@
 import gradlebuild.basics.buildFinalRelease
 import gradlebuild.basics.buildMilestoneNumber
 import gradlebuild.basics.buildRcNumber
-import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.buildTimestamp
 import gradlebuild.basics.buildVersionQualifier
-import gradlebuild.basics.ignoreIncomingBuildReceipt
 import gradlebuild.basics.isPromotionBuild
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.identity.extension.GradleModuleExtension
 import gradlebuild.identity.extension.ReleasedVersionsDetails
-import gradlebuild.identity.provider.BuildTimestampFromBuildReceiptValueSource
-import gradlebuild.identity.provider.BuildTimestampValueSource
-import gradlebuild.identity.tasks.BuildReceipt
 import java.util.Optional
 import java.util.jar.Attributes
 
@@ -105,42 +100,6 @@ tasks.withType<Jar>().configureEach {
  */
 fun Project.trimmedContentsOfFile(path: String): Provider<String> =
     providers.fileContents(repoRoot().file(path)).asText.map { it.trim() }
-
-// TODO Simplify the buildTimestamp() calculation if possible
-fun Project.buildTimestamp(): Provider<String> =
-    providers.of(BuildTimestampValueSource::class) {
-        parameters {
-            buildTimestampFromBuildReceipt = buildTimestampFromBuildReceipt()
-            buildTimestampFromGradleProperty = buildTimestamp
-            runningOnCi = buildRunningOnCi
-            runningInstallTask = provider { isRunningInstallTask() }
-            runningDocsTestTask = provider { isRunningDocsTestTask() }
-            enableConfigurationCacheForDocsTests = providers.gradleProperty("enableConfigurationCacheForDocsTests").map { it.toBoolean() }
-        }
-    }
-
-
-fun Project.buildTimestampFromBuildReceipt(): Provider<String> =
-    providers.of(BuildTimestampFromBuildReceiptValueSource::class) {
-        parameters {
-            ignoreIncomingBuildReceipt = project.ignoreIncomingBuildReceipt
-            buildReceiptFileContents = repoRoot()
-                .dir("incoming-distributions")
-                .file(BuildReceipt.buildReceiptFileName)
-                .let(providers::fileContents)
-                .asText
-        }
-    }
-
-
-fun isRunningInstallTask() =
-    listOf("install", "installAll")
-        .flatMap { listOf(":distributions-full:$it", "distributions-full:$it", it) }
-        .any(gradle.startParameter.taskNames::contains)
-
-fun isRunningDocsTestTask() =
-    setOf(":docs:docsTest", "docs:docsTest")
-        .any(gradle.startParameter.taskNames::contains)
 
 
 /**

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -18,6 +18,18 @@ import gradlebuild.basics.BuildEnvironmentExtension
 import gradlebuild.basics.BuildEnvironmentService
 
 with(layout.rootDirectory) {
+    // The requested task names are only available from the `StartParameter`, which a build service
+    // cannot reach, so they are resolved here and passed in as service parameters.
+    //
+    // These must be locals rather than script-level properties: the `beforeProject` action below is
+    // isolated, and capturing a script property would drag in a reference to the script object itself.
+    val runningInstallTask = listOf("install", "installAll")
+        .flatMap { listOf(":distributions-full:$it", "distributions-full:$it", it) }
+        .any(gradle.startParameter.taskNames::contains)
+
+    val runningDocsTestTask = setOf(":docs:docsTest", "docs:docsTest")
+        .any(gradle.startParameter.taskNames::contains)
+
     gradle.lifecycle.beforeProject {
         val service = gradle.sharedServices.registerIfAbsent("buildEnvironmentService", BuildEnvironmentService::class) {
             check(project.path == ":") {
@@ -26,11 +38,14 @@ with(layout.rootDirectory) {
             }
             parameters.rootProjectDir = this@with
             parameters.rootProjectBuildDir = project.layout.buildDirectory
+            parameters.runningInstallTask = runningInstallTask
+            parameters.runningDocsTestTask = runningDocsTestTask
         }
         val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
         buildEnvironmentExtension.gitBranch = service.flatMap { it.gitBranch }
         buildEnvironmentExtension.scriptTemplateCommitId = service.flatMap { it.scriptTemplateCommitId }
+        buildEnvironmentExtension.buildTimestamp = service.flatMap { it.buildTimestamp }
         buildEnvironmentExtension.repoRoot = this@with
         buildEnvironmentExtension.rootProjectBuildDir = service.flatMap { it.parameters.rootProjectBuildDir }
     }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
@@ -24,6 +24,13 @@ interface BuildEnvironmentExtension {
     val gitCommitId: Property<String>
     val gitBranch: Property<String>
     val scriptTemplateCommitId: Property<String>
+
+    /**
+     * The build timestamp, computed once per build and identical in every project.
+     *
+     * @see BuildEnvironmentService.buildTimestamp
+     */
+    val buildTimestamp: Property<String>
     val repoRoot: DirectoryProperty
     val rootProjectBuildDir: DirectoryProperty
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
@@ -17,19 +17,50 @@
 package gradlebuild.basics
 
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.internal.os.OperatingSystem
+// Using star import to workaround https://youtrack.jetbrains.com/issue/KTIJ-24390
+import org.gradle.kotlin.dsl.*
 import javax.inject.Inject
 
 
 abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Parameters> {
 
+    companion object {
+        // Keep in sync with the corresponding constants in `gradlebuild.basics.BuildParams`,
+        // which this project cannot depend on (`basics` depends on `build-environment`, not the other way around).
+        private
+        const val BUILD_TIMESTAMP_PROPERTY = "buildTimestamp"
+
+        private
+        const val IGNORE_INCOMING_BUILD_RECEIPT_PROPERTY = "ignoreIncomingBuildReceipt"
+
+        private
+        const val ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS_PROPERTY = "enableConfigurationCacheForDocsTests"
+
+        private
+        const val CI_ENVIRONMENT_VARIABLE = "CI"
+    }
+
     interface Parameters : BuildServiceParameters {
         val rootProjectDir: DirectoryProperty
         val rootProjectBuildDir: DirectoryProperty
+
+        /**
+         * Whether `install`/`installAll` was requested on the command line.
+         *
+         * Computed from `StartParameter` at settings time, since a build service cannot see it.
+         */
+        val runningInstallTask: Property<Boolean>
+
+        /**
+         * Whether `:docs:docsTest` was requested on the command line.
+         */
+        val runningDocsTestTask: Property<Boolean>
     }
 
     @get:Inject
@@ -38,6 +69,45 @@ abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Pa
     val gitCommitId = git("rev-parse", "HEAD")
     val gitBranch = git("rev-parse", "--abbrev-ref", "HEAD")
     val scriptTemplateCommitId = git("log", "-1", "--format=%H", "--", "platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt")
+
+    /**
+     * The timestamp identifying the distribution built by this build, shared by every project.
+     *
+     * This service is a build-scoped singleton, so the value source below is instantiated once
+     * per build and its value is memoized. That matters: when `install`, `:docs:docsTest` or CI
+     * selects the current instant rather than local midnight, obtaining the value source more
+     * than once yields *different* timestamps. Creating it per project (as this used to be) made
+     * the projects of a single build disagree about the version of the distribution being built,
+     * so e.g. the installed distribution and the tests exercising it ended up on different versions.
+     *
+     * It stays a value source rather than a plain `Date` captured at settings time so that the
+     * configuration cache keeps tracking it as an input and re-obtains it on the next build.
+     */
+    val buildTimestamp: Provider<String> = providers.of(BuildTimestampValueSource::class) {
+        parameters {
+            buildTimestampFromBuildReceipt.set(this@BuildEnvironmentService.buildTimestampFromBuildReceipt())
+            buildTimestampFromGradleProperty.set(providers.gradleProperty(BUILD_TIMESTAMP_PROPERTY))
+            enableConfigurationCacheForDocsTests.set(providers.gradleProperty(ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS_PROPERTY).map { it.toBoolean() })
+            runningOnCi.set(providers.environmentVariable(CI_ENVIRONMENT_VARIABLE).map { true }.orElse(false))
+            runningInstallTask.set(this@BuildEnvironmentService.parameters.runningInstallTask)
+            runningDocsTestTask.set(this@BuildEnvironmentService.parameters.runningDocsTestTask)
+        }
+    }
+
+    private
+    fun buildTimestampFromBuildReceipt(): Provider<String> =
+        providers.of(BuildTimestampFromBuildReceiptValueSource::class) {
+            parameters {
+                ignoreIncomingBuildReceipt.set(providers.gradleProperty(IGNORE_INCOMING_BUILD_RECEIPT_PROPERTY).map { true }.orElse(false))
+                buildReceiptFileContents.set(
+                    providers.fileContents(
+                        this@BuildEnvironmentService.parameters.rootProjectDir.get()
+                            .dir("incoming-distributions")
+                            .file(BuildTimestampFromBuildReceiptValueSource.BUILD_RECEIPT_FILE_NAME)
+                    ).asText
+                )
+            }
+        }
 
     @Suppress("UnstableApiUsage")
     private

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildTimestampFromBuildReceiptValueSource.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildTimestampFromBuildReceiptValueSource.kt
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package gradlebuild.identity.provider
+package gradlebuild.basics
 
-import gradlebuild.identity.tasks.BuildReceipt
 import org.gradle.api.Describable
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Optional
+import java.util.Properties
 
 
 abstract class BuildTimestampFromBuildReceiptValueSource : ValueSource<String, BuildTimestampFromBuildReceiptValueSource.Parameters>, Describable {
+
+    companion object {
+        const val BUILD_RECEIPT_FILE_NAME = "build-receipt.properties"
+    }
 
     interface Parameters : ValueSourceParameters {
 
@@ -36,7 +40,7 @@ abstract class BuildTimestampFromBuildReceiptValueSource : ValueSource<String, B
 
     override fun obtain(): String? = parameters.run {
         buildReceiptString()
-            ?.let(BuildReceipt::readBuildReceiptFromString)
+            ?.let { Properties().apply { load(it.reader()) } }
             ?.let { buildReceipt ->
                 buildReceipt["buildTimestamp"] as String
             }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildTimestampValueSource.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildTimestampValueSource.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.identity.provider
+package gradlebuild.basics
 
 import org.gradle.api.Describable
 import org.gradle.api.provider.Property
@@ -26,6 +26,13 @@ import java.util.Date
 import java.util.TimeZone
 
 
+/**
+ * Computes the timestamp that identifies the distribution built by this build.
+ *
+ * On the [Date] paths below the result is *not* stable across invocations of [obtain], so this
+ * value source must be obtained exactly once per build and the result shared by every project.
+ * See [BuildEnvironmentService.buildTimestamp], which is the only place that may create it.
+ */
 abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampValueSource.Parameters>, Describable {
 
     interface Parameters : ValueSourceParameters {


### PR DESCRIPTION
Fixes the problem [Rodrigo reported](https://gradle.slack.com/archives/CBSJ2GUTV/p1786892287575069): with `install` on the command line, every project computes its own build timestamp, so a single build produces more than one distribution version.

## The bug

`gradlebuild.module-identity` called `buildTimestamp()` inside the per-project `identity {}` block, so each project created its own `BuildTimestampValueSource` instance. Gradle memoizes a value source per *provider instance* — there is no dedup across instances — so N projects meant N calls to `obtain()`.

`BuildTimestampValueSource.obtain()` returns two different kinds of value:

```kotlin
runningInstallTask.get() || runningDocsTestTask.get() || runningOnCi.get() -> Date()   // current instant
else                                                                      -> Date().withoutTime()  // local midnight
```

`Date().withoutTime()` is stable, so on that path the per-project instances agree by construction. `Date()` is not, so on the `install` / `:docs:docsTest` / CI paths each instance observes a different clock reading. Note `isRunningInstallTask()` only checks whether `install`/`installAll` appears in `startParameter.taskNames` — merely *mentioning* the task flips the switch.

This is how `./gradlew :dF:bDZ install -Pgradle_installPath=... :xIT:fIT` broke: the installed distribution and the forking integration tests exercising it resolved different Gradle versions. That surfaced as eight failing `Xdcl*DistributionIntegrationTest` cases, and a `9.7.0-20260814135452+0000` version where a bin distribution should have carried a midnight-snapped one.

## Measured

An init script that groups projects by the version they compute, with `install` in the task list:

| | distinct versions across 250 projects |
|---|---|
| `master` | **198** |
| this branch | **1** |

## The fix

Move the timestamp onto `BuildEnvironmentService` — a build-scoped singleton — and hand it to every project through `BuildEnvironmentExtension`, exactly the way `gitCommitId` is already shared. The value source is instantiated once per build, so its value is memoized and every project sees the same string.

The two value sources move from `build-logic-commons/module-identity` to `build-logic-settings/build-environment` so the service can reach them (`basics` depends on `build-environment`, not the reverse). `BuildTimestampFromBuildReceiptValueSource` inlines the two-line properties parse it used to borrow from the `BuildReceipt` task, which would otherwise have to move too.

The requested task names come from `StartParameter`, which a build service cannot see, so `runningInstallTask`/`runningDocsTestTask` are resolved in the settings script and passed in as service parameters. They have to be locals rather than script-level properties — `beforeProject` is an isolated action, and capturing a script property drags in a reference to the script object.

### Why not the alternatives

- **A `Date` captured at settings time and pushed via `beforeProject`.** All projects would agree, but the value freezes into the configuration cache entry and gets replayed on a hit. `install` would then reuse a stale version.
- **Making `obtain()` deterministic** (e.g. deriving from a build-start instant passed as a parameter). Same problem: CC re-obtains with the recorded parameters, matches, and hits with a stale timestamp. The freshness *depends* on `obtain()` being non-deterministic.
- **Sharing the `Provider` itself through `beforeProject`.** Isolated actions explicitly reject value-source providers (`unsupportedProviderTypes()` in `IsolatedActionCodecsFactory`).

So this keeps the value source, and only removes the duplication. What it deliberately does *not* do is give `install` a configuration cache hit — that needs the shared-live-value-source support [discussed in #configuration-cache](https://gradle.slack.com/archives/C05Q92AUM8D/p1786731252873549), and is out of scope here.

## Behaviour

Unchanged apart from the deduplication:

- `install` still invalidates CC every build — verified: `configuration cache cannot be reused because the build timestamp (from current time because installing) has changed`.
- The plain path still hits: two consecutive `./gradlew help` runs give `stored` then `reused`.
- `-PbuildTimestamp`, the incoming build receipt, and `enableConfigurationCacheForDocsTests` paths are untouched.

One deliberate change: the `build-logic`/`build-logic-commons` builds and the synthetic projects behind `generatePrecompiledScriptPluginAccessors` do not get the `gradlebuild.build-environment` settings plugin, so they fall back to the local-midnight value source. They still need a present `identity.version`, but none of them produce a distribution, and midnight is stable so their projects agree too. (I did not apply `gradlebuild.build-environment` to those builds: its `repoRoot` would resolve to `build-logic/` rather than the repo root.)

## Verification

- `./gradlew help` — configures clean under the default IP + CC.
- `./gradlew install -Pgradle_installPath=... --dry-run` — configures clean under the default IP + CC.
- Version-agreement probe above, run with and without the change.

I have not run a full `install` end to end, nor the `Xdcl*` tests from Rodrigo's report — those need the xdcl repo alongside.
