### PR TITLE
Update Documentation: Add security subscription to lifecycle page

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/feature_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/feature_lifecycle.adoc
@@ -134,3 +134,5 @@ As such, each major Gradle release causes:
 
 * The previous major version becomes maintenance only. It will only receive critical bug fixes and security fixes.
 * The major version before the previous one to become end-of-life (EOL), and that release line will not receive any new fixes.
+
+NOTE: This policy governs the open-source distribution. If you need security fixes for releases it no longer covers, or contractual timelines for those fixes, see the https://gradle.org/security-subscription/[Gradle Security Subscription].


### PR DESCRIPTION
### Details
This is a Documentation infrastructure change ONLY.

### Context
New Security Subscription

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description     