### PR TITLE
Prevent signing from realizing component variants

### DIFF
--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -16,39 +16,44 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
-import org.gradle.api.Task;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.api.tasks.TaskProvider;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
 public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
 
-    private final TaskProvider<? extends Task> generator;
     private final Provider<RegularFile> file;
+    private final Provider<Boolean> enabled;
     private final IvyPublicationCoordinates coordinates;
     private final String extension;
     private final String type;
     private final String classifier;
     private final TaskDependencyInternal buildDependencies;
 
-    public SingleOutputTaskIvyArtifact(TaskProvider<? extends Task> generator, Provider<RegularFile> file, IvyPublicationCoordinates coordinates, String extension, String type, @Nullable String classifier, TaskDependencyFactory taskDependencyFactory) {
+    public SingleOutputTaskIvyArtifact(
+        Provider<RegularFile> file,
+        Provider<Boolean> enabled,
+        IvyPublicationCoordinates coordinates,
+        String extension,
+        String type,
+        @Nullable String classifier,
+        TaskDependencyFactory taskDependencyFactory
+    ) {
         super(taskDependencyFactory);
-        this.generator = generator;
         this.file = file;
+        this.enabled = enabled;
         this.coordinates = coordinates;
         this.extension = extension;
         this.type = type;
         this.classifier = classifier;
         this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> {
-            context.add(generator.get());
+            context.add(file);
         });
     }
 
