### PR TITLE
Parse HTTP directory listings without jsoup

### DIFF
--- a/platforms/software/resources-http/build.gradle.kts
+++ b/platforms/software/resources-http/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(libs.commonsLang)
     implementation(libs.jacksonDatabind)
     implementation(libs.jcifs)
-    implementation(libs.jsoup)
     implementation(libs.slf4jApi)
 
     runtimeOnly(projects.core)

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParser.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParser.java
@@ -16,11 +16,9 @@
 
 package org.gradle.internal.resource.transport.http;
 
+import org.apache.commons.io.IOUtils;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.resource.UriTextResource;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,11 +31,12 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ApacheDirectoryListingParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApacheDirectoryListingParser.class);
+
+    private final HtmlAnchorHrefScanner anchorScanner = new HtmlAnchorHrefScanner();
 
     public List<String> parse(URI baseURI, InputStream content, String contentType) throws Exception {
         baseURI = addTrailingSlashes(baseURI);
@@ -45,13 +44,13 @@ public class ApacheDirectoryListingParser {
             throw new ResourceException(baseURI, String.format("Unsupported ContentType %s for directory listing '%s'", contentType, baseURI));
         }
         Charset contentEncoding = UriTextResource.extractCharacterEncoding(contentType, StandardCharsets.UTF_8);
-        Document document = Jsoup.parse(content, contentEncoding.name(), baseURI.toString());
-        Elements elements = document.select("a[href]");
-        List<String> hrefs = elements.stream()
-            .map(it -> it.attr("href"))
-            .collect(Collectors.toList());
+        List<String> hrefs = anchorScanner.scan(stripByteOrderMark(IOUtils.toString(content, contentEncoding)));
         List<URI> uris = resolveURIs(baseURI, hrefs);
         return filterNonDirectChilds(baseURI, uris);
+    }
+
+    private static String stripByteOrderMark(String html) {
+        return !html.isEmpty() && html.charAt(0) == '\uFEFF' ? html.substring(1) : html;
     }
 
     private URI addTrailingSlashes(URI uri) throws IOException, URISyntaxException {

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParser.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParser.java
@@ -44,13 +44,9 @@ public class ApacheDirectoryListingParser {
             throw new ResourceException(baseURI, String.format("Unsupported ContentType %s for directory listing '%s'", contentType, baseURI));
         }
         Charset contentEncoding = UriTextResource.extractCharacterEncoding(contentType, StandardCharsets.UTF_8);
-        List<String> hrefs = anchorScanner.scan(stripByteOrderMark(IOUtils.toString(content, contentEncoding)));
+        List<String> hrefs = anchorScanner.scan(IOUtils.toString(content, contentEncoding));
         List<URI> uris = resolveURIs(baseURI, hrefs);
         return filterNonDirectChilds(baseURI, uris);
-    }
-
-    private static String stripByteOrderMark(String html) {
-        return !html.isEmpty() && html.charAt(0) == '\uFEFF' ? html.substring(1) : html;
     }
 
     private URI addTrailingSlashes(URI uri) throws IOException, URISyntaxException {

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScanner.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScanner.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Collects the {@code href} of every {@code <a>} start tag in an HTML document, in document order.
+ *
+ * <p>Directory listings are produced by whatever server happens to host the repository, so the
+ * markup cannot be assumed to be well formed: tags are frequently left unclosed and attribute
+ * values unquoted. Building a document tree would mean taking a position on how to repair all of
+ * that; since only the anchor hrefs are of interest, this scans the raw text for start tags
+ * instead, which is indifferent to how the surrounding markup nests.
+ *
+ * <p>The scan follows the HTML tokenizer closely enough for that purpose: it skips comments,
+ * doctypes, CDATA sections and the content of raw text elements such as {@code <script>}, it
+ * accepts single-quoted and unquoted attribute values, and it resolves the character references
+ * that can appear in a URL.
+ */
+@NullMarked
+class HtmlAnchorHrefScanner {
+
+    /**
+     * Elements whose content is text rather than markup, so an {@code <a>} inside one of them is
+     * not a link. See <a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments">the HTML specification</a>.
+     */
+    private static final Set<String> RAW_TEXT_ELEMENTS = new HashSet<>(Arrays.asList(
+        "script", "style", "textarea", "title", "xmp", "iframe", "noembed", "noframes"
+    ));
+
+    List<String> scan(String html) {
+        List<String> hrefs = new ArrayList<>();
+        // Scanning only ever moves forwards, so once a raw text element is known to have no end
+        // tag ahead of the current position it can have none ahead of any later position either.
+        // Remembering that keeps a document full of unclosed tags from being rescanned each time.
+        Set<String> unterminated = new HashSet<>();
+        int position = 0;
+        while (position < html.length()) {
+            int tagStart = html.indexOf('<', position);
+            if (tagStart < 0 || tagStart == html.length() - 1) {
+                break;
+            }
+            char afterAngleBracket = html.charAt(tagStart + 1);
+            if (afterAngleBracket == '!') {
+                position = skipMarkupDeclaration(html, tagStart + 2);
+            } else if (afterAngleBracket == '?' || afterAngleBracket == '/') {
+                position = skipPast(html, tagStart + 2, ">");
+            } else if (isAsciiLetter(afterAngleBracket)) {
+                position = readStartTag(html, tagStart, hrefs, unterminated);
+            } else {
+                // A '<' that starts no tag is just text
+                position = tagStart + 1;
+            }
+        }
+        return hrefs;
+    }
+
+    /**
+     * Reads the start tag beginning at {@code tagStart}, adding its href if it is an anchor, and
+     * returns the position to carry on scanning from. For a raw text element that is the end of
+     * its content rather than the end of the tag, so that its text is not scanned for tags.
+     */
+    private static int readStartTag(String html, int tagStart, List<String> hrefs, Set<String> unterminated) {
+        int position = tagStart + 1;
+        int nameStart = position;
+        while (position < html.length() && isTagNameCharacter(html.charAt(position))) {
+            position++;
+        }
+        String tagName = html.substring(nameStart, position).toLowerCase(Locale.ROOT);
+        boolean anchor = tagName.equals("a");
+
+        String href = null;
+        boolean hrefSeen = false;
+        while (position < html.length()) {
+            position = skipWhitespace(html, position);
+            if (position == html.length()) {
+                break;
+            }
+            char next = html.charAt(position);
+            if (next == '>') {
+                position++;
+                break;
+            }
+            if (next == '/') {
+                // Either a self-closing tag or a stray slash between attributes
+                position++;
+                continue;
+            }
+
+            int attributeNameStart = position;
+            while (position < html.length() && !isAttributeNameEnd(html.charAt(position))) {
+                position++;
+            }
+            String attributeName = html.substring(attributeNameStart, position).toLowerCase(Locale.ROOT);
+
+            boolean anchorHref = anchor && !hrefSeen && attributeName.equals("href");
+            int afterName = skipWhitespace(html, position);
+            if (afterName == html.length() || html.charAt(afterName) != '=') {
+                // A valueless attribute has the empty string as its value. Leave the position
+                // alone, so that the character stopping the name starts the next attribute.
+                if (anchorHref) {
+                    href = "";
+                    hrefSeen = true;
+                }
+                continue;
+            }
+            position = skipWhitespace(html, afterName + 1);
+            int valueStart;
+            int valueEnd;
+            char quote = position < html.length() ? html.charAt(position) : '>';
+            if (quote == '"' || quote == '\'') {
+                valueStart = position + 1;
+                valueEnd = html.indexOf(quote, valueStart);
+                if (valueEnd < 0) {
+                    valueEnd = html.length();
+                    position = valueEnd;
+                } else {
+                    position = valueEnd + 1;
+                }
+            } else {
+                valueStart = position;
+                while (position < html.length() && !isUnquotedValueEnd(html.charAt(position))) {
+                    position++;
+                }
+                valueEnd = position;
+            }
+
+            if (anchorHref) {
+                href = resolveCharacterReferences(html.substring(valueStart, valueEnd));
+                hrefSeen = true;
+            }
+        }
+
+        if (href != null) {
+            hrefs.add(href);
+        }
+        if (!RAW_TEXT_ELEMENTS.contains(tagName) || unterminated.contains(tagName)) {
+            return position;
+        }
+        return skipRawText(html, position, tagName, unterminated);
+    }
+
+    /**
+     * Skips a comment, doctype, CDATA section or any other {@code <!...>} construct. Anything that
+     * is not a comment ends at the first {@code >}, which is what makes a listing wrapped in a
+     * CDATA section yield no links, matching how a browser reads it.
+     */
+    private static int skipMarkupDeclaration(String html, int position) {
+        if (html.startsWith("--", position)) {
+            return skipPast(html, position + 2, "-->");
+        }
+        return skipPast(html, position, ">");
+    }
+
+    /**
+     * Skips the text content of a raw text element, returning the position just past its end tag.
+     *
+     * <p>If there is no end tag the content is not skipped at all. Treating the rest of the
+     * document as text would be the letter of the specification, but for a listing that would
+     * silently discard every remaining link; picking the links up is the more useful reading of
+     * markup that is already broken.
+     */
+    private static int skipRawText(String html, int position, String tagName, Set<String> unterminated) {
+        int searchFrom = position;
+        while (searchFrom < html.length()) {
+            int closeTagStart = html.indexOf("</", searchFrom);
+            if (closeTagStart < 0) {
+                break;
+            }
+            int nameStart = closeTagStart + 2;
+            int nameEnd = nameStart + tagName.length();
+            if (html.regionMatches(true, nameStart, tagName, 0, tagName.length())
+                && (nameEnd == html.length() || isTagNameEnd(html.charAt(nameEnd)))) {
+                return skipPast(html, nameEnd, ">");
+            }
+            searchFrom = nameStart;
+        }
+        unterminated.add(tagName);
+        return position;
+    }
+
+    private static int skipPast(String html, int position, String terminator) {
+        int end = html.indexOf(terminator, position);
+        return end < 0 ? html.length() : end + terminator.length();
+    }
+
+    private static int skipWhitespace(String html, int position) {
+        while (position < html.length() && isWhitespace(html.charAt(position))) {
+            position++;
+        }
+        return position;
+    }
+
+    /**
+     * Replaces the named and numeric character references that can appear in a URL. References
+     * that are not recognized are left as they are, which keeps an unescaped {@code &} in a query
+     * string intact rather than mangling it.
+     */
+    private static String resolveCharacterReferences(String value) {
+        if (value.indexOf('&') < 0) {
+            return value;
+        }
+        StringBuilder resolved = new StringBuilder(value.length());
+        int position = 0;
+        while (position < value.length()) {
+            int ampersand = value.indexOf('&', position);
+            int semicolon = ampersand < 0 ? -1 : value.indexOf(';', ampersand + 1);
+            if (semicolon < 0) {
+                resolved.append(value, position, value.length());
+                break;
+            }
+            resolved.append(value, position, ampersand);
+            String reference = value.substring(ampersand + 1, semicolon);
+            String replacement = characterFor(reference);
+            resolved.append(replacement != null ? replacement : value.substring(ampersand, semicolon + 1));
+            position = semicolon + 1;
+        }
+        return resolved.toString();
+    }
+
+    private static @Nullable String characterFor(String reference) {
+        switch (reference) {
+            case "amp":
+                return "&";
+            case "lt":
+                return "<";
+            case "gt":
+                return ">";
+            case "quot":
+                return "\"";
+            case "apos":
+                return "'";
+            case "nbsp":
+                return " ";
+            default:
+                return numericCharacterFor(reference);
+        }
+    }
+
+    private static @Nullable String numericCharacterFor(String reference) {
+        if (reference.length() < 2 || reference.charAt(0) != '#') {
+            return null;
+        }
+        boolean hex = reference.charAt(1) == 'x' || reference.charAt(1) == 'X';
+        String digits = reference.substring(hex ? 2 : 1);
+        if (digits.isEmpty()) {
+            return null;
+        }
+        try {
+            int codePoint = Integer.parseInt(digits, hex ? 16 : 10);
+            if (!Character.isValidCodePoint(codePoint)) {
+                return null;
+            }
+            return new String(Character.toChars(codePoint));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static boolean isAsciiLetter(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static boolean isTagNameCharacter(char c) {
+        return !isTagNameEnd(c);
+    }
+
+    private static boolean isTagNameEnd(char c) {
+        return isWhitespace(c) || c == '>' || c == '/';
+    }
+
+    private static boolean isAttributeNameEnd(char c) {
+        return isWhitespace(c) || c == '=' || c == '>';
+    }
+
+    private static boolean isUnquotedValueEnd(char c) {
+        return isWhitespace(c) || c == '>';
+    }
+
+    private static boolean isWhitespace(char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f';
+    }
+}

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScanner.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScanner.java
@@ -93,7 +93,6 @@ class HtmlAnchorHrefScanner {
         boolean anchor = tagName.equals("a");
 
         String href = null;
-        boolean hrefSeen = false;
         while (position < html.length()) {
             position = skipWhitespace(html, position);
             if (position == html.length()) {
@@ -116,14 +115,14 @@ class HtmlAnchorHrefScanner {
             }
             String attributeName = html.substring(attributeNameStart, position).toLowerCase(Locale.ROOT);
 
-            boolean anchorHref = anchor && !hrefSeen && attributeName.equals("href");
+            // Duplicate attributes are dropped by the HTML parser, so only the first href counts
+            boolean anchorHref = anchor && href == null && attributeName.equals("href");
             int afterName = skipWhitespace(html, position);
             if (afterName == html.length() || html.charAt(afterName) != '=') {
                 // A valueless attribute has the empty string as its value. Leave the position
                 // alone, so that the character stopping the name starts the next attribute.
                 if (anchorHref) {
                     href = "";
-                    hrefSeen = true;
                 }
                 continue;
             }
@@ -150,7 +149,6 @@ class HtmlAnchorHrefScanner {
 
             if (anchorHref) {
                 href = resolveCharacterReferences(html.substring(valueStart, valueEnd));
-                hrefSeen = true;
             }
         }
 

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParserTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheDirectoryListingParserTest.groovy
@@ -95,6 +95,14 @@ class ApacheDirectoryListingParserTest extends Specification {
         uris.collect { it.toString() } == ["\u0321\u0322"]
     }
 
+    def "parse handles a listing served with a byte order mark"() {
+        def html = "\uFEFF<a href=\"directory1\">directory1</a>"
+
+        expect:
+        def uris = parser.parse(baseUrl, new ByteArrayInputStream(html.getBytes("utf-8")), CONTENT_TYPE)
+        uris.collect { it.toString() } == ["directory1"]
+    }
+
     def "parse ignores #descr"() {
         expect:
         parser.parse(baseUrl, new ByteArrayInputStream(href.bytes), CONTENT_TYPE).isEmpty()

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScannerTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HtmlAnchorHrefScannerTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import spock.lang.Specification
+import spock.lang.Timeout
+
+class HtmlAnchorHrefScannerTest extends Specification {
+
+    private HtmlAnchorHrefScanner scanner = new HtmlAnchorHrefScanner()
+
+    def "collects hrefs in document order"() {
+        expect:
+        scanner.scan('<a href="one">1</a><p><a href="two">2</a></p><a href="three">3</a>') == ["one", "two", "three"]
+    }
+
+    def "finds anchors written as #descr"() {
+        expect:
+        scanner.scan(html) == ["directory1"]
+
+        where:
+        html                                              | descr
+        '<a href="directory1">'                           | "double quoted values"
+        "<a href='directory1'>"                           | "single quoted values"
+        '<a href=directory1>'                             | "unquoted values"
+        '<a href = "directory1" >'                        | "spaces around the equals sign"
+        '<A HREF="directory1">'                           | "upper case names"
+        '<a href="directory1"/>'                          | "self closing tags"
+        '<a class="link" href="directory1" rel="nofollow">' | "other attributes"
+        '<a download href="directory1">'                  | "valueless attributes"
+        '<a\nhref="directory1">'                          | "newlines between attributes"
+        '<a href="directory1"'                            | "an unterminated tag"
+    }
+
+    def "ignores #descr"() {
+        expect:
+        scanner.scan(html).isEmpty()
+
+        where:
+        html                                                    | descr
+        '<a name="anchorname">headline</a>'                     | "anchors without an href"
+        '<p href="directory1">'                                 | "hrefs on other elements"
+        '<!-- <a href="directory1"> -->'                        | "anchors inside comments"
+        '<![CDATA[<a href="directory1">]]>'                     | "anchors inside CDATA sections"
+        '<script>var l = \'<a href="directory1">\';</script>'   | "anchors inside script"
+        '<style>/* <a href="directory1"> */</style>'            | "anchors inside style"
+        '<textarea><a href="directory1"></textarea>'            | "anchors inside textarea"
+        '<title><a href="directory1"></title>'                  | "anchors inside title"
+        'a < b and <a> without an href'                         | "a bare less-than sign"
+        ''                                                      | "empty content"
+    }
+
+    def "keeps scanning after a raw text element"() {
+        expect:
+        scanner.scan('<script>ignored <a href="no"></script><a href="yes">') == ["yes"]
+        scanner.scan('<title>Index of /repo</title><a href="yes">') == ["yes"]
+    }
+
+    def "recovers the remaining links when a raw text element is never closed"() {
+        expect:
+        scanner.scan('<script><a href="directory1">') == ["directory1"]
+        scanner.scan('<title>Index of <a href="directory1">') == ["directory1"]
+    }
+
+    def "reads a valueless href as an empty href"() {
+        expect:
+        scanner.scan(html) == [""]
+
+        where:
+        html << ['<a href>', '<a href >', '<a href=>', '<a href="">']
+    }
+
+    def "resolves #descr in href values"() {
+        expect:
+        scanner.scan("<a href=\"$href\">") == [resolved]
+
+        where:
+        href              | resolved     | descr
+        'a&amp;b'         | 'a&b'        | "named references"
+        'a&#38;b'         | 'a&b'        | "decimal references"
+        'a&#x26;b'        | 'a&b'        | "hexadecimal references"
+        'a&quot;b'        | 'a"b'        | "quote references"
+        'a&b=c'           | 'a&b=c'      | "an unescaped ampersand"
+        'a&unknown;b'     | 'a&unknown;b'| "unrecognised references"
+    }
+
+    def "uses the first href when an anchor repeats the attribute"() {
+        expect:
+        scanner.scan('<a href="first" href="second">') == ["first"]
+    }
+
+    /**
+     * Rescanning the rest of the document for each unclosed tag would take minutes here.
+     */
+    @Timeout(30)
+    def "does not rescan the document for each unclosed raw text element"() {
+        given:
+        def html = '<script>' * 200000 + '<a href="directory1">'
+
+        expect:
+        scanner.scan(html) == ["directory1"]
+    }
+}

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
     protected static final NATIVE_PLATFORM_BINARIES = 16
-    protected static final THIRD_PARTY_LIB_COUNT = 116
+    protected static final THIRD_PARTY_LIB_COUNT = 115
 
     @Shared
     String baseVersion = GradleVersion.current().baseVersion.version


### PR DESCRIPTION
### Context

`resources-http` was the only place jsoup was used in the Gradle distribution, in a single call site: `ApacheDirectoryListingParser`, which reads the HTML directory listing an Ivy repository served over HTTP returns when resolving a dynamic version. Dropping it removes jsoup from the distribution entirely.

Only the `href` of each anchor is of interest, so a document tree is more machinery than the job needs. The new `HtmlAnchorHrefScanner` scans the markup for start tags instead, which is indifferent to how the surrounding elements nest and so needs no position on how to repair the ones that don't. It skips comments, doctypes, CDATA sections and the content of raw text elements such as `<script>`, accepts single-quoted and unquoted attribute values, and resolves the character references that can appear in a URL.

### How this was validated

Beyond the unit tests, the scanner was compared directly against jsoup:

- **The three repository listing fixtures in this repo** (Artifactory, Maven Central, Nexus): 22 anchors each, **reproduced exactly**.
- **30,000 fuzzed documents built from well-formed fragments**: 2,796 differ (9.3%), and every one falls into two classes, both artifacts of jsoup's tree building rather than of the markup:
  - 2,778 where jsoup **duplicates** an anchor. Leaving an `<a>` unclosed across a block element makes jsoup's active-formatting-elements reconstruction clone it, so the entry is listed twice. Deduplicated, the two results are identical.
  - 18 where jsoup **reorders** anchors foster-parented out of a `<table>`. The scanner keeps document order.

  Neither changes which entries a listing yields. `ResourceVersionLister` collects results into a `List` that already admits duplicates from multiple patterns, and version selection compares with a version comparator, so neither count nor order is semantically meaningful downstream.

One deliberate divergence, for malformed markup: where a raw text element such as `<script>` is **never closed**, jsoup treats the rest of the document as text, which would silently discard every remaining link. The scanner reads the remainder as markup instead — recovering links from already-broken markup seemed better than losing them. A memo of which tags were found unterminated keeps that recovery linear rather than quadratic on a document full of unclosed tags (covered by a test).

### On using a JDK parser instead

`javax.swing.text.html.parser.ParserDelegator` is the only HTML parser in the JDK, and it was measured too. It matches jsoup on the three real fixtures, but on the fuzz corpus it differs from jsoup on 27% of documents versus this scanner's 9.5%: 849 where a valueless `href` comes back as the sentinel string `#DEFAULT`, and 497 structural, which include **silently dropping** anchors that appear inside a `<table>` outside a row or cell (its HTML 3.2 content model). A version vanishing from resolution with no error is the worst available failure mode here. It also lives in `java.desktop`, which no Gradle production code currently depends on, and `resources-http` is on the client path. The `javax.xml` parsers are not an option — real listings contain `<hr>`, unquoted attributes and `&nbsp;`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — existing HTTP directory-listing integ tests cover this path end to end; no behaviour change to add tests for
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, internal
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`. — ran `:resources-http:test` (331 tests), the HTTP directory-listing integ tests in `:dependency-management` (76 tests), `checkstyleMain`, `codenarcTest` and `projectHealth`; relying on CI for the full `quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things