### PR TITLE
Fix release8x nightly: corrupt artifact-cache workspace and empty-dir m2 check

### DIFF
--- a/.teamcity/hooks/pre-build
+++ b/.teamcity/hooks/pre-build
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Repository pre-build hook (file name required by the teamcity-hooks-plugin).
+# Runs after the agent pre-build hook has restored the Gradle user home from the
+# Develocity artifact cache, and before the first build step.
+#
+# Drops immutable workspaces that were restored without their `metadata.bin`.
+#
+# Gradle's AssignImmutableWorkspaceStep treats an existing workspace directory as
+# authoritative and reads `metadata.bin` from it. If the directory is there but the
+# metadata file is not, the build dies during settings evaluation with
+#
+#   java.io.UncheckedIOException: Could not read workspace metadata from
+#   <gradle-home>/caches/<version>/dependencies-accessors/<hash>/metadata.bin
+#
+# The artifact cache can hold such a truncated entry, and because it is keyed by path
+# rather than by content, a later healthy build does not overwrite it ("Content already
+# exists in cache") - every agent restores the same broken directory until the entry is
+# evicted by hand. That took out ~60 builds of the release8x nightly on 2026-05-07,
+# 2026-08-16, 2026-08-22 and 2026-08-23 (gradle/gradle-private#5181).
+#
+# Gradle 9.4 reworked this code path so the workspace self-heals (gradle/gradle#36220,
+# gradle/gradle#36227). release8x builds itself with Gradle 8.14.3, which cannot, so
+# clean the restored workspaces up before the build tool ever looks at them. Deleting a
+# workspace is safe: Gradle regenerates it on demand.
+#
+# Only caches whose *own* entries use `metadata.bin` are considered. Older Gradle
+# versions kept these caches in a layout that has no metadata file at all - the agents
+# hold caches going back to 7.6.x for the cross-version tests - and every entry there
+# would otherwise look corrupt. A cache is treated as metadata-using only if at least
+# one of its entries has a `metadata.bin`; that keeps the check self-calibrating instead
+# of hard-coding which Gradle versions grew the layout.
+
+set -uo pipefail
+
+GRADLE_HOME="${GRADLE_USER_HOME:-${HOME}/.gradle}"
+
+# Refuse to act on a cache where this many entries look corrupt: real corruption is a
+# handful of entries, a number like that means the heuristic is wrong for that layout.
+MAX_REMOVALS_PER_CACHE=20
+
+if [ ! -d "${GRADLE_HOME}" ]; then
+    echo "No Gradle user home at ${GRADLE_HOME}, nothing to check."
+    exit 0
+fi
+
+removed=0
+for cache in \
+    "${GRADLE_HOME}"/caches/*/dependencies-accessors \
+    "${GRADLE_HOME}"/caches/*/groovy-dsl \
+    "${GRADLE_HOME}"/caches/*/kotlin-dsl/scripts ; do
+    # Unmatched globs come through literally; -d filters them out.
+    [ -d "${cache}" ] || continue
+
+    incomplete=()
+    complete=0
+    for workspace in "${cache}"/*/ ; do
+        [ -d "${workspace}" ] || continue
+        if [ -f "${workspace}metadata.bin" ]; then
+            complete=$((complete + 1))
+        else
+            incomplete+=("${workspace}")
+        fi
+    done
+
+    [ "${#incomplete[@]}" -eq 0 ] && continue
+
+    if [ "${complete}" -eq 0 ]; then
+        echo "Skipping ${cache}: no entry uses metadata.bin, so this is a pre-8.x layout."
+        continue
+    fi
+
+    if [ "${#incomplete[@]}" -gt "${MAX_REMOVALS_PER_CACHE}" ]; then
+        echo "Skipping ${cache}: ${#incomplete[@]} of $((complete + ${#incomplete[@]})) entries lack metadata.bin, too many to be corruption."
+        continue
+    fi
+
+    for workspace in "${incomplete[@]}"; do
+        echo "Removing immutable workspace without metadata.bin: ${workspace}"
+        rm -rf "${workspace}"
+        removed=$((removed + 1))
+    done
+done
+
+if [ "${removed}" -eq 0 ]; then
+    echo "No incomplete immutable workspaces found in ${GRADLE_HOME}."
+else
+    echo "Removed ${removed} incomplete immutable workspace(s) from ${GRADLE_HOME}."
+fi
+
+# Never fail the build because of this hook.
+exit 0

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -39,10 +39,15 @@ fun checkCleanDirUnixLike(
 ) = """
     REPO=$dir
     if [ -e ${'$'}REPO ] ; then
-        tree ${'$'}REPO
-        rm -rf ${'$'}REPO
-        echo "${'$'}REPO was polluted during the build"
-        ${if (exitOnFailure) "exit 1" else ""}
+        if [ -n "${'$'}(ls -A ${'$'}REPO)" ] ; then
+            tree ${'$'}REPO
+            rm -rf ${'$'}REPO
+            echo "${'$'}REPO was polluted during the build"
+            ${if (exitOnFailure) "exit 1" else ""}
+        else
+            rm -rf ${'$'}REPO
+            echo "${'$'}REPO exists but is empty"
+        fi
     else
         echo "${'$'}REPO does not exist"
     fi
@@ -55,9 +60,13 @@ fun checkCleanDirWindows(
 ) = """
 
     IF exist $dir (
-        TREE $dir
-        RMDIR /S /Q $dir
-        ${if (exitOnFailure) "EXIT 1" else ""}
+        DIR /B /A "$dir" | findstr "^" >nul && (
+            TREE $dir
+            RMDIR /S /Q $dir
+            ${if (exitOnFailure) "EXIT 1" else ""}
+        ) || (
+            RMDIR /S /Q $dir
+        )
     )
     """.trimIndent()
 


### PR DESCRIPTION
## Why

The `release8x` nightly [Ready for Release #137](https://builds.gradle.org/buildConfiguration/Gradle_Release8x_Check_Stage_ReadyforRelease_Trigger/116573205) failed with 82 red builds in the chain. Two distinct infrastructure problems account for 65 of them; this PR addresses both.

### 1. An artifact-cache entry poisons every agent (62 builds)

Every failing `Parallel_7`, `ForceRealizeDependencyManagement_15`, `NoDaemon_12`, `AllVersionsCrossVersion_10`, `AllVersionsIntegMultiVersion_33` and `Soak_8_0` bucket dies the same way, during settings evaluation, before a single test runs:

```
FAILURE: Build failed with an exception.

* What went wrong:
Error resolving plugin [id: 'org.gradle.toolchains.foojay-resolver-convention', version: '1.0.0']
> java.io.UncheckedIOException: Could not read workspace metadata from
  /home/tcagent1/.gradle/caches/8.14.3/dependencies-accessors/7541752a0b68dbb06aaf0ef6f8054a69fb55399a/metadata.bin
Caused by: java.io.FileNotFoundException: .../metadata.bin (No such file or directory)
```

The directory is not something the build produced. The agent pre-build hook restores it from the Develocity artifact cache:

```
[HooksPlugin] Restored content (key: yyxdp3ppl4qgxjxgxk4nnxhmqrgdaq7vikit3rvnohwy75ybzyeq,
  type: Gradle home, path: caches/8.14.3/dependencies-accessors/7541752a0b68dbb06aaf0ef6f8054a69fb55399a, 324 B)
```

and the restored copy has no `metadata.bin`. `AssignImmutableWorkspaceStep` treats an existing workspace directory as authoritative and reads the metadata file from it, so a directory-without-metadata is a hard failure rather than a cache miss.

Two things make this stick rather than heal:

- **The entry cannot be overwritten.** It is keyed by path, not by content. The 2026-08-20 build that legitimately regenerated the workspace logged `Content already exists in cache (key: yyxdp3...)` and uploaded nothing. Only a manual eviction clears it.
- **The builds that passed did so by accident.** 2026-08-20 either hit `Content not found in cache` for those paths, or ran on `dev366-agent1`, which has no artifact-cache hook at all.

This is a recurrence of gradle/gradle-private#5181 — same workspace hash, closed on 2026-05-08 after a manual eviction. It has since taken out the nightly on 2026-08-16, 2026-08-22 and 2026-08-23.

gradle/gradle#36220 and gradle/gradle#36227 rework this code path so the workspace self-heals, but they shipped in 9.4.0. `release8x` builds itself with Gradle 8.14.3 and cannot pick them up.

### 2. `CHECK_CLEAN_M2_ANDROID_USER_HOME` fails on an empty directory (3 builds)

`Quick_1_bucket11`, `BuildDistributions` and `Platform_3_bucket10` failed with:

```
/home/tcagent1/.m2/repository
0 directories, 0 files
/home/tcagent1/.m2/repository was polluted during the build
```

The check uses `[ -e $REPO ]`, so a bare empty directory fails the build even though nothing was written into it. Already fixed on `master` in e1b895958bd; `release8x` never got it.

### Not addressed here

The one unmuted test failure in the chain, `JavaIncrementalExecutionPerformanceTest.assemble for non-abi change` (configurationCaching), is 70.5 ms slower on a 6.8 s baseline — 1.04%. That is noise, not a regression.

## What

- **Cherry-pick e1b895958bd** - only fail the m2/android cleanliness check when the directory is actually non-empty.
- **Add `.teamcity/hooks/pre-build`** - a repository pre-build hook that runs after the agent has restored the Gradle user home and before the first build step, removing any immutable workspace that is missing its `metadata.bin`. Deleting a workspace is safe: Gradle regenerates it on demand. The hook never fails the build.

Scoping matters here, because the naive rule is destructive. The long-lived agents keep Gradle homes going back to 7.6.x for the cross-version tests, and those versions kept `kotlin-dsl/scripts` and `transforms-3` in a layout with no metadata file at all - every entry there looks corrupt under a plain "no metadata.bin" test. The hook therefore:

- scans only `dependencies-accessors`, `groovy-dsl` and `kotlin-dsl/scripts`; artifact transform caches are left alone, since the failure has only ever been seen in `dependencies-accessors` and transforms are the most expensive thing to regenerate;
- treats a cache as metadata-using only if at least one of its entries has a `metadata.bin`, so pre-8.x layouts are skipped wholesale rather than by a hard-coded version list;
- refuses to act on a cache where more than 20 entries look corrupt, because real corruption is a handful of entries and a number like that means the heuristic does not fit that layout.

## Verification

- `.teamcity` compiles from clean (`./mvnw clean compile`); `shellcheck` is clean on the hook.
- The hook was exercised against a synthetic Gradle home covering all four cases: the real-world shape (three `dependencies-accessors` entries, one without `metadata.bin`) loses exactly the corrupt one; a 300-entry `caches/7.6.4/kotlin-dsl/scripts` in the pre-8.x layout is untouched; a metadata-using cache with 30 corrupt entries is left alone by the cap; `transforms-3` is not scanned. Missing Gradle home and unmatched globs are both handled.
- Dry-run over a real developer `~/.gradle`: one removal out of 4732 entries under `caches/9.7.0/kotlin-dsl/scripts`, which is a genuine instance of the same corruption.

- [ForceRealizeDependencyManagement_15_bucket1 #116635749](https://builds.gradle.org/build/116635749) is green on this branch, and the hook logged `No incomplete immutable workspaces found` on a warm agent home in under a second. An earlier, unscoped version of the hook removed 2338 directories from that same kind of home, which is what the scoping rules above exist to prevent.

**The artifact-cache path is not verified end to end, and that is why this is a draft.**

Only the ephemeral `ec2-gbt-us-west-2-fleet` agents run the agent pre-build hook that restores the Gradle home from the artifact cache. The long-lived `dev*` agents log `No agent pre-build hook found` and never fetch the poisoned entry, so every green build above proves the hook is harmless, not that it fixes anything.

Getting a build onto a fleet agent turned out not to be something I could force. The fleet sits scaled to zero, and a build pinned to a specific agent id does not register as demand for the cloud image, so the instance is scaled back in before the build is ever assigned - `The agent selected for the build is either incompatible or unavailable`. Four attempts, including one that pinned the build within seconds of the agent registering, all lost the agent the same way.

What would settle it: a run of any of the affected build configs on a fleet agent. The next `release8x` nightly does that by default. Its log should show the hook removing `caches/8.14.3/dependencies-accessors/7541752a.../` right after the restore, and the ~60 buckets going green.

## Follow-up, not fixed by this PR

The hook lets builds survive the poisoned entry; it does not remove it. Every `release8x` build will keep downloading and discarding it until the blob at key `yyxdp3ppl4qgxjxgxk4nnxhmqrgdaq7vikit3rvnohwy75ybzyeq` is evicted from the artifact cache. gradle/gradle-private#5181 should be reopened for that.

Worth asking the artifact-cache CLI owners to reject a store whose immutable workspace has no `metadata.bin` - that is what let the bad blob in, and the path-keying is what makes it permanent.
