### PR TITLE
Update Gradle wrapper to 9.8.0-milestone-2 and drop the signing deferral

### DIFF
--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -177,14 +177,8 @@ tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(pgpSigningKeyId.orNull, pgpSigningKey.orNull, pgpSigningPassPhrase.orNull)
-}
-
-// See the comment on the same workaround in gradlebuild.publish-public-libraries: signing a
-// publication eagerly finalizes the published component, so it must not be wired up before the
-// applying build script has declared its dependencies.
-if (signArtifacts) {
-    afterEvaluate {
-        publishing.publications.configureEach {
+    publishing.publications.configureEach {
+        if (signArtifacts) {
             signing.sign(this)
         }
     }

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -56,22 +56,8 @@ signing {
         pgpSigningKey.orNull,
         pgpSigningPassPhrase.orNull
     )
-}
-
-// Signing eagerly realizes the artifact files of a publication, which finalizes the variants and
-// the dependencies of the published component. Wiring signing up while this project is still being
-// configured therefore freezes its dependency configurations, and the `dependencies { }` block of
-// the build script applying this plugin then fails with "Cannot mutate the dependencies of
-// configuration ':x:api' after the configuration's child configuration ':x:apiElements' was
-// published as a variant". Deferring the wiring until the project is evaluated avoids that.
-//
-// The build tool side of this was fixed by https://github.com/gradle/gradle/pull/38917, but the
-// promotion build bootstraps with a released distribution, so this workaround is needed for as long
-// as the wrapper predates that fix. Only signing builds are affected, which is why master CI stays
-// green while nightly promotion does not.
-if (signArtifacts) {
-    afterEvaluate {
-        publishing.publications.configureEach {
+    publishing.publications.configureEach {
+        if (signArtifacts) {
             signing.sign(this)
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.8.0-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.8.0-milestone-2-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -101,14 +101,8 @@ signing {
         pgpSigningKey.orNull,
         pgpSigningPassPhrase.orNull
     )
-}
-
-// See the comment on the same workaround in gradlebuild.publish-public-libraries: signing a
-// publication eagerly finalizes the published component, so it must not be wired up before this
-// script has finished configuring the project.
-if (signArtifacts) {
-    afterEvaluate {
-        publishing.publications.configureEach {
+    publishing.publications.configureEach {
+        if (signArtifacts) {
             signing.sign(this)
         }
     }


### PR DESCRIPTION
Two changes that belong together:

1. **Wrapper `9.8.0-milestone-1` → `9.8.0-milestone-2`.** M2 was promoted by [Release - Milestone #85](https://builds.gradle.org/buildConfiguration/Gradle_Master_Promotion_Milestone/116591954) and contains #38917.
2. **Revert of #38932** — the temporary signing deferral in `gradlebuild.publish-public-libraries`, `gradlebuild.kotlin-dsl-plugin-bundle` and `packaging/public-api`.

## Why now

#38932 worked around the fact that the released 9.8.0-milestone-1 wrapper predates #38917: signing eagerly realized a publication's artifact files, which finalized the published component's variants, so wiring `signing.sign(publication)` at plugin-apply time froze each module's dependency configurations and every published module failed to configure. That broke nightly promotion (#1840–#1843) and `Publish Kotlin DSL Plugin`.

There was no distribution to bump to at the time — nightlies are produced by the very job that was broken — so the build logic had to stop tripping over the released wrapper. With M2 out, the underlying fix is in the wrapper and the workaround is obsolete.

It should not be kept: Gradle's own best practice, `best_practices_general.adoc#avoid_after_evaluate` (added in 9.6.0), says *"Do not use `project.afterEvaluate {}` to configure tasks"* and *"afterEvaluate should be a last resort, not a first choice."* Wiring Sign tasks is exactly that, so it was only ever a stopgap.

## Verification

Ran the promotion command locally with signing enabled and the workaround removed, on the M2 wrapper
(`clean promotionBuild --dry-run -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache`,
dummy artifactory credentials so the `taskGraph.whenReady` credential check passes):

`BUILD SUCCESSFUL` in 15m5s on `gradle-9.8.0-milestone-2`, with:

- **0** occurrences of `Cannot mutate the dependencies of configuration ...`
- **29 `sign*Publication` tasks** in the task graph — the same count as with the workaround in place, so
  signing is still wired up without it

So M2 does carry #38917, and the deferral is no longer needed. Nothing else in the repo referenced
`9.8.0-milestone-1`.

For contrast, the same command on this branch with the M1 wrapper is what produced the original
`Cannot mutate the dependencies of configuration ':build-cache:api' ...` failure.

Refs: #38932, #38917, #38424, gradle/gradle-private#5323
