### PR TITLE
Make the cross-build scheduling protocol an explicit scheduler concern

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildControllers.java
@@ -21,8 +21,11 @@ import org.gradle.internal.build.ExecutionResult;
 import java.io.Closeable;
 
 interface BuildControllers extends Closeable {
+
     /**
-     * Finish populating work graphs, once all entry point tasks have been scheduled.
+     * Finish populating work graphs once all entry point tasks have been scheduled. Runs the cross-build
+     * scheduling protocol to a fixed point ensuring that execution plans for referenced nodes in other builds
+     * are populated.
      */
     void populateWorkGraphs();
 
@@ -39,4 +42,5 @@ interface BuildControllers extends Closeable {
 
     @Override
     void close();
+
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -16,6 +16,7 @@
 
 package org.gradle.composite.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.CircularReferenceException;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
@@ -98,6 +99,12 @@ class DefaultBuildController implements BuildController {
         scheduled.addAll(queuedForExecution);
         queuedForExecution.clear();
         return added;
+    }
+
+    @Override
+    public ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences() {
+        assertInState(State.DiscoveringTasks);
+        return workGraph.takeCrossBuildReferences();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
@@ -18,6 +18,7 @@ package org.gradle.composite.internal;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.execution.plan.PlanExecutor;
+import org.gradle.execution.plan.TaskInAnotherBuild;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.ExecutionResult;
@@ -65,18 +66,51 @@ class DefaultBuildControllers implements BuildControllers {
 
     @Override
     public void populateWorkGraphs() {
-        boolean tasksDiscovered = true;
-        while (tasksDiscovered) {
-            tasksDiscovered = false;
-            for (BuildController buildController : ImmutableList.copyOf(controllers.values())) {
-                if (buildController.scheduleQueuedTasks()) {
-                    tasksDiscovered = true;
-                }
-            }
-        }
+        // Scheduling the work of a build can discover references to tasks in other builds. The target of each such
+        // reference has to be queued in the work graph of the build that owns it, which can in turn discover further
+        // references, and so on until no build has anything left to schedule.
+        boolean tasksScheduled;
+        do {
+            queueForeignNodesInOwningGraphs();
+            tasksScheduled = scheduleQueuedWork();
+        } while (tasksScheduled);
+
         for (BuildController buildController : controllers.values()) {
             buildController.finalizeWorkGraph();
         }
+    }
+
+    /**
+     * Queues the target of every reference discovered so far in the work graph of the build that owns it.
+     */
+    private void queueForeignNodesInOwningGraphs() {
+        // Queuing a target can add a controller for a build that is not yet present, so iterate over a copy
+        for (BuildController buildController : ImmutableList.copyOf(controllers.values())) {
+            for (TaskInAnotherBuild reference : buildController.takeCrossBuildReferences()) {
+                BuildState targetBuild = reference.getTargetBuild();
+                if (targetBuild == null) {
+                    throw new IllegalStateException("No target build is known for " + reference + ".");
+                }
+                getBuildController(targetBuild).queueForExecution(reference.getTargetNode());
+            }
+        }
+    }
+
+    /**
+     * Schedules the work queued for each build, including any build whose controller was just added by
+     * {@link #queueForeignNodesInOwningGraphs()}. Scheduling work can discover further references, which is why the
+     * caller has to keep queuing and scheduling until there is nothing left to schedule.
+     *
+     * @return true if any work was scheduled.
+     */
+    private boolean scheduleQueuedWork() {
+        boolean tasksScheduled = false;
+        for (BuildController buildController : controllers.values()) {
+            if (buildController.scheduleQueuedTasks()) {
+                tasksScheduled = true;
+            }
+        }
+        return tasksScheduled;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -60,8 +60,6 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
     private final int monitoringPollTime;
     private final TimeUnit monitoringPollTimeUnit;
     private final ManagedExecutor executorService;
-    @SuppressWarnings("ThreadLocalUsage") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
-    private final ThreadLocal<DefaultBuildTreeWorkGraph> current = new ThreadLocal<>();
 
     @Inject
     public DefaultIncludedBuildTaskGraph(
@@ -99,40 +97,14 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
 
     @Override
     public <T> T withNewWorkGraph(Function<? super BuildTreeWorkGraph, T> action) {
-        DefaultBuildTreeWorkGraph previous = current.get();
-        DefaultBuildTreeWorkGraph workGraph = new DefaultBuildTreeWorkGraph(createControllers());
-        current.set(workGraph);
-        try {
-            try {
-                return action.apply(workGraph);
-            } finally {
-                workGraph.close();
-            }
-        } finally {
-            current.set(previous);
+        try (DefaultBuildTreeWorkGraph workGraph = new DefaultBuildTreeWorkGraph(createControllers())) {
+            return action.apply(workGraph);
         }
-    }
-
-    @Override
-    public void queueForExecution(BuildState targetBuild, Node node) {
-        withState(workGraph -> {
-            workGraph.queueForExecution(targetBuild, node);
-            return null;
-        });
     }
 
     @Override
     public void close() throws IOException {
         CompositeStoppable.stoppable(executorService).stop();
-    }
-
-    private <T> T withState(Function<DefaultBuildTreeWorkGraph, T> action) {
-        DefaultBuildTreeWorkGraph workGraph = current.get();
-        if (workGraph == null) {
-            throw new IllegalStateException("No work graph available for this thread.");
-        }
-        workGraph.assertIsOwner();
-        return action.apply(workGraph);
     }
 
     private class DefaultBuildTreeWorkGraphBuilder implements BuildTreeWorkGraph.Builder {
@@ -175,12 +147,6 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
         public DefaultBuildTreeWorkGraph(DefaultBuildControllers controllers) {
             this.owner = Thread.currentThread();
             this.controllers = controllers;
-        }
-
-        public void queueForExecution(BuildState build, Node node) {
-            assertIsOwner();
-            assertCanQueueTask();
-            controllers.getBuildController(build).queueForExecution(node);
         }
 
         @Override
@@ -226,10 +192,6 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
         public void close() {
             assertIsOwner();
             controllers.close();
-        }
-
-        private void assertCanQueueTask() {
-            expectInState(State.Preparing);
         }
 
         private void expectInState(State expectedState) {

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.composite.internal
 
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.build.BuildWorkGraph
 import org.gradle.internal.build.BuildWorkGraphController
 import org.gradle.internal.build.IncludedBuildState
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -33,6 +34,13 @@ abstract class AbstractIncludedBuildTaskGraphTest extends ConcurrentSpec {
         }
         _ * buildStateRegistry.getBuild(path) >> build
         return build
+    }
+
+    BuildState buildWithWorkGraph(Path path, BuildWorkGraph workGraph) {
+        def workGraphController = Mock(BuildWorkGraphController) {
+            newWorkGraph() >> workGraph
+        }
+        return build(path, workGraphController)
     }
 
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultBuildControllersTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultBuildControllersTest.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal
+
+import com.google.common.collect.ImmutableList
+import org.gradle.execution.plan.PlanExecutor
+import org.gradle.execution.plan.TaskInAnotherBuild
+import org.gradle.execution.plan.TaskNode
+import org.gradle.internal.build.BuildState
+import org.gradle.internal.build.BuildWorkGraph
+import org.gradle.internal.concurrent.ManagedExecutor
+import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.util.Path
+
+import java.util.concurrent.TimeUnit
+
+class DefaultBuildControllersTest extends AbstractIncludedBuildTaskGraphTest {
+
+    def controllers = new DefaultBuildControllers(Stub(ManagedExecutor), Stub(WorkerLeaseService), Stub(PlanExecutor), 1, TimeUnit.SECONDS)
+
+    def rootWorkGraph = Mock(BuildWorkGraph)
+    def childWorkGraph = Mock(BuildWorkGraph)
+    def rootBuild = buildWithWorkGraph(Path.ROOT, rootWorkGraph)
+    def childBuild = buildWithWorkGraph(Path.path(":child"), childWorkGraph)
+
+    def "queues the target of a discovered cross-build reference in the build that owns it"() {
+        given:
+        def targetNode = Stub(TaskNode)
+        controllers.getBuildController(rootBuild)
+
+        when:
+        controllers.populateWorkGraphs()
+
+        then:
+        // The reference is discovered by the root build, and its target is scheduled in the child build
+        1 * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of(reference(childBuild, targetNode))
+        1 * childWorkGraph.schedule({ it as List == [targetNode] }) >> true
+
+        and:
+        _ * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        _ * childWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        1 * rootWorkGraph.finalizeGraph()
+        1 * childWorkGraph.finalizeGraph()
+    }
+
+    def "queues the target of a reference discovered by a build that was itself only just scheduled"() {
+        given:
+        def grandChildWorkGraph = Mock(BuildWorkGraph)
+        def grandChildBuild = buildWithWorkGraph(Path.path(":child:grandChild"), grandChildWorkGraph)
+        def grandChildTargetNode = Stub(TaskNode)
+        controllers.getBuildController(rootBuild)
+
+        when:
+        controllers.populateWorkGraphs()
+
+        then:
+        1 * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of(reference(childBuild, Stub(TaskNode)))
+        1 * childWorkGraph.schedule(_) >> true
+        // Discovered while scheduling the child build, so the fixed point has to keep going
+        1 * childWorkGraph.takeCrossBuildReferences() >> ImmutableList.of(reference(grandChildBuild, grandChildTargetNode))
+        1 * grandChildWorkGraph.schedule({ it as List == [grandChildTargetNode] }) >> true
+
+        and:
+        _ * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        _ * childWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        _ * grandChildWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        1 * rootWorkGraph.finalizeGraph()
+        1 * childWorkGraph.finalizeGraph()
+        1 * grandChildWorkGraph.finalizeGraph()
+    }
+
+    def "does not schedule the target of a reference that has already been scheduled"() {
+        given:
+        def targetNode = Stub(TaskNode)
+        controllers.getBuildController(rootBuild)
+
+        when:
+        controllers.populateWorkGraphs()
+
+        then:
+        // The same target is reported twice, once by the root build and once by the child build itself
+        1 * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of(reference(childBuild, targetNode))
+        1 * childWorkGraph.takeCrossBuildReferences() >> ImmutableList.of(reference(childBuild, targetNode))
+        1 * childWorkGraph.schedule({ it as List == [targetNode] }) >> true
+
+        and:
+        _ * rootWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        _ * childWorkGraph.takeCrossBuildReferences() >> ImmutableList.of()
+        1 * rootWorkGraph.finalizeGraph()
+        1 * childWorkGraph.finalizeGraph()
+    }
+
+    private static TaskInAnotherBuild reference(BuildState targetBuild, TaskNode targetNode) {
+        return TaskInAnotherBuild.of(targetNode, targetBuild)
+    }
+}

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -115,7 +115,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         CurrentBuildOperationRef.instance().clear()
     }
 
-    def taskNodeFactory = new TaskNodeFactory(Stub(BuildTreeWorkGraphController), buildStateRegistry, Stub(NodeValidator), new TestBuildOperationRunner(), new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_INSENSITIVE, Stub(Stat)), TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
+    def taskNodeFactory = new TaskNodeFactory(buildStateRegistry, Stub(NodeValidator), new TestBuildOperationRunner(), new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_INSENSITIVE, Stub(Stat)), TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
 
     def "does nothing when nothing scheduled"() {
         when:

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.execution.plan.Node
+import com.google.common.collect.ImmutableList
 import org.gradle.execution.plan.PlanExecutor
-import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildWorkGraph
 import org.gradle.internal.build.BuildWorkGraphController
 import org.gradle.internal.build.ExecutionResult
@@ -65,99 +64,37 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
         1 * workGraphController.newWorkGraph() >> workGraph
         1 * preparer.prepareToScheduleTasks(_)
         1 * workGraph.populateWorkGraph(_)
+        _ * workGraph.takeCrossBuildReferences() >> ImmutableList.of()
         1 * workGraph.finalizeGraph()
         1 * workGraph.runWork() >> ExecutionResult.succeeded()
     }
 
-    def "cannot schedule tasks when graph has not been created"() {
-        when:
-        graph.queueForExecution(Stub(BuildState), Stub(Node))
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == "No work graph available for this thread."
-    }
-
-    def "cannot schedule tasks when after graph has finished execution"() {
-        when:
-        graph.withNewWorkGraph { 12 }
-        graph.queueForExecution(Stub(BuildState), Stub(Node))
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == "No work graph available for this thread."
-    }
-
-    def "cannot schedule tasks when graph is not yet being prepared for execution"() {
-        given:
-        def build = build(Path.ROOT)
-
-        when:
-        graph.withNewWorkGraph { g ->
-            graph.queueForExecution(build, Stub(Node))
-        }
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == "Work graph is in an unexpected state: NotPrepared, expected: Preparing"
-    }
-
-    def "cannot schedule tasks when graph has been prepared for execution"() {
-        given:
-        def build = build(Path.ROOT)
-
+    def "cannot schedule work more than once for a graph"() {
         when:
         graph.withNewWorkGraph { g ->
             g.scheduleWork {
             }
-            graph.queueForExecution(build, Stub(Node))
+            g.scheduleWork {
+            }
         }
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == "Work graph is in an unexpected state: ReadyToRun, expected: Preparing"
+        e.message == "Work graph is in an unexpected state: ReadyToRun, expected: NotPrepared"
     }
 
-    def "cannot schedule tasks when graph has started task execution"() {
-        given:
-        def buildPath = Path.ROOT
-        def workGraphController = Mock(BuildWorkGraphController)
-        def workGraph = Mock(BuildWorkGraph)
-        def build = build(buildPath, workGraphController)
-
-        workGraphController.newWorkGraph() >> workGraph
-        workGraph.runWork() >> {
-            graph.queueForExecution(build, Stub(Node))
-        }
-
+    def "cannot run the work of a graph more than once"() {
         when:
         graph.withNewWorkGraph { g ->
-            def f = g.scheduleWork { b ->
-                b.withWorkGraph(build) {}
+            def f = g.scheduleWork {
             }
             f.runWork().rethrow()
-        }
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == "No work graph available for this thread."
-    }
-
-    def "cannot schedule tasks when graph has completed task execution"() {
-        given:
-        def build = build(Path.ROOT)
-
-        when:
-        graph.withNewWorkGraph { g ->
-            def f= g.scheduleWork {
-            }
             f.runWork()
-            graph.queueForExecution(build, Stub(Node))
         }
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == "Work graph is in an unexpected state: Finished, expected: Preparing"
+        e.message == "Work graph is in an unexpected state: Finished, expected: ReadyToRun"
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildController.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.composite.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.execution.EntryTaskSelector;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.QueryableExecutionPlan;
+import org.gradle.execution.plan.TaskInAnotherBuild;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.concurrent.Stoppable;
@@ -56,6 +58,15 @@ public interface BuildController extends Stoppable {
      * @return true if any tasks were scheduled, false if not.
      */
     boolean scheduleQueuedTasks();
+
+    /**
+     * Returns the references to tasks in other builds that were discovered while scheduling the work of this build,
+     * then clears those references from state. The target of each reference must be queued for execution in the build
+     * that owns it.
+     *
+     * @see org.gradle.execution.plan.ExecutionPlan#takeCrossBuildReferences()
+     */
+    ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences();
 
     /**
      * Prepares the work graph, once all tasks have been scheduled.

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
@@ -16,14 +16,11 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.execution.plan.Node;
-import org.gradle.internal.build.BuildState;
 import org.gradle.internal.buildtree.BuildTreeWorkGraph;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
 
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -31,11 +28,6 @@ import java.util.function.Function;
  */
 @ServiceScope(Scope.BuildTree.class)
 public interface BuildTreeWorkGraphController {
-
-    /**
-     * Queues the given node of the given build for execution, but does not schedule it. Use {@link BuildTreeWorkGraph#scheduleWork(Consumer)} to schedule queued tasks.
-     */
-    void queueForExecution(BuildState targetBuild, Node node);
 
     /**
      * Runs the given action against a new, empty work graph. This allows tasks to be run while calculating the task graph of the build tree, for example to run `buildSrc` tasks or

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.execution.EntryTaskSelector;
@@ -25,6 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public interface BuildWorkPlan extends Stoppable {
+
     /**
      * Invokes the given action when a task completes (as per {@link Node#isComplete()}). Does nothing for tasks that have already completed.
      */
@@ -33,4 +35,10 @@ public interface BuildWorkPlan extends Stoppable {
     void addFilter(Spec<Task> filter);
 
     void addFinalization(BiConsumer<EntryTaskSelector.Context, QueryableExecutionPlan> finalization);
+
+    /**
+     * See {@link ExecutionPlan#takeCrossBuildReferences()}.
+     */
+    ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences();
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -66,6 +66,13 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
 
     private final Set<Node> filteredNodes = newIdentityHashSet();
     private final Set<Node> finalizers = new LinkedHashSet<>();
+
+    /**
+     * The references to tasks in other builds discovered while walking the entry nodes of this plan. Each element is a
+     * node of this plan that stands in for a task owned by another build, rather than that task's own node.
+     */
+    private final Set<TaskInAnotherBuild> crossBuildReferences = new LinkedHashSet<>();
+
     private final OrdinalNodeAccess ordinalNodeAccess;
     private Consumer<LocalTaskNode> completionHandler = localTaskNode -> {
     };
@@ -204,6 +211,11 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
             if (visiting.add(node)) {
                 // Have not seen this node before - add its dependencies to the head of the queue and leave this
                 // node in the queue
+                if (node instanceof TaskInAnotherBuild) {
+                    // The target of this dependency has to be scheduled in the work graph of the build that owns it.
+                    // Remember it so that the scheduler can queue it later.
+                    crossBuildReferences.add((TaskInAnotherBuild) node);
+                }
                 node.resolveDependencies(dependencyResolver);
                 for (Node successor : node.getHardSuccessors()) {
                     successor.maybeInheritOrdinalAsDependency(node.getGroup().asOrdinal());
@@ -235,6 +247,16 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
             return filter.isSatisfiedBy(((LocalTaskNode) successor).getTask());
         }
         return true;
+    }
+
+    @Override
+    public ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences() {
+        if (crossBuildReferences.isEmpty()) {
+            return ImmutableList.of();
+        }
+        ImmutableList<TaskInAnotherBuild> result = ImmutableList.copyOf(crossBuildReferences);
+        crossBuildReferences.clear();
+        return result;
     }
 
     @Override
@@ -331,6 +353,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         nodeMapping.clear();
         filteredNodes.clear();
         finalizers.clear();
+        crossBuildReferences.clear();
         scheduledNodes = null;
         ordinalNodeAccess.reset();
         dependencyResolver.clear();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
 import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -63,6 +64,14 @@ public interface ExecutionPlan extends Describable, Closeable {
      * Returns a snapshot of the current contents of this plan. Note that this plan is mutable, so the contents may later change.
      */
     QueryableExecutionPlan getContents();
+
+    /**
+     * Returns the references to tasks in other builds that were discovered while populating this plan and forgets them.
+     * <p>
+     * A reference is discovered when its node is first visited, which does not necessarily mean that node ends up in this
+     * plan. Callers are expected to schedule the target of each reference in the work graph of the build that owns it.
+     */
+    ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences();
 
     /**
      * Calculates the execution plan for the current entry tasks. May be called multiple times.

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
-import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
@@ -34,19 +33,13 @@ public abstract class TaskInAnotherBuild extends TaskNode {
 
     public static TaskInAnotherBuild of(
         TaskNode targetNode,
-        BuildState targetBuild,
-        BuildTreeWorkGraphController workGraph
+        BuildState targetBuild
     ) {
-        return new TaskInAnotherBuild(targetNode.getTask().getIdentityPath()) {
+        return new TaskInAnotherBuild(targetNode.getTask().getIdentityPath(), targetBuild) {
 
             @Override
             public TaskNode getTargetNode() {
                 return targetNode;
-            }
-
-            @Override
-            protected void queueTargetForExecution() {
-                workGraph.queueForExecution(targetBuild, targetNode);
             }
 
         };
@@ -72,7 +65,9 @@ public abstract class TaskInAnotherBuild extends TaskNode {
         private @Nullable TaskNode targetNode;
 
         private Restored(Path taskIdentityPath) {
-            super(taskIdentityPath);
+            // The target node is always part of its build's restored work graph, so this reference is never
+            // queued for execution and does not need to know which build owns the target.
+            super(taskIdentityPath, null);
         }
 
         /**
@@ -90,22 +85,30 @@ public abstract class TaskInAnotherBuild extends TaskNode {
             return targetNode;
         }
 
-        @Override
-        protected void queueTargetForExecution() {
-            // Nothing to queue. The target node is always part of its build's restored work graph
-        }
-
     }
 
-    private @Nullable DependenciesState targetOutcome;
     private final Path taskIdentityPath;
+    private final @Nullable BuildState targetBuild;
 
-    protected TaskInAnotherBuild(Path taskIdentityPath) {
+    private @Nullable DependenciesState targetOutcome;
+
+    protected TaskInAnotherBuild(Path taskIdentityPath, @Nullable BuildState targetBuild) {
         this.taskIdentityPath = taskIdentityPath;
+        this.targetBuild = targetBuild;
     }
 
     public Path getTaskIdentityPath() {
         return taskIdentityPath;
+    }
+
+    /**
+     * The build that owns the target task. Determines which work graph the target node has to be scheduled in.
+     * <p>
+     * Null for a reference restored from the configuration cache, as the target node is always part of its build's
+     * restored work graph and so is never queued for execution.
+     */
+    public @Nullable BuildState getTargetBuild() {
+        return targetBuild;
     }
 
     /**
@@ -175,13 +178,9 @@ public abstract class TaskInAnotherBuild extends TaskNode {
 
     @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver) {
-        queueTargetForExecution();
+        // This node has no dependencies of its own. The target node is scheduled in its own build's work graph
+        // by the scheduler, which discovers this reference via ExecutionPlan#takeCrossBuildReferences.
     }
-
-    /**
-     * Queues the target task for execution in its build's work graph.
-     */
-    protected abstract void queueTargetForExecution();
 
     @Override
     public DependenciesState doCheckDependenciesComplete() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.problems.internal.ProblemsInternal;
-import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.internal.Cast;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -58,7 +57,6 @@ public class TaskNodeFactory implements HoldsProjectState {
     private final InMemoryLoadingCache<ExternalTaskKey, TaskInAnotherBuild> externalTaskNodes;
 
     public TaskNodeFactory(
-        BuildTreeWorkGraphController workGraphController,
         BuildStateRegistry buildRegistry,
         NodeValidator nodeValidator,
         BuildOperationRunner buildOperationRunner,
@@ -80,7 +78,7 @@ public class TaskNodeFactory implements HoldsProjectState {
             Path targetBuildPath = buildPathOf(key.task);
             BuildState targetBuild = buildRegistry.getBuild(targetBuildPath);
             TaskNode targetNode = localTaskNodes.get(key.task);
-            return TaskInAnotherBuild.of(targetNode, targetBuild, workGraphController);
+            return TaskInAnotherBuild.of(targetNode, targetBuild);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraph.java
@@ -16,11 +16,13 @@
 
 package org.gradle.internal.build;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.execution.EntryTaskSelector;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.QueryableExecutionPlan;
+import org.gradle.execution.plan.TaskInAnotherBuild;
 import org.gradle.internal.concurrent.Stoppable;
 
 import java.util.Collection;
@@ -47,6 +49,14 @@ public interface BuildWorkGraph extends Stoppable {
      * Adds a finalization step to this work graph.
      */
     void addFinalization(BiConsumer<EntryTaskSelector.Context, QueryableExecutionPlan> finalization);
+
+    /**
+     * See {@link org.gradle.execution.plan.ExecutionPlan#takeCrossBuildReferences()}.
+     * <p>
+     * Returns an empty list when nothing has been added to this work graph yet, so that asking for the discovered
+     * references does not create a plan for a build that has none.
+     */
+    ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences();
 
     /**
      * Finalize the work graph for execution, after all work has been scheduled. This method should not schedule any additional work.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -36,6 +36,7 @@ import org.gradle.execution.plan.LocalTaskNode;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.QueryableExecutionPlan;
 import org.gradle.execution.plan.ScheduledWork;
+import org.gradle.execution.plan.TaskInAnotherBuild;
 import org.gradle.internal.Describables;
 import org.gradle.internal.Pair;
 import org.gradle.internal.exception.ExceptionAnalyser;
@@ -400,6 +401,11 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         @Override
         public void onComplete(Consumer<LocalTaskNode> handler) {
             handlers.add(handler);
+        }
+
+        @Override
+        public ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences() {
+            return plan.takeCrossBuildReferences();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.build;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.specs.Spec;
@@ -23,9 +24,11 @@ import org.gradle.execution.EntryTaskSelector;
 import org.gradle.execution.plan.BuildWorkPlan;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.QueryableExecutionPlan;
+import org.gradle.execution.plan.TaskInAnotherBuild;
 import org.gradle.execution.plan.TaskNode;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.work.WorkerLeaseService;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,7 +85,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
 
     private class DefaultBuildWorkGraph implements BuildWorkGraph {
         private final Thread owner;
-        BuildWorkPlan plan;
+        @Nullable BuildWorkPlan plan;
 
         public DefaultBuildWorkGraph() {
             this.owner = Thread.currentThread();
@@ -139,6 +142,15 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
         @Override
         public void addFinalization(BiConsumer<EntryTaskSelector.Context, QueryableExecutionPlan> finalization) {
             getOwnedPlan().addFinalization(finalization);
+        }
+
+        @Override
+        public ImmutableList<TaskInAnotherBuild> takeCrossBuildReferences() {
+            assertIsOwner();
+            if (plan == null) {
+                return ImmutableList.of();
+            }
+            return plan.takeCrossBuildReferences();
         }
 
         private BuildWorkPlan getOwnedPlan() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
-import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.file.Stat
@@ -55,7 +54,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     DefaultFinalizedExecutionPlan finalizedPlan
 
     def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(Stub(BuildTreeWorkGraphController), Stub(BuildStateRegistry), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
+    def taskNodeFactory = new TaskNodeFactory(Stub(BuildStateRegistry), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
 
     def setup() {
         executionPlan = newExecutionPlan()

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.internal.tasks.WorkNodeAction
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
-import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.file.Stat
@@ -48,7 +47,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     DefaultFinalizedExecutionPlan finalizedPlan
 
     def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(Stub(BuildTreeWorkGraphController), Stub(BuildStateRegistry), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
+    def taskNodeFactory = new TaskNodeFactory(Stub(BuildStateRegistry), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
     def build = Mock(BuildState) {
         getIdentityPath() >> Path.ROOT
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/NodeComparatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/NodeComparatorTest.groovy
@@ -154,14 +154,9 @@ class NodeComparatorTest extends Specification {
     }
 
     protected TaskInAnotherBuild createTaskInAnotherBuild(int index) {
-        return new TaskInAnotherBuild(path(index)) {
+        return new TaskInAnotherBuild(path(index), null) {
             @Override
             TaskNode getTargetNode() {
-                throw new NotImplementedException()
-            }
-
-            @Override
-            protected void queueTargetForExecution() {
                 throw new NotImplementedException()
             }
         }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TestTaskIdentities
-import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.util.Path
@@ -37,7 +36,7 @@ class TaskNodeFactoryTest extends Specification {
     def e = task('e')
 
     def setup() {
-        factory = new TaskNodeFactory(Stub(BuildTreeWorkGraphController), Stub(BuildStateRegistry), Stub(NodeValidator), new TestBuildOperationRunner(), Stub(ExecutionNodeAccessHierarchies), TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
+        factory = new TaskNodeFactory(Stub(BuildStateRegistry), Stub(NodeValidator), new TestBuildOperationRunner(), Stub(ExecutionNodeAccessHierarchies), TestUtil.problemsService(), TestUtil.inMemoryCacheFactory())
     }
 
     private TaskInternal task(String name) {


### PR DESCRIPTION
`TaskInAnotherBuild.resolveDependencies()` queued its target for execution in another build's work graph, reaching the scheduler through an ambient `ThreadLocal`. The cross-build fixed point was therefore spread across a node subclass, a thread-local lookup and the loop in `DefaultBuildControllers`, which makes it hard to follow and harder to replace.

Replacing that protocol is the hard part of unifying the per-build execution plans into a single build-tree plan, and it is much easier to replace when it is one explicit, well-named mechanism. Pushing it out of the node also leaves `TaskInAnotherBuild` closer to a pure edge marker, so its eventual deletion is close to a no-op.

The one intended behavioural difference: a discovered target is now scheduled in the next pass of the loop rather than possibly the current one, so ordinal numbering for cross-build targets can differ. The ordering constraints ordinals express do not.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
