### PR TITLE
Keep test buckets at their previous position when regenerating

### DIFF
--- a/.teamcity/src/main/kotlin/model/BucketSlotAssignment.kt
+++ b/.teamcity/src/main/kotlin/model/BucketSlotAssignment.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import java.io.File
+
+/**
+ * The position of a bucket within a test coverage is part of the id of the TeamCity build configuration
+ * it produces, see [getBucketUuid]. Moving a bucket to a different position therefore hands its build
+ * configuration a different set of subprojects, which invalidates that configuration's caches and history.
+ *
+ * This holds the bucket layout of a previously generated `test-buckets.json` so a newly computed split can
+ * be emitted in the same order, see [assignToPreviousSlots].
+ *
+ * The file is not purely machine generated - it is regularly edited by hand to rename subprojects, drop
+ * deleted ones or re-split a single coverage - so it is read leniently: entries that no longer make sense
+ * are simply not matched against, they never fail the generation.
+ */
+class PreviousBucketLayout(
+    private val slotsByCoverageUuid: Map<Int, List<Set<String>>>,
+) {
+    /**
+     * The subprojects of each bucket of the given test coverage, in slot order.
+     * Empty when the coverage did not appear in the previous layout, which means "no constraint".
+     */
+    fun slotsFor(testCoverageUuid: Int): List<Set<String>> = slotsByCoverageUuid[testCoverageUuid] ?: emptyList()
+
+    companion object {
+        val EMPTY = PreviousBucketLayout(emptyMap())
+
+        fun readFrom(jsonFile: File): PreviousBucketLayout {
+            if (!jsonFile.isFile) {
+                return EMPTY
+            }
+            return try {
+                val coverages: List<Map<String, Any>> = ObjectMapper().registerKotlinModule().readValue(jsonFile.readText())
+                val slotsByCoverageUuid = mutableMapOf<Int, List<Set<String>>>()
+                coverages.forEach { coverage ->
+                    val uuid = coverage["testCoverageUuid"]?.toString()?.toIntOrNull()
+                    val buckets = coverage["buckets"] as? List<*>
+                    if (uuid != null && buckets != null) {
+                        slotsByCoverageUuid[uuid] =
+                            buckets.map { bucket ->
+                                ((bucket as? Map<*, *>)?.get("subprojects") as? List<*>)
+                                    ?.map { it.toString() }
+                                    ?.toSet()
+                                    ?: emptySet()
+                            }
+                    }
+                }
+                PreviousBucketLayout(slotsByCoverageUuid)
+            } catch (e: Exception) {
+                println("Ignoring unreadable previous bucket layout in ${jsonFile.absolutePath}: $e")
+                EMPTY
+            }
+        }
+    }
+}
+
+/**
+ * Reorders freshly computed buckets so that each one keeps the slot its closest predecessor occupied in
+ * [previousSlots], which keeps the generated `test-buckets.json` - and with it the TeamCity build
+ * configurations derived from it - as close to unchanged as the new split allows.
+ *
+ * Buckets are matched to slots by how much their subprojects overlap, most similar pair first, so an
+ * unchanged bucket always reclaims its own slot. Buckets without a predecessor fill the remaining slots in
+ * order; if the new split has more buckets than the previous one the surplus is appended.
+ *
+ * This only changes the order of [newBuckets], never their contents, and is a no-op when [previousSlots] is
+ * empty.
+ */
+fun <T> assignToPreviousSlots(
+    newBuckets: List<T>,
+    previousSlots: List<Set<String>>,
+    subprojectsOf: (T) -> Set<String>,
+): List<T> {
+    if (previousSlots.isEmpty() || newBuckets.isEmpty()) {
+        return newBuckets
+    }
+
+    val newSubprojects = newBuckets.map(subprojectsOf)
+    val candidates =
+        newSubprojects
+            .flatMapIndexed { newIndex: Int, subprojects: Set<String> ->
+                previousSlots.mapIndexedNotNull { slotIndex, previousSubprojects ->
+                    val similarity = similarity(subprojects, previousSubprojects)
+                    if (similarity > 0.0) SlotCandidate(newIndex, slotIndex, similarity) else null
+                }
+                // Ties are broken by slot and then by bucket index so that the assignment only depends on
+                // the two inputs, never on iteration order.
+            }.sortedWith(compareByDescending<SlotCandidate> { it.similarity }.thenBy { it.slotIndex }.thenBy { it.newIndex })
+
+    val slotOfBucket = arrayOfNulls<Int>(newBuckets.size)
+    val takenSlots = mutableSetOf<Int>()
+    candidates.forEach { candidate ->
+        if (slotOfBucket[candidate.newIndex] == null && takenSlots.add(candidate.slotIndex)) {
+            slotOfBucket[candidate.newIndex] = candidate.slotIndex
+        }
+    }
+
+    val freeSlots = previousSlots.indices.filter { it !in takenSlots }.iterator()
+    var surplusSlot = previousSlots.size
+    newBuckets.indices.forEach { newIndex ->
+        if (slotOfBucket[newIndex] == null) {
+            slotOfBucket[newIndex] = if (freeSlots.hasNext()) freeSlots.next() else surplusSlot++
+        }
+    }
+
+    // Slots are unique, so sorting by them yields a total order. Buckets are compacted into a dense list:
+    // when the new split has fewer buckets than the previous one the relative order is what survives.
+    return newBuckets.indices.sortedBy { slotOfBucket[it]!! }.map { newBuckets[it] }
+}
+
+private class SlotCandidate(
+    val newIndex: Int,
+    val slotIndex: Int,
+    val similarity: Double,
+)
+
+/**
+ * Jaccard index of the two subproject sets: 1.0 for an unchanged bucket, 0.0 when they share nothing.
+ */
+private fun similarity(
+    subprojects: Set<String>,
+    previousSubprojects: Set<String>,
+): Double {
+    val shared = subprojects.count { it in previousSubprojects }
+    return if (shared == 0) {
+        0.0
+    } else {
+        shared.toDouble() / (subprojects.size + previousSubprojects.size - shared)
+    }
+}

