### PR TITLE
Synchronize DefaultClassLoaderScope loader initialization

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -36,7 +36,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
     private boolean locked;
 
-    protected ClassPath export = ClassPath.EMPTY;
+    private ClassPath export = ClassPath.EMPTY;
     private List<ClassLoader> exportLoaders; // if not null, is not empty
     private ClassPath local = ClassPath.EMPTY;
     private List<ClassLoader> ownLoaders;
@@ -45,7 +45,8 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     private MultiParentClassLoader exportingClassLoader;
     private MultiParentClassLoader localClassLoader;
 
-    // What is actually exposed
+    // Effective loaders, materialized once on the first query. `built` guards the memoization
+    private boolean built;
     private ClassLoader effectiveLocalClassLoader;
     private ClassLoader effectiveExportClassLoader;
 
@@ -85,8 +86,8 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
         return loader(classLoaderId, parent, classPath);
     }
 
-    private void buildEffectiveLoaders() {
-        if (effectiveLocalClassLoader == null) {
+    private synchronized void buildEffectiveLoaders() {
+        if (!built) {
             boolean hasExports = !export.isEmpty() || exportLoaders != null;
             boolean hasLocals = !local.isEmpty();
             if (locked) {
@@ -120,17 +121,18 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
             }
 
             exportLoaders = null;
+            built = true;
         }
     }
 
     @Override
-    public ClassLoader getExportClassLoader() {
+    public synchronized ClassLoader getExportClassLoader() {
         buildEffectiveLoaders();
         return effectiveExportClassLoader;
     }
 
     @Override
-    public ClassLoader getLocalClassLoader() {
+    public synchronized ClassLoader getLocalClassLoader() {
         buildEffectiveLoaders();
         return effectiveLocalClassLoader;
     }
@@ -141,7 +143,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public boolean defines(Class<?> clazz) {
+    public synchronized boolean defines(Class<?> clazz) {
         if (ownLoaders != null) {
             for (ClassLoader ownLoader : ownLoaders) {
                 if (ownLoader.equals(clazz.getClassLoader())) {
@@ -152,7 +154,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
         return false;
     }
 
-    protected ClassLoader loader(ClassLoaderId classLoaderId, ClassLoader parent, ClassPath classPath) {
+    private synchronized ClassLoader loader(ClassLoaderId classLoaderId, ClassLoader parent, ClassPath classPath) {
         if (classPath.isEmpty()) {
             return parent;
         }
@@ -166,7 +168,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope local(ClassPath classPath) {
+    public synchronized ClassLoaderScope local(ClassPath classPath) {
         if (classPath.isEmpty()) {
             return this;
         }
@@ -183,7 +185,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope export(ClassPath classPath) {
+    public synchronized ClassLoaderScope export(ClassPath classPath) {
         if (classPath.isEmpty()) {
             return this;
         }
@@ -199,7 +201,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope export(ClassLoader classLoader) {
+    public synchronized ClassLoaderScope export(ClassLoader classLoader) {
         assertNotLocked();
         if (exportingClassLoader != null) {
             exportingClassLoader.addParent(classLoader);
@@ -220,25 +222,38 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope lock() {
+    public synchronized ClassLoaderScope lock() {
         locked = true;
         return this;
     }
 
     @Override
-    public boolean isLocked() {
+    public synchronized boolean isLocked() {
         return locked;
     }
 
     @Override
     public void onReuse() {
         parent.onReuse();
-        listener.childScopeCreated(parent.getId(), id, origin);
-        if (!export.isEmpty()) {
-            listener.classloaderCreated(this.id, id.exportId(), effectiveExportClassLoader, export, null);
+
+        // As this method runs under a cross-build cache lock, we minimize monitor holding time
+        ClassPath exportSnapshot;
+        ClassPath localSnapshot;
+        ClassLoader exportLoader;
+        ClassLoader localLoader;
+        synchronized (this) {
+            exportSnapshot = export;
+            localSnapshot = local;
+            exportLoader = effectiveExportClassLoader;
+            localLoader = effectiveLocalClassLoader;
         }
-        if (!local.isEmpty()) {
-            listener.classloaderCreated(this.id, id.localId(), effectiveLocalClassLoader, local, null);
+
+        listener.childScopeCreated(parent.getId(), id, origin);
+        if (!exportSnapshot.isEmpty()) {
+            listener.classloaderCreated(this.id, id.exportId(), exportLoader, exportSnapshot, null);
+        }
+        if (!localSnapshot.isEmpty()) {
+            listener.classloaderCreated(this.id, id.localId(), localLoader, localSnapshot, null);
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -29,6 +29,11 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
 class DefaultClassLoaderScopeTest extends Specification {
 
     ClassLoaderScope root
@@ -417,6 +422,57 @@ class DefaultClassLoaderScopeTest extends Specification {
         and:
         !scope.defines(exportLoader.loadClass(TestClass1.name))
         !scope.defines(exportLoader.loadClass(TestClass2.name))
+    }
+
+    def "concurrent queries of a #description scope all observe the same fully built loaders"() {
+        given:
+        def threads = 8
+        def barrier = new CyclicBarrier(threads)
+        def executor = Executors.newFixedThreadPool(threads)
+        scope.export(classPath("export"))
+        scope.local(classPath("local"))
+        if (locked) {
+            scope.lock()
+        }
+
+        when: "many threads race to trigger the lazy initialization"
+        def results = executor.invokeAll((1..threads).collect { i ->
+            { ->
+                barrier.await(30, TimeUnit.SECONDS)
+                def export
+                def local
+                // Alternate which accessor triggers initialization
+                if (i % 2 == 0) {
+                    export = scope.exportClassLoader
+                    local = scope.localClassLoader
+                } else {
+                    local = scope.localClassLoader
+                    export = scope.exportClassLoader
+                }
+                [export, local]
+            } as Callable
+        })*.get(30, TimeUnit.SECONDS)
+
+        def exports = results*.first()
+        def locals = results*.last()
+
+        then: "no thread ever observes a partially initialized scope"
+        exports.size == threads
+        locals.size == threads
+        exports.every { it != null }
+        locals.every { it != null }
+
+        and: "every thread observes the very same loader instances"
+        exports.every { it === exports.first() }
+        locals.every { it === locals.first() }
+
+        cleanup:
+        executor.shutdownNow()
+
+        where:
+        description   | locked
+        "locked"      | true
+        "unlocked"    | false
     }
 
     void copyTo(Class<?> clazz, TestFile destDir) {


### PR DESCRIPTION
Fixes #38866

### Summary

Makes the lazy initialization of a class loader scope thread-safe. This removes the intermittent `NullPointerException` during plugin application in Isolated Projects mode.

### Why

Isolated Projects mode configures projects in parallel. A project's class loader scope is a child of the scope of its parent project, so sibling projects share one ancestor scope object. Each sibling configures on its own thread, and each one asks that shared ancestor for its export class loader while it resolves plugin requests.

The scope built its loaders on the first query, but it did no locking. Two threads could both find the scope unbuilt, both run the initialization, and interleave their writes. A thread could then receive a class loader that another thread was still assembling, or receive nothing at all. The plugin resolver stored that empty result and failed much later, at a point far from the cause.

The stack trace in the issue is misleading. The frames show where the empty value is used, not where the defect is. The defect is in the class loader scope, and the plugin-use code is only the victim.

Other modes are not affected, because they do not configure projects in parallel. There, a single project lock serializes access by accident.

### What

- The scope now serializes access to its own mutable state. The lifecycle is unchanged: callers mutate the scope, lock it, then query it.
  - Initialization is guarded by an explicit "already built" state instead of by one of the two loader fields.
  - Reuse notification reads its state under the lock, but does its recursion and its callbacks outside the lock.
- The internal loader factory and the export classpath are no longer visible to subclasses.

### Verification

- A unit test races many threads into the initialization of one scope and asserts that they all get the same loaders.
  - It covers both the locked and the unlocked state.
  - It was confirmed to fail against the unfixed code before it was accepted as proof of the fix.

### Details

**Consumer impact.** None for correct sequential use. A shared scope is now a point of serialization for the sibling projects that query it, but the work inside the lock is small once the scope is locked.

**Mutators take the lock, although only one thread mutates.** Initialization reads the accumulated classpath and the locked state while it holds the lock. A lock gives an ordering guarantee only between threads that take the same lock, so the writes must take it too. Without this, a lock on the reader alone guarantees nothing.

**Reuse notification does not take the lock for its whole body.** It recurses through the parent chain, and it runs inside a cross-build cache callback that must stay fast. A lock on the whole method would hold the lock of every ancestor scope at the same time. A snapshot of the state avoids this.

**An explicit built state, and not a check for an empty loader field.** The two loader fields are assigned in a different order in different branches. Therefore a check on either field gives a result that depends on which branch ran.

**Risk: the test proves less than the fix claims.** It reliably shows that two threads no longer initialize the scope at the same time. It does not force the delayed-visibility case, where one thread does not yet see the completed work of another. That case is permitted by the memory model but is rare in practice, so the test is a lower bound on the guarantee.

**Risk: lock order is reasoned about, not proven.** Initialization holds the lock of the scope while it asks the parent scope for its loader, and the loader factory then takes the lock of the loader cache. The order is always child, then parent, then cache. No path takes them in the opposite order, as far as I can tell. A cycle here would be a deadlock, and it would not be visible in the diff.
