### PR TITLE
Kill worker daemons still running abandoned work after a task timeout

### DIFF
--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -26,7 +26,6 @@ import org.gradle.process.internal.worker.MultiRequestClient;
 import org.gradle.process.internal.worker.WorkerProcess;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 class WorkerDaemonClient implements Stoppable, Describable {
     public static final String DISABLE_EXPIRATION_PROPERTY_KEY = "org.gradle.workers.internal.disable-daemons-expiration";
@@ -36,8 +35,8 @@ class WorkerDaemonClient implements Stoppable, Describable {
     private final LogLevel logLevel;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private int uses;
-    private final AtomicBoolean executing = new AtomicBoolean();
-    private final AtomicBoolean abandoned = new AtomicBoolean();
+    private volatile boolean executing;
+    private volatile boolean abandoned;
     private boolean cannotBeExpired = Boolean.getBoolean(DISABLE_EXPIRATION_PROPERTY_KEY);
 
     public WorkerDaemonClient(DaemonForkOptions forkOptions, MultiRequestClient<TransportableActionExecutionSpec, DefaultWorkResult> workerClient, WorkerProcess workerProcess, LogLevel logLevel, ActionExecutionSpecFactory actionExecutionSpecFactory) {
@@ -57,22 +56,20 @@ class WorkerDaemonClient implements Stoppable, Describable {
     }
 
     public DefaultWorkResult execute(IsolatedParametersActionExecutionSpec<?> spec) {
+        TransportableActionExecutionSpec transportableSpec = actionExecutionSpecFactory.newTransportableSpec(spec);
         uses++;
-        executing.set(true);
-        boolean completed = false;
+        executing = true;
         try {
-            DefaultWorkResult result = workerClient.run(actionExecutionSpecFactory.newTransportableSpec(spec));
-            completed = true;
-            return result;
+            return workerClient.run(transportableSpec);
+        } catch (Throwable t) {
+            // The request never produced a response, typically because the thread waiting on it was
+            // interrupted when the owning task exceeded its timeout. The build has given up on the result,
+            // but the worker process is still running the work item, so this client is neither safe to
+            // reuse nor safe to stop gracefully.
+            abandoned = true;
+            throw t;
         } finally {
-            executing.set(false);
-            if (!completed) {
-                // The request never produced a response, typically because the thread waiting on it was
-                // interrupted when the owning task exceeded its timeout. The build has given up on the result,
-                // but the worker process is still running the work item, so this client is neither safe to
-                // reuse nor safe to stop gracefully.
-                abandoned.set(true);
-            }
+            executing = false;
         }
     }
 
@@ -80,7 +77,7 @@ class WorkerDaemonClient implements Stoppable, Describable {
      * Whether this client is currently executing a work item, i.e. the worker process is busy running it.
      */
     public boolean isExecuting() {
-        return executing.get();
+        return executing;
     }
 
     /**
@@ -88,7 +85,7 @@ class WorkerDaemonClient implements Stoppable, Describable {
      * The worker process may still be running that work item.
      */
     public boolean isAbandoned() {
-        return abandoned.get();
+        return abandoned;
     }
 
     public boolean isCompatibleWith(DaemonForkOptions required) {

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -26,6 +26,7 @@ import org.gradle.process.internal.worker.MultiRequestClient;
 import org.gradle.process.internal.worker.WorkerProcess;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class WorkerDaemonClient implements Stoppable, Describable {
     public static final String DISABLE_EXPIRATION_PROPERTY_KEY = "org.gradle.workers.internal.disable-daemons-expiration";
@@ -35,6 +36,8 @@ class WorkerDaemonClient implements Stoppable, Describable {
     private final LogLevel logLevel;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private int uses;
+    private final AtomicBoolean executing = new AtomicBoolean();
+    private final AtomicBoolean abandoned = new AtomicBoolean();
     private boolean cannotBeExpired = Boolean.getBoolean(DISABLE_EXPIRATION_PROPERTY_KEY);
 
     public WorkerDaemonClient(DaemonForkOptions forkOptions, MultiRequestClient<TransportableActionExecutionSpec, DefaultWorkResult> workerClient, WorkerProcess workerProcess, LogLevel logLevel, ActionExecutionSpecFactory actionExecutionSpecFactory) {
@@ -55,7 +58,37 @@ class WorkerDaemonClient implements Stoppable, Describable {
 
     public DefaultWorkResult execute(IsolatedParametersActionExecutionSpec<?> spec) {
         uses++;
-        return workerClient.run(actionExecutionSpecFactory.newTransportableSpec(spec));
+        executing.set(true);
+        boolean completed = false;
+        try {
+            DefaultWorkResult result = workerClient.run(actionExecutionSpecFactory.newTransportableSpec(spec));
+            completed = true;
+            return result;
+        } finally {
+            executing.set(false);
+            if (!completed) {
+                // The request never produced a response, typically because the thread waiting on it was
+                // interrupted when the owning task exceeded its timeout. The build has given up on the result,
+                // but the worker process is still running the work item, so this client is neither safe to
+                // reuse nor safe to stop gracefully.
+                abandoned.set(true);
+            }
+        }
+    }
+
+    /**
+     * Whether this client is currently executing a work item, i.e. the worker process is busy running it.
+     */
+    public boolean isExecuting() {
+        return executing.get();
+    }
+
+    /**
+     * Whether a work item submitted to this client was abandoned before the worker reported a result.
+     * The worker process may still be running that work item.
+     */
+    public boolean isAbandoned() {
+        return abandoned.get();
     }
 
     public boolean isCompatibleWith(DaemonForkOptions required) {

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -175,13 +175,11 @@ public class WorkerDaemonClientsManager implements Stoppable {
     }
 
     /**
-     * Stops a client, killing it instead if it is still executing a work item.
+     * Stops a client, or kills it if it is still busy.
      *
-     * <p>By the time workers are stopped, a client that is still executing a work item is executing one that
-     * nothing is waiting for any more, for example because the owning task exceeded its {@code timeout}. Asking
-     * such a worker to stop gracefully only queues the stop request behind the abandoned work item, and the build
-     * then blocks in {@code WorkerProcess.waitForStop()} until that work item finishes on its own. Kill those
-     * workers instead, so that the build is not held up by work whose result is already being discarded.</p>
+     * <p>A client that is still busy when we get here is running work that nothing is waiting for any more,
+     * because the owning task timed out or failed. A graceful stop would wait for that work to finish, hanging
+     * the build on a result that is going to be thrown away.</p>
      */
     private void stopOrKillClient(WorkerDaemonClient client) {
         if (client.isExecuting() || client.isAbandoned()) {
@@ -249,8 +247,8 @@ public class WorkerDaemonClientsManager implements Stoppable {
         @Override
         public void beforeComplete() {
             synchronized (lock) {
-                List<WorkerDaemonClient> sessionScopedClients = CollectionUtils.filter(allClients, client -> client.getKeepAliveMode() == KeepAliveMode.SESSION);
-                stopWorkers(sessionScopedClients);
+                List<WorkerDaemonClient> clientsToStop = CollectionUtils.filter(allClients, client -> client.getKeepAliveMode() == KeepAliveMode.SESSION || client.isAbandoned());
+                stopWorkers(clientsToStop);
             }
         }
     }

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -129,7 +129,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
 
     void release(WorkerDaemonClient client) {
         synchronized (lock) {
-            if (!client.isFailed()) {
+            if (!client.isFailed() && !client.isAbandoned()) {
                 idleClients.add(client);
             }
         }
@@ -171,7 +171,25 @@ public class WorkerDaemonClientsManager implements Stoppable {
     }
 
     private void stopWorkers(List<WorkerDaemonClient> clientsToStop) {
-        stopWorkers(clientsToStop, STOP_CLIENT);
+        stopWorkers(clientsToStop, this::stopOrKillClient);
+    }
+
+    /**
+     * Stops a client, killing it instead if it is still executing a work item.
+     *
+     * <p>By the time workers are stopped, a client that is still executing a work item is executing one that
+     * nothing is waiting for any more, for example because the owning task exceeded its {@code timeout}. Asking
+     * such a worker to stop gracefully only queues the stop request behind the abandoned work item, and the build
+     * then blocks in {@code WorkerProcess.waitForStop()} until that work item finishes on its own. Kill those
+     * workers instead, so that the build is not held up by work whose result is already being discarded.</p>
+     */
+    private void stopOrKillClient(WorkerDaemonClient client) {
+        if (client.isExecuting() || client.isAbandoned()) {
+            LOGGER.info("Worker daemon '{}' is still executing work that is no longer being waited for, stopping it immediately.", client.getDisplayName());
+            client.kill();
+        } else {
+            client.stop();
+        }
     }
 
     private void stopWorkers(List<WorkerDaemonClient> clientsToStop, Consumer<WorkerDaemonClient> stopAction) {
@@ -210,7 +228,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
     }
 
     public void stopAllWorkers() {
-        stopAllWorkers(STOP_CLIENT);
+        stopAllWorkers(this::stopOrKillClient);
     }
 
     public void killAllWorkers() {
@@ -237,6 +255,5 @@ public class WorkerDaemonClientsManager implements Stoppable {
         }
     }
 
-    private static final Consumer<WorkerDaemonClient> STOP_CLIENT = WorkerDaemonClient::stop;
     private static final Consumer<WorkerDaemonClient> KILL_CLIENT = WorkerDaemonClient::kill;
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -33,6 +33,7 @@ import java.time.Duration
 class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
     private static final TIMEOUT = 500
+    private static final ABANDONED_WORK_MILLIS = 60_000
 
     long postTimeoutCheckFrequencyMs = Duration.ofMinutes(3).toMillis()
     long slowStopLogStacktraceFrequencyMs = Duration.ofMinutes(3).toMillis()
@@ -227,6 +228,109 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         isolationMode << ['no', 'classLoader', 'process']
+    }
+
+
+    /**
+     * Deterministic reproducer for https://github.com/gradle/gradle-private/issues/5086.
+     *
+     * When a task times out while a work item is running in a process isolation worker daemon,
+     * nothing stops that work item: session teardown calls WorkerDaemonClient.stop(), which asks the
+     * worker to stop *after* its current request and then blocks in DefaultExecHandle.waitForFinish()
+     * with no timeout. The build therefore blocks for as long as the abandoned work item runs.
+     *
+     * The ':warmup' task exists purely to fork a worker daemon and return it to the idle pool, so that
+     * ':block' reuses a warm daemon and its work item starts immediately. Without that, whether the
+     * build hangs depends on a race between worker daemon startup and the task timeout, which is why
+     * "timeout stops long running work items with process isolation" is only intermittently red.
+     */
+    @LeaksFileHandles
+    @IntegrationTestTimeout(180)
+    def "build does not wait for abandoned process isolation work after a timeout"() {
+        given:
+        // Worker startup threads can be interrupted during teardown, see https://github.com/gradle/gradle/issues/8699
+        executer.withStackTraceChecksDisabled()
+        def marker = file("work-started.txt")
+        buildFile << """
+            import java.util.concurrent.CountDownLatch
+            import java.util.concurrent.TimeUnit
+            import org.gradle.workers.WorkParameters
+
+            interface BlockingParams extends WorkParameters {
+                Property<Long> getBlockMillis()
+                Property<String> getMarkerPath()
+            }
+
+            abstract class BlockingWorkAction implements WorkAction<BlockingParams> {
+                void execute() {
+                    long millis = parameters.blockMillis.get()
+                    if (millis > 0) {
+                        new File(parameters.markerPath.get()).text = "started"
+                        new CountDownLatch(1).await(millis, TimeUnit.MILLISECONDS)
+                    }
+                }
+            }
+
+            abstract class WorkerTask extends DefaultTask {
+
+                @Inject
+                abstract WorkerExecutor getWorkerExecutor()
+
+                @Internal
+                abstract Property<Long> getBlockMillis()
+
+                @Internal
+                abstract Property<String> getMarkerPath()
+
+                @TaskAction
+                void executeTask() {
+                    def millis = blockMillis.get()
+                    def path = markerPath.get()
+                    workerExecutor.processIsolation().submit(BlockingWorkAction) {
+                        it.blockMillis.set(millis)
+                        it.markerPath.set(path)
+                    }
+                    if (millis > 0) {
+                        // Wait until the work item is really inside its blocking section, so that the
+                        // timeout below cannot fire before the worker has started doing the work.
+                        def markerFile = new File(path)
+                        def deadline = System.currentTimeMillis() + 60000
+                        while (!markerFile.exists() && System.currentTimeMillis() < deadline) {
+                            Thread.sleep(50)
+                        }
+                    }
+                }
+            }
+
+            tasks.register("warmup", WorkerTask) {
+                blockMillis = 0L
+                markerPath = layout.projectDirectory.file("unused-marker.txt").asFile.absolutePath
+            }
+
+            tasks.register("block", WorkerTask) {
+                dependsOn "warmup"
+                blockMillis = ${ABANDONED_WORK_MILLIS}L
+                markerPath = layout.projectDirectory.file("work-started.txt").asFile.absolutePath
+                timeout = Duration.ofSeconds(5)
+            }
+            """
+
+        when:
+        def start = System.nanoTime()
+        fails "block"
+        def elapsedMillis = Duration.ofNanos(System.nanoTime() - start).toMillis()
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':block' (registered in build file 'build.gradle').")
+        failure.assertHasCause("Timeout has been exceeded")
+
+        and: "the worker daemon really was executing the work item when the timeout fired"
+        marker.exists()
+
+        and: "the build did not wait for the abandoned work item to run to completion"
+        assert elapsedMillis < ABANDONED_WORK_MILLIS / 2,
+            "Build took ${elapsedMillis}ms, i.e. it waited for the abandoned ${ABANDONED_WORK_MILLIS}ms work item " +
+                "instead of stopping the worker daemon executing it."
     }
 
     def "message is logged when stop is requested"() {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5086

### Context

`Task.timeout` does not stop work submitted with `processIsolation()`. It fails the task, and then the build blocks for the full remaining duration of the abandoned work item.

When a task times out while a work item is running in a worker daemon:

1. The thread waiting on the work item is interrupted. `AbstractConditionalExecution.await()` responds by cancelling the execution, which interrupts the thread inside `WorkerDaemonClient.execute()`. The client is therefore released back to the **idle pool**, even though the worker process is still running the work item and has never reported a result.
2. Session teardown then asks that worker to stop gracefully. `RequestProtocol.stop()` and `run()` arrive on the same incoming queue in the worker (`WorkerAction`), so the stop request simply queues behind the in-flight work item. The build then blocks in `DefaultExecHandle.waitForFinish()`, which has **no timeout**, until the abandoned work item finishes on its own.

The only path that actually kills a worker, `WorkerDaemonClientsManager.killAllWorkers()`, is wired solely to `WorkerDaemonClientCancellationHandler` (build cancellation). Nothing on the timeout path.

Standalone demonstration on 9.7, no Gradle checkout involved — a task with `timeout = Duration.ofMillis(500)` submitting process isolation work items that block for 30s:

```
> Task :block FAILED
Requesting stop of task ':block' as it has exceeded its configured timeout of 500ms.
BUILD FAILED in 2s          <- what Gradle reports
WORK ACTION FINISHED ...    <- every work item still runs to completion
real 33.1s                  <- actual wall clock
```

Wall clock tracks the abandoned work 1:1: 30s work → ~34s build, 10s work → ~13s build, work never started → ~4s.

There is a second, independent consequence of (1): an abandoned client goes straight back into the idle pool, so the next task to reserve a worker can be handed one whose process is still executing the previous work item, and queues behind it. No timeout required to hit that.

### Why the test is flaky rather than always red

`TaskTimeoutIntegrationTest.timeout stops long running work items with process isolation` has been intermittently red for years and is currently the top failure in the Windows flaky-test quarantine builds ([116452314](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_Quick_2/116452314), [116426068](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_Quick_2/116426068)).

It hangs only when a worker daemon wins a race against the 500ms task timeout. When the daemon has not connected yet, teardown aborts it mid-startup and the test passes in ~3s. When it has reached the blocking section, the build waits out the 90s work item and the 60s `@IntegrationTestTimeout` kills it. In one quarantine build the five reruns took 60.2s, 60.3s, **3.2s**, 60.6s, 60.6s — the fast one being the run where no work item ever started.

### Changes

`WorkerDaemonClient` records whether a submitted work item was abandoned before the worker reported a result. Such a client:

- is no longer returned to the idle pool, since its worker is still busy with the old request;
- is killed rather than stopped gracefully when workers are stopped.

Well-behaved workers keep the existing graceful stop.

### Reproducer

The added integration test removes the race, so it fails deterministically rather than intermittently. A `:warmup` task forks a worker daemon and returns it to the idle pool, so `:block` reuses a warm daemon and its work item starts immediately; the task action then waits on a marker file so the timeout provably fires while the worker is inside its blocking section. The test asserts the marker exists, so a lost race fails loudly instead of passing silently.

Before the fix, 4/4 runs:

```
Build took 61912ms, i.e. it waited for the abandoned 60000ms work item
instead of stopping the worker daemon executing it.
```

### Verification

Local (macOS):

| | before | after |
|---|---|---|
| `build does not wait for abandoned process isolation work after a timeout` | 60.8s FAIL (4/4) | **5.65s pass** |
| `timeout stops long running work items with process isolation` | 60.0s FAIL | **1.58s pass** |
| `TaskTimeoutIntegrationTest` | 2 failed | **13/13 pass** |
| `:workers:embeddedIntegTest` + `:workers:test` | | **426 tests, 0 failures** |

Windows (`Rerun Flaky Test - Windows Amd64`, Java 17, 10 iterations per build), which is where this has been failing:

| build | commit | test | result |
|---|---|---|---|
| [116525063](https://builds.gradle.org/build/116525063) | repro **without** the fix | `build does not wait for abandoned process isolation work after a timeout` | **0/30 pass**, 67.4–69.4s each |
| [116505410](https://builds.gradle.org/build/116505410) | with the fix | same test | **10/10 pass**, ~12.7s each |
| [116524572](https://builds.gradle.org/build/116524572) | with the fix | `timeout stops long running work items with #isolationMode isolation` (the long-standing flaky test) | **30/30 pass** — `no` 10/10 (6.2–7.3s), `classLoader` 10/10 (2.4–2.7s), **`process` 10/10 (5.9–7.8s)** |

- [x] `./gradlew sanityCheck` — green on CI (`Sanity Check on Linux`, `Sanity Check (Quick Feedback - Linux Only)`)

### Note for reviewers

This is a deliberate behaviour change, not only a bug fix: a work item that was still running when its task timed out is now **terminated mid-flight** rather than left to run to completion. That seems right, since the build has already discarded its result and the task is failing regardless — but it is worth an explicit opinion.

Not included, deliberately: a bounded `waitForStop` that escalates to a kill on expiry. That is worth having as defence in depth for a worker wedged for some reason this change does not classify as abandoned, but as the primary fix it would be a timeout papering over the real gap, and it would have muddied the signal from the reproducer. Happy to add it here or separately.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Existing unit tests (`WorkerDaemonClientsManagerTest`) pass; no new unit test, the behaviour is only observable end to end.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, internal types only
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`. — green on CI
- [x] Ensure that tests pass locally: `./gradlew :workers:quickTest` equivalent, see table above.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things


