### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - id: setup-matrix
         run: echo "matrix=$(jq -c -f .github/workflows/extract-unit-test-split.jq .teamcity/subprojects.json)" >> $GITHUB_OUTPUT
       - name: setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25
@@ -70,7 +70,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@v7
       - name: setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25
@@ -104,7 +104,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@v7
       - name: setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25
@@ -133,7 +133,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@v7
       - name: setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: microsoft # no temurin available
           java-version: 21

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-java@v5.7.0
+    - uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 25

--- a/.github/workflows/update-agp-versions.yml
+++ b/.github/workflows/update-agp-versions.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25

--- a/.github/workflows/update-kotlin-versions.yml
+++ b/.github/workflows/update-kotlin-versions.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/update-perf-test-buckets.yml
+++ b/.github/workflows/update-perf-test-buckets.yml
@@ -32,7 +32,7 @@ jobs:
             PERFORMANCE_DB_USERNAME, gha/gradle/_all/PERFORMANCE_DB_USERNAME
             PERFORMANCE_DB_PASSWORD_TCAGENT, gha/gradle/_all/PERFORMANCE_DB_PASSWORD
       - name: Setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25

--- a/.github/workflows/upgrade-to-latest-wrapper.yml
+++ b/.github/workflows/upgrade-to-latest-wrapper.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Setup java
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25


### PR DESCRIPTION
### Context

Upgrade `actions/setup-java` from v5.7.0 to v6 in all active workflows. The two manually disabled workflows are intentionally unchanged.

GitHub Copilot CLI assisted with the repetitive workflow edits and verification; I reviewed the resulting changes.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. (Not applicable: workflow-only maintenance.)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic. (Not applicable: workflow-only maintenance.)
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes. (Not applicable.)
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`. (Not run: workflow-only maintenance.)
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`. (Not applicable.)

Validation: verified the resulting active workflow references and ran `git diff --check`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