@@ -88,8 +93,7 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     }
 
     public boolean isEnabled() {
-        TaskInternal task = (TaskInternal) generator.get();
-        return task.getOnlyIf().isSatisfiedBy(task);
+        return enabled.get();
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -17,9 +17,11 @@
 package org.gradle.api.publish.ivy.internal.artifact;
 
 import org.gradle.api.Task;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
@@ -30,15 +32,17 @@ import java.io.File;
 public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
 
     private final TaskProvider<? extends Task> generator;
+    private final Provider<RegularFile> file;
     private final IvyPublicationCoordinates coordinates;
     private final String extension;
     private final String type;
     private final String classifier;
     private final TaskDependencyInternal buildDependencies;
 
-    public SingleOutputTaskIvyArtifact(TaskProvider<? extends Task> generator, IvyPublicationCoordinates coordinates, String extension, String type, @Nullable String classifier, TaskDependencyFactory taskDependencyFactory) {
+    public SingleOutputTaskIvyArtifact(TaskProvider<? extends Task> generator, Provider<RegularFile> file, IvyPublicationCoordinates coordinates, String extension, String type, @Nullable String classifier, TaskDependencyFactory taskDependencyFactory) {
         super(taskDependencyFactory);
         this.generator = generator;
+        this.file = file;
         this.coordinates = coordinates;
         this.extension = extension;
         this.type = type;
@@ -80,7 +84,7 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
 
     @Override
     public File getFile() {
-        return generator.get().getOutputs().getFiles().getSingleFile();
+        return file.get().getAsFile();
     }
 
     public boolean isEnabled() {

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.ivy.internal.publication;
 import com.google.common.collect.Streams;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.component.SoftwareComponent;
@@ -53,6 +52,8 @@ import org.gradle.api.publish.ivy.internal.artifact.NormalizedIvyArtifact;
 import org.gradle.api.publish.ivy.internal.artifact.SingleOutputTaskIvyArtifact;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
+import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
@@ -91,7 +92,7 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
 
     private final Set<String> silencedVariants = new HashSet<>();
     private IvyArtifact ivyDescriptorArtifact;
-    private TaskProvider<? extends Task> moduleDescriptorGenerator;
+    private TaskProvider<? extends GenerateModuleMetadata> moduleDescriptorGenerator;
     private SingleOutputTaskIvyArtifact gradleModuleDescriptorArtifact;
     private boolean alias;
     private boolean populated;
@@ -192,17 +193,17 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
-    public void setIvyDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
+    public void setIvyDescriptorGenerator(TaskProvider<? extends GenerateIvyDescriptor> descriptorGenerator) {
         if (ivyDescriptorArtifact != null) {
             metadataArtifacts.remove(ivyDescriptorArtifact);
         }
-        ivyDescriptorArtifact = new SingleOutputTaskIvyArtifact(descriptorGenerator, publicationCoordinates, "xml", "ivy", null, taskDependencyFactory);
+        ivyDescriptorArtifact = new SingleOutputTaskIvyArtifact(descriptorGenerator, descriptorGenerator.flatMap(GenerateIvyDescriptor::getDestinationFile), publicationCoordinates, "xml", "ivy", null, taskDependencyFactory);
         ivyDescriptorArtifact.setName("ivy");
         metadataArtifacts.add(ivyDescriptorArtifact);
     }
 
     @Override
-    public void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
+    public void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> descriptorGenerator) {
         moduleDescriptorGenerator = descriptorGenerator;
         if (gradleModuleDescriptorArtifact != null) {
             metadataArtifacts.remove(gradleModuleDescriptorArtifact);
@@ -218,7 +219,7 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
         if (moduleDescriptorGenerator == null) {
             return;
         }
-        gradleModuleDescriptorArtifact = new SingleOutputTaskIvyArtifact(moduleDescriptorGenerator, publicationCoordinates, "module", "json", null, taskDependencyFactory);
+        gradleModuleDescriptorArtifact = new SingleOutputTaskIvyArtifact(moduleDescriptorGenerator, moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile), publicationCoordinates, "module", "json", null, taskDependencyFactory);
         metadataArtifacts.add(gradleModuleDescriptorArtifact);
         moduleDescriptorGenerator = null;
     }

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -22,6 +22,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.AttributesFactory;
@@ -32,6 +33,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -52,7 +54,6 @@ import org.gradle.api.publish.ivy.internal.artifact.NormalizedIvyArtifact;
 import org.gradle.api.publish.ivy.internal.artifact.SingleOutputTaskIvyArtifact;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
-import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
@@ -193,11 +194,19 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
-    public void setIvyDescriptorGenerator(TaskProvider<? extends GenerateIvyDescriptor> descriptorGenerator) {
+    public void setIvyDescriptorGenerator(Provider<RegularFile> descriptorFile, Provider<Boolean> generatorEnabled) {
         if (ivyDescriptorArtifact != null) {
             metadataArtifacts.remove(ivyDescriptorArtifact);
         }
-        ivyDescriptorArtifact = new SingleOutputTaskIvyArtifact(descriptorGenerator, descriptorGenerator.flatMap(GenerateIvyDescriptor::getDestinationFile), publicationCoordinates, "xml", "ivy", null, taskDependencyFactory);
+        ivyDescriptorArtifact = new SingleOutputTaskIvyArtifact(
+            descriptorFile,
+            generatorEnabled,
+            publicationCoordinates,
+            "xml",
+            "ivy",
+            null,
+            taskDependencyFactory
+        );
         ivyDescriptorArtifact.setName("ivy");
         metadataArtifacts.add(ivyDescriptorArtifact);
     }
@@ -219,7 +228,15 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
         if (moduleDescriptorGenerator == null) {
             return;
         }
-        gradleModuleDescriptorArtifact = new SingleOutputTaskIvyArtifact(moduleDescriptorGenerator, moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile), publicationCoordinates, "module", "json", null, taskDependencyFactory);
+        gradleModuleDescriptorArtifact = new SingleOutputTaskIvyArtifact(
+            moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile),
+            moduleDescriptorGenerator.map(task -> task.getOnlyIf().isSatisfiedBy(task)),
+            publicationCoordinates,
+            "module",
+            "json",
+            null,
+            taskDependencyFactory
+        );
         metadataArtifacts.add(gradleModuleDescriptorArtifact);
         moduleDescriptorGenerator = null;
     }

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.publish.ivy.internal.publication;
 
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
-import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -29,7 +30,7 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
     @Override
     IvyModuleDescriptorSpecInternal getDescriptor();
 
-    void setIvyDescriptorGenerator(TaskProvider<? extends GenerateIvyDescriptor> descriptorGenerator);
+    void setIvyDescriptorGenerator(Provider<RegularFile> descriptorFile, Provider<Boolean> generatorEnabled);
 
     void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> descriptorGenerator);
 

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.publish.ivy.internal.publication;
 
