### PR TITLE
Merge all childless runs when a later run reports children

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModel.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModel.java
@@ -197,12 +197,25 @@ public class TestTreeModel {
                         existingRootInfos.add(rootInfo);
                     }
                 } else {
-                    // Merge into the one that is also not a leaf if possible, otherwise just merge into the first one.
-                    PerRootInfo.Builder toMerge = existingRootInfos.stream()
+                    // Merge into the one that is also not a leaf if possible.
+                    PerRootInfo.Builder existingNonLeaf = existingRootInfos.stream()
                         .filter(info -> !info.isLeaf())
                         .findFirst()
-                        .orElseGet(() -> existingRootInfos.get(0));
-                    toMerge.merge(rootInfo);
+                        .orElse(null);
+                    if (existingNonLeaf != null) {
+                        existingNonLeaf.merge(rootInfo);
+                    } else {
+                        // Every existing entry is a leaf, but this one has children, so none of them were ever
+                        // a genuine test method retry -- they're earlier runs of this same node that happened to
+                        // report no children (e.g. a class rescheduled onto a worker that was lost before any
+                        // test method could report). Fold them all into the first entry along with this one,
+                        // rather than stranding the rest, which would leave more than one entry for this node.
+                        PerRootInfo.Builder first = existingRootInfos.get(0);
+                        for (int i = existingRootInfos.size() - 1; i > 0; i--) {
+                            first.merge(existingRootInfos.remove(i));
+                        }
+                        first.merge(rootInfo);
+                    }
                 }
             } else {
                 existingRootInfos.add(rootInfo);

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelTest.groovy
@@ -32,10 +32,12 @@ import java.nio.file.Path
  * Tests for {@link TestTreeModel}, specifically the merging behavior in finalizePath().
  *
  * <p>When a test group (e.g. a test class) is emitted multiple times within the same root,
- * some executions may have no children (e.g. when all methods are skipped). These childless
- * executions appear as leaves and must be merged into any existing non-leaf entry for the same
- * node, rather than being added as separate entries. True leaf retries (where all entries are
- * leaves) should still be preserved as separate entries.</p>
+ * some executions may have no children (e.g. when all methods are skipped, or a worker is
+ * lost before any method reports). These childless executions appear as leaves and must be
+ * merged into a non-leaf entry for the same node, regardless of whether that non-leaf entry
+ * already exists or arrives later -- otherwise every childless execution before the first
+ * execution with children would survive as its own entry. True leaf retries (where all
+ * entries are leaves) should still be preserved as separate entries.</p>
  */
 class TestTreeModelTest extends Specification {
 
@@ -93,6 +95,77 @@ class TestTreeModelTest extends Specification {
             def suite2 = descriptor("MySuite", root, "com.example.MySuite")
             writer.started(suite2, new TestStartEvent(300))
             writer.completed(suite2, successResult(300, 400), new TestCompleteEvent(400))
+
+            writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
+        }
+
+        when:
+        TestTreeModelResultsProvider.useResultsFrom(tempDir.resolve("store")) { provider ->
+            provider.visitClasses { }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "merges multiple childless executions into a later execution with children"() {
+        given:
+        def store = writeStore { writer ->
+            def root = descriptor("root", null)
+
+            def suite1 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(root, new TestStartEvent(100))
+            writer.started(suite1, new TestStartEvent(100))
+            writer.completed(suite1, successResult(100, 200), new TestCompleteEvent(200))
+
+            def suite2 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(suite2, new TestStartEvent(200))
+            writer.completed(suite2, successResult(200, 300), new TestCompleteEvent(300))
+
+            def suite3 = descriptor("MySuite", root, "com.example.MySuite")
+            def testA = descriptor("testA", suite3, "com.example.MySuite")
+            writer.started(suite3, new TestStartEvent(300))
+            writer.started(testA, new TestStartEvent(300))
+            writer.completed(testA, successResult(300, 400), new TestCompleteEvent(400))
+            writer.completed(suite3, successResult(300, 400), new TestCompleteEvent(400))
+
+            writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
+        }
+
+        when:
+        def model = TestTreeModel.loadModelFromStores([store])
+
+        then:
+        model.children.size() == 1
+        def suiteNode = model.children[0]
+        suiteNode.path.name == "MySuite"
+        suiteNode.perRootInfo[0].size() == 1
+        !suiteNode.perRootInfo[0][0].isLeaf()
+        suiteNode.perRootInfo[0][0].results.size() == 3
+        suiteNode.children.size() == 1
+        suiteNode.children[0].path.name == "testA"
+    }
+
+    def "report generation does not crash when execution with children follows multiple childless executions"() {
+        given:
+        def storeDir = writeStore { writer ->
+            def root = descriptor("root", null)
+
+            def suite1 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(root, new TestStartEvent(100))
+            writer.started(suite1, new TestStartEvent(100))
+            writer.completed(suite1, successResult(100, 200), new TestCompleteEvent(200))
+
+            def suite2 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(suite2, new TestStartEvent(200))
+            writer.completed(suite2, successResult(200, 300), new TestCompleteEvent(300))
+
+            def suite3 = descriptor("MySuite", root, "com.example.MySuite")
+            def testA = descriptor("testA", suite3, "com.example.MySuite")
+            writer.started(suite3, new TestStartEvent(300))
+            writer.started(testA, new TestStartEvent(300))
+            writer.completed(testA, successResult(300, 400), new TestCompleteEvent(400))
+            writer.completed(suite3, successResult(300, 400), new TestCompleteEvent(400))
 
             writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
         }


### PR DESCRIPTION
Fixes #38891

`TestTreeModel.finalizePath()` merges the several runs of a test group into a single
`PerRootInfo` entry. A run with no children (a leaf) only merges into an existing
non-leaf entry; if none exists yet, it is appended, correct for a genuinely retried
test method, which should show as separate runs.

That rule breaks down when the leaf-shaped runs are not test methods but childless runs
of a *container* (e.g. a class rescheduled onto a worker that was lost before any method
could report). If two or more such runs arrive before the run that finally reports
children, the incoming non-leaf only merges into the *first* existing entry, leaving the
rest stranded as separate `PerRootInfo` entries for the same grouping node.
`TestTreeModelResultsProvider.createEmptyClassResult` then asserts exactly one entry and
throws `IllegalStateException`.

This was a surviving gap in the fix for #36808 (PR #36814): that fix covered
`children, then childless`; this covers `childless, childless, ..., then children`.

## Fix

Fold every existing leaf entry into one before merging in the arriving non-leaf, instead
of merging only into the first. A node that arrives as a non-leaf was never a genuine
test method, so its earlier leaf-shaped entries are childless runs of the same
container, not retries, folding them together is safe and confined to that case.

## Testing

- Added two tests to `TestTreeModelTest` reproducing the failing sequence directly and
  through `TestTreeModelResultsProvider`, both failing before the fix and passing after.
- Verified end-to-end against a standalone reproducer
  ([rpalcolea/gradle-childless-retry-repro](https://github.com/rpalcolea/gradle-childless-retry-repro))
  that drives the event sequence through the public `TestEventReporterFactory` API.

### Context
Any build using Gradle 9.4+'s generic test report, where a test group (typically a test
class) can be started on more than one worker before any of those runs reports a test
method, hits this. In practice that means Develocity Test Distribution rescheduling a
class after a remote executor disconnects, the same trigger as #36808, but this time
the class loses its executor *twice* before it finally runs to completion with children.

Because the failure happens during report generation rather than during the tests
themselves, `--continue` and `ignoreFailures` don't help, and the thrown
`IllegalStateException` names an internal grouping node with no actionable signal, so it
reads as a build infrastructure failure rather than a flaky test. This is especially
disruptive on large, multi-project builds under heavy Test Distribution use, where
correlated executor loss (e.g. a wave of backend disconnects) is far more likely to hit
the same class twice.

#36808 / #36814 fixed the `children, then childless` ordering six months ago, but the
`childless, childless, ..., then children` ordering was never covered and still throws
today on every release since, including the latest (9.4.0 through 9.7.0 confirmed). A
deterministic, minimal reproducer isolating the defect (no Test Distribution or retry
plugin required) is at
[rpalcolea/gradle-childless-retry-repro](https://github.com/rpalcolea/gradle-childless-retry-repro).

*This PR, including the diagnosis, fix, tests, and this description, was developed with
AI assistance (Claude Code); the reproducer, fix approach, and verification were
reviewed and validated by me before submission.*

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
