### PR TITLE
Remove unused GRADLE_CACHE_REMOTE_* credential env vars

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -150,9 +150,6 @@ fun javaHome(jvm: Jvm, os: Os, arch: Arch = Arch.AMD64) = "%${os.name.lowercase(
 fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os, arch: Arch = Arch.AMD64) {
     params {
         param("env.BOT_TEAMCITY_GITHUB_TOKEN", "%github.bot-teamcity.token%")
-        param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
-        param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
-        param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
 
         param("env.JAVA_HOME", javaHome(buildJvm, os, arch))
         param("env.ANDROID_HOME", os.androidHome)

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 # Default performance baseline
-defaultPerformanceBaselines=7.6.5-commit-4fa245d5a48
+defaultPerformanceBaselines=7.6.6-commit-f7438cdf2b7


### PR DESCRIPTION
Removes three TeamCity parameter mappings that nothing reads.

The remote build cache authenticates with `DEVELOCITY_ACCESS_KEY`, not HTTP basic auth, so these env vars are set on every build and consumed by nobody:

- `env.GRADLE_CACHE_REMOTE_URL`
- `env.GRADLE_CACHE_REMOTE_USERNAME`
- `env.GRADLE_CACHE_REMOTE_PASSWORD`

### How this was verified

The remote cache is configured by the conventions plugin. Decompiling the two versions in use across the org shows neither reads these:

- `gradle-enterprise-conventions-plugin` 0.10.3 — `BuildCacheConfigureAction` reads `DEVELOCITY_ACCESS_KEY`, `GRADLE_ENTERPRISE_ACCESS_KEY`, `gradle.cache.remote.server`, `gradle.cache.remote.push`, `cacheNode`, `disableLocalCache`
- `gradle-org-conventions-plugin` 0.15.0 — reads `DEVELOCITY_ACCESS_KEY`, `gradle.cache.remote.push`, `disableLocalCache`

Repos that configure the cache inline gate it on `DEVELOCITY_ACCESS_KEY` via `remote(develocity.buildCache)`.

An org-wide search for `GRADLE_CACHE_REMOTE_PASSWORD` / `GRADLE_CACHE_REMOTE_USERNAME` returns only TeamCity DSL writes plus one pass-through in `gradle/gradle-promote`. There are no readers anywhere.

Note that `gradle.cache.remote.server` **is** still read and is unaffected by this change.

### Context

SecOps flagged `gradle.cache.remote.password` for rotation. It is defined on the TeamCity `_Root` project, so all 44,667 build configs inherit it. The investigation found the credential is dead org-wide — 9 repos set these env vars, zero read them. It's basic-auth plumbing left over from the pre-Develocity HTTP build cache (the LastPass entry is still named for `eu.gradle.org`).

So rather than rotating it, we're removing the references and then deleting the parameters from `_Root`.

**These DSL removals must merge before the `_Root` parameters are deleted** — TeamCity treats an unresolved `%...%` reference as a hard error, so deleting the parameter first would break the build configurations that still reference it.


### Alternative considered: migrating to `gradle-org-conventions-plugin`

Not viable on `release7x`, and it would not help anyway:

- **Blocked.** Every published version of `gradle-org-conventions-plugin` (0.13.0, 0.14.0, 0.14.1, 0.15.0) declares `org.gradle.jvm.version = 17`. This branch builds with `BuildToolBuildJvm = JvmVersion.java11`, so resolution fails on the variant mismatch.
- **Wouldn't help.** These three parameters are TeamCity DSL writes, not plugin inputs. `git grep GRADLE_CACHE_REMOTE` across the branch returns hits only in `.teamcity/`; no conventions plugin — old or new — reads URL/USERNAME/PASSWORD. Swapping plugins would remove none of these references.

Deleting the three lines is the whole fix.


### Added: performance-test rebaseline

A second commit bumps `defaultPerformanceBaselines` in `gradle.properties`:

```
7.6.5-commit-4fa245d5a48  ->  7.6.6-commit-f7438cdf2b7
```

The old baseline had drifted — recent runs measure roughly 4% slower on `largeJavaMultiProject` (289-297 ms on a ~7.2 s build) across `TaskOutputCachingJavaPerformanceTest`, `JavaIncrementalExecutionPerformanceTest` and others, with two of the six scenarios already muted. These did not block the merge queue (`testFailure = false` means the perf builds report SUCCESS regardless); this is housekeeping.

`f7438cdf2b7` is the current tip of `release7x` and this PR's parent commit, where `version.txt` is `7.6.6`. `BuildCommitDistribution` builds the baseline distribution from that commit on demand, so no pre-published artifact is needed.
