### PR TITLE
Polish documentation around parallel execution and CC

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache.adoc
@@ -64,13 +64,13 @@ To do this, Gradle does the following:
 | Task outputs and artifact transform outputs
 | Each task's declared inputs (sources, classpath, action implementation)
 | Skips task execution by reusing previous outputs
-| Composes with `--parallel` for cross-project parallel execution
+| Orthogonal to parallelism; composes with `--parallel` for cross-project parallel execution
 
 | *Configuration Cache*
 | The result of the configuration phase: the task graph, each task's configured state, and dependency information
 | Build logic and environment (build scripts, init scripts, environment variables and properties read at configuration time, and more)
 | Skips the configuration phase entirely on a cache hit
-| Enables parallel task execution within the same project
+| Enables parallel task execution, including within the same project
 
 |===
 
@@ -107,7 +107,7 @@ But **whether they run, and when they do, depends on a cache hit or miss**.
 
 | *Execution*
 | Runs the scheduled tasks against the just-computed task graph.
-| Runs the scheduled tasks against the deserialized task graph. Tasks are isolated from each other through serialization (see <<config_cache:intro:serialization, Serialization>>), which enables intra-project parallel execution.
+| Runs the scheduled tasks against the deserialized task graph. Tasks are isolated from each other through serialization (see <<config_cache:intro:serialization, Serialization>>), which enables parallel task execution, including tasks in the same project.
 |===
 
 image::configuration-cache-6.png[]
@@ -134,7 +134,7 @@ Gradle then **serializes the resulting task graph and writes it to the cache** b
 
 Even on a miss, Gradle then **loads the task graph back from the cache it just wrote** and executes against the loaded copy.
 This always-load behavior is intentional: it guarantees that hits and misses execute through the same code path, so any serialization-related issue surfaces on the first run rather than later.
-It also means that parallel task execution within the same project is available even on a cache miss.
+It also means that parallel task execution is available even on a cache miss.
 
 [NOTE]
 ====
@@ -238,7 +238,7 @@ Using those features is supported but incurs a performance penalty and should be
 
 Serialization gives each task its **own** deserialized copy of the state it references.
 Two tasks that, before serialization, both held a reference to the same `ArrayList` will end up holding independent (but equal) lists after the cache is loaded.
-This isolation is what makes intra-project parallel task execution safe: tasks cannot leak mutable state to each other through a shared reference.
+This isolation is what makes parallel task execution safe: tasks cannot leak mutable state to each other through a shared reference.
 
 image::configuration-cache-8.png[]
 
@@ -269,16 +269,17 @@ Beyond skipping the configuration phase on a cache hit, the Configuration Cache 
 [[config_cache:in_action]]
 image::configuration-cache/running-help.gif[]
 
+[[config_cache:intro:parallel_task_execution]]
 === Parallel Task Execution
 
-When the Configuration Cache is enabled, tasks *within the same project* can run in parallel, subject to their declared input/output dependencies.
+When the Configuration Cache is enabled, all tasks can run in parallel, even *within the same project*, subject to their declared input/output dependencies.
 Without the Configuration Cache, intra-project parallelism is constrained because tasks within a project share access to the `Project` instance and contend on project-level locks.
 The Configuration Cache eliminates this contention by giving each task an isolated, deserialized copy of its state (see <<config_cache:intro:serialization, Serialization>>), so tasks no longer need to acquire project-level locks at execution time.
 
-This complements Gradle's existing `--parallel` flag, which executes tasks across *different* projects in parallel.
-With the Configuration Cache, parallelism applies *within* a single project as well.
+This is a step up from Gradle's existing `--parallel` flag, which only executes tasks across *different* projects in parallel.
+With the Configuration Cache, parallelism applies to all tasks, and the `--parallel` flag no longer controls it, unless the build falls back to non-cached execution, for example because a scheduled task is marked <<configuration_cache_debugging.adoc#config_cache:task_opt_out, incompatible with the Configuration Cache>>.
 
