### PR TITLE
Trigger wrapper update from master milestone

### DIFF
--- a/.teamcity/scripts/update_wrapper_and_create_pr.sh
+++ b/.teamcity/scripts/update_wrapper_and_create_pr.sh
@@ -14,6 +14,7 @@ set -e
 #   GITHUB_TOKEN    - GitHub bot token
 #   TRIGGERED_BY    - Optional. If it's "Release - Final", version will be from version-info-final-release/version-info.properties
 #                     If it's "Release - Release Candidate", version will be from version-info-release-candidate/version-info.properties
+#                     If it's "Release - Milestone", version will be from version-info-milestone/version-info.properties
 
 post() {
     local endpoint="$1"
@@ -50,6 +51,9 @@ main() {
         export WRAPPER_VERSION="$promotedVersion"
     elif [[ "$TRIGGERED_BY" == *"Release - Release Candidate"* ]]; then
         source version-info-release-candidate/promote-projects/gradle/build/version-info.properties
+        export WRAPPER_VERSION="$promotedVersion"
+    elif [[ "$TRIGGERED_BY" == *"Release - Milestone"* ]]; then
+        source version-info-milestone/promote-projects/gradle/build/version-info.properties
         export WRAPPER_VERSION="$promotedVersion"
     fi
 

--- a/.teamcity/src/main/kotlin/util/UpdateWrapper.kt
+++ b/.teamcity/src/main/kotlin/util/UpdateWrapper.kt
@@ -12,6 +12,7 @@ import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.buildSteps.exec
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 import promotion.FINAL_RELEASE_BUILD_CONFIGURATION_ID
+import promotion.MILESTONE_BUILD_CONFIGURATION_ID
 import promotion.RELEASE_CANDIDATE_BUILD_CONFIGURATION_ID
 import vcsroots.useAbsoluteVcs
 
@@ -43,14 +44,24 @@ object UpdateWrapper : BuildType({
         param("env.TRIGGERED_BY", "%teamcity.build.triggeredBy%")
     }
 
-    if (!vcsBranch.isMaster) {
-        listOf(FINAL_RELEASE_BUILD_CONFIGURATION_ID, RELEASE_CANDIDATE_BUILD_CONFIGURATION_ID).forEach {
-            triggers {
-                finishBuildTrigger {
-                    buildType =
-                        "Gradle_${vcsBranch.branchName.toCapitalized()}_$it"
-                    successfulOnly = true
-                }
+    // Only promotions that actually exist for this branch can be observed:
+    // `master` publishes milestones, the release branches publish RCs and final releases.
+    val promotions =
+        if (vcsBranch.isMaster) {
+            mapOf(MILESTONE_BUILD_CONFIGURATION_ID to "version-info-milestone")
+        } else {
+            mapOf(
+                FINAL_RELEASE_BUILD_CONFIGURATION_ID to "version-info-final-release",
+                RELEASE_CANDIDATE_BUILD_CONFIGURATION_ID to "version-info-release-candidate",
+            )
+        }
+
+    promotions.keys.forEach {
+        triggers {
+            finishBuildTrigger {
+                buildType =
+                    "Gradle_${vcsBranch.branchName.toCapitalized()}_$it"
+                successfulOnly = true
             }
         }
     }
@@ -64,16 +75,12 @@ object UpdateWrapper : BuildType({
     }
 
     dependencies {
-        dependency(AbsoluteId("Gradle_${vcsBranch.branchName.toCapitalized()}_$FINAL_RELEASE_BUILD_CONFIGURATION_ID")) {
-            artifacts {
-                buildRule = lastSuccessful()
-                artifactRules = "version-info.properties => ./version-info-final-release"
-            }
-        }
-        dependency(AbsoluteId("Gradle_${vcsBranch.branchName.toCapitalized()}_$RELEASE_CANDIDATE_BUILD_CONFIGURATION_ID")) {
-            artifacts {
-                buildRule = lastSuccessful()
-                artifactRules = "version-info.properties => ./version-info-release-candidate"
+        promotions.forEach { (buildConfigurationId, targetDirectory) ->
+            dependency(AbsoluteId("Gradle_${vcsBranch.branchName.toCapitalized()}_$buildConfigurationId")) {
+                artifacts {
+                    buildRule = lastSuccessful()
+                    artifactRules = "version-info.properties => ./$targetDirectory"
+                }
             }
         }
     }


### PR DESCRIPTION
`UpdateWrapper` declared artifact dependencies on `Promotion_FinalRelease` and `Promotion_ReleaseCandidate` on every branch, but `PromotionProject` only creates those on the release branches. On master both pointed at non-existent build configurations, so the build failed immediately with "Inaccessible external dependency". The finish-build triggers were also skipped on master, so a master milestone never opened a wrapper PR.

- Derive the observed promotions from the branch: master watches `Promotion_Milestone`, release branches keep `Promotion_FinalRelease` + `Promotion_ReleaseCandidate`.
- Drive both the finish-build triggers and the artifact dependencies from that single mapping, so master now gets a trigger it previously lacked.
- Teach `update_wrapper_and_create_pr.sh` to read `promotedVersion` from `version-info-milestone` when triggered by `Release - Milestone`.

Release-branch behaviour is unchanged (verified by regenerating the config for `branch=release`).