### PR TITLE
Defer signing wiring until projects are evaluated

### DIFF
--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -177,8 +177,14 @@ tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(pgpSigningKeyId.orNull, pgpSigningKey.orNull, pgpSigningPassPhrase.orNull)
-    publishing.publications.configureEach {
-        if (signArtifacts) {
+}
+
+// See the comment on the same workaround in gradlebuild.publish-public-libraries: signing a
+// publication eagerly finalizes the published component, so it must not be wired up before the
+// applying build script has declared its dependencies.
+if (signArtifacts) {
+    afterEvaluate {
+        publishing.publications.configureEach {
             signing.sign(this)
         }
     }

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -56,8 +56,22 @@ signing {
         pgpSigningKey.orNull,
         pgpSigningPassPhrase.orNull
     )
-    publishing.publications.configureEach {
-        if (signArtifacts) {
+}
+
+// Signing eagerly realizes the artifact files of a publication, which finalizes the variants and
+// the dependencies of the published component. Wiring signing up while this project is still being
+// configured therefore freezes its dependency configurations, and the `dependencies { }` block of
+// the build script applying this plugin then fails with "Cannot mutate the dependencies of
+// configuration ':x:api' after the configuration's child configuration ':x:apiElements' was
+// published as a variant". Deferring the wiring until the project is evaluated avoids that.
+//
+// The build tool side of this was fixed by https://github.com/gradle/gradle/pull/38917, but the
+// promotion build bootstraps with a released distribution, so this workaround is needed for as long
+// as the wrapper predates that fix. Only signing builds are affected, which is why master CI stays
+// green while nightly promotion does not.
+if (signArtifacts) {
+    afterEvaluate {
+        publishing.publications.configureEach {
             signing.sign(this)
         }
     }

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -101,8 +101,14 @@ signing {
         pgpSigningKey.orNull,
         pgpSigningPassPhrase.orNull
     )
-    publishing.publications.configureEach {
-        if (signArtifacts) {
+}
+
+// See the comment on the same workaround in gradlebuild.publish-public-libraries: signing a
+// publication eagerly finalizes the published component, so it must not be wired up before this
+// script has finished configuring the project.
+if (signArtifacts) {
+    afterEvaluate {
+        publishing.publications.configureEach {
             signing.sign(this)
         }
     }


### PR DESCRIPTION
Nightly promotion of `master` has been red since 2026-08-20 (#1840, #1841, #1842, #1843), so there
have been no new master nightlies since the 2026-08-19 build. `Publish Kotlin DSL Plugin` is red for
the same reason. Both fail during **configuration**:

```
* Where:
Build file '.../platforms/core-execution/build-cache/build.gradle.kts' line: 10

* What went wrong:
Cannot mutate the dependencies of configuration ':build-cache:api' after the configuration's child
configuration ':build-cache:apiElements' was published as a variant. After a configuration has been
observed, it should not be modified.
```

## Why

As described in #38917: #38424 made `GenerateMavenPom`'s `pom` a `@Nested` input, so realizing the
task's output files also realizes the pom's nested dependencies provider, which finalizes the
variants of the published component. Signing eagerly realizes a publication's artifact files, so
`sign(Publication)` now freezes the project's dependency configurations at configuration time.

Our publishing plugins call `signing.sign(publication)` while the plugin is being applied — that is,
from the `plugins { }` block of every published module, *before* that module's `dependencies { }`
block runs. Hence the failure above, and hence it only affects builds where signing is active
(`PGP_SIGNING_KEY` set), which is why ordinary master CI is green and only promotion/publishing jobs
are broken.

#38917 fixed the build tool on 2026-08-21, but that does not unblock promotion on its own: the
promotion build bootstraps with the wrapper's **released** distribution, currently
`9.8.0-milestone-1`, which predates the fix. And no newer 9.8 nightly exists to bump to, because
nightlies are produced by the very job that is broken — the latest published nightly is still
`9.8.0-20260819011813+0000`. So the build logic has to stop tripping over the released wrapper.

## What this does

Defers wiring `signing.sign(...)` until the project has been evaluated, in the three places that set
it up, and only when signing is actually enabled — so nothing changes for non-signing builds.

`afterEvaluate` is already used in build logic for the same "must run after the applying script"
reason (`gradlebuild.minify`, `gradlebuild.no-module-annotation`, `JvmCompilation`).

The alternative would be reverting the wrapper to 9.7.1, but the wrapper bot bumps to the latest
released version, so it would go straight back to `9.8.0-milestone-1` and break again.

## Verification

Ran the promotion command locally on this branch with the `9.8.0-milestone-1` wrapper
(`clean promotionBuild --dry-run -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache`,
with dummy artifactory credentials so the `taskGraph.whenReady` credential check passes):

| | result |
|---|---|
| `PGP_SIGNING_KEY*` set, before this change | fails at `platforms/core-execution/build-cache/build.gradle.kts` line 10, as on CI |
| `PGP_SIGNING_KEY*` set, after this change | `BUILD SUCCESSFUL`, full task graph built, **29 `sign*Publication` tasks** present |
| no `PGP_SIGNING_KEY*`, after this change | `BUILD SUCCESSFUL`, 0 sign tasks and 32 `publish*PublicationTo*` tasks — unchanged from before |

So signing is still wired into the publishing graph, and non-signing builds are untouched.

Also confirmed on a 10-line standalone reproducer that this is a wrapper-version behaviour change:
`java-library` + `maven-publish` + `signing`, a publication with
`versionMapping { usage("java-api") { fromResolutionResult() } }`, `sign()` wired before
`dependencies { api(...) }` — fails on 9.8.0-milestone-1, passes on 9.7.0.

## Follow-up

This workaround can be removed once the wrapper points at a distribution that contains #38917.

Internal tracking: gradle/gradle-private#5323