-import org.gradle.api.Task;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
+import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 
 public interface IvyPublicationInternal extends IvyPublication, PublicationInternal<IvyArtifact> {
@@ -28,9 +29,9 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
     @Override
     IvyModuleDescriptorSpecInternal getDescriptor();
 
-    void setIvyDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator);
+    void setIvyDescriptorGenerator(TaskProvider<? extends GenerateIvyDescriptor> descriptorGenerator);
 
-    void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator);
+    void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> descriptorGenerator);
 
     IvyNormalizedPublication asNormalisedPublication();
 

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -176,7 +176,10 @@ public abstract class IvyPublishPlugin implements Plugin<Project> {
                 buildDir.file("publications/" + publicationName + "/ivy.xml")
             );
         });
-        publication.setIvyDescriptorGenerator(generatorTask);
+        publication.setIvyDescriptorGenerator(
+            generatorTask.flatMap(GenerateIvyDescriptor::getDestinationFile),
+            generatorTask.map(task -> task.getOnlyIf().isSatisfiedBy(task))
+        );
     }
 
     private void createGenerateMetadataTask(final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir, NamedDomainObjectList<IvyArtifactRepository> repositories) {

--- a/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
@@ -40,13 +40,13 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.publish.internal.mapping.DefaultDependencyCoordinateResolverFactory
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates
-import org.gradle.api.tasks.TaskOutputs
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.typeconversion.NotationParser
@@ -388,13 +388,8 @@ class DefaultIvyPublicationTest extends Specification {
 
     def createArtifactGenerator(File file) {
         return Stub(TaskProvider) {
-            get() >> Stub(Task) {
-                getOutputs() >> Stub(TaskOutputs) {
-                    getFiles() >> Stub(FileCollection) {
-                        getSingleFile() >> file
-                    }
-                }
-            }
+            get() >> Stub(Task)
+            flatMap(_) >> Providers.of({ file } as RegularFile)
         }
     }
 

--- a/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy.internal.publication
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Task
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -296,7 +295,7 @@ class DefaultIvyPublicationTest extends Specification {
     def "resolving the publishable files does not throw if gradle metadata is not activated"() {
         given:
         def publication = createPublication()
-        publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
+        publication.setIvyDescriptorGenerator(createFileProvider(ivyDescriptorFile), Providers.of(true))
 
         when:
         publication.publishableArtifacts.files.files
@@ -381,15 +380,19 @@ class DefaultIvyPublicationTest extends Specification {
             notationParser,
             versionMappingStrategy
         )
-        publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
+        publication.setIvyDescriptorGenerator(createFileProvider(ivyDescriptorFile), Providers.of(true))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(moduleDescriptorFile))
         return publication
     }
 
+    def createFileProvider(File file) {
+        return Providers.of({ file } as RegularFile)
+    }
+
     def createArtifactGenerator(File file) {
         return Stub(TaskProvider) {
-            get() >> Stub(Task)
-            flatMap(_) >> Providers.of({ file } as RegularFile)
+            flatMap(_) >> createFileProvider(file)
+            map(_) >> Providers.of(true)
         }
     }
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -17,7 +17,9 @@
 package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.Task;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 
@@ -25,13 +27,15 @@ import java.io.File;
 
 public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
     private final TaskProvider<? extends Task> generator;
+    private final Provider<RegularFile> file;
     private final String extension;
     private final String classifier;
     private final TaskDependencyInternal buildDependencies;
 
-    public SingleOutputTaskMavenArtifact(TaskProvider<? extends Task> generator, String extension, String classifier, TaskDependencyFactory taskDependencyFactory) {
+    public SingleOutputTaskMavenArtifact(TaskProvider<? extends Task> generator, Provider<RegularFile> file, String extension, String classifier, TaskDependencyFactory taskDependencyFactory) {
         super(taskDependencyFactory);
         this.generator = generator;
+        this.file = file;
         this.extension = extension;
         this.classifier = classifier;
         this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> context.add(getGenerator()));
@@ -39,7 +43,7 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
 
     @Override
     public File getFile() {
-        return getGenerator().getOutputs().getFiles().getSingleFile();
+        return file.get().getAsFile();
     }
 
     private Task getGenerator() {

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -16,38 +16,38 @@
 
 package org.gradle.api.publish.maven.internal.artifact;
 
-import org.gradle.api.Task;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
 
 import java.io.File;
 
 public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
-    private final TaskProvider<? extends Task> generator;
     private final Provider<RegularFile> file;
+    private final Provider<Boolean> enabled;
     private final String extension;
     private final String classifier;
     private final TaskDependencyInternal buildDependencies;
 
-    public SingleOutputTaskMavenArtifact(TaskProvider<? extends Task> generator, Provider<RegularFile> file, String extension, String classifier, TaskDependencyFactory taskDependencyFactory) {
+    public SingleOutputTaskMavenArtifact(
+        Provider<RegularFile> file,
+        Provider<Boolean> enabled,
+        String extension,
+        String classifier,
+        TaskDependencyFactory taskDependencyFactory
+    ) {
         super(taskDependencyFactory);
-        this.generator = generator;
         this.file = file;
+        this.enabled = enabled;
         this.extension = extension;
         this.classifier = classifier;
-        this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> context.add(getGenerator()));
+        this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> context.add(file));
     }
 
     @Override
     public File getFile() {
         return file.get().getAsFile();
-    }
-
-    private Task getGenerator() {
-        return generator.get();
     }
 
     @Override
@@ -66,7 +66,7 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
     }
 
     public boolean isEnabled() {
-        return getGenerator().getEnabled();
+        return enabled.get();
     }
 
     @Override

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -39,6 +40,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -57,7 +59,6 @@ import org.gradle.api.publish.maven.internal.artifact.SingleOutputTaskMavenArtif
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MavenPublicationCoordinates;
 import org.gradle.api.publish.maven.internal.validation.MavenPublicationErrorChecker;
-import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
@@ -197,11 +198,17 @@ public abstract class DefaultMavenPublication implements MavenPublicationInterna
     }
 
     @Override
-    public void setPomGenerator(TaskProvider<? extends GenerateMavenPom> pomGenerator) {
+    public void setPomGenerator(Provider<RegularFile> pomFile, Provider<Boolean> generatorEnabled) {
         if (pomArtifact != null) {
             metadataArtifacts.remove(pomArtifact);
         }
-        pomArtifact = new SingleOutputTaskMavenArtifact(pomGenerator, pomGenerator.flatMap(GenerateMavenPom::getDestinationFile), "pom", null, taskDependencyFactory);
+        pomArtifact = new SingleOutputTaskMavenArtifact(
+            pomFile,
+            generatorEnabled,
+            "pom",
+            null,
+            taskDependencyFactory
+        );
         metadataArtifacts.add(pomArtifact);
     }
 
@@ -222,7 +229,13 @@ public abstract class DefaultMavenPublication implements MavenPublicationInterna
         if (moduleDescriptorGenerator == null) {
             return;
         }
-        moduleMetadataArtifact = new SingleOutputTaskMavenArtifact(moduleDescriptorGenerator, moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile), "module", null, taskDependencyFactory);
+        moduleMetadataArtifact = new SingleOutputTaskMavenArtifact(
+            moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile),
+            moduleDescriptorGenerator.map(GenerateModuleMetadata::getEnabled),
+            "module",
+            null,
+            taskDependencyFactory
+        );
         metadataArtifacts.add(moduleMetadataArtifact);
         moduleDescriptorGenerator = null;
     }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -21,7 +21,6 @@ import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.component.SoftwareComponent;
