### PR TITLE
Track flaky cross-version tests in subprojects.json

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -129,13 +129,22 @@ class FlakyTestQuarantine(
             gradleWrapper {
                 name =
                     "FLAKY_TEST_QUARANTINE_${testCoverage.testType.name.uppercase()}_${testCoverage.testJvmVersion.name.uppercase()}"
+                val defaultTestTaskName = "${testCoverage.testType.asCamelCase()}Test"
                 val testTaskName =
-                    if (testCoverage.testType ==
-                        TestType.ISOLATED_PROJECTS
-                    ) {
-                        "isolatedProjectsIntegTest"
-                    } else {
-                        "${testCoverage.testType.asCamelCase()}Test"
+                    when (testCoverage.testType) {
+                        TestType.ISOLATED_PROJECTS -> "isolatedProjectsIntegTest"
+                        // Cross-version test tasks are registered per tested Gradle version *per subproject*, so this
+                        // coverage schedules ~1000 of them unqualified. Under `-PflakyTests=ONLY` the tag filter is
+                        // evaluated during JUnit discovery inside the test JVM, so Gradle cannot know up front that a
+                        // task selects nothing - it forks a JVM for each one anyway. Qualify the task with the
+                        // subprojects that actually have an `@Flaky` cross-version test, which subprojects.json tracks
+                        // and `:checkSubprojectsInfo` keeps up to date.
+                        TestType.ALL_VERSIONS_CROSS_VERSION, TestType.QUICK_FEEDBACK_CROSS_VERSION ->
+                            model.subprojects.subprojects
+                                .filter { it.flakyCrossVersionTests }
+                                .joinToString(" ") { ":${it.name}:$defaultTestTaskName" }
+                                .ifEmpty { defaultTestTaskName }
+                        else -> defaultTestTaskName
                     }
                 tasks = "clean $testTaskName"
                 gradleParams = parameters

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -420,6 +420,12 @@ data class GradleSubproject(
     val unitTests: Boolean = true,
     val functionalTests: Boolean = true,
     val crossVersionTests: Boolean = false,
+    /**
+     * Whether this subproject has a cross-version test that `-PflakyTests=ONLY` could select. Generated into
+     * subprojects.json by `:generateSubprojectsInfo` and kept honest by `:checkSubprojectsInfo` in `sanityCheck`,
+     * so annotating a cross-version test anywhere adds its subproject to the flaky test quarantine build.
+     */
+    val flakyCrossVersionTests: Boolean = false,
 ) {
     fun hasTestsOf(testType: TestType) =
         (unitTests && testType.unitTests) ||

--- a/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
+++ b/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
@@ -55,6 +55,7 @@ data class JsonBasedGradleSubprojectProvider(
         val unitTests = !ignoredSubprojects.contains(name) && subproject["unitTests"] as Boolean
         val functionalTests = !ignoredSubprojects.contains(name) && subproject["functionalTests"] as Boolean
         val crossVersionTests = !ignoredSubprojects.contains(name) && subproject["crossVersionTests"] as Boolean
-        return GradleSubproject(name, path, unitTests, functionalTests, crossVersionTests)
+        val flakyCrossVersionTests = !ignoredSubprojects.contains(name) && subproject["flakyCrossVersionTests"] as Boolean
+        return GradleSubproject(name, path, unitTests, functionalTests, crossVersionTests, flakyCrossVersionTests)
     }
 }

--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -4,1763 +4,2015 @@
     "path": "platforms/software/ant",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ant-api",
     "path": "platforms/software/ant-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ant-impl",
     "path": "platforms/software/ant-impl",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ant-worker",
     "path": "platforms/software/ant-worker",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "antlr",
     "path": "platforms/jvm/antlr",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "api-metadata",
     "path": "platforms/core-configuration/api-metadata",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "architecture-test",
     "path": "testing/architecture-test",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-asm",
     "path": "platforms/core-runtime/base-asm",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-compiler-worker",
     "path": "platforms/software/base-compiler-worker",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-diagnostics",
     "path": "platforms/core-configuration/base-diagnostics",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-ide-plugins",
     "path": "platforms/ide/base-ide-plugins",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-services",
     "path": "platforms/core-runtime/base-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "base-services-groovy",
     "path": "platforms/core-configuration/base-services-groovy",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "bean-serialization-services",
     "path": "platforms/core-configuration/bean-serialization-services",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache",
     "path": "platforms/core-execution/build-cache",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-base",
     "path": "platforms/core-execution/build-cache-base",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-core",
     "path": "platforms/core-execution/build-cache-core",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-example-client",
     "path": "platforms/core-execution/build-cache-example-client",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-http",
     "path": "platforms/core-execution/build-cache-http",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-local",
     "path": "platforms/core-execution/build-cache-local",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-packaging",
     "path": "platforms/core-execution/build-cache-packaging",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-cache-spi",
     "path": "platforms/core-execution/build-cache-spi",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-configuration",
     "path": "platforms/core-runtime/build-configuration",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-discovery",
     "path": "platforms/core-runtime/build-discovery",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-discovery-impl",
     "path": "platforms/core-runtime/build-discovery-impl",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-discovery-reporting",
     "path": "platforms/core-runtime/build-discovery-reporting",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-init",
     "path": "platforms/software/build-init",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-init-specs",
     "path": "platforms/software/build-init-specs",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-init-specs-api",
     "path": "platforms/software/build-init-specs-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-operations",
     "path": "platforms/core-runtime/build-operations",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-operations-trace",
     "path": "platforms/core-runtime/build-operations-trace",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-option",
     "path": "platforms/core-runtime/build-option",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-process-services",
     "path": "platforms/core-runtime/build-process-services",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-profile",
     "path": "platforms/core-runtime/build-profile",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "build-state",
     "path": "platforms/core-runtime/build-state",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "classloaders",
     "path": "platforms/core-runtime/classloaders",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "classpath",
     "path": "platforms/core-runtime/classpath",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "cli",
     "path": "platforms/core-runtime/cli",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "client-services",
     "path": "platforms/core-runtime/client-services",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "code-quality",
     "path": "platforms/jvm/code-quality",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "code-quality-workers",
     "path": "platforms/jvm/code-quality-workers",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "collections",
     "path": "platforms/core-runtime/collections",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "composite-builds",
     "path": "subprojects/composite-builds",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "concurrent",
     "path": "platforms/core-runtime/concurrent",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "configuration-cache",
     "path": "platforms/core-configuration/configuration-cache",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "configuration-cache-base",
     "path": "platforms/core-configuration/configuration-cache-base",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "configuration-problems-base",
     "path": "platforms/core-configuration/configuration-problems-base",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core",
     "path": "subprojects/core",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core-api",
     "path": "subprojects/core-api",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core-flow-services-api",
     "path": "platforms/core-configuration/core-flow-services-api",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core-kotlin-extensions",
     "path": "platforms/core-configuration/core-kotlin-extensions",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core-platform",
     "path": "packaging/core-platform",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "core-serialization-codecs",
     "path": "platforms/core-configuration/core-serialization-codecs",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "credentials",
     "path": "platforms/software/credentials",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "credentials-api",
     "path": "platforms/software/credentials-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "credentials-impl",
     "path": "platforms/software/credentials-impl",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-logging",
     "path": "platforms/core-runtime/daemon-logging",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-main",
     "path": "platforms/core-runtime/daemon-main",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-messaging",
     "path": "platforms/core-runtime/daemon-messaging",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-protocol",
     "path": "platforms/core-runtime/daemon-protocol",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-server",
     "path": "platforms/core-runtime/daemon-server",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-server-worker",
     "path": "platforms/core-execution/daemon-server-worker",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "daemon-services",
     "path": "platforms/core-runtime/daemon-services",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-api",
     "path": "platforms/core-configuration/declarative-dsl-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-core",
     "path": "platforms/core-configuration/declarative-dsl-core",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-evaluator",
     "path": "platforms/core-configuration/declarative-dsl-evaluator",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-provider",
     "path": "platforms/core-configuration/declarative-dsl-provider",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-tooling-builders",
     "path": "platforms/core-configuration/declarative-dsl-tooling-builders",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "declarative-dsl-tooling-models",
     "path": "platforms/core-configuration/declarative-dsl-tooling-models",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "dependency-management",
     "path": "platforms/software/dependency-management",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "dependency-management-serialization-codecs",
     "path": "platforms/core-configuration/dependency-management-serialization-codecs",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-basics",
     "path": "testing/distributions-basics",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-core",
     "path": "testing/distributions-core",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-dependencies",
     "path": "packaging/distributions-dependencies",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-full",
     "path": "packaging/distributions-full",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-integ-tests",
     "path": "testing/distributions-integ-tests",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-jvm",
     "path": "platforms/jvm/distributions-jvm",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-native",
     "path": "platforms/native/distributions-native",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "distributions-publishing",
     "path": "platforms/software/distributions-publishing",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "docs",
     "path": "platforms/documentation/docs",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "docs-asciidoctor-extensions",
     "path": "platforms/documentation/docs-asciidoctor-extensions",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "docs-asciidoctor-extensions-base",
     "path": "platforms/documentation/docs-asciidoctor-extensions-base",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "domain-object-collections",
     "path": "platforms/core-configuration/domain-object-collections",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ear",
     "path": "platforms/jvm/ear",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "encryption-services",
     "path": "platforms/core-configuration/encryption-services",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "enterprise",
     "path": "platforms/enterprise/enterprise",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "enterprise-logging",
     "path": "platforms/enterprise/enterprise-logging",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "enterprise-operations",
     "path": "platforms/enterprise/enterprise-operations",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "enterprise-plugin-performance",
     "path": "platforms/enterprise/enterprise-plugin-performance",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "enterprise-workers",
     "path": "platforms/enterprise/enterprise-workers",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "execution",
     "path": "platforms/core-execution/execution",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "execution-e2e-tests",
     "path": "platforms/core-execution/execution-e2e-tests",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "file-collections",
     "path": "platforms/core-configuration/file-collections",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "file-operations",
     "path": "platforms/core-configuration/file-operations",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "file-temp",
     "path": "platforms/core-runtime/file-temp",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "file-watching",
     "path": "platforms/core-execution/file-watching",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "files",
     "path": "platforms/core-runtime/files",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "flow-services",
     "path": "platforms/core-configuration/flow-services",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "functional",
     "path": "platforms/core-runtime/functional",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "gradle-cli",
     "path": "platforms/core-runtime/gradle-cli",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "gradle-cli-main",
     "path": "platforms/core-runtime/gradle-cli-main",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "graph-isolation",
     "path": "platforms/core-configuration/graph-isolation",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "graph-serialization",
     "path": "platforms/core-configuration/graph-serialization",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "groovy-compiler-worker",
     "path": "platforms/jvm/groovy-compiler-worker",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "groovy-loader",
     "path": "platforms/core-runtime/groovy-loader",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "groovydoc-worker",
     "path": "platforms/jvm/groovydoc-worker",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "guava-serialization-codecs",
     "path": "platforms/core-configuration/guava-serialization-codecs",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "hashing",
     "path": "platforms/core-execution/hashing",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "hashing-services",
     "path": "platforms/core-execution/hashing-services",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ide",
     "path": "platforms/ide/ide",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ide-model-impls",
     "path": "platforms/ide/ide-model-impls",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ide-native",
     "path": "platforms/ide/ide-native",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ide-plugins",
     "path": "platforms/ide/ide-plugins",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "input-tracking",
     "path": "platforms/core-configuration/input-tracking",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "installation-beacon",
     "path": "platforms/core-runtime/installation-beacon",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "instrumentation-agent",
     "path": "platforms/core-runtime/instrumentation-agent",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "instrumentation-agent-services",
     "path": "platforms/core-runtime/instrumentation-agent-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "instrumentation-declarations",
     "path": "platforms/core-runtime/instrumentation-declarations",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "instrumentation-reporting",
     "path": "platforms/core-runtime/instrumentation-reporting",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "integ-test",
     "path": "testing/integ-test",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-build-reports",
     "path": "packaging/internal-build-reports",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-distribution-testing",
     "path": "testing/internal-distribution-testing",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-instrumentation-api",
     "path": "platforms/core-runtime/internal-instrumentation-api",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-instrumentation-processor",
     "path": "platforms/core-runtime/internal-instrumentation-processor",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-integ-testing",
     "path": "testing/internal-integ-testing",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-performance-testing",
     "path": "testing/internal-performance-testing",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "internal-testing",
     "path": "testing/internal-testing",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "io",
     "path": "platforms/core-runtime/io",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "isolated-action-services",
     "path": "platforms/core-configuration/isolated-action-services",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "isolated-ant-builder",
     "path": "platforms/software/isolated-ant-builder",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "ivy",
     "path": "platforms/software/ivy",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "jacoco",
     "path": "platforms/jvm/jacoco",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "jacoco-workers",
     "path": "platforms/jvm/jacoco-workers",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "java-api-extractor",
     "path": "platforms/core-configuration/java-api-extractor",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "java-compiler-plugin",
     "path": "platforms/jvm/java-compiler-plugin",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "java-compiler-worker",
     "path": "platforms/jvm/java-compiler-worker",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "java-platform",
     "path": "platforms/jvm/java-platform",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "javadoc",
     "path": "platforms/jvm/javadoc",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "jvm-compiler-worker",
     "path": "platforms/jvm/jvm-compiler-worker",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "jvm-services",
     "path": "platforms/jvm/jvm-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl",
     "path": "platforms/core-configuration/kotlin-dsl",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-integ-tests",
     "path": "platforms/core-configuration/kotlin-dsl-integ-tests",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-plugins",
     "path": "platforms/core-configuration/kotlin-dsl-plugins",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-provider-plugins",
     "path": "platforms/core-configuration/kotlin-dsl-provider-plugins",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-tooling-builders",
     "path": "platforms/core-configuration/kotlin-dsl-tooling-builders",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-tooling-model-impls",
     "path": "platforms/core-configuration/kotlin-dsl-tooling-model-impls",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "kotlin-dsl-tooling-models",
     "path": "platforms/core-configuration/kotlin-dsl-tooling-models",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "language-groovy",
     "path": "platforms/jvm/language-groovy",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "language-java",
     "path": "platforms/jvm/language-java",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "language-jvm",
     "path": "platforms/jvm/language-jvm",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "language-native",
     "path": "platforms/native/language-native",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "launcher",
     "path": "platforms/core-runtime/launcher",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "logging",
     "path": "platforms/core-runtime/logging",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "logging-api",
     "path": "platforms/core-runtime/logging-api",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "maven",
     "path": "platforms/software/maven",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "messaging",
     "path": "platforms/core-runtime/messaging",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "model-core",
     "path": "platforms/core-configuration/model-core",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "model-groovy",
     "path": "platforms/core-configuration/model-groovy",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "model-reflect",
     "path": "platforms/core-configuration/model-reflect",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "native",
     "path": "platforms/core-runtime/native",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "normalization",
     "path": "platforms/core-execution/normalization",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "normalization-api",
     "path": "platforms/core-execution/normalization-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "normalization-java",
     "path": "platforms/core-execution/normalization-java",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "performance",
     "path": "testing/performance",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "persistent-cache",
     "path": "platforms/core-execution/persistent-cache",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "platform-base",
     "path": "platforms/software/platform-base",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "platform-jvm",
     "path": "platforms/jvm/platform-jvm",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "platform-native",
     "path": "platforms/native/platform-native",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugin-development",
     "path": "platforms/extensibility/plugin-development",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugin-use",
     "path": "platforms/extensibility/plugin-use",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-application",
     "path": "platforms/jvm/plugins-application",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-distribution",
     "path": "platforms/software/plugins-distribution",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-groovy",
     "path": "platforms/jvm/plugins-groovy",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-java",
     "path": "platforms/jvm/plugins-java",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-java-base",
     "path": "platforms/jvm/plugins-java-base",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-java-library",
     "path": "platforms/jvm/plugins-java-library",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-jvm-test-fixtures",
     "path": "platforms/jvm/plugins-jvm-test-fixtures",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-jvm-test-suite",
     "path": "platforms/jvm/plugins-jvm-test-suite",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-model-native",
     "path": "platforms/native/plugins-model-native",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-test-report-aggregation",
     "path": "platforms/jvm/plugins-test-report-aggregation",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "plugins-version-catalog",
     "path": "platforms/software/plugins-version-catalog",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "precondition-tester",
     "path": "testing/precondition-tester",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "problems",
     "path": "platforms/ide/problems",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "problems-api",
     "path": "platforms/ide/problems-api",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "problems-impl",
     "path": "platforms/ide/problems-impl",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "problems-rendering",
     "path": "platforms/ide/problems-rendering",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "problems-reporting",
     "path": "platforms/ide/problems-reporting",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "process-memory-services",
     "path": "platforms/core-runtime/process-memory-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "process-services",
     "path": "platforms/core-runtime/process-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "process-services-api",
     "path": "platforms/core-runtime/process-services-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "process-services-base",
     "path": "platforms/core-runtime/process-services-base",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "project-features",
     "path": "platforms/core-configuration/project-features",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "project-features-api",
     "path": "platforms/core-configuration/project-features-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "project-features-demos",
     "path": "platforms/core-configuration/project-features-demos",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "public-api",
     "path": "packaging/public-api",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "public-api-tests",
     "path": "testing/public-api-tests",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "publish",
     "path": "platforms/software/publish",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "reflection-services",
     "path": "platforms/core-runtime/reflection-services",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "report-rendering",
     "path": "platforms/core-runtime/report-rendering",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "reporting",
     "path": "platforms/software/reporting",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "request-handler-worker",
     "path": "platforms/core-execution/request-handler-worker",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "resources",
     "path": "platforms/software/resources",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "resources-gcs",
     "path": "platforms/software/resources-gcs",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "resources-http",
     "path": "platforms/software/resources-http",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "resources-s3",
     "path": "platforms/software/resources-s3",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "resources-sftp",
     "path": "platforms/software/resources-sftp",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "samples",
     "path": "platforms/documentation/samples",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "scala",
     "path": "platforms/jvm/scala",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "scala-compiler-worker",
     "path": "platforms/jvm/scala-compiler-worker",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "scaladoc-worker",
     "path": "platforms/jvm/scaladoc-worker",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "scoped-persistent-cache",
     "path": "platforms/core-execution/scoped-persistent-cache",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "security",
     "path": "platforms/software/security",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "serialization",
     "path": "platforms/core-runtime/serialization",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "service-lookup",
     "path": "platforms/core-runtime/service-lookup",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "service-provider",
     "path": "platforms/core-runtime/service-provider",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "service-registry-builder",
     "path": "platforms/core-runtime/service-registry-builder",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "service-registry-impl",
     "path": "platforms/core-runtime/service-registry-impl",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "signing",
     "path": "platforms/software/signing",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "smoke-ide-test",
     "path": "testing/smoke-ide-test",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "smoke-test",
     "path": "testing/smoke-test",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "snapshots",
     "path": "platforms/core-execution/snapshots",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "soak",
     "path": "testing/soak",
     "unitTests": false,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "software-diagnostics",
     "path": "platforms/software/software-diagnostics",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "start-parameter",
     "path": "platforms/core-runtime/start-parameter",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "stdlib-java-extensions",
     "path": "platforms/core-runtime/stdlib-java-extensions",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "stdlib-kotlin-extensions",
     "path": "platforms/core-configuration/stdlib-kotlin-extensions",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "stdlib-serialization-codecs",
     "path": "platforms/core-configuration/stdlib-serialization-codecs",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "test-kit",
     "path": "platforms/extensibility/test-kit",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "test-suites-base",
     "path": "platforms/software/test-suites-base",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "testing-base",
     "path": "platforms/software/testing-base",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "testing-base-infrastructure",
     "path": "platforms/software/testing-base-infrastructure",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "testing-jvm",
     "path": "platforms/jvm/testing-jvm",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "testing-jvm-infrastructure",
     "path": "platforms/jvm/testing-jvm-infrastructure",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "testing-native",
     "path": "platforms/native/testing-native",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "time",
     "path": "platforms/core-runtime/time",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "toolchains-jvm",
     "path": "platforms/jvm/toolchains-jvm",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "toolchains-jvm-shared",
     "path": "platforms/jvm/toolchains-jvm-shared",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "tooling-api",
     "path": "platforms/ide/tooling-api",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": true
   },
   {
     "name": "tooling-api-builders",
     "path": "platforms/ide/tooling-api-builders",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "tooling-api-provider",
     "path": "platforms/core-runtime/tooling-api-provider",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "tooling-native",
     "path": "platforms/native/tooling-native",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "tooling-native-model-impls",
     "path": "platforms/native/tooling-native-model-impls",
     "unitTests": false,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "unit-test-fixtures",
     "path": "platforms/extensibility/unit-test-fixtures",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "version-control",
     "path": "platforms/software/version-control",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "versioned-cache",
     "path": "platforms/core-runtime/versioned-cache",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "war",
     "path": "platforms/jvm/war",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "worker-main",
     "path": "platforms/core-execution/worker-main",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "worker-process-services",
     "path": "platforms/core-execution/worker-process-services",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "worker-shared",
     "path": "platforms/core-execution/worker-shared",
     "unitTests": true,
     "functionalTests": false,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "workers",
     "path": "platforms/core-execution/workers",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "wrapper-main",
     "path": "platforms/core-runtime/wrapper-main",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": true
+    "crossVersionTests": true,
+    "flakyCrossVersionTests": false
   },
   {
     "name": "wrapper-shared",
     "path": "platforms/core-runtime/wrapper-shared",
     "unitTests": true,
     "functionalTests": true,
-    "crossVersionTests": false
+    "crossVersionTests": false,
+    "flakyCrossVersionTests": false
   }
 ]

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/model/GradleSubproject.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/model/GradleSubproject.kt
@@ -17,4 +17,4 @@
 package gradlebuild.buildutils.model
 
 
-data class GradleSubproject(val name: String, val path: String, val unitTests: Boolean, val functionalTests: Boolean, val crossVersionTests: Boolean)
+data class GradleSubproject(val name: String, val path: String, val unitTests: Boolean, val functionalTests: Boolean, val crossVersionTests: Boolean, val flakyCrossVersionTests: Boolean)

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
@@ -29,6 +29,9 @@ import kotlin.io.path.invariantSeparatorsPathString
 abstract class SubprojectsInfo : DefaultTask() {
 
     private
+    val FLAKY_ANNOTATION = "org.gradle.test.fixtures.Flaky"
+
+    private
     val rootPath = project.layout.projectDirectory.asFile.toPath()
 
     private
@@ -83,8 +86,32 @@ abstract class SubprojectsInfo : DefaultTask() {
             rootPath.relativize(subprojectDir.toPath()).invariantSeparatorsPathString,
             subprojectDir.hasDescendantDirWithFiles("src/test"),
             subprojectDir.hasDescendantDirWithFiles("src/integTest"),
-            subprojectDir.hasDescendantDirWithFiles("src/crossVersionTest")
+            subprojectDir.hasDescendantDirWithFiles("src/crossVersionTest"),
+            subprojectDir.hasFlakyCrossVersionTest()
         )
+    }
+
+    /**
+     * Whether this subproject has a cross-version test that `-PflakyTests=ONLY` could select.
+     *
+     * That filter is a JUnit Platform tag include, evaluated during discovery inside the test JVM, so Gradle cannot
+     * tell up front that a task will select nothing - it forks a JVM for every one regardless. Cross-version test
+     * tasks are registered per tested Gradle version per subproject, so scheduling the subprojects without any
+     * `@Flaky` cross-version test costs ~1000 JVM forks that discover nothing and exit, which does not fit in the
+     * flaky test quarantine build's timeout unless the build cache happens to serve nearly all of it.
+     *
+     * The match is deliberately loose: a false positive only restores the old behaviour for one subproject, while a
+     * false negative would silently drop a test from the quarantine build.
+     */
+    private
+    fun File.hasFlakyCrossVersionTest(): Boolean {
+        val dir = resolve("src/crossVersionTest")
+        if (!dir.isDirectory) {
+            return false
+        }
+        return dir.walk()
+            .filter { it.isFile && it.extension in setOf("groovy", "java", "kt") }
+            .any { file -> file.useLines { lines -> lines.any { "@Flaky" in it || FLAKY_ANNOTATION in it } } }
     }
 
     private


### PR DESCRIPTION
## Problem

`Flaky Test Quarantine - AllVersionsCrossVersion ... Windows` has timed out on 13 of its last 15 runs on `master` ([example](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_11/116452318)). It is not a flaky test — the job cannot finish on a cold build cache.

Cross-version test tasks are registered per tested Gradle version **per subproject**, so the build runs **~1100 test tasks across 19 subprojects**.

Under `-PflakyTests=ONLY` the filter is a JUnit Platform tag include, evaluated during discovery *inside* the test JVM. Gradle cannot tell up front that a task will select nothing, so it forks a JVM for every one regardless. Only `:tooling-api` has `@Flaky` cross-version tests (9 spec files), so ~1050 of those tasks start a JVM, discover nothing, and exit.

Already noted in `TestFilesCleanupService.kt`:

> `-PflakyTests=ONLY` does that to almost every task of the flaky test quarantine build for AllVersionsCrossVersion: it has one task per tested Gradle version per subproject, over a thousand of them, and only the handful in subprojects that actually have flaky cross-version tests select anything.

## Evidence

The job only fits in its 120-minute timeout when the build cache serves nearly all those tasks — and because the step runs `clean`, the cache is the *only* avoidance mechanism.

| Windows run | `CrossVersionTest FROM-CACHE` | Outcome |
|---|---|---|
| #16 | 92 / 1032 (9%) | timeout at 2:02 |
| #10 | 900 / ~986 (91%) | green at 1:48 |

In the passing run, 96% of avoidance savings came from the *remote* cache, on a different agent than the preceding failed run — those entries came from an earlier build of the same revision.

Grouping Windows runs by whether the revision had been built before:

```
First run on a revision:   0 / 8 passed
Repeat run on a revision:  2 / 4 passed
```

Windows has never passed on a fresh revision. Linux passes cold at 1:35–1:45, but has timed out once too (build #10, 2:02:31).

## Change

`.teamcity/subprojects.json` already records, per subproject, whether it has unit / functional / cross-version tests. This adds `flakyCrossVersionTests` alongside them, and qualifies the quarantine build's task with the subprojects that have one.

Putting it there means the staleness enforcement is already in place: `:checkSubprojectsInfo` runs in `sanityCheck`, so annotating a cross-version test anywhere fails the build with the existing message asking for `:generateSubprojectsInfo` — the same workflow as adding a new subproject — and regenerating adds that subproject to the quarantine build.

## Verification

- `:generateSubprojectsInfo` emits `flakyCrossVersionTests: true` for `tooling-api` only (252 entries).
- Regenerating against current `master` produces no diff — the committed file is up to date.
- `:checkSubprojectsInfo` passes on the branch.
- Planted `@Flaky` in a `:maven` cross-version test → `:checkSubprojectsInfo` **fails**:
  `New project(s) added without updating subproject JSON. Please run ':generateSubprojectsInfo' task.`
  Regenerating then yields `['maven', 'tooling-api']`, so `:maven` joins the quarantine build.
- `.teamcity` DSL compiles (`./mvnw compile`); build logic compiles.

Not verified: actual wall-clock on a real Windows agent — that needs a CI run of this branch.

## Alternative considered

**Delete the AllVersionsCrossVersion quarantine coverage.** `Flaky Test Quarantine - QuickFeedbackCrossVersion` already exists on both platforms, is 6/6 green, runs in 26 min on Windows, and covers the same 9 spec files against ~6 Gradle versions instead of 58. That would remove the build rather than fix it, so it is a separate discussion.