### PR TITLE
Update signing configuration

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -41,6 +41,7 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
         param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
         password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
     }

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -53,15 +53,19 @@ publishing {
     configurePublishingTasks()
 }
 
+// The key ID is required because the signing key is a subkey.
+val pgpSigningKeyId: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_ID")
 val pgpSigningKey: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY")
+val pgpSigningPassPhrase: Provider<String> = providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE")
 val signArtifacts: Boolean = !pgpSigningKey.orNull.isNullOrEmpty()
 
 tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(
-        project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
-        project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
+        pgpSigningKeyId.orNull,
+        pgpSigningKey.orNull,
+        pgpSigningPassPhrase.orNull
     )
     publishing.publications.configureEach {
         if (signArtifacts) {


### PR DESCRIPTION
Backport of #38874 to `release7x`.

After the move to a signing subkey, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key. The promotion build configuration also has to pass it as `env.PGP_SIGNING_KEY_ID`.

This branch needs it because `Gradle_Release7x` has versioned settings enabled and syncs its TeamCity configuration from `release7x`, so `Gradle_Release7x_Promotion` currently has no `env.PGP_SIGNING_KEY_ID` — while the promotion build itself runs `gradle-promote` `master`, which already expects one.

Adapted for the release7x layout: the convention plugin lives in `build-logic/publishing` rather than `build-logic-commons`, and there is no `packaging/public-api` or `kotlin-dsl-plugin-bundle` on this branch. `PublishKotlinDslPlugin.kt` carries no PGP parameters here, so it is left alone.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321