### PR TITLE
Don't leave a closed connector factory reachable

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -57,9 +57,15 @@ public class ConnectorServices {
     }
 
     public static synchronized void close() {
-        if (sharedConnectorFactory != null) {
-            sharedConnectorFactory.close();
+        GradleConnectorFactory factory = sharedConnectorFactory;
+        if (factory != null) {
+            // Drop the reference before closing. The underlying service registry marks itself as
+            // closed before it stops its services, so a failure while stopping them (for example
+            // an interrupt while shutting a hanging daemon connection down) would otherwise leave
+            // a reachable factory backed by a closed registry, failing every later connector
+            // creation with "connector services has been closed."
             sharedConnectorFactory = null;
+            factory.close();
         }
     }
 
@@ -84,8 +90,11 @@ public class ConnectorServices {
      */
     @VisibleForTesting
     public static synchronized void reset() {
-        close();
-        activeConnectors = 0;
+        try {
+            close();
+        } finally {
+            activeConnectors = 0;
+        }
     }
 
     /**

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
@@ -16,10 +16,14 @@
 
 package org.gradle.tooling.internal.consumer
 
-
+import org.gradle.tooling.GradleConnector
 import spock.lang.Specification
 
 class ConnectorServicesTest extends Specification {
+
+    def cleanup() {
+        ConnectorServices.reset()
+    }
 
     def "services sharing configuration"() {
         when:
@@ -43,5 +47,59 @@ class ConnectorServicesTest extends Specification {
 
         then:
         connector != null
+    }
+
+    def "discards the shared factory when closing it fails"() {
+        given:
+        def failure = new RuntimeException("cannot stop services")
+        //noinspection GroovyAccessibility
+        ConnectorServices.sharedConnectorFactory = new BrokenConnectorFactory(failure)
+
+        when:
+        ConnectorServices.close()
+
+        then:
+        def e = thrown(RuntimeException)
+        e === failure
+
+        when: "a connector is requested after the failed close"
+        def connector = ConnectorServices.createConnector()
+
+        then: "the broken factory is gone and a fresh one is used"
+        connector != null
+    }
+
+    def "resets the active connector count when closing the shared factory fails"() {
+        given:
+        //noinspection GroovyAccessibility
+        ConnectorServices.sharedConnectorFactory = new BrokenConnectorFactory(new RuntimeException("cannot stop services"))
+
+        when:
+        ConnectorServices.reset()
+
+        then:
+        thrown(RuntimeException)
+
+        and:
+        //noinspection GroovyAccessibility
+        ConnectorServices.activeConnectors == 0
+    }
+
+    private static class BrokenConnectorFactory implements GradleConnectorFactory {
+        private final RuntimeException failure
+
+        BrokenConnectorFactory(RuntimeException failure) {
+            this.failure = failure
+        }
+
+        @Override
+        GradleConnector createConnector() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void close() {
+            throw failure
+        }
     }
 }

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
@@ -70,7 +70,12 @@ class ConnectorServicesTest extends Specification {
     }
 
     def "resets the active connector count when closing the shared factory fails"() {
-        given:
+        given: "an active connector, so that the count is not already zero"
+        ConnectorServices.createConnector()
+        //noinspection GroovyAccessibility
+        assert ConnectorServices.activeConnectors == 1
+
+        and:
         //noinspection GroovyAccessibility
         ConnectorServices.sharedConnectorFactory = new BrokenConnectorFactory(new RuntimeException("cannot stop services"))
 


### PR DESCRIPTION
<!-- Fixes gradle/gradle-private#5330 -->

### Context

Fixes https://github.com/gradle/gradle-private/issues/5330.

`AllVersionsCrossVersion` has gone red on master five times since 2026-08-12, with 11–68 test failures per build — 124 test failures in total — all with the same signature:

```
java.lang.IllegalStateException: connector services has been closed.
  at DefaultServiceRegistry.serviceRequested(DefaultServiceRegistry.java:310)
  at ConnectorServices$DefaultGradleConnectorFactory.createConnector(ConnectorServices.java:104)
  at ConnectorServices.createConnector(ConnectorServices.java:56)
  at GradleConnector.newConnector(GradleConnector.java:85)
```

| Bucket | Build | Date | Target version(s) | Failures |
|---|---|---|---|---|
| bucket15 | [#425](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_bucket15/116150552) | 2026-08-12 | 9.5.1 | 11 |
| bucket15 | [#431](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_bucket15/116275327) | 2026-08-15 | 9.5.1 | 11 |
| bucket13 | [#415](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_bucket13/116275325) | 2026-08-15 | 9.0.0 + 9.2.1 | 22 |
| bucket13 | [#424](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_bucket13/116472069) | 2026-08-20 | 9.0.0 | 12 |
| bucket12 | [#654](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_bucket12/116549505) | 2026-08-22 | 8.12.1 | 68 |

I swept every `AllVersionsCrossVersion` bucket's last 100 master builds (back to 2026-02-26). These five are the only occurrences, and they are also the only failures those three buckets have had in that whole window. Nothing before 2026-08-12. Five distinct target versions are affected (8.12.1, 9.0.0, 9.2.1, 9.5.1), so this is not specific to any one Gradle version.

The failing tests never reach Gradle — they die inside `GradleConnector.newConnector()`. This is one poisoned static, not 12 independent bugs.

#### Mechanism

`ConnectorServices.close()` closed the shared factory before clearing the reference to it:

```java
if (sharedConnectorFactory != null) {
    sharedConnectorFactory.close();   // throws
    sharedConnectorFactory = null;    // never runs
}
```

`DefaultServiceRegistry.close()` flips its state to `CLOSED` *before* stopping its services:

```java
if (state.compareAndSet(State.STARTED, State.CLOSED)) {
    CompositeStoppable.stoppable(allServices).stop();   // throws
}
```

So any failure while stopping services leaves `sharedConnectorFactory` non-null but backed by a registry that already rejects every lookup. The static is poisoned for the remaining life of the JVM.

#### Blast radius

`ToolingApiShutdownCrossVersionSpec` calls only `requireIsolatedDaemons()`, not `requireIsolatedToolingApi()`, so it uses the shared static factory. The damage therefore escapes the spec and takes out every later TAPI test in the same worker JVM. How many that is depends on how Test Distribution packed the JVM — 11 tests in bucket15 #425, but 68 across 11 spec classes in bucket12 #654:

```
11  ToolingApiShutdownCrossVersionSpec        7  VersionConsumerCrossVersionSpec
11  RunTasksBeforeRunActionCrossVersionSpec   7  ProblemThresholdCrossVersionSpec
 8  CompositeBuildCrossVersionSpec            5  ToolingApiEclipseModelCrossVersionSpec
 8  SystemPropertyPropagationCrossVersionSpec 4  ToolingApiEclipseModelDependencyAccessRuleCrossVersionSpec
 4  AdHocCompositeDependencySubstitutionCrossVersionSpec
 2  CombiningCommandLineArgumentsCrossVersionSpec
 1  TestFilteringCrossVersionSpec
```

#### Trigger

In CI the trigger is `ToolingApiShutdownCrossVersionSpec."disconnect during hanging build does not block the client"` exceeding its 30s `@Timeout`. The test hangs the daemon on purpose (`systemProp.org.gradle.internal.testing.daemon.hang=60000`) and asserts `disconnect()` returns anyway; when it doesn't, Spock interrupts the test thread — repeatedly, and to no effect:

```
[spock.lang.Timeout] Method 'disconnect during hanging build does not block the client'
  has not stopped after timing out 0.76 seconds ago - interrupting. Next try in 1.00 seconds.
... 1.76s ... 3.77s ... 7.77s ... 15.77s ... 31.78s
```

That interrupt lands inside `CachingToolingImplementationLoader.close()` → `ConsumerConnection.stop()` on the hung daemon, `close()` throws, and the factory is poisoned. Every later test in that worker JVM then fails at connector creation. `@Retry(count = 3)` provides no cover, since retries 2–4 also fail immediately; that is why each test reports "Multiple Failures (4 failures)".

The hazard was introduced in #34491, which added the disconnect-triggered auto-close and the lazy re-init.

### Changes

- `ConnectorServices.close()` drops the reference before closing the factory, so a failed teardown cannot be observed by later callers.
- `ConnectorServices.reset()` resets `activeConnectors` in a `finally`, so a throwing `close()` cannot leave a stale count either.

Both new unit tests fail without the production change, the first one through the same `ConnectorServices.createConnector(ConnectorServices.java:56)` frame as the CI stack trace:

```
discards the shared factory when closing it fails FAILED
resets the active connector count when closing the shared factory fails FAILED
```

### Scope

This fixes the amplifier, not the trigger. The flaky timeout in `disconnect during hanging build does not block the client` remains, and is worth investigating separately — an interrupt-resistant 32s stall is exactly the behaviour that test exists to rule out. What changes here is that hitting it costs one retried test instead of an entire worker JVM.

Two things I deliberately left alone:

- **I did not raise the timeout.** That would hide the trigger rather than fix anything.
- **`activeConnectors` drift.** `close()` discards the factory without zeroing the counter, so after an explicit `DefaultGradleConnector.close()` the count can never return to 0 and the disconnect-triggered auto-close stops firing — reintroducing the JVM-hang #34491 fixed. Zeroing it in `close()` is *not* a safe local fix: with connector A live, `close()`, then connector B created, `A.disconnect()` would drop the count to 0 and tear down B's registry underneath it — the same class of bug from the other direction. A correct fix tracks live connectors per factory instance, which is a wider refactor than this build failure warrants.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — n/a, the observable behaviour is internal teardown robustness; covered by unit tests
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, internal API
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck` — ran `:tooling-api:checkstyleMain`, `:tooling-api:checkstyleTest`, `:tooling-api:codenarcTest`
- [x] Ensure that tests pass locally: `./gradlew :tooling-api:test --tests '*ConnectorServicesTest'` (4/4 green)
