### PR TITLE
Stop capturing the release notes date formatters

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
@@ -42,6 +42,9 @@ import java.time.format.DateTimeFormatter;
  * TODO: Maybe eventually convert this asciidoc too, so everything uses the same markup language.
  */
 public class GradleReleaseNotesPlugin implements Plugin<Project> {
+    private static final DateTimeFormatter BUILD_TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ");
+    private static final DateTimeFormatter RELEASE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
     @Override
     public void apply(Project project) {
         ProjectLayout layout = project.getLayout();
@@ -77,9 +80,8 @@ public class GradleReleaseNotesPlugin implements Plugin<Project> {
 
             MapProperty<String, String> replacementTokens = task.getReplacementTokens();
             Provider<String> buildTimestamp = moduleIdentity.getBuildTimestamp();
-            DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ");
-            DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-            Provider<String> dateTime = buildTimestamp.map(timestamp -> ZonedDateTime.parse(timestamp, inputFormatter).format(outputFormatter));
+            Provider<String> dateTime = buildTimestamp.map(timestamp ->
+                ZonedDateTime.parse(timestamp, BUILD_TIMESTAMP_FORMAT).format(RELEASE_DATE_FORMAT));
 
             replacementTokens.put("releaseDate", dateTime);
             replacementTokens.put("version", moduleIdentity.getVersion().map(GradleVersion::getVersion));

--- a/build-logic/documentation/src/test/groovy/gradlebuild/docs/GradleReleaseNotesPluginTest.groovy
+++ b/build-logic/documentation/src/test/groovy/gradlebuild/docs/GradleReleaseNotesPluginTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.docs
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.time.LocalDate
+
+class GradleReleaseNotesPluginTest extends Specification {
+    private static final String BASE_VERSION = "9.9.9"
+    private static final String RELEASE_DATE_PREFIX = "Released on "
+    private static final String RELEASE_DATE_TERMINATOR = "."
+
+    @TempDir
+    private File projectDir
+    private File releaseNotesHtml
+
+    def setup() {
+        write("src/docs/release/notes.md", "## Release notes\n\n${RELEASE_DATE_PREFIX}@releaseDate@${RELEASE_DATE_TERMINATOR}\n")
+        write("src/docs/release/content/releaseIssues.js", "// empty\n")
+        write("src/docs/css/base.css", "body { }\n")
+        write("src/docs/css/release-notes.css", "body { }\n")
+
+        releaseNotesHtml = new File(projectDir, "build/working/release-notes/release-notes.html")
+
+        write("settings.gradle", """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    create('buildLibs') {
+                        version('asciidoctor', '3.0.1')
+                        version('asciidoctorPdf', '2.3.23')
+                    }
+                }
+            }
+        """.stripIndent())
+
+        // `repoRoot()` walks up the tree looking for `version.txt`; `released-versions.json` is the
+        // source for the `gradleVersion8` Asciidoctor attribute. Provide both so the documentation
+        // plugin applies cleanly in this minimal TestKit project.
+        write("version.txt", BASE_VERSION)
+        write("released-versions.json", '{"finalReleases":[{"version":"8.99.99","buildTime":"20260101000000+0000"}]}')
+        write("src/docs/javaPackageList/8/package-list", "java.lang\n")
+
+        write("build.gradle", """
+            plugins {
+                id 'java'
+                id 'checkstyle'
+                id 'gradlebuild.module-identity'
+                id 'gradlebuild.documentation'
+            }
+
+            gradleDocumentation {
+                javadocs {
+                    javaApi = project.uri("https://docs.oracle.com/javase/8/docs/api")
+                    javaPackageListLoc = project.layout.projectDirectory.dir("src/docs/javaPackageList/8/")
+                    groovyApi = project.uri("https://docs.groovy-lang.org/docs/groovy-4.0.28/html/gapi")
+                    groovyPackageListSrc = "org.apache.groovy:groovy-all:4.0.28:groovydoc"
+                }
+            }
+
+            tasks.register('assembleSamples')
+
+            javadocAll {
+                enabled = false
+            }
+        """)
+    }
+
+    /**
+     * The rendered date, taken from between the marker text and the full stop that follows it.
+     * `LocalDate.parse` accepts ISO_LOCAL_DATE only, so it doubles as the format check.
+     */
+    private String renderedReleaseDate() {
+        def text = releaseNotesHtml.text
+        def start = text.indexOf(RELEASE_DATE_PREFIX) + RELEASE_DATE_PREFIX.length()
+        return text.substring(start, text.indexOf(RELEASE_DATE_TERMINATOR, start))
+    }
+
+    private void write(String path, String content) {
+        def target = new File(projectDir, path)
+        target.parentFile.mkdirs()
+        target.text = content
+    }
+
+    def "is compatible with the configuration cache for a #description version"() {
+        when:
+        def result = run(['releaseNotes', '--configuration-cache'] + versionArgs).build()
+
+        then:
+        result.task(':releaseNotes').outcome.name() == 'SUCCESS'
+
+        and:
+        LocalDate.parse(renderedReleaseDate())
+
+        where:
+        // Only the last three rows take the build timestamp out of the version. The snapshot row
+        // keeps it and resolves it early, so it stays green even when the formatters are captured.
+        description         | versionArgs
+        'snapshot'          | []
+        'final release'     | ['-PfinalRelease=true']
+        'release candidate' | ['-PrcNumber=1']
+        'milestone'         | ['-PmilestoneNumber=1']
+    }
+
+    private GradleRunner run(List<String> args) {
+        return GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(args)
+            .forwardOutput()
+    }
+}


### PR DESCRIPTION
Fixes #38911

### Context

Building Gradle from source fails at `:docs:releaseNotes` whenever the version carries no build timestamp. `-PfinalRelease`, `-PrcNumber` and `-PmilestoneNumber` all produce such a version, so a release build cannot store its configuration cache entry.

This matters well beyond the few people who run the build. Distributions ship final releases only, never snapshots, release candidates or milestones, and here the version stays a snapshot unless one of those three properties is set. `-PfinalRelease=true` is therefore not optional for a packager, which puts every distribution build on the failing path. The plain command a reviewer would try first passes, which is what kept this quiet.

A packager is a chokepoint rather than an audience. Everyone who installs Gradle from a distribution repository gets whatever came out of that build, and so does everyone who consumes those machines downstream. Working around the failure means turning the configuration cache and Isolated Projects off, so the binary those users receive is produced in a configuration you do not test.

I hit it while updating the `gradle` package in ALT Linux Sisyphus from 8.14.3 to 9.7.1: https://packages.altlinux.org/en/sisyphus/srpms/gradle

The package builds from the upstream sources in an rpm buildroot with no network access. Until now the spec passed `--no-configuration-cache`, which no longer works on its own because Isolated Projects is enabled as well, so it needs `-Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache`.

The same failure reproduces on `master` and on `v9.7.1`, and a full build is not needed for it:

```console
./gradlew :docs:releaseNotes -PfinalRelease=true
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

Notes on the checklist, since `build-logic` does not work quite like a product subproject:

**Integration tests.** `build-logic`, `build-logic-commons` and `build-logic-settings` have no `src/integTest` directory. The test went to `src/test` next to `FindBrokenInternalLinksTest`, which drives a real build through TestKit in the same way. It is parameterised over the four version shapes and fails on three of them without the production change.

**Documentation.** Nothing here is public facing, so there was nothing to update.

**Sanity check.** Run, passes. It still does not cover this change: none of its eleven tasks reaches `build-logic`.

**quickTest.** `build-logic` has no `quickTest` task. The equivalent for an included build is `gradle.includedBuilds.map { it.task(":check") }`, which belongs to `checkBuildLogic` rather than to `sanityCheck`. I ran it as `./gradlew :build-logic:check` and it passes.
