### PR TITLE
Report why a plugin repository could not be searched

### DIFF
--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginResolutionFailureReportingSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginResolutionFailureReportingSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.repository
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
+
+class PluginResolutionFailureReportingSpec extends AbstractHttpDependencyResolutionTest {
+
+    private static final String PLUGIN_ID = "org.test.foo"
+    private static final String PLUGIN_VERSION = "1.0"
+
+    def setup() {
+        buildFile """
+            plugins {
+                id "$PLUGIN_ID" version "$PLUGIN_VERSION"
+            }
+"""
+    }
+
+    private void usePluginRepositories(MavenHttpRepository... repositories) {
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    ${repositories.collect { "maven { url = '${it.uri}' }" }.join("\n")}
+                }
+            }
+"""
+    }
+
+    private marker(MavenHttpRepository repo) {
+        repo.module(PLUGIN_ID, "${PLUGIN_ID}.gradle.plugin", PLUGIN_VERSION)
+    }
+
+    private void markerBroken(MavenHttpRepository repo) {
+        marker(repo).pom.expectGetBroken()
+    }
+
+    private void markerMissing(MavenHttpRepository repo) {
+        // Only the POM is requested. Resolution stops as soon as the marker is reported missing.
+        marker(repo).pom.expectGetMissing()
+    }
+
+    def "reports the underlying failure when the plugin repository cannot be reached"() {
+        given:
+        def repo = mavenHttpRepo("broken")
+        usePluginRepositories(repo)
+        markerBroken(repo)
+
+        when:
+        fails("help")
+
+        then:
+        failureDescriptionContains("could not resolve plugin artifact")
+        failureCauseContains("Could not GET")
+    }
+
+    def "does not report resolution failures when plugin is simply missing"() {
+        given:
+        def repo = mavenHttpRepo("empty")
+        usePluginRepositories(repo)
+        markerMissing(repo)
+
+        when:
+        fails("help")
+
+        then:
+        failureDescriptionContains("could not resolve plugin artifact")
+        failure.assertHasNoCause()
+    }
+
+    def "reports a broken repository that is searched after one simply missing the plugin"() {
+        given:
+        def fizzRepo = mavenHttpRepo("fizz")
+        def buzzRepo = mavenHttpRepo("buzz")
+        usePluginRepositories(fizzRepo, buzzRepo)
+        markerMissing(fizzRepo)
+        markerBroken(buzzRepo)
+
+        when:
+        fails("help")
+
+        then:
+        failureDescriptionContains("Searched in the following repositories")
+        failureCauseContains("Could not GET '${buzzRepo.uri}")
+    }
+
+    def "reports the underlying failure when the repository host is unreachable"() {
+        given:
+        def repo = mavenHttpRepo("gone")
+        usePluginRepositories(repo)
+        server.stop()
+
+        when:
+        fails("help")
+
+        then:
+        failureDescriptionContains("could not resolve plugin artifact")
+        failureCauseContains("Connection refused")
+    }
+
+    def "reports the underlying failure when the repository rejects credentials"() {
+        given:
+        def repo = mavenHttpRepo("secured")
+        usePluginRepositories(repo)
+        marker(repo).pom.expectGetUnauthorized()
+
+        when:
+        fails("help")
+
+        then:
+        failureDescriptionContains("could not resolve plugin artifact")
+        failureCauseContains("Could not GET '${repo.uri}")
+        failureCauseContains("status code 401")
+    }
+
+    def "stops at the first repository that could not be searched"() {
+        given:
+        def firstRepo = mavenHttpRepo("first")
+        def secondRepo = mavenHttpRepo("second")
+        usePluginRepositories(firstRepo, secondRepo)
+        markerBroken(firstRepo)
+        // No expectation on the second repository. A failure that disables one clears the queue,
+        // so the second is never queried, even though it is still listed as searched.
+
+        when:
+        fails("help")
+
+        then:
+        failureCauseContains("Could not GET '${firstRepo.uri}")
+        !failure.output.contains("Could not GET '${secondRepo.uri}")
+    }
+}

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -36,7 +36,9 @@ import org.gradle.plugin.management.internal.PluginCoordinates;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.use.PluginId;
 
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -62,14 +64,18 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
         }
 
         boolean autoApplied = pluginRequest.getOrigin() == PluginRequestInternal.Origin.AUTO_APPLIED;
-        if (exists(markerDependency) || autoApplied) {
+        Collection<Throwable> failures = tryResolve(markerDependency);
+        if (failures.isEmpty() || autoApplied) {
             // Even if we don't find the auto-applied plugin version, continue trying to resolve it with a preferred version,
             // in case the user provides an explicit or transitive required version.
             // The resolution will fail if there is no user-provided required version, however it avoids us failing here
             // if the weak version is not present but never selected.
             return PluginResolutionResult.found(new ExternalPluginResolution(getDependencyFactory(), pluginRequest, autoApplied));
         } else {
-            return handleNotFound("could not resolve plugin artifact '" + getNotation(markerDependency) + "'");
+            return handleNotFound(
+                "could not resolve plugin artifact '" + getNotation(markerDependency) + "'",
+                failures
+            );
         }
     }
 
@@ -156,19 +162,26 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
         }
     }
 
-    private PluginResolutionResult handleNotFound(String message) {
-        StringBuilder detail = new StringBuilder("Searched in the following repositories:\n");
-        for (Iterator<ArtifactRepository> it = resolutionServices.getResolveRepositoryHandler().iterator(); it.hasNext();) {
-            detail.append("  ").append(((ArtifactRepositoryInternal) it.next()).getDisplayName());
-            if (it.hasNext()) {
-                detail.append("\n");
-            }
+    private PluginResolutionResult handleNotFound(String message, Collection<Throwable> failures) {
+        return PluginResolutionResult.notFound(
+            SOURCE_NAME,
+            message,
+            describeSearchedRepositories(),
+            ReportableResolutionFailures.selectUnexpected(failures)
+        );
+    }
+
+    private String describeSearchedRepositories() {
+        List<String> repositories = new ArrayList<>();
+        for (ArtifactRepository repository : resolutionServices.getResolveRepositoryHandler()) {
+            repositories.add("  " + ((ArtifactRepositoryInternal) repository).getDisplayName());
         }
-        return PluginResolutionResult.notFound(SOURCE_NAME, message, detail.toString());
+        return "Searched in the following repositories:\n" + Joiner.on("\n").join(repositories);
     }
 
     /**
-     * Checks whether the plugin marker artifact exists in the backing artifacts repositories.
+     * Attempts to resolve the plugin marker artifact from the backing artifact repositories,
+     * returning the failures that occurred. An empty collection means the marker was resolved.
      *
      * TODO: Performing resolution here is likely quite inefficient. This performs resolution
      * for each plugin request that is not already found on the classpath. Doing this allows
@@ -176,14 +189,14 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
      * number of resolutions we perform in the buildscript context in order to avoid IO and
      * serial bottlenecks before the build can start configuration and thus perform actual work.
      */
-    private boolean exists(ModuleDependency dependency) {
+    private Collection<Throwable> tryResolve(ModuleDependency dependency) {
         ConfigurationContainer configurations = resolutionServices.getConfigurationContainer();
         Configuration configuration = configurations.detachedConfiguration(dependency);
         configuration.setTransitive(false);
         ArtifactView lenientView = configuration.getIncoming().artifactView(view -> {
             view.setLenient(true);
         });
-        return lenientView.getArtifacts().getFailures().isEmpty();
+        return lenientView.getArtifacts().getFailures();
     }
 
     private ModuleDependency getMarkerDependency(PluginRequestInternal pluginRequest) {

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolutionResult.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolutionResult.java
@@ -18,11 +18,13 @@ package org.gradle.plugin.use.resolve.internal;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.plugins.UnknownPluginException;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 
@@ -66,6 +68,23 @@ public class PluginResolutionResult {
     public static PluginResolutionResult notFound(String sourceDescription, String notFoundMessage, String notFoundDetail) {
         return new PluginResolutionResult(null, ImmutableList.of(new NotFound(sourceDescription, notFoundMessage, notFoundDetail)));
     }
+
+    /**
+     * Record that the plugin was not found in some source of plugins, carrying the failures
+     * that occurred while searching it.
+     */
+    public static PluginResolutionResult notFound(
+        String sourceDescription,
+        String notFoundMessage,
+        String notFoundDetail,
+        Iterable<? extends Throwable> failures
+    ) {
+        NotFound notFound = new NotFound(
+            sourceDescription, notFoundMessage, notFoundDetail, failures
+        );
+        return new PluginResolutionResult(null, ImmutableList.of(notFound));
+    }
+
     /**
      * Record that the plugin was not found in multiple sources of plugins
      */
@@ -108,9 +127,32 @@ public class PluginResolutionResult {
             }
         }
 
-        String message = sb.toString();
-        Exception exception = new UnknownPluginException(message, request.getId().getId());
+        Exception exception = new UnknownPluginException(sb.toString(), request.getId().getId());
+        Throwable cause = collectFailures();
+        if (cause != null) {
+            exception.initCause(cause);
+        }
+
         throw new LocationAwareException(exception, request.getScriptDisplayName(), request.getLineNumber());
+    }
+
+    /**
+     * Folds the failures from every source into one cause, or {@code null} when there are none.
+     */
+    private @Nullable Throwable collectFailures() {
+        List<Throwable> failures = new ArrayList<>();
+        for (NotFound notFound : notFoundList) {
+            failures.addAll(notFound.failures);
+        }
+        if (failures.isEmpty()) {
+            return null;
+        }
+        if (failures.size() == 1) {
+            return failures.get(0);
+        }
+        return new DefaultMultiCauseException(
+            "Plugin resolution failed in more than one source", failures
+        );
     }
 
     public List<NotFound> getNotFound() {
@@ -122,11 +164,22 @@ public class PluginResolutionResult {
         private final String source;
         private final String message;
         private final String detail;
+        private final ImmutableList<Throwable> failures;
 
         private NotFound(String source, String message, @Nullable String detail) {
+            this(source, message, detail, ImmutableList.of());
+        }
+
+        private NotFound(
+            String source,
+            String message,
+            @Nullable String detail,
+            Iterable<? extends Throwable> failures
+        ) {
             this.source = source;
             this.message = message;
             this.detail = detail;
+            this.failures = ImmutableList.copyOf(failures);
         }
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ReportableResolutionFailures.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ReportableResolutionFailures.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugin.use.resolve.internal;
+
+import org.gradle.internal.resolve.ArtifactNotFoundException;
+import org.gradle.internal.resolve.ModuleVersionNotFoundException;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Picks out the failures that mean more than "the plugin marker is absent". A plugin that is
+ * genuinely missing yields nothing here, so it keeps the message it had before.
+ */
+@NullMarked
+class ReportableResolutionFailures {
+
+    private ReportableResolutionFailures() {
+    }
+
+    static List<Throwable> selectUnexpected(Collection<Throwable> failures) {
+        List<Throwable> unexpected = new ArrayList<>(failures.size());
+        for (Throwable failure : failures) {
+            if (!isNotFound(failure)) {
+                unexpected.add(failure);
+            }
+        }
+        return unexpected;
+    }
+
+    // Only the narrow subtypes count as absence. ModuleVersionResolveException itself carries
+    // the failures worth reporting, so matching on it would filter everything out.
+    private static boolean isNotFound(Throwable failure) {
+        return failure instanceof ModuleVersionNotFoundException
+            || failure instanceof ArtifactNotFoundException;
+    }
+}

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/PluginResolutionResultTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/PluginResolutionResultTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.use.resolve.internal
+
+import com.google.common.collect.ImmutableList
+import org.gradle.api.plugins.UnknownPluginException
+import org.gradle.internal.exceptions.LocationAwareException
+import org.gradle.internal.exceptions.MultiCauseException
+import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.PluginId
+import spock.lang.Specification
+
+class PluginResolutionResultTest extends Specification {
+
+    def request = Mock(PluginRequestInternal) {
+        getDisplayName() >> "[id: 'org.test.foo', version: '1.0']"
+        getId() >> Mock(PluginId) { getId() >> "org.test.foo" }
+        getScriptDisplayName() >> "build file 'build.gradle'"
+        getLineNumber() >> 2
+    }
+
+    def "reports the failure of a single source as the cause"() {
+        given:
+        def failure = new RuntimeException("repository is on fire")
+
+        expect:
+        causeOf(sources(notFound("Plugin Repositories", failure))).is(failure)
+    }
+
+    def "ignores the sources that reported no failure"() {
+        given:
+        def failure = new RuntimeException("repository is on fire")
+        def result = sources(
+            notFound("Gradle Core Plugins"),
+            notFound("Included Builds"),
+            notFound("Plugin Repositories", failure)
+        )
+
+        expect:
+        causeOf(result).is(failure)
+    }
+
+    def "folds the failures of several sources into one cause"() {
+        given:
+        def first = new RuntimeException("first repository is on fire")
+        def second = new RuntimeException("second repository is on fire")
+
+        when:
+        def cause = causeOf(sources(notFound("First", first), notFound("Second", second)))
+
+        then:
+        cause instanceof MultiCauseException
+        cause.causes == [first, second]
+    }
+
+    def "leaves the reported exception without a cause when no source reported a failure"() {
+        expect:
+        causeOf(sources(notFound("Plugin Repositories"))) == null
+    }
+
+    private Throwable causeOf(PluginResolutionResult result) {
+        try {
+            result.getFound(request)
+        } catch (LocationAwareException e) {
+            assert e.cause instanceof UnknownPluginException
+            return e.cause.cause
+        }
+        throw new AssertionError("expected getFound to fail" as Object)
+    }
+
+    private static PluginResolutionResult sources(List<PluginResolutionResult.NotFound>... notFound) {
+        PluginResolutionResult.notFound(ImmutableList.copyOf(notFound.flatten()))
+    }
+
+    private static List<PluginResolutionResult.NotFound> notFound(String source, Throwable... failures) {
+        PluginResolutionResult.notFound(source, "message", "detail", failures.toList()).getNotFound()
+    }
+}

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ReportableResolutionFailuresTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ReportableResolutionFailuresTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.use.resolve.internal
+
+import org.gradle.internal.resolve.ArtifactNotFoundException
+import org.gradle.internal.resolve.ModuleVersionNotFoundException
+import org.gradle.internal.resolve.ModuleVersionResolveException
+import spock.lang.Specification
+
+import static org.gradle.plugin.use.resolve.internal.ReportableResolutionFailures.selectUnexpected
+
+class ReportableResolutionFailuresTest extends Specification {
+
+    def "selects nothing when every failure only means the module is missing"() {
+        expect:
+        selectUnexpected([
+            Mock(ModuleVersionNotFoundException),
+            Mock(ModuleVersionNotFoundException)
+        ]).isEmpty()
+    }
+
+    def "selects nothing when every failure only means the artifact is missing"() {
+        expect:
+        selectUnexpected([Mock(ArtifactNotFoundException)]).isEmpty()
+    }
+
+    def "selects nothing when there are no failures"() {
+        expect:
+        selectUnexpected([]).isEmpty()
+    }
+
+    def "selects a resolve failure that is not one of the missing subtypes"() {
+        given:
+        // Matching on ModuleVersionResolveException instead of its subtypes would filter this out,
+        // and every real failure with it, without any other test noticing.
+        def failure = Mock(ModuleVersionResolveException)
+
+        expect:
+        selectUnexpected([failure]) == [failure]
+    }
+
+    def "selects a failure that is not a missing module"() {
+        given:
+        def failure = new RuntimeException("repository is on fire")
+
+        expect:
+        selectUnexpected([failure]) == [failure]
+    }
+
+    def "selects only the failures that are not missing modules"() {
+        given:
+        def failure = new RuntimeException("repository is on fire")
+
+        expect:
+        selectUnexpected([
+            Mock(ModuleVersionNotFoundException),
+            failure,
+            Mock(ArtifactNotFoundException)
+        ]) == [failure]
+    }
+
+    def "keeps every failure worth reporting, in the order they were given"() {
+        given:
+        def first = new RuntimeException("first repository is on fire")
+        def second = new RuntimeException("second repository is on fire")
+
+        expect:
+        selectUnexpected([first, second]) == [first, second]
+    }
+
+    def "selects a failure whose cause is a missing module"() {
+        given:
+        // Only the top level is examined, so a not-found cause does not hide its parent.
+        def notFound = Mock(ModuleVersionNotFoundException)
+        def failure = new RuntimeException("repository is on fire", notFound)
+
+        expect:
+        selectUnexpected([failure]) == [failure]
+    }
+}


### PR DESCRIPTION
Fixes #29726
Fixes #23836
Fixes #15424

### Context

When a plugin cannot be resolved, Gradle reports that it was not found and stops there. An unreachable host, a TLS handshake failure, an HTTP 500 and a rejected credential all produce the same message, so there is no way to tell a genuinely missing plugin from a repository that could not be searched at all.

`ArtifactRepositoriesPluginResolver.exists` asks the resolution engine what went wrong and then discards the answer:

```java
return lenientView.getArtifacts().getFailures().isEmpty();
```

`--stacktrace` does not help either, which is what makes this hard to diagnose in practice. The reported `UnknownPluginException` is built without a cause, so the trace ends at `PluginResolutionResult.getFound` and there is no `Caused by:` section to read.

#### Reproducer

```groovy
// settings.gradle
pluginManagement {
    repositories {
        maven { url = "https://a-broken-repository.example.com/repo" }
    }
}

// build.gradle
plugins {
    id "org.test.foo" version "1.0"
}
```

```
./gradlew help
```

#### Before

```
* What went wrong:
Plugin [id: 'org.test.foo', version: '1.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'org.test.foo:org.test.foo.gradle.plugin:1.0')
  Searched in the following repositories:
    maven(https://a-broken-repository.example.com/repo)
```

#### After

```
* What went wrong:
Plugin [id: 'org.test.foo', version: '1.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'org.test.foo:org.test.foo.gradle.plugin:1.0')
  Searched in the following repositories:
    maven(https://a-broken-repository.example.com/repo)
> Could not resolve org.test.foo:org.test.foo.gradle.plugin:1.0.
  Required by:
      plugin resolution
   > Could not resolve org.test.foo:org.test.foo.gradle.plugin:1.0.
      > Could not get resource '.../org.test.foo.gradle.plugin-1.0.pom'.
         > Could not GET '.../org.test.foo.gradle.plugin-1.0.pom'.
            > The server may not support the client's requested TLS protocol versions: (TLSv1.2, TLSv1.3). You may need to configure the client to allow other protocols to be used. For more on this, please refer to https://docs.gradle.org/9.9.0/userguide/build_environment.html#sec:gradle_system_properties in the Gradle documentation.
               > Remote host terminated the handshake
```

Repositories often put remediation guidance into their own failure messages. That text now reaches the user, along with the documentation links in it.

I checked two more repositories that fail differently: one answering 500, and one with nothing listening on the port. Their "before" output is identical to the one above except for the repository URL, which is the problem in a sentence. Afterwards they end the chain with `Received status code 500 from server: Internal Server Error` and `Connection refused` respectively.

#### Implementation

The failures travel out of `tryResolve`, through `PluginResolutionResult.NotFound`, and onto the thrown `UnknownPluginException` as a real cause. The contextual-exception renderer already knows how to print such a chain, so this path needs no formatting of its own and its output matches what dependency resolution prints elsewhere. No new public API is needed: `Throwable.initCause` is enough, and `DefaultIsolatedProjectEvaluationListenerProvider` already does the same to this exception type.

`ReportableResolutionFailures` drops the failures that only mean the marker is absent, so a plugin that is simply missing keeps exactly the message it had before. An integration test pins that case by asserting the failure has no cause at all.

#### Notes for review

Three decisions that are easier to argue about now than later.

**Only the first failing repository is reported.** `RepositoryChainComponentMetaDataResolver.findBestMatch` clears the queue and marks a fatal error as soon as a repository is disabled and cannot be continued with, so later repositories are never contacted. A message naming several broken repositories is not reachable through this path today. The test `stops at the first repository that could not be searched` pins that, so a change there will surface as a failing test rather than a silent difference. `PluginResolutionResult` still folds failures from several sources into a `DefaultMultiCauseException`, and that is unit tested, so the behaviour is defined if the engine ever stops short-circuiting.

**`ReportableResolutionFailures.isNotFound` names two exception types from `dependency-management`.** `ModuleVersionNotFoundException` and `ArtifactNotFoundException` have no common supertype, and `ResolveExceptionAnalyzer.isCriticalFailure` covers a different set: it treats a 401 as recoverable, while this path has to report it. A marker interface would be the clean answer, but it belongs to that module, so I left it alone.

**No release notes entry.** The change is user-visible, so it may deserve one, but that file looks like it belongs to the release process rather than to contributors. Glad to add it if you want it here.

One thing I could not capture locally: a DNS failure. The behaviour is the same, but my resolver answers NXDOMAIN with an address, so `UnknownHostException` never happens on my machine. #23836 describes that case.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :plugin-use:quickTest`.
