### PR TITLE
Suppress software model deprecation checks in native IDE samples test

### DIFF
--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
@@ -37,6 +37,7 @@ class NativeIdeSamplesIntegrationTest extends AbstractVisualStudioIntegrationSpe
     @ToBeFixedForConfigurationCache(issue = "https://github.com/gradle/gradle/issues/36854")
     def "visual studio"() {
         given:
+        executer.beforeExecute { it.noDeprecationChecks() }
         sample visualStudio
 
         when:
@@ -62,6 +63,7 @@ class NativeIdeSamplesIntegrationTest extends AbstractVisualStudioIntegrationSpe
         useMsbuildTool()
 
         given:
+        executer.beforeExecute { it.noDeprecationChecks() }
         sample visualStudio
         run "visualStudio"
 


### PR DESCRIPTION
### Context

`NativeIdeSamplesIntegrationTest."visual studio"` has been failing on `master` since
f142efbf43857f48e1ed9902854d152c3611c89f ("Nag when rule source plugins are applied", #38378),
on both toolchain variants (gcc 11.4.0 and clang 11.1.0):

```
java.lang.AssertionError: Standard output line 3 contains an unexpected deprecation warning:
 - The org.gradle.platform.base.plugins.ComponentBasePlugin plugin has been deprecated. ...
```

Failing build: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsIntegMultiVersion_33/116452302

The build under test succeeds (`BUILD SUCCESSFUL`) — only the deprecation assertion fails. The
`visual-studio` sample applies `id 'cpp'` + `id 'visual-studio'`, which transitively pull in nine
rule-based/software model plugins (`ComponentBasePlugin`, `LanguageBasePlugin`, `BinaryBasePlugin`,
`ComponentModelBasePlugin`, `NativeComponentModelPlugin`, `CppLangPlugin` and the three
`VisualStudioPluginRules`), and the sample additionally uses four `model { }` DSL blocks — 13 new
deprecation warnings in total, none of which the test declared.

#38378 handled this consistently everywhere else: it touched 118 files under
`platforms/native/plugins-model-native/src/integTest`, including all four sibling native sample
tests. `NativeIdeSamplesIntegrationTest` is the only native sample test that lives outside
`plugins-model-native` (it is under `platforms/ide/ide-native`, and #38378 changed no files under
`platforms/ide`), so the platform-scoped sweep missed it.

This follows the approach already used for the other sample tests in #38378 — the exact set of
warnings a sample produces is a property of the sample, so enumerating 13 expectations here would
be brittle for no benefit. Compare `CUnitSamplesIntegrationTest`,
`GoogleTestSamplesIntegrationTest`, and `ModelRuleSamplesIntegrationTest`, which all call
`executer.beforeExecute { it.noDeprecationChecks() }`.

Both feature methods need it, since `"build generated visual studio solution"` also runs
`run "visualStudio"`.

#### Why CI did not catch this pre-merge

`MultiVersionTestCategoryExtension` skips the **entire spec** when *any* feature method carries
`@Flaky`:

```groovy
def hasFlaky = specHasFlaky || anyFeatureHasFlaky
if (excludeAnnotations.contains(flakyClassName) && hasFlaky) {
    spec.setSkipped(true)
}
```

`"build generated visual studio solution"` is annotated `@Flaky`, so the healthy `"visual studio"`
method is excluded from every regular `Check` configuration and runs only in the nightly
`FlakyQuarantine` build. TeamCity test history confirms it: on `master` and `release` this test
only ever appears in `FlakyQuarantine` configurations, whereas on `release8x` (which predates the
annotation) it runs in `Quick`, `Parallel`, `Platform`, `NoDaemon`, `ConfigCache` and
`ForceRealizeDependencyManagement`.

Worth a follow-up, but out of scope here: gradle-private#4488, the issue justifying that `@Flaky`,
was closed on 2024-09-30, so the annotation may no longer be needed — removing it would restore
pre-merge coverage for this class.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. — n/a, test-only change
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, test-only change
- [x] Ensure that tests pass locally: `./gradlew :ide-native:forkingIntegTest --tests "org.gradle.ide.visualstudio.NativeIdeSamplesIntegrationTest"`

### Verification

Verified locally on macOS (clang 21.0.0), reproducing the CI assertion and confirming the fix:

| | `visual studio` |
|---|---|
| Before | **FAILED** at `NativeIdeSamplesIntegrationTest.groovy:43` — `Standard output line 3 contains an unexpected deprecation warning` (identical to CI) |
| After | **PASSED** |

`build generated visual studio solution` is skipped locally (`@Requires(HasMsBuild)`), so its
identical change is only exercised by CI on Windows.