--- a/.teamcity/src/main/kotlin/model/BucketSlotAssignment.kt
+++ b/.teamcity/src/main/kotlin/model/BucketSlotAssignment.kt
@@ -110,8 +110,13 @@ fun <T> assignToPreviousSlots(
     val slotOfBucket = arrayOfNulls<Int>(newBuckets.size)
     val takenSlots = mutableSetOf<Int>()
     candidates.forEach { candidate ->
-        if (slotOfBucket[candidate.newIndex] == null && takenSlots.add(candidate.slotIndex)) {
-            slotOfBucket[candidate.newIndex] = candidate.slotIndex
+        // Kept as two nested checks rather than one `&&`: `takenSlots.add` mutates, so folding it into a
+        // short-circuiting condition would silently claim slots for already-assigned buckets if the
+        // operands were ever reordered.
+        if (slotOfBucket[candidate.newIndex] == null) {
+            if (takenSlots.add(candidate.slotIndex)) {
+                slotOfBucket[candidate.newIndex] = candidate.slotIndex
+            }
         }
     }
 

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -30,7 +30,10 @@ fun main() {
     val testClassDataJson = File(System.getProperty("inputTestClassDataJson") ?: throw IllegalArgumentException("Input file not found!"))
     val generatedBucketsJson = File(System.getProperty("outputBucketSplitJson", "./test-buckets.json"))
 
-    FunctionalTestBucketGenerator(model, testClassDataJson).generate(generatedBucketsJson)
+    // The layout to preserve always comes from the checked-in file, never from the output path: writing
+    // the split elsewhere (a dry run, say) must still produce the order the checked-in file has, otherwise
+    // that output cannot be compared against it.
+    FunctionalTestBucketGenerator(model, testClassDataJson).generate(generatedBucketsJson, File("./test-buckets.json"))
 }
 
 class FunctionalTestBucketGenerator(

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -40,10 +40,27 @@ class FunctionalTestBucketGenerator(
     private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
     private val buckets: Map<TestCoverage, List<SmallSubprojectBucket>> = buildBuckets(testTimeDataJson, model)
 
-    fun generate(jsonFile: File) {
+    /**
+     * Writes the new split to [jsonFile], keeping every bucket at the position its predecessor in
+     * [previousBucketsJson] occupied. The bucket position determines the id of the TeamCity build
+     * configuration generated from it, so preserving it keeps that configuration's caches valid.
+     *
+     * [previousBucketsJson] defaults to [jsonFile], which is the file being regenerated in place.
+     */
+    @JvmOverloads
+    fun generate(
+        jsonFile: File,
+        previousBucketsJson: File = jsonFile,
+    ) {
+        val previousLayout = PreviousBucketLayout.readFrom(previousBucketsJson)
         val output =
-            buckets.map {
-                TestCoverageAndBucketSplits(it.key.uuid, it.value.map { it.toJsonBucket() })
+            buckets.map { (testCoverage, testCoverageBuckets) ->
+                val orderedBuckets =
+                    assignToPreviousSlots(
+                        testCoverageBuckets,
+                        previousLayout.slotsFor(testCoverage.uuid),
+                    ) { bucket -> bucket.subprojects.map { it.name }.toSet() }
+                TestCoverageAndBucketSplits(testCoverage.uuid, orderedBuckets.map { it.toJsonBucket() })
             }
         jsonFile.writeText(gson.toJson(output))
     }

--- a/.teamcity/src/test/kotlin/BucketSlotAssignmentTest.kt
+++ b/.teamcity/src/test/kotlin/BucketSlotAssignmentTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import model.PreviousBucketLayout
+import model.assignToPreviousSlots
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class BucketSlotAssignmentTest {
+    private fun assign(
+        newBuckets: List<Set<String>>,
+        previousSlots: List<Set<String>>,
+    ): List<Set<String>> = assignToPreviousSlots(newBuckets, previousSlots) { it }
+
+    private fun buckets(vararg buckets: String): List<Set<String>> = buckets.map { it.split(",").toSet() }
+
+    @Test
+    fun `unchanged buckets keep their previous slots`() {
+        val previous = buckets("core", "dependency-management", "a,b,c")
+
+        // The split algorithm orders buckets by measured test time, so unchanged buckets still show up
+        // in a different order whenever the timings move a little.
+        assertEquals(previous, assign(buckets("a,b,c", "core", "dependency-management"), previous))
+    }
+
+    @Test
+    fun `keeps the computed order when there is no previous layout`() {
+        val new = buckets("core", "a,b", "c")
+
+        assertEquals(new, assign(new, emptyList()))
+        assertEquals(new, assign(new, PreviousBucketLayout.EMPTY.slotsFor(1)))
+    }
+
+    @Test
+    fun `a bucket that only changed slightly reclaims its slot`() {
+        val previous = buckets("core", "a,b,c,d", "dependency-management")
+
+        // "b" moved into the last bucket, which must not shuffle the whole file.
+        assertEquals(
+            buckets("core", "a,c,d", "b,dependency-management"),
+            assign(buckets("b,dependency-management", "a,c,d", "core"), previous),
+        )
+    }
+
+    @Test
+    fun `an entirely new bucket takes a freed slot`() {
+        val previous = buckets("core", "a,b", "dependency-management")
+
+        assertEquals(
+            buckets("core", "x,y", "dependency-management"),
+            assign(buckets("core", "dependency-management", "x,y"), previous),
+        )
+    }
+
+    @Test
+    fun `surplus buckets are appended after the known slots`() {
+        val previous = buckets("core", "a,b")
+
+        assertEquals(
+            buckets("core", "a,b", "x"),
+            assign(buckets("x", "a,b", "core"), previous),
+        )
+    }
+
+    @Test
+    fun `a shrinking split keeps the relative order of the surviving buckets`() {
+        val previous = buckets("core", "a,b", "dependency-management", "x,y")
+
+        assertEquals(
+            buckets("core", "dependency-management"),
+            assign(buckets("dependency-management", "core"), previous),
+        )
+    }
+
+    @Test
+    fun `every bucket is emitted exactly once`() {
+        val new = buckets("core", "a,b", "x", "dependency-management", "y,z")
+        val previous = buckets("dependency-management", "a,b,c", "core")
+
+        assertEquals(new.sortedBy { it.toString() }, assign(new, previous).sortedBy { it.toString() })
+    }
+
+    @Test
+    fun `reads the bucket layout of a previously generated file`(
+        @TempDir tempDir: File,
+    ) {
+        val layout = PreviousBucketLayout.readFrom(tempDir.resolve("test-buckets.json").apply { writeText(TEST_BUCKETS_JSON) })
+
+        assertEquals(buckets("core", "a,b"), layout.slotsFor(1))
+        assertEquals(buckets("dependency-management"), layout.slotsFor(14))
+        assertEquals(emptyList<Set<String>>(), layout.slotsFor(99))
+    }
+
+    @Test
+    fun `treats a missing or unreadable file as no previous layout`(
+        @TempDir tempDir: File,
+    ) {
+        assertEquals(emptyList<Set<String>>(), PreviousBucketLayout.readFrom(tempDir.resolve("absent.json")).slotsFor(1))
+        assertEquals(
+            emptyList<Set<String>>(),
+            PreviousBucketLayout.readFrom(tempDir.resolve("broken.json").apply { writeText("{ not json") }).slotsFor(1),
+        )
+    }
+
+    companion object {
+        private val TEST_BUCKETS_JSON =
+            """
+            [
+              {
+                "testCoverageUuid": 1,
+                "buckets": [
+                  { "subprojects": [ "core" ], "parallelizationMethod": { "name": "TestDistribution" } },
+                  { "subprojects": [ "a", "b" ], "parallelizationMethod": { "name": "TestDistribution" } }
+                ]
+              },
+              {
+                "testCoverageUuid": 14,
+                "buckets": [
+                  {
+                    "subprojects": [ "dependency-management" ],
+                    "parallelizationMethod": { "name": "TeamCityParallelTests", "numberOfBatches": 2 }
+                  }
+                ]
+              }
+            ]
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
A bucket's position within a test coverage is part of the id of the TeamCity build configuration generated from it (see `getBucketUuid`). The split algorithm orders buckets by measured test time, so timing noise alone reorders them — handing a build configuration a different set of subprojects and invalidating its caches.

- `FunctionalTestBucketGenerator` now reads the `test-buckets.json` it is about to overwrite and emits the new split in the order of the old one, matching each bucket to its previous slot by subproject overlap.
- Bucket contents are unaffected, only their order. No change needed to `.github/workflows/update-test-buckets.yml`.
- The previous layout is read leniently, since the file is regularly hand-edited: a missing file, unparseable JSON, an unknown test coverage uuid or a stale subproject name all mean "no constraint" rather than a failure.
- Over the current `test-buckets.json` (18 coverages, 321 slots), a pure reordering goes from 301 changed slots to 0, leaving only genuine membership changes.

Issue: https://github.com/gradle/gradle-private/issues/4597