### PR TITLE
Skip cross-version test tasks that cannot select flaky tests under -PflakyTests=ONLY

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -53,17 +53,7 @@ class FlakyTestQuarantineProject(
         model.stages
             .filter { it.stageName <= StageName.READY_FOR_RELEASE }
             .flatMap { it.functionalTests }
-            // AllVersionsCrossVersion is excluded, every other coverage - including QuickFeedbackCrossVersion - is
-            // still quarantined. A quarantine build is not split into buckets, so this coverage runs one test task per
-            // tested Gradle version per subproject, over a thousand of them, on a single agent. `-PflakyTests=ONLY`
-            // selects nothing in almost all of them, but the tag filter is applied during JUnit discovery inside the
-            // test JVM, so each still forks one to discover nothing. That only finishes within the timeout when the
-            // build cache serves nearly all of it, which on Windows it has never done on a revision that was not
-            // already built - the build has never passed there on first run of a revision.
-            //
-            // Nothing is lost by dropping it: the QuickFeedbackCrossVersion quarantine covers the same @Flaky
-            // cross-version tests, against fewer Gradle versions, in a fraction of the time.
-            .filter { it.os == os && it.testType != TestType.ALL_VERSIONS_CROSS_VERSION }
+            .filter { it.os == os }
             .forEach {
                 buildType(FlakyTestQuarantine(model, stage, it))
             }

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -53,7 +53,17 @@ class FlakyTestQuarantineProject(
         model.stages
             .filter { it.stageName <= StageName.READY_FOR_RELEASE }
             .flatMap { it.functionalTests }
-            .filter { it.os == os }
+            // AllVersionsCrossVersion is excluded, every other coverage - including QuickFeedbackCrossVersion - is
+            // still quarantined. A quarantine build is not split into buckets, so this coverage runs one test task per
+            // tested Gradle version per subproject, over a thousand of them, on a single agent. `-PflakyTests=ONLY`
+            // selects nothing in almost all of them, but the tag filter is applied during JUnit discovery inside the
+            // test JVM, so each still forks one to discover nothing. That only finishes within the timeout when the
+            // build cache serves nearly all of it, which on Windows it has never done on a revision that was not
+            // already built - the build has never passed there on first run of a revision.
+            //
+            // Nothing is lost by dropping it: the QuickFeedbackCrossVersion quarantine covers the same @Flaky
+            // cross-version tests, against fewer Gradle versions, in a fraction of the time.
+            .filter { it.os == os && it.testType != TestType.ALL_VERSIONS_CROSS_VERSION }
             .forEach {
                 buildType(FlakyTestQuarantine(model, stage, it))
             }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -190,11 +190,8 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
         description = "Runs ${testType.prefix} with $executer executer"
         systemProperties["org.gradle.integtest.executer"] = executer
         addDebugProperties()
-        if (excludedByFlakyOnlyStrategy(sourceSet, testType)) {
-            // Under -PflakyTests=ONLY, a test task whose sources never mention @Flaky cannot select any test, but
-            // the tag filter is only applied during JUnit Platform discovery inside the forked test JVM. Wiring no
-            // test classes at all makes the task NO-SOURCE (Test.getCandidateClassFiles is @SkipWhenEmpty), which
-            // skips the JVM fork and drops the task dependencies on the test compilation.
+        if (excludedByFlakyOnlyStrategy(sourceSet)) {
+            // No test here can be flaky: make the task NO-SOURCE instead of forking a JVM that discovers nothing.
             testClassesDirs = project.files()
             classpath = project.files()
         } else {
@@ -214,23 +211,16 @@ const val FLAKY_ANNOTATION_REFERENCE = "org.gradle.test.fixtures.Flaky"
 
 
 /**
- * Whether the task can be skipped outright under `-PflakyTests=ONLY` because no source file of the
- * source set references the `@Flaky` annotation, so no test in it can carry the flaky tag. Using
- * `@Flaky` requires its fully qualified name in the file (as an import or inline), so a plain text
- * scan cannot produce a false negative, with one caveat: a spec inheriting class-level `@Flaky`
- * from a base class in a different source set would be missed. No such case exists today. A false
- * positive (e.g. the name in a comment) is harmless: the task then runs and discovers nothing,
- * which is what every task of a flaky-free source set does today.
+ * Whether the task can be skipped under `-PflakyTests=ONLY` because no source file of the source set
+ * references `@Flaky`. Using the annotation requires its fully qualified name in the file, so the text
+ * scan cannot miss a use.
  */
 private
-fun Project.excludedByFlakyOnlyStrategy(sourceSet: SourceSet, testType: TestType): Boolean {
-    if (testType != TestType.CROSSVERSION || flakyTestStrategy != FlakyTestStrategy.ONLY) {
+fun Project.excludedByFlakyOnlyStrategy(sourceSet: SourceSet): Boolean {
+    if (flakyTestStrategy != FlakyTestStrategy.ONLY) {
         return false
     }
-    // precondition-tester re-points every DistributionTest at the untagged Jupiter tests of its 'test' source
-    // set, which the ONLY strategy deliberately runs on every build (they are matched by the none() part of the
-    // tag expression), so the flaky source scan does not apply to it. Its build script also appends to the task
-    // classpath, which an emptied classpath here would corrupt.
+    // precondition-tester reconfigures its test tasks to always run its (untagged) precondition tests
     if (name == "precondition-tester") {
         return false
     }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -16,8 +16,10 @@
 
 package gradlebuild.integrationtests
 
+import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.capitalize
 import gradlebuild.basics.daemonDebuggingIsEnabled
+import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.launcherDebuggingIsEnabled
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.testSplitExcludeTestClasses
@@ -188,14 +190,50 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
         description = "Runs ${testType.prefix} with $executer executer"
         systemProperties["org.gradle.integtest.executer"] = executer
         addDebugProperties()
-        testClassesDirs = sourceSet.output.classesDirs
-        classpath = sourceSet.runtimeClasspath
+        if (excludedByFlakyOnlyStrategy(sourceSet, testType)) {
+            // Under -PflakyTests=ONLY, a test task whose sources never mention @Flaky cannot select any test, but
+            // the tag filter is only applied during JUnit Platform discovery inside the forked test JVM. Wiring no
+            // test classes at all makes the task NO-SOURCE (Test.getCandidateClassFiles is @SkipWhenEmpty), which
+            // skips the JVM fork and drops the task dependencies on the test compilation.
+            testClassesDirs = project.files()
+            classpath = project.files()
+        } else {
+            testClassesDirs = sourceSet.output.classesDirs
+            classpath = sourceSet.runtimeClasspath
+        }
         extraConfig.execute(this)
         if (!integTest.generateDefaultAutoTestedSamplesTest.get()) {
             inputs.dir(layout.projectDirectory.dir("src/main")).withPathSensitivity(PathSensitivity.RELATIVE)
         }
         setUpAgentIfNeeded(testType, executer)
     }
+
+
+private
+const val FLAKY_ANNOTATION_REFERENCE = "org.gradle.test.fixtures.Flaky"
+
+
+/**
+ * Whether the task can be skipped outright under `-PflakyTests=ONLY` because no source file of the
+ * source set references the `@Flaky` annotation, so no test in it can carry the flaky tag. Using
+ * `@Flaky` requires its fully qualified name in the file (as an import or inline), so a plain text
+ * scan cannot produce a false negative, with one caveat: a spec inheriting class-level `@Flaky`
+ * from a base class in a different source set would be missed. No such case exists today. A false
+ * positive (e.g. the name in a comment) is harmless: the task then runs and discovers nothing,
+ * which is what every task of a flaky-free source set does today.
+ */
+private
+fun Project.excludedByFlakyOnlyStrategy(sourceSet: SourceSet, testType: TestType): Boolean {
+    if (testType != TestType.CROSSVERSION || flakyTestStrategy != FlakyTestStrategy.ONLY) {
+        return false
+    }
+    val key = "gradlebuild.internal.flakySourceScan.${sourceSet.name}"
+    val extra = extensions.extraProperties
+    if (!extra.has(key)) {
+        extra.set(key, sourceSet.allSource.any { it.isFile && it.readText().contains(FLAKY_ANNOTATION_REFERENCE) })
+    }
+    return !(extra.get(key) as Boolean)
+}
 
 
 private

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -227,6 +227,13 @@ fun Project.excludedByFlakyOnlyStrategy(sourceSet: SourceSet, testType: TestType
     if (testType != TestType.CROSSVERSION || flakyTestStrategy != FlakyTestStrategy.ONLY) {
         return false
     }
+    // precondition-tester re-points every DistributionTest at the untagged Jupiter tests of its 'test' source
+    // set, which the ONLY strategy deliberately runs on every build (they are matched by the none() part of the
+    // tag expression), so the flaky source scan does not apply to it. Its build script also appends to the task
+    // classpath, which an emptied classpath here would corrupt.
+    if (name == "precondition-tester") {
+        return false
+    }
     val key = "gradlebuild.internal.flakySourceScan.${sourceSet.name}"
     val extra = extensions.extraProperties
     if (!extra.has(key)) {


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/5331

## Why

`Flaky Test Quarantine - AllVersionsCrossVersion ... Windows` has timed out on **13 of its last 15 runs** on `master` ([example](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_11/116452318)). It is not a flaky test — the build cannot finish on a cold build cache.

A quarantine build is not split into buckets, so this coverage runs one test task per tested Gradle version per subproject — **~1100 of them** across 19 subprojects — on a single agent. Under `-PflakyTests=ONLY` almost none select anything, but the filter is a JUnit Platform tag include applied during discovery *inside* the test JVM, so Gradle cannot tell up front and forks a JVM for each one anyway. Only `:tooling-api` has `@Flaky` cross-version tests (9 spec files), so ~1050 tasks start a JVM, discover nothing, and exit.

The step also runs `clean`, so the build cache was the only mechanism that could avoid that work — and its entries are per revision: Windows has never passed this build on a revision that was not already built.

## What

Skip the tasks at configuration time instead of forking a JVM to discover nothing:

- Under `-PflakyTests=ONLY`, the sources of each integration and cross-version test source set are checked for a reference to `org.gradle.test.fixtures.Flaky`. Using `@Flaky` requires its fully qualified name in the file (import or inline), so a text scan cannot miss a use. A false positive (the FQN in a comment) is harmless: the task runs and discovers nothing, which is what every task of a flaky-free source set does today.
- If there is no reference, the task gets empty `testClassesDirs` and `classpath`, making it `NO-SOURCE` (`Test.getCandidateClassFiles` is `@SkipWhenEmpty`): no test JVM fork, no cache lookup, and the test compilations drop out of the task graph. This applies to integration test tasks as well, so the other quarantine coverages benefit too.
- Emptying the file collections rather than disabling the task matters: a disabled task's dependencies still run, and a `Test` task's dependencies come implicitly from its input file collections (`testClassesDirs` carries the test compilation, `classpath` carries the fixture and model jars). With the inputs gone those tasks are never scheduled; disabling would have skipped only the JVM fork and still compiled all of it after `clean`. For `:maven`, emptying removes 94 tasks from the graph, not just the 59 test tasks.
- `:precondition-tester` is exempt: it re-points every `DistributionTest` at the untagged Jupiter precondition tests of its `test` source set, which the ONLY strategy deliberately runs on every build via the `none()` part of the tag expression.

Known limitation: a spec inheriting a class-level `@Flaky` from a base class in a different source set would be missed by the scan. No such case exists today — all `@Flaky` cross-version specs are annotated directly.

## Result

In the quarantine runs below, 1003 of ~1100 cross-version test tasks went `NO-SOURCE`; only `:tooling-api` and `:precondition-tester` forked test JVMs. The speedup does not depend on the build cache, which was exactly what the Windows build could not count on.

| AllVersionsCrossVersion quarantine | before (master, cold revision) | after (this change, cold revision) |
|---|---|---|
| Linux | 1:35–1:45, timed out once | **0:48** ([build](https://builds.gradle.org/build/116728824)) and **0:53** ([build](https://builds.gradle.org/build/116732875)), both green |
| Windows | timed out at 2:00 on 13 of last 15 runs, never passed on a fresh revision | **1:57** ([build](https://builds.gradle.org/build/116728822)) and **1:51** ([build](https://builds.gradle.org/build/116732873)), both green — the first passes ever on fresh revisions |

Windows still lands close to the limit because what remains is real test work: the run contains ~146 minutes of quarantined test execution, 61% of it from `ResolveArtifactsProgressCrossVersionSpec` alone, whose class-level `@Flaky` runs all of its feature methods against all 58 versions. Narrowing the class-level annotations to the flaky methods is the next lever, independent of this change.

## Alternatives considered

1. Drop AllVersionsCrossVersion from the quarantine (previous version of this PR). Loses flakiness signal for Gradle versions outside the quick-feedback set.
2. Add `flakyCrossVersionTest` to `subprojects.json`. Cumbersome and goes stale.
3. Scan the compiled classes for the `@Flaky` annotation in a task action. Runs after the fork decision is already made, so it cannot avoid the JVM forks.
4. Bucket the build. Slow, ugly and cumbersome.




