### PR TITLE
Update signing configuration

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -60,6 +60,7 @@ class PromotionProject(
             param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
             password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
             param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
+            param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
             param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
             param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
             param("env.DEVELOCITY_SERVER_URL", "%gbt.internal.develocity.server.url%")

--- a/.teamcity/src/main/kotlin/util/PublishKotlinDslPlugin.kt
+++ b/.teamcity/src/main/kotlin/util/PublishKotlinDslPlugin.kt
@@ -41,6 +41,7 @@ object PublishKotlinDslPlugin : BuildType({
         param("env.JAVA_HOME", javaHome(BuildToolBuildJvm, Os.LINUX))
         param("env.GRADLE_PUBLISH_KEY", "%plugin.portal.publish.key%")
         param("env.GRADLE_PUBLISH_SECRET", "%plugin.portal.publish.secret%")
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
     }

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -167,6 +167,8 @@ configurations.archives.get().allArtifacts.removeIf {
     it.name != "plugins"
 }
 
+// The key ID is required because the signing key is a subkey.
+val pgpSigningKeyId: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_ID")
 val pgpSigningKey: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY")
 val pgpSigningPassPhrase: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE")
 val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
@@ -174,7 +176,7 @@ val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
 tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
-    useInMemoryPgpKeys(pgpSigningKey.orNull, pgpSigningPassPhrase.orNull)
+    useInMemoryPgpKeys(pgpSigningKeyId.orNull, pgpSigningKey.orNull, pgpSigningPassPhrase.orNull)
     publishing.publications.configureEach {
         if (signArtifacts) {
             signing.sign(this)

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -42,15 +42,19 @@ publishing {
     }
 }
 
+// The key ID is required because the signing key is a subkey.
+val pgpSigningKeyId: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_ID")
 val pgpSigningKey: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY")
+val pgpSigningPassPhrase: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE")
 val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
 
 tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(
-        project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
-        project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
+        pgpSigningKeyId.orNull,
+        pgpSigningKey.orNull,
+        pgpSigningPassPhrase.orNull
     )
     publishing.publications.configureEach {
         if (signArtifacts) {

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -87,15 +87,19 @@ publishing {
 }
 
 // Temporary solution as we cannot simply apply publish-public-libraries for now
+// The key ID is required because the signing key is a subkey.
+val pgpSigningKeyId: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_ID")
 val pgpSigningKey: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY")
+val pgpSigningPassPhrase: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE")
 val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
 
 tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(
-        project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
-        project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
+        pgpSigningKeyId.orNull,
+        pgpSigningKey.orNull,
+        pgpSigningPassPhrase.orNull
     )
     publishing.publications.configureEach {
         if (signArtifacts) {


### PR DESCRIPTION
Backport of #38874 to `xperimental`.

After the move to a signing subkey, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key. The promotion build configuration also has to pass it as `env.PGP_SIGNING_KEY_ID`.

This branch needs it because `Gradle_Xperimental` has versioned settings enabled and syncs its TeamCity configuration from `xperimental`, so `Gradle_Xperimental_Promotion` currently has no `env.PGP_SIGNING_KEY_ID` — while the promotion build itself runs `gradle-promote` `master`, which already expects one.

Clean cherry-pick of the original commit (`4bdf0da`); no adaptation needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321