-IMPORTANT: Intra-project parallel execution is always enabled when the Configuration Cache is active. The `--no-parallel` flag and `org.gradle.parallel=false` do not disable it. Builds that depend on tasks within the same project running sequentially should properly wire task inputs and outputs to enforce task order or use <<build_services.adoc#sec:accessing_the_build_service_concurrently, shared build services>> to coordinate access to shared resources.
+IMPORTANT: Parallel task execution cannot be disabled when the Configuration Cache is active. The `--no-parallel` flag and `org.gradle.parallel=false` have no effect. Builds that depend on tasks running sequentially should properly wire task inputs and outputs to enforce task order or use <<build_services.adoc#sec:accessing_the_build_service_concurrently, shared build services>> to coordinate access to shared resources.
 
 === Cached Dependency Resolution
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_adoption.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_adoption.adoc
@@ -541,20 +541,19 @@ For most builds the parallel task execution and skipped configuration phase on c
 If a specific invocation is noticeably slower with CC than without, profile that invocation with a <<build_scans.adoc#build_scans, build scan>> to see whether resolution time (rather than configuration or execution time) is the culprit.
 
 [[config_cache:adoption_guide:faq:parallel]]
-=== Does `--no-parallel` work with CC?
+=== Do `--parallel` or `--no-parallel` work with CC?
 
-Not in the way the flag name implies.
+Yes, but only under limited circumstances, when Gradle falls back to non-cached execution:
 
-CC enables **intra-project parallel task execution** regardless of `--parallel`, `--no-parallel`, or `org.gradle.parallel`.
-Every task has its own isolated deserialized state and no project-level lock contention, so tasks within a project run in parallel automatically.
+* When a task marked with `notCompatibleWithConfigurationCache` is present in the task graph.
+* When an unsupported feature is used in the build.
+* When the Configuration Cache is in read-only mode and there was no cache hit.
 
-`--parallel` still controls **cross-project** parallel task execution, exactly as it does without CC.
-CC's intra-project parallelism composes with it: with `--parallel`, tasks run in parallel both within and across projects; without it, only within.
+Otherwise, in normal usage, where Configuration Cache writes or loads the entry successfully, tasks run in parallel regardless of the flags or the value of the `org.gradle.parallel` property.
 
-`--no-parallel` is effectively ignored for CC's intra-project parallelism — task execution within each project stays parallel — but it does disable cross-project parallelism.
-
-Writing the CC entry itself in parallel is a separate, incubating option: `-Dorg.gradle.configuration-cache.parallel=true`.
-It is unrelated to `--parallel`.
+However, it might be beneficial to keep `org.gradle.parallel=true` in the `gradle.properties` file if <<configuration_cache_enabling.adoc#config_cache:usage:parallel, parallel Configuration Caching>> is enabled.
+Storing a project's configuration requires access to that project, and Gradle grants such access one project at a time unless parallel project execution is enabled, so with `--parallel` disabled much of the store stays sequential.
+Parallel Configuration Caching is an incubating feature, and this restriction <<configuration_cache_status.adoc#config_cache:not_yet_implemented:parallel_store, may eventually be removed>>.
 
 [[config_cache:adoption_guide:faq:plugin_without_cc]]
 === Will my plugin still work for users who do not enable CC?
@@ -626,7 +625,7 @@ link:https://gradle.com/develocity/[Develocity] and link:https://scans.gradle.co
 When hit rates drop, open the CC report's "build configuration inputs" list and look for inputs that change every run but are not actually used.
 Each is either a candidate for switching to a `provider` (so the input is dropped if unused) or for one of the temporary opt-outs in <<configuration_cache_enabling.adoc#config_cache:usage:input_opt_outs, Temporary Opt-Outs for Configuration Cache Behavior>>.
 
-The next performance step beyond plain CC is typically **Parallel Configuration Cache** (`org.gradle.configuration-cache.parallel=true`), which parallelizes the storing and loading of CC entries themselves.
+The next performance step beyond plain CC is typically **Parallel Configuration Cache** (`org.gradle.configuration-cache.parallel=true`), which parallelizes the storing of CC entries themselves (loading is always parallel).
 It is still incubating; see <<configuration_cache_enabling.adoc#config_cache:usage:parallel, Enabling Parallel Configuration Caching>>.
 
 Looking further ahead, Isolated Projects builds on CC's per-project isolation to enable parallel project configuration, but it is pre-alpha and depends on CC being fully adopted first.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_enabling.adoc
