### PR TITLE
Give the AllVersionsCrossVersion flaky quarantine 240 minutes

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -80,9 +80,11 @@ class FlakyTestQuarantine(
         // Unlike the regular functional test builds, a quarantine build is not split into buckets and does not use
         // test distribution, so it runs every test task of its coverage on a single agent. For AllVersionsCrossVersion
         // that is one task per tested Gradle version per subproject - over a thousand of them - and how long they take
-        // depends entirely on how much of that the build cache can serve. Runs have landed anywhere between 45 minutes
-        // and well past an hour, so the timeout has to accommodate a cold cache.
-        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = 120)
+        // depends entirely on how much of that the build cache can serve. The runs that do pass land between 60 and
+        // 119 minutes, i.e. right at the 120 minute limit, and on Windows 20 of the last 25 runs were killed by it,
+        // so that coverage gets double the headroom until the amount of work itself is reduced.
+        val timeout = if (testCoverage.testType == TestType.ALL_VERSIONS_CROSS_VERSION) 240 else 120
+        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = timeout)
 
         if (os == Os.LINUX) {
             steps {


### PR DESCRIPTION
## Problem

[`Flaky Test Quarantine - AllVersionsCrossVersion ... Windows`](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_11) has been killed by the 120 minute execution timeout in **20 of its last 25 runs**.

It is not a hang. The coverage is not split into buckets and does not use test distribution, so a single agent runs ~1100 cross-version test tasks (one per tested Gradle version per subproject), and the wall clock depends entirely on how much of that the build cache can serve. Since the step runs `clean` and cache entries are per-revision, a fresh revision means a cold cache.

The runs that do pass land right at the limit:

| # | Result | Duration |
|---|--------|----------|
| 25 | SUCCESS | 119 min |
| 24 | SUCCESS | 107 min |
| 23 | timeout | 121 min |
| 22 | timeout | 121 min |
| 21 | timeout | 121 min |
| 19 | SUCCESS | 96 min |
| 10 | SUCCESS | 108 min |

Linux (`..._10`) is not failing, but runs 61-101 minutes — equally close.

## Change

Double the timeout to 240 minutes for `ALL_VERSIONS_CROSS_VERSION` only. Every other quarantine coverage finishes well inside 120 minutes (QuickFeedbackCrossVersion ~13 min, NoDaemon ~25, Quick ~20, AllVersionsIntegMultiVersion ~15), so there is no reason to raise their ceiling as well.

## This is a stopgap

The underlying waste is that only `:tooling-api` has `@Flaky` cross-version tests, but under `-PflakyTests=ONLY` the filter is a JUnit Platform tag include evaluated during discovery *inside* the test JVM — so Gradle cannot know a task selects nothing and forks a JVM for each of the other ~1050 tasks anyway. #38906 tried to address that structurally and was closed; until something replaces it, the timeout has to accommodate a cold cache.

Note also that some recent red runs of this config are the `ConnectorServices` poisoned-static bug (#38916), which is a separate issue from the timeouts.