@@ -58,6 +57,8 @@ import org.gradle.api.publish.maven.internal.artifact.SingleOutputTaskMavenArtif
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MavenPublicationCoordinates;
 import org.gradle.api.publish.maven.internal.validation.MavenPublicationErrorChecker;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
@@ -97,7 +98,7 @@ public abstract class DefaultMavenPublication implements MavenPublicationInterna
     private final Set<String> silencedVariants = new HashSet<>();
     private MavenArtifact pomArtifact;
     private SingleOutputTaskMavenArtifact moduleMetadataArtifact;
-    private TaskProvider<? extends Task> moduleDescriptorGenerator;
+    private TaskProvider<? extends GenerateModuleMetadata> moduleDescriptorGenerator;
     private boolean isPublishWithOriginalFileName;
     private boolean alias;
     private boolean populated;
@@ -196,16 +197,16 @@ public abstract class DefaultMavenPublication implements MavenPublicationInterna
     }
 
     @Override
-    public void setPomGenerator(TaskProvider<? extends Task> pomGenerator) {
+    public void setPomGenerator(TaskProvider<? extends GenerateMavenPom> pomGenerator) {
         if (pomArtifact != null) {
             metadataArtifacts.remove(pomArtifact);
         }
-        pomArtifact = new SingleOutputTaskMavenArtifact(pomGenerator, "pom", null, taskDependencyFactory);
+        pomArtifact = new SingleOutputTaskMavenArtifact(pomGenerator, pomGenerator.flatMap(GenerateMavenPom::getDestinationFile), "pom", null, taskDependencyFactory);
         metadataArtifacts.add(pomArtifact);
     }
 
     @Override
-    public void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
+    public void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> descriptorGenerator) {
         moduleDescriptorGenerator = descriptorGenerator;
         if (moduleMetadataArtifact != null) {
             metadataArtifacts.remove(moduleMetadataArtifact);
@@ -221,7 +222,7 @@ public abstract class DefaultMavenPublication implements MavenPublicationInterna
         if (moduleDescriptorGenerator == null) {
             return;
         }
-        moduleMetadataArtifact = new SingleOutputTaskMavenArtifact(moduleDescriptorGenerator, "module", null, taskDependencyFactory);
+        moduleMetadataArtifact = new SingleOutputTaskMavenArtifact(moduleDescriptorGenerator, moduleDescriptorGenerator.flatMap(GenerateModuleMetadata::getOutputFile), "module", null, taskDependencyFactory);
         metadataArtifacts.add(moduleMetadataArtifact);
         moduleDescriptorGenerator = null;
     }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.publish.maven.internal.publication;
 
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
-import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -29,7 +30,7 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
     @Override
     MavenPomInternal getPom();
 
-    void setPomGenerator(TaskProvider<? extends GenerateMavenPom> pomGenerator);
+    void setPomGenerator(Provider<RegularFile> pomFile, Provider<Boolean> generatorEnabled);
 
     void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> moduleMetadataGenerator);
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.publish.maven.internal.publication;
 