@@ -101,10 +101,11 @@ org.gradle.configuration-cache.max-problems=5
 [[config_cache:usage:parallel]]
 === Enabling Parallel Configuration Caching
 
-By default, Configuration Cache storing and loading are sequential.
-Enabling parallel storing and loading can improve performance, but not all builds are compatible with it.
+Loading a Configuration Cache entry is always parallel; this option concerns storing, which is sequential by default.
+Enabling parallel storing can improve performance, but not all builds are compatible with it.
+In general, if the project builds with `--parallel` without issues, it should not have problems with parallel storing.
 
-To enable parallel configuration caching at build time, use:
+To enable parallel storing at build time, use:
 
 [source,bash]
 ----
@@ -124,6 +125,8 @@ The parallel configuration caching feature is _incubating_, and some builds may 
 A common symptom of incompatibility is `ConcurrentModificationException` errors during the <<build_lifecycle_intermediate.adoc#sec:configuration,configuration phase>>.
 However, this feature is expected to work well for <<configuration_on_demand.adoc#sec:decoupled_projects,decoupled>> multi-project builds.
 ====
+
+NOTE: While incubating, this option delivers less than its full benefit unless parallel project execution is enabled with `--parallel` or `org.gradle.parallel=true`. See <<configuration_cache_status.adoc#config_cache:not_yet_implemented:parallel_store, Parallel Storing of Cache Entries Independent of Parallel Project Execution>>.
 
 [[config_cache:usage:read_only]]
 === Making the Configuration Cache Read-Only

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -148,15 +148,6 @@ Task execution is parallel under the Configuration Cache regardless of `--parall
 
 See link:{gradle-issues}36002[gradle/gradle#36002].
 
-[[config_cache:not_yet_implemented:fine_grained_tracking_of_gradle_properties]]
-=== Fine-grained Tracking of Gradle Properties as Build Configuration Inputs
-
-Currently, all external sources of Gradle properties—such as `gradle.properties` files (both in project directories and in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`), environment variables, system properties that set properties, and properties specified via command-line flags—are considered build configuration inputs, regardless of whether they are actually used during configuration.
-
-However, these sources are not included in the Configuration Cache report.
-
-See link:{gradle-issues}20969[gradle/gradle#20969].
-
 [[config_cache:not_yet_implemented:java_serialization]]
 === Java Object Serialization
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -135,6 +135,19 @@ It can be reused by both hot and cold local Gradle daemons, but it cannot be sha
 
 See link:{gradle-issues}13510[gradle/gradle#13510].
 
+[[config_cache:not_yet_implemented:parallel_store]]
+=== Parallel Storing of Cache Entries Independent of Parallel Project Execution
+
+<<configuration_cache_enabling.adoc#config_cache:usage:parallel, Parallel storing>> writes the configuration state of each project concurrently, and writing a project's state requires access to that project.
+Gradle only grants access to projects one at a time unless parallel project execution is enabled, so with `--parallel` disabled — the default — much of the storing may still happen sequentially and the option delivers less than its full benefit.
+
+Until the two are decoupled, enable `org.gradle.parallel=true` together with `org.gradle.configuration-cache.parallel=true`.
+
+This limitation applies to storing a cache entry only.
+Task execution is parallel under the Configuration Cache regardless of `--parallel`, as is loading a cache entry; see <<configuration_cache.adoc#config_cache:intro:parallel_task_execution, Parallel Task Execution>>.
+
+See link:{gradle-issues}36002[gradle/gradle#36002].
+
 [[config_cache:not_yet_implemented:fine_grained_tracking_of_gradle_properties]]
 === Fine-grained Tracking of Gradle Properties as Build Configuration Inputs
 


### PR DESCRIPTION
There were some claims that could be understood incorrectly or weren't fully correct.

I tried to limit the exposure of the (hopefully) interim state of `--parallel` being somewhat required for the parallel store and `--no-parallel` having no effect.
