### PR TITLE
Change LinkedList to array-based types in execution plan code

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -33,8 +33,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -148,7 +146,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
 
     private void doAddEntryNodes(SortedSet<? extends Node> nodes, int ordinal) {
         scheduledNodes = null;
-        LinkedList<Node> queue = new LinkedList<>();
+        ArrayDeque<Node> queue = new ArrayDeque<>();
         OrdinalGroup group = ordinalNodeAccess.group(ordinal);
 
         for (Node node : nodes) {
@@ -161,9 +159,9 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         discoverNodeRelationships(queue);
     }
 
-    @SuppressWarnings("NonApiType") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
-    private void discoverNodeRelationships(LinkedList<Node> queue) {
+    private void discoverNodeRelationships(Deque<Node> queue) {
         Set<Node> visiting = new HashSet<>();
+        HeadInsertBuffer<Node> successorBuffer = new HeadInsertBuffer<>();
         while (!queue.isEmpty()) {
             Node node = queue.getFirst();
             node.prepareForScheduling();
@@ -191,12 +189,12 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
                 for (Node successor : node.getHardSuccessors()) {
                     successor.maybeInheritOrdinalAsDependency(node.getGroup().asOrdinal());
                 }
-                ListIterator<Node> insertPoint = queue.listIterator();
                 for (Node successor : node.getDependencySuccessors()) {
                     if (!visiting.contains(successor)) {
-                        insertPoint.add(successor);
+                        successorBuffer.add(successor);
                     }
                 }
+                successorBuffer.drainTo(queue);
             } else {
                 // Have visited this node's dependencies - add it to the graph
                 queue.removeFirst();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
@@ -70,6 +70,7 @@ class DetermineExecutionPlanAction {
     private final Set<Node> entryNodes;
     private final Set<Node> finalizers;
 
+    // Uses a LinkedList to allow for efficient removal of elements from the middle of the queue when a finalizer is added
     private final LinkedList<NodeInVisitingSegment> nodeQueue = new LinkedList<>();
     private final HashMultimap<Node, Integer> visitingNodes = HashMultimap.create();
     private final Deque<GraphEdge> walkedShouldRunAfterEdges = new ArrayDeque<>();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
@@ -19,6 +19,7 @@ package org.gradle.execution.plan;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.CircularReferenceException;
 import org.gradle.api.GradleException;
@@ -37,12 +38,12 @@ import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 import java.io.StringWriter;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -103,7 +104,7 @@ class DetermineExecutionPlanAction {
         }
 
         // Collect the finalizers and their dependencies so that each node is ordered before all of its dependencies
-        LinkedList<Node> nodes = new LinkedList<>();
+        ArrayList<Node> nodes = new ArrayList<>();
         Set<Node> visiting = new HashSet<>();
         Set<Node> visited = new HashSet<>();
         Deque<Node> queue = new ArrayDeque<>(finalizers);
@@ -122,11 +123,11 @@ class DetermineExecutionPlanAction {
                 // all of its dependencies)
                 visiting.remove(node);
                 visited.add(node);
-                nodes.addFirst(node);
+                nodes.add(node);
             }
         }
 
-        for (Node node : nodes) {
+        for (Node node : Lists.reverse(nodes)) {
             node.maybeInheritFinalizerGroups();
         }
     }
@@ -138,6 +139,7 @@ class DetermineExecutionPlanAction {
     }
 
     private void processNodeQueue() {
+        HeadInsertBuffer<NodeInVisitingSegment> successorBuffer = new HeadInsertBuffer<>();
         while (!nodeQueue.isEmpty()) {
             final NodeInVisitingSegment nodeInVisitingSegment = nodeQueue.peekFirst();
             final int currentSegment = nodeInVisitingSegment.visitingSegment;
@@ -169,7 +171,6 @@ class DetermineExecutionPlanAction {
                     addFinalizerToQueue(visitingSegmentCounter++, finalizer);
                 }
 
-                ListIterator<NodeInVisitingSegment> insertPoint = nodeQueue.listIterator();
                 for (Node successor : node.getAllSuccessors()) {
                     if (visitingNodes.containsEntry(successor, currentSegment)) {
                         if (!walkedShouldRunAfterEdges.isEmpty()) {
@@ -179,6 +180,8 @@ class DetermineExecutionPlanAction {
                             TaskNode sourceTask = (TaskNode) toBeRemoved.from;
                             TaskNode targetTask = (TaskNode) toBeRemoved.to;
                             sourceTask.removeShouldSuccessor(targetTask);
+                            // The successors visited so far must be in the queue before it is restored
+                            successorBuffer.drainTo(nodeQueue);
                             restorePath(path, toBeRemoved);
                             restoreQueue(toBeRemoved);
                             restoreExecutionPlan(planBeforeVisiting, toBeRemoved);
@@ -187,8 +190,9 @@ class DetermineExecutionPlanAction {
                             onOrderingCycle(successor, node);
                         }
                     }
-                    insertPoint.add(new NodeInVisitingSegment(successor, currentSegment));
+                    successorBuffer.add(new NodeInVisitingSegment(successor, currentSegment));
                 }
+                successorBuffer.drainTo(nodeQueue);
                 path.push(node);
             } else {
                 // Have visited this node's dependencies - add it to the end of the plan

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
@@ -70,7 +70,7 @@ class DetermineExecutionPlanAction {
     private final Set<Node> entryNodes;
     private final Set<Node> finalizers;
 
-    // Uses a LinkedList to allow for efficient removal of elements from the middle of the queue when a finalizer is added
+    // Uses a LinkedList because a finalizer must be inserted into the middle of the queue, which a Deque does not support
     private final LinkedList<NodeInVisitingSegment> nodeQueue = new LinkedList<>();
     private final HashMultimap<Node, Integer> visitingNodes = HashMultimap.create();
     private final Deque<GraphEdge> walkedShouldRunAfterEdges = new ArrayDeque<>();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/HeadInsertBuffer.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/HeadInsertBuffer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Collects elements to be inserted at the head of a {@link Deque}, preserving the order in which they were added.
+ *
+ * <p>
+ * That is, if elements are added as [A, B, C], then when they are added to a {@code Deque} of [D], the resulting {@code Deque} will be [A, B, C, D].
+ * </p>
+ *
+ * <p>Instances are intended to be reused across iterations of a traversal to save memory by reusing the allocated buffer.</p>
+ */
+class HeadInsertBuffer<T> {
+    private final List<T> buffer = new ArrayList<>();
+
+    /**
+     * Adds an element to the buffer.
+     *
+     * @param element the element to add
+     */
+    public void add(T element) {
+        buffer.add(element);
+    }
+
+    /**
+     * Drains the buffer to the given {@link Deque}, adding the elements in the order they were added to the buffer.
+     *
+     * @param queue the {@link Deque} to drain the buffer to
+     */
+    public void drainTo(Deque<? super T> queue) {
+        for (T element : Lists.reverse(buffer)) {
+            queue.addFirst(element);
+        }
+        buffer.clear();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/HeadInsertBuffer.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/HeadInsertBuffer.java
@@ -16,20 +16,16 @@
 
 package org.gradle.execution.plan;
 
-import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 
 /**
  * Collects elements to be inserted at the head of a {@link Deque}, preserving the order in which they were added.
- *
  * <p>
  * That is, if elements are added as [A, B, C], then when they are added to a {@code Deque} of [D], the resulting {@code Deque} will be [A, B, C, D].
- * </p>
- *
- * <p>Instances are intended to be reused across iterations of a traversal to save memory by reusing the allocated buffer.</p>
+ * <p>
+ * Instances are intended to be reused across iterations of a traversal to save memory by reusing the allocated buffer.
  */
 class HeadInsertBuffer<T> {
     private final List<T> buffer = new ArrayList<>();
@@ -49,8 +45,8 @@ class HeadInsertBuffer<T> {
      * @param queue the {@link Deque} to drain the buffer to
      */
     public void drainTo(Deque<? super T> queue) {
-        for (T element : Lists.reverse(buffer)) {
-            queue.addFirst(element);
+        for (int i = buffer.size() - 1; i >= 0; i--) {
+            queue.addFirst(buffer.get(i));
         }
         buffer.clear();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -615,6 +615,28 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         executedTasks == [a, b, c]
     }
 
+    def "should run after ordering is ignored when the cycle is discovered after other successors have been queued"() {
+        Task extraDependency = task("extraDependency")
+        Task shouldRunAfterSource = createTask("shouldRunAfterSource")
+        Task shouldRunAfterTarget = createTask("shouldRunAfterTarget")
+        Task cycleNode = createTask("cycleNode")
+        Task entry = createTask("entry")
+
+        relationships(entry, dependsOn: [shouldRunAfterSource])
+        relationships(shouldRunAfterSource, shouldRunAfter: [shouldRunAfterTarget])
+        relationships(shouldRunAfterTarget, dependsOn: [cycleNode])
+        // Successors are visited in name order, so "extraDependency" is queued before the cycle back to
+        // "shouldRunAfterSource" is discovered. The partially queued successors must be unwound along with
+        // the rest of the queue when the walked shouldRunAfter edge is removed.
+        relationships(cycleNode, dependsOn: [extraDependency, shouldRunAfterSource])
+
+        when:
+        addToGraphAndPopulate([entry, shouldRunAfterTarget])
+
+        then:
+        executedTasks == [shouldRunAfterSource, entry, extraDependency, cycleNode, shouldRunAfterTarget]
+    }
+
     @Issue("GRADLE-3127")
     def "circular dependency detected with shouldRunAfter dependencies in the graph"() {
         Task a = createTask("a")

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -262,6 +262,31 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         executes(finalized, finalizer)
     }
 
+    def "finalizer of multiple entry tasks does not reorder an unrelated entry task"() {
+        Task finalizer = task("finalizer")
+        Task a = task("a", finalizedBy: [finalizer])
+        Task b = task("b")
+        Task c = task("c", finalizedBy: [finalizer])
+
+        when:
+        addToGraphAndPopulate([a, b, c])
+
+        then:
+        executes(a, b, c, finalizer)
+    }
+
+    def "finalizer of an entry task does not reorder another entry task that depends on it"() {
+        Task finalizer = task("c")
+        Task dependency = task("b", finalizedBy: [finalizer])
+        Task dependent = task("a", dependsOn: [dependency])
+
+        when:
+        addToGraphAndPopulate([dependent, dependency])
+
+        then:
+        executes(dependency, dependent, finalizer)
+    }
+
     def "finalizer tasks and their dependencies are executed even in case of a task failure"() {
         Task finalizerDependency = task("finalizerDependency")
         Task finalizer1 = task("finalizer1", dependsOn: [finalizerDependency])


### PR DESCRIPTION
This should reduce some unnecessary allocations in hot parts of this
code. This also adds a new HeadInsertBuffer to make it clearer what
is going on with some of the insertions.

There is also some tests and a comment from my attempt to do a full clean up of `LinkedList` in case anyone looks at that in the future.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
