### PR TITLE
Run the test-bucket update on JDK 21

### DIFF
--- a/.github/workflows/update-test-buckets.yml
+++ b/.github/workflows/update-test-buckets.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 21
       - name: Clone gradle/ci-health repository
         run: |
           git clone https://${{ env.BOT_GRADLE_GITHUB_TOKEN }}@github.com/gradle/ci-health.git /tmp/gradle-ci-health


### PR DESCRIPTION
The `Auto update test buckets` workflow fails on JDK 25.

`kotlin-maven-plugin` 2.0.21 — pinned by the TeamCity `configs-dsl-kotlin-parent`, so not something this repo can bump — cannot parse a JDK 25 version string:

```
[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:2.0.21:compile
        (compile) on project Gradle_Check_dsl: Compilation failure
[ERROR] java.lang.IllegalArgumentException: 25.0.4
```

d475ce208e3 bumped this workflow from 17 to 25 on 2026-05-15, ten days after the workflow had been disabled, so the break sat unexercised until the workflow was switched back on this week.

17 is not the right value either — the `configs-dsl` jars are class-file 65, so the `.teamcity` suite cannot run on it. 21 satisfies both the Kotlin plugin and the DSL jars:

| JDK | `mvnw compile` | `mvnw test` |
|---|---|---|
| 17 | ok | 42 errors (`UnsupportedClassVersionError`) |
| **21** | ok | **60/60 pass** |
| 25 | fails | - |

Verified end to end: [run 32821620968](https://github.com/gradle/gradle/actions/runs/32821620968) completed successfully with this step on a pre-25 JDK, after three consecutive failures on 25.

Only this workflow is affected. `update-perf-test-buckets.yml` got the same 17 -> 25 bump but drives `./gradlew`, not the Kotlin/Maven DSL build, so it is fine on 25.
