### PR TITLE
Protect against deadlock from null command/arguments

### DIFF
--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -216,16 +216,9 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     }
 
     private void setEndStateInfo(ExecHandleState newState, int exitValue, Throwable failureCause) {
+        ExecHandleState currentState = getState();
         ExecResultImpl newResult = null;
         try {
-            ExecHandleState currentState;
-            lock.lock();
-            try {
-                currentState = this.state;
-            } finally {
-                lock.unlock();
-            }
-
             newResult = new ExecResultImpl(exitValue, execExceptionFor(failureCause, currentState), displayName);
 
             ShutdownHooks.removeShutdownHook(shutdownHookAction);
@@ -240,6 +233,14 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
             }
         } catch (Throwable t) {
             LOGGER.debug("Failed to finalize state for process '{}'; recording terminal state anyway.", displayName, t);
+            if (newResult == null) {
+                if (failureCause != null) {
+                    failureCause.addSuppressed(t);
+                } else {
+                    failureCause = t;
+                }
+                newResult = new ExecResultImpl(exitValue, new ProcessExecutionException(basicFailureMessageFor(currentState), failureCause), displayName);
+            }
         } finally {
             lock.lock();
             try {
@@ -261,10 +262,21 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     }
 
     private String failureMessageFor(Throwable failureCause, ExecHandleState currentState) {
+        if (currentState == ExecHandleState.STARTING
+            && hasCommandLineExceedMaxLength(command, arguments)
+            && hasCommandLineExceedMaxLengthException(failureCause)) {
+            return format("Process '%s' could not be started because the command line exceed operating system limits.", displayName);
+        }
+        return basicFailureMessageFor(currentState);
+    }
+
+    /**
+     * Builds a failure message without inspecting the command line or the failure cause.
+     * <p>
+     * This is used as the last resort when {@link #failureMessageFor} itself throws, so it must stay simple and not throw.
+     */
+    private String basicFailureMessageFor(ExecHandleState currentState) {
         if (currentState == ExecHandleState.STARTING) {
-            if (hasCommandLineExceedMaxLength(command, arguments) && hasCommandLineExceedMaxLengthException(failureCause)) {
-                return format("Process '%s' could not be started because the command line exceed operating system limits.", displayName);
-            }
             return format("A problem occurred starting process '%s'", displayName);
         }
         return format("A problem occurred waiting for process '%s' to complete.", displayName);

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -17,6 +17,7 @@
 package org.gradle.process.internal;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import jnr.constants.platform.Signal;
 import net.rubygrapefruit.platform.ProcessLauncher;
 import org.gradle.api.logging.Logger;
@@ -87,7 +88,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     /**
      * Arguments to pass to the executable.
      */
-    private final List<String> arguments;
+    private final ImmutableList<String> arguments;
 
     /**
      * The variables to set in the environment the executable is run in.
@@ -130,10 +131,14 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
                       Map<String, String> environment, StreamsHandler outputHandler, StreamsHandler inputHandler,
                       List<ExecHandleListener> listeners, boolean redirectErrorStream, int timeoutMillis, boolean daemon,
                       Executor executor, BuildCancellationToken buildCancellationToken) {
+        if (command == null) {
+            throw new IllegalArgumentException("Cannot start a process with a null command.");
+        }
         this.displayName = displayName;
         this.directory = directory;
         this.command = command;
-        this.arguments = arguments;
+        // Defensive copy and null-check arguments.
+        this.arguments = ImmutableList.copyOf(arguments);
         this.environment = environment;
         this.outputHandler = outputHandler;
         this.inputHandler = inputHandler;
@@ -172,7 +177,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
     @Override
     public List<String> getArguments() {
-        return Collections.unmodifiableList(arguments);
+        return arguments;
     }
 
     @Override
@@ -211,31 +216,38 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     }
 
     private void setEndStateInfo(ExecHandleState newState, int exitValue, Throwable failureCause) {
-        ShutdownHooks.removeShutdownHook(shutdownHookAction);
-        buildCancellationToken.removeCallback(shutdownHookAction);
-        ExecHandleState currentState;
-        lock.lock();
+        ExecResultImpl newResult = null;
         try {
-            currentState = this.state;
-        } finally {
-            lock.unlock();
-        }
-
-        ExecResultImpl newResult = new ExecResultImpl(exitValue, execExceptionFor(failureCause, currentState), displayName);
-        if (!currentState.isTerminal() && newState != ExecHandleState.DETACHED) {
+            ExecHandleState currentState;
+            lock.lock();
             try {
-                broadcast.getSource().executionFinished(this, newResult);
-            } catch (Exception e) {
-                newResult = new ExecResultImpl(exitValue, execExceptionFor(e, currentState), displayName);
+                currentState = this.state;
+            } finally {
+                lock.unlock();
             }
-        }
 
-        lock.lock();
-        try {
-            setState(newState);
-            this.execResult = newResult;
+            newResult = new ExecResultImpl(exitValue, execExceptionFor(failureCause, currentState), displayName);
+
+            ShutdownHooks.removeShutdownHook(shutdownHookAction);
+            buildCancellationToken.removeCallback(shutdownHookAction);
+
+            if (!currentState.isTerminal() && newState != ExecHandleState.DETACHED) {
+                try {
+                    broadcast.getSource().executionFinished(this, newResult);
+                } catch (Exception e) {
+                    newResult = new ExecResultImpl(exitValue, execExceptionFor(e, currentState), displayName);
+                }
+            }
+        } catch (Throwable t) {
+            LOGGER.debug("Failed to finalize state for process '{}'; recording terminal state anyway.", displayName, t);
         } finally {
-            lock.unlock();
+            lock.lock();
+            try {
+                setState(newState);
+                this.execResult = newResult;
+            } finally {
+                lock.unlock();
+            }
         }
 
         LOGGER.debug("Process '{}' finished with exit value {} (state: {})", displayName, exitValue, newState);

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
@@ -40,6 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ExecHandleRunner implements Runnable {
     private static final Logger LOGGER = Logging.getLogger(ExecHandleRunner.class);
+    private static final long DESTROY_TIMEOUT_MILLIS = 10_000;
 
     private final ProcessBuilderFactory processBuilderFactory;
     private final DefaultExecHandle execHandle;
@@ -203,8 +205,22 @@ public class ExecHandleRunner implements Runnable {
             }
             ProcessBuilder processBuilder = processBuilderFactory.createProcessBuilder(execHandle);
             Process process = processLauncher.start(processBuilder);
-            streamsHandler.connectStreams(process, execHandle.getDisplayName(), executor);
             this.process = process;
+            try {
+                streamsHandler.connectStreams(process, execHandle.getDisplayName(), executor);
+            } catch (Throwable t) {
+                try {
+                    destroyProcessTree();
+                    if (!process.waitFor(DESTROY_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                        process.destroyForcibly().waitFor(DESTROY_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                    }
+                } catch (Throwable cleanupFailure) {
+                    t.addSuppressed(cleanupFailure);
+                } finally {
+                    this.process = null;
+                }
+                throw t;
+            }
         } finally {
             lock.unlock();
         }

--- a/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
+++ b/platforms/core-runtime/process-services-base/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
@@ -54,9 +54,10 @@ public class LongCommandLineDetectionUtil {
         Throwable cause = failureCause;
         do {
             String message = cause.getMessage();
-            if (message.contains(WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE)
+            if (message != null
+                && (message.contains(WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE)
                 || message.contains(NIX_LONG_COMMAND_EXCEPTION_MESSAGE)
-                || message.contains(NEW_NIX_LONG_COMMAND_EXCEPTION_MESSAGE)) {
+                || message.contains(NEW_NIX_LONG_COMMAND_EXCEPTION_MESSAGE))) {
                 return true;
             }
         } while ((cause = cause.getCause()) != null);

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultClientExecHandleBuilderTest.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultClientExecHandleBuilderTest.groovy
@@ -63,4 +63,28 @@ class DefaultClientExecHandleBuilderTest extends Specification {
         builder.args == ['1', '2', '3']
         builder.allArguments == ['1', '2', '3']
     }
+
+    def "build fails fast when the command is null"() {
+        given:
+        builder.setWorkingDir(new File(".").absoluteFile)
+
+        when:
+        builder.build()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Cannot start a process with a null command."
+    }
+
+    def "build fails fast when an argument is null"() {
+        given:
+        builder.setExecutable("cmd")
+        builder.setWorkingDir(new File(".").absoluteFile)
+
+        when:
+        builder.buildWithEffectiveArguments([null])
+
+        then:
+        thrown(NullPointerException)
+    }
 }

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -174,6 +174,20 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         e.message == "A problem occurred starting process 'awesome'"
     }
 
+    void "does not deadlock when end state bookkeeping throws while start is failing"() {
+        given:
+        def execHandle = handle().setDisplayName("awesome").setExecutable("no_such_command").build()
+        buildCancellationToken.removeCallback(_) >> { throw new RuntimeException("boom") }
+
+        when:
+        execHandle.start()
+
+        then:
+        def e = thrown(ProcessExecutionException)
+        e.message == "A problem occurred starting process 'awesome'"
+        execHandle.state == ExecHandleState.FAILED
+    }
+
     void "aborts process"() {
         def execHandle = handle().args(args(SlowApp.class)).build()
 

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -188,6 +188,26 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         execHandle.state == ExecHandleState.FAILED
     }
 
+    void "does not lose the failure when the error message cannot be built"() {
+        given:
+        System.setProperty("org.gradle.internal.cmdline.max.length", "1")
+        def streamsHandler = Stub(FinishNotifyingStreamsHandler) {
+            connectStreams(_, _, _) >> { throw new RuntimeException() }
+        }
+        def execHandle = handle().setDisplayName("awesome").streamsHandler(streamsHandler).build()
+
+        when:
+        execHandle.start()
+
+        then:
+        def e = thrown(ProcessExecutionException)
+        e.message == "A problem occurred starting process 'awesome'"
+        execHandle.state == ExecHandleState.FAILED
+
+        cleanup:
+        System.clearProperty("org.gradle.internal.cmdline.max.length")
+    }
+
     void "aborts process"() {
         def execHandle = handle().args(args(SlowApp.class)).build()
 

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -40,6 +40,7 @@ import spock.lang.Timeout
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicReference
 
 @UsesNativeServices
 @Timeout(60)
@@ -206,6 +207,26 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
 
         cleanup:
         System.clearProperty("org.gradle.internal.cmdline.max.length")
+    }
+
+    void "destroys started process when streams cannot be connected"() {
+        given:
+        def startedProcess = new AtomicReference<Process>()
+        def streamsHandler = Stub(FinishNotifyingStreamsHandler) {
+            connectStreams(_, _, _) >> { Process process, String displayName, Executor executor ->
+                startedProcess.set(process)
+                throw new RuntimeException()
+            }
+        }
+        def execHandle = handle().args(args(SlowApp.class)).streamsHandler(streamsHandler).build()
+
+        when:
+        execHandle.start()
+
+        then:
+        thrown(ProcessExecutionException)
+        startedProcess.get() != null
+        !startedProcess.get().isAlive()
     }
 
     void "aborts process"() {

--- a/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/util/LongCommandLineDetectionUtilTest.groovy
+++ b/platforms/core-runtime/process-services-base/src/test/groovy/org/gradle/process/internal/util/LongCommandLineDetectionUtilTest.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal.util
+
+import spock.lang.Specification
+
+class LongCommandLineDetectionUtilTest extends Specification {
+    def "tolerates exceptions without a message in cause chain"() {
+        expect:
+        !LongCommandLineDetectionUtil.hasCommandLineExceedMaxLengthException(
+            new RuntimeException((String) null, new IOException())
+        )
+        LongCommandLineDetectionUtil.hasCommandLineExceedMaxLengthException(
+            new RuntimeException((String) null, new IOException("error=7, Argument list too long"))
+        )
+    }
+}


### PR DESCRIPTION
We disallow null upfront for a clearer outcome there, and also harden setEndStateInfo so it no longer deadlocks on certain fatal errors

Found while investigating https://github.com/gradle/gradle-private/issues/5316

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
