### PR TITLE
Provide bot-gradle GPG signing key to promotion builds

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -28,8 +28,8 @@ abstract class BasePublishGradleDistribution(
     val promotedBranch: String,
     val prepTask: String?,
     val triggerName: String,
-    val gitUserName: String = "bot-teamcity",
-    val gitUserEmail: String = "bot-teamcity@gradle.com",
+    val gitUserName: String = "bot-gradle",
+    val gitUserEmail: String = "bot-gradle@gradle.com",
     val extraParameters: String = "",
     cleanCheckout: Boolean = true,
 ) : BasePromotionBuildType(cleanCheckout) {

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -62,6 +62,9 @@ class PromotionProject(
             param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
             param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
             param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
+            // bot-gradle's git commit signing key, see https://github.com/gradle/gradle-private/issues/4730
+            param("env.GPG_KEY", "%github.bot-gradle.gpg.key.id%")
+            password("env.GPG_PRIVATE_KEY", "%github.bot-gradle.gpg.private.key%")
             param("env.DEVELOCITY_SERVER_URL", "%gbt.internal.develocity.server.url%")
             // https://github.com/gradle/gradle-private/issues/5256
             param("env.PROMOTED_GBT_BUILD_DEVELOCITY_SERVER_URL", "%gbt.public.develocity.server.url%")

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
@@ -22,8 +22,8 @@ abstract class PublishGradleDistributionFullBuild(
     prepTask: String? = null,
     promoteTask: String,
     triggerName: String,
-    gitUserName: String = "bot-teamcity",
-    gitUserEmail: String = "bot-teamcity@gradle.com",
+    gitUserName: String = "bot-gradle",
+    gitUserEmail: String = "bot-gradle@gradle.com",
     extraParameters: String = "",
 ) : BasePublishGradleDistribution(promotedBranch, prepTask, triggerName, gitUserName, gitUserEmail, extraParameters) {
     init {

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -102,8 +102,8 @@ class PromotionProjectTests {
         val expectedGradleParams =
             """
             -PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% 
-            "-PgitUserName=bot-teamcity"
-            "-PgitUserEmail=bot-teamcity@gradle.com"
+            "-PgitUserName=bot-gradle"
+            "-PgitUserEmail=bot-gradle@gradle.com"
             $pluginPortalUrlOverride
             -DenablePredictiveTestSelection=false
             %additional.gradle.parameters%
@@ -162,8 +162,8 @@ class PromotionProjectTests {
         val expectedGradleParams =
             """
             -PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number% 
-            "-PgitUserName=bot-teamcity"
-            "-PgitUserEmail=bot-teamcity@gradle.com"
+            "-PgitUserName=bot-gradle"
+            "-PgitUserEmail=bot-gradle@gradle.com"
             $pluginPortalUrlOverride
             -DenablePredictiveTestSelection=false
             %additional.gradle.parameters%
@@ -194,8 +194,8 @@ class PromotionProjectTests {
             """
             -PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number%
             -PpromotedBranch=%branch.qualifier%
-            "-PgitUserName=bot-teamcity"
-            "-PgitUserEmail=bot-teamcity@gradle.com"
+            "-PgitUserName=bot-gradle"
+            "-PgitUserEmail=bot-gradle@gradle.com"
             $pluginPortalUrlOverride
             -DenablePredictiveTestSelection=false
             %additional.gradle.parameters%
@@ -225,8 +225,8 @@ class PromotionProjectTests {
         val expectedParams =
             """
             -PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number% 
-            "-PgitUserName=bot-teamcity"
-            "-PgitUserEmail=bot-teamcity@gradle.com"
+            "-PgitUserName=bot-gradle"
+            "-PgitUserEmail=bot-gradle@gradle.com"
             $pluginPortalUrlOverride
             -DenablePredictiveTestSelection=false
             %additional.gradle.parameters%
@@ -252,8 +252,8 @@ class PromotionProjectTests {
         val expectedGradleParams =
             """
             -PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number% 
-            "-PgitUserName=bot-teamcity"
-            "-PgitUserEmail=bot-teamcity@gradle.com"
+            "-PgitUserName=bot-gradle"
+            "-PgitUserEmail=bot-gradle@gradle.com"
             $pluginPortalUrlOverride
             -DenablePredictiveTestSelection=false
             %additional.gradle.parameters%


### PR DESCRIPTION
## Summary

- Expose the new `github.bot-gradle.gpg.key.id` / `github.bot-gradle.gpg.private.key` TeamCity parameters (defined on the `Gradle` project on builds.gradle.org) to all Promotion build types as `env.GPG_KEY` / `env.GPG_PRIVATE_KEY`.
- Together with the corresponding gradle-promote change, this lets promotion builds GPG-sign the commits they push, e.g. `releases.xml` updates to gradle/documentation-portal, which requires signed commits.

Part of https://github.com/gradle/gradle-private/issues/4730