-import org.gradle.api.Task;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
+import org.gradle.api.publish.tasks.GenerateModuleMetadata;
 import org.gradle.api.tasks.TaskProvider;
 
 public interface MavenPublicationInternal extends MavenPublication, PublicationInternal<MavenArtifact> {
@@ -28,9 +29,9 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
     @Override
     MavenPomInternal getPom();
 
-    void setPomGenerator(TaskProvider<? extends Task> pomGenerator);
+    void setPomGenerator(TaskProvider<? extends GenerateMavenPom> pomGenerator);
 
-    void setModuleDescriptorGenerator(TaskProvider<? extends Task> moduleMetadataGenerator);
+    void setModuleDescriptorGenerator(TaskProvider<? extends GenerateModuleMetadata> moduleMetadataGenerator);
 
     MavenNormalizedPublication asNormalisedPublication();
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -194,7 +194,10 @@ public abstract class MavenPublishPlugin implements Plugin<Project> {
                 buildDir.file("publications/" + publication.getName() + "/pom-default.xml")
             );
         });
-        publication.setPomGenerator(generatorTask);
+        publication.setPomGenerator(
+            generatorTask.flatMap(GenerateMavenPom::getDestinationFile),
+            generatorTask.map(GenerateMavenPom::getEnabled)
+        );
     }
 
     private void createGenerateMetadataTask(final TaskContainer tasks, final MavenPublicationInternal publication, final Set<? extends MavenPublicationInternal> publications, final DirectoryProperty buildDir) {

--- a/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
@@ -44,6 +44,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.DefaultSoftwareComponentVariant
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.publish.internal.PublicationArtifactInternal
 import org.gradle.api.publish.internal.PublicationInternal
@@ -53,7 +54,6 @@ import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInte
 import org.gradle.api.publish.maven.MavenArtifact
 import org.gradle.api.publish.maven.internal.dependencies.VersionRangeMapper
 import org.gradle.api.tasks.TaskDependency
-import org.gradle.api.tasks.TaskOutputs
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.test.fixtures.file.TestFile
@@ -627,13 +627,8 @@ class DefaultMavenPublicationTest extends Specification {
 
     def createArtifactGenerator(File file) {
         return Stub(TaskProvider) {
-            get() >> Stub(Task) {
-                getOutputs() >> Stub(TaskOutputs) {
-                    getFiles() >> Stub(FileCollection) {
-                        getSingleFile() >> file
-                    }
-                }
-            }
+            get() >> Stub(Task)
+            flatMap(_) >> Providers.of({ file } as RegularFile)
         }
     }
 

--- a/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -557,7 +557,7 @@ class DefaultMavenPublicationTest extends Specification {
     def "resolving the publishable files does not throw if gradle metadata is not activated"() {
         given:
         def publication = createPublication()
-        publication.setPomGenerator(createArtifactGenerator(pomFile))
+        publication.setPomGenerator(createFileProvider(pomFile), Providers.of(true))
 
         when:
         publication.publishableArtifacts.files.files
@@ -620,15 +620,19 @@ class DefaultMavenPublicationTest extends Specification {
             notationParser,
             versionMappingStrategy
         )
-        publication.setPomGenerator(createArtifactGenerator(pomFile))
+        publication.setPomGenerator(createFileProvider(pomFile), Providers.of(true))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(gradleMetadataFile))
         return publication
     }
 
+    def createFileProvider(File file) {
+        return Providers.of({ file } as RegularFile)
+    }
+
     def createArtifactGenerator(File file) {
         return Stub(TaskProvider) {
-            get() >> Stub(Task)
-            flatMap(_) >> Providers.of({ file } as RegularFile)
+            flatMap(_) >> createFileProvider(file)
+            map(_) >> Providers.of(true)
         }
     }
 

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -874,4 +874,201 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         file("build", "libs", "sign-1.0.jar.asc").text
         file("build", "publications", "mavenJava", "pom-default.xml.asc").text
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/38909")
+    def "signing a Maven publication does not observe the component, so it can still be mutated afterwards"() {
+        given:
+        buildFile << """
+            apply plugin: 'maven-publish'
+            ${keyInfo.addAsPropertiesScript()}
+
+            publishing {
+                publications {
+                    mavenJava(MavenPublication) {
+                        from(components.java)
+                    }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign(publishing.publications.mavenJava)
+            }
+
+            java {
+                withSourcesJar()
+            }
+        """
+
+        when:
+        run("signMavenJavaPublication")
+
+        then:
+        executedAndNotSkipped(":signMavenJavaPublication")
+
+        and:
+        file("build", "libs", "sign-1.0.jar.asc").text
+        file("build", "libs", "sign-1.0-sources.jar.asc").text
+        file("build", "publications", "mavenJava", "pom-default.xml.asc").text
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38909")
+    def "signing a version-mapped Maven publication does not resolve mapped configurations, so dependencies can still be declared afterwards"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+
+        buildFile << """
+            apply plugin: 'maven-publish'
+            ${keyInfo.addAsPropertiesScript()}
+
+            repositories {
+                maven { url = "${mavenRepo.uri}" }
+            }
+
+            publishing {
+                publications {
+                    mavenJava(MavenPublication) {
+                        from(components.java)
+                        artifactId = '$artifactId'
+                        versionMapping {
+                            allVariants {
+                                fromResolutionResult()
+                            }
+                        }
+                    }
+                }
+                repositories {
+                    maven { url = "${mavenRepo.uri}" }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign(publishing.publications.mavenJava)
+            }
+
+            dependencies {
+                implementation("org:foo:1.+")
+            }
+        """
+
+        when:
+        succeeds("publish")
+
+        then:
+        executedAndNotSkipped(":publishMavenJavaPublicationToMavenRepository")
+
+        and:
+        def module = mavenRepo.module("sign", artifactId, version)
+        module.parsedPom.scopes.runtime.assertDependsOn("org:foo:1.0")
+
+        and:
+        module.pomFile.assertExists()
+        signatureFileFor(module.pomFile).assertExists()
+        module.artifactFile.assertExists()
+        signatureFileFor(module.artifactFile).assertExists()
+        module.getArtifactFile(type: "module").assertExists()
+        signatureFileFor(module.getArtifactFile(type: "module")).assertExists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38909")
+    def "signing an Ivy publication does not observe the component, so it can still be mutated afterwards"() {
+        given:
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            ${keyInfo.addAsPropertiesScript()}
+
+            publishing {
+                publications {
+                    ivyJava(IvyPublication) {
+                        from(components.java)
+                    }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign(publishing.publications.ivyJava)
+            }
+
+            java {
+                withSourcesJar()
+            }
+        """
+
+        when:
+        run("signIvyJavaPublication")
+
+        then:
+        executedAndNotSkipped(":signIvyJavaPublication")
+
+        and:
+        file("build", "libs", "sign-1.0.jar.asc").text
+        file("build", "libs", "sign-1.0-sources.jar.asc").text
+        file("build", "publications", "ivyJava", "ivy.xml.asc").text
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/38909")
+    def "signing a version-mapped Ivy publication does not resolve mapped configurations, so dependencies can still be declared afterwards"() {
+        given:
+        ivyRepo.module("org", "foo", "1.0").publish()
+
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            ${keyInfo.addAsPropertiesScript()}
+
+            repositories {
+                ivy { url = "${ivyRepo.uri}" }
+            }
+
+            publishing {
+                publications {
+                    ivyJava(IvyPublication) {
+                        from(components.java)
+                        module = '$artifactId'
+                        versionMapping {
+                            allVariants {
+                                fromResolutionResult()
+                            }
+                        }
+                    }
+                }
+                repositories {
+                    ivy { url = "${ivyRepo.uri}" }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign(publishing.publications.ivyJava)
+            }
+
+            dependencies {
+                implementation("org:foo:1.+")
+            }
+        """
+
+        when:
+        succeeds("publish")
+
+        then:
+        executedAndNotSkipped(":publishIvyJavaPublicationToIvyRepository")
+
+        and:
+        def module = ivyRepo.module("sign", artifactId, version)
+        module.parsedIvy.assertDependsOn("org:foo:1.0@runtime")
+
+        and:
+        module.ivyFile.assertExists()
+        signatureFileFor(module.ivyFile).assertExists()
+        module.jarFile.assertExists()
+        signatureFileFor(module.jarFile).assertExists()
+        module.moduleMetadataFile.assertExists()
+        signatureFileFor(module.moduleMetadataFile).assertExists()
+    }
+
+    private static TestFile signatureFileFor(TestFile file) {
+        new TestFile(file.parentFile, "${file.name}.asc")
+    }
+
 }


### PR DESCRIPTION
#38424 introduced input annotations to GenerateMavenPom. This caused calls to generateMavenPom.getOutputs().getFiles() to realize the properties of GenerateMavenPom, including the @Nested pom and its nested dependencies provider. Realizing that provider parses the dependencies of the publication, which finalizes the variants of the published component and resolves any configurations providing version-mapped dependency versions.

Signing eagerly realizes publication artifact files, which for Maven POMs, GMM files, and Ivy descriptor files, were provided by getOutputs(). As a result, after #38424, signing a publication caused failures during configuration time when any mutations to the set of variants or set of dependencies were made after sign(Publication).

We resolve this by directly wiring the known POM, GMM, and Ivy descriptor output files to the publications' metadata artifacts rather than relying on getOutputs(). Note that explicit calls to generateMavenPom.getOutputs() will continue to cause this same behavior change, but workarounds exist similar to ours: directly wire the task's output file properties without eagerly realizing its output properties. The benefits to Maven publication and configuration cache compatibility resulting from #38424 are likely worth this trade-off.

Note that #38424 does not cause a regression with Ivy, as GenerateIvyDescriptor does not yet declare input annotations for its descriptor, but we apply the same fix as we do for Maven for consistency and for forward compatibility with a similar change to Ivy when it is implemented.

Fixes #38909


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
