### PR TITLE
Document and test behavior of status attribute with dynamic versions

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
@@ -504,7 +504,7 @@ For example, a Maven `SNAPSHOT` module always points to the latest artifact publ
 
 A dynamic version typically considers all versions for matching, including snapshot versions.
 Given the published versions `1.0`, `1.1`, `1.2-SNAPSHOT`, and `2.0`, both `[1, 2)` and `1.+` select `1.2-SNAPSHOT`, because it is the highest version that matches.
-However, in some cases you may want to select `1.1` instead of `1.2-SNAPSHOT` because you only want to use released versions.
+However, you may want to select `1.1` instead of `1.2-SNAPSHOT` if you only want released versions.
 You can do this by requesting the `org.gradle.status` attribute on the dependency:
 
 ====
@@ -514,8 +514,7 @@ include::sample[dir="snippets/reference/dependency-management/declaring-dependen
 
 With the attribute in place, `com.example:lib:[1, 2)` resolves to `1.1` instead of `1.2-SNAPSHOT`, while `com.example:other:[1, 2)` is unaffected and still resolves to `1.2-SNAPSHOT`.
 This is because during <<graph_resolution.adoc#sec:conflict-resolution,version selection>>, Gradle matches the requested attributes against the _component-level_ attributes of each candidate version and discards the candidates that don't match.
-This works for every kind of dynamic version.
-For example, with a prefix version range:
+The same approach works with any dynamic version, including prefix version ranges:
 
 ====
 include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin",files="prefixVersion/build.gradle.kts[tags=prefix-version]"]
@@ -524,7 +523,7 @@ include::sample[dir="snippets/reference/dependency-management/declaring-dependen
 
 This has the same effect as the previous example.
 
-For matching only snapshot versions instead, you can replace `release` with `integration` in the above examples.
+To match only integration versions (SNAPSHOTs in a Maven repository), replace `release` with `integration` in the examples above.
 See <<component_metadata_rules.adoc#sec:custom-status-scheme,version selection based on status>> for the available statuses and what they mean.
 
 [[sec:dynamic-version-status-per-configuration]]
@@ -543,8 +542,9 @@ This means that you need to declare it on `compileClasspath` and `runtimeClasspa
 You may want to apply <<dependency_resolution_consistency.adoc#sec:java_consistency,dependency resolution consistency>> to ensure that the same set of dependencies is resolved for these configurations.
 
 WARNING: `org.gradle.status` is also published as a variant attribute and is matched exactly.
-Requesting `release` on a configuration therefore fails variant selection for any dependency that uses a static snapshot version, including transitive dependencies.
-Prefer declaring the attribute on individual dependencies unless you intend every dependency in the graph to be a release.
+Requesting `release` on a configuration therefore fails variant selection for any dependency that resolves to a static snapshot; requesting `integration` fails for any dependency that resolves to a static release.
+This applies to transitive dependencies as well.
+Prefer declaring the attribute on individual dependencies unless you intend every dependency in the graph to share the same status.
 
 [[sec:declaring-dependency-with-changing-version]]
 == Declaring changing versions

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
@@ -499,6 +499,53 @@ Therefore, use this feature with caution.
 CAUTION: For reproducible builds, it’s crucial to use <<dependency_locking.adoc#locking-versions,dependency locking>> when declaring dependencies with dynamic versions. Without this, the module you request may change even for the same version, which is known as a <<#sec:declaring-dependency-with-changing-version,changing version>>.
 For example, a Maven `SNAPSHOT` module always points to the latest artifact published, making it a "changing module."
 
+[[sec:dynamic-version-status]]
+=== Restricting a dynamic version to a specific status
+
+A dynamic version typically considers all versions for matching, including snapshot versions.
+Given the published versions `1.0`, `1.1`, `1.2-SNAPSHOT`, and `2.0`, both `[1, 2)` and `1.+` select `1.2-SNAPSHOT`, because it is the highest version that matches.
+However, in some cases you may want to select `1.1` instead of `1.2-SNAPSHOT` because you only want to use released versions.
+You can do this by requesting the `org.gradle.status` attribute on the dependency:
+
+====
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin",files="range/build.gradle.kts[tags=range]"]
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy",files="range/build.gradle[tags=range]"]
+====
+
+With the attribute in place, `com.example:lib:[1, 2)` resolves to `1.1` instead of `1.2-SNAPSHOT`, while `com.example:other:[1, 2)` is unaffected and still resolves to `1.2-SNAPSHOT`.
+This is because during <<graph_resolution.adoc#sec:conflict-resolution,version selection>>, Gradle matches the requested attributes against the _component-level_ attributes of each candidate version and discards the candidates that don't match.
+This works for every kind of dynamic version.
+For example, with a prefix version range:
+
+====
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin",files="prefixVersion/build.gradle.kts[tags=prefix-version]"]
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy",files="prefixVersion/build.gradle[tags=prefix-version]"]
+====
+
+This has the same effect as the previous example.
+
+For matching only snapshot versions instead, you can replace `release` with `integration` in the above examples.
+See <<component_metadata_rules.adoc#sec:custom-status-scheme,version selection based on status>> for the available statuses and what they mean.
+
+[[sec:dynamic-version-status-per-configuration]]
+==== Restricting the status of every dependency of a configuration
+
+The attribute can also be requested on a resolvable configuration, which applies it to every dependency resolved through that configuration, including transitive ones:
+
+====
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin",files="perConfiguration/build.gradle.kts[tags=configuration-wide]"]
+include::sample[dir="snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy",files="perConfiguration/build.gradle[tags=configuration-wide]"]
+====
+
+Configuration-level attributes apply only to the configuration they are declared on.
+They are not inherited through `extendsFrom`, so declaring the attribute on a dependency scope such as `implementation` has no effect.
+This means that you need to declare it on `compileClasspath` and `runtimeClasspath` separately, for example.
+You may want to apply <<dependency_resolution_consistency.adoc#sec:java_consistency,dependency resolution consistency>> to ensure that the same set of dependencies is resolved for these configurations.
+
+WARNING: `org.gradle.status` is also published as a variant attribute and is matched exactly.
+Requesting `release` on a configuration therefore fails variant selection for any dependency that uses a static snapshot version, including transitive dependencies.
+Prefer declaring the attribute on individual dependencies unless you intend every dependency in the graph to be a release.
+
 [[sec:declaring-dependency-with-changing-version]]
 == Declaring changing versions
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-dependencies/dependency_versions.adoc
@@ -542,7 +542,7 @@ This means that you need to declare it on `compileClasspath` and `runtimeClasspa
 You may want to apply <<dependency_resolution_consistency.adoc#sec:java_consistency,dependency resolution consistency>> to ensure that the same set of dependencies is resolved for these configurations.
 
 WARNING: `org.gradle.status` is also published as a variant attribute and is matched exactly.
-Requesting `release` on a configuration therefore fails variant selection for any dependency that resolves to a static snapshot; requesting `integration` fails for any dependency that resolves to a static release.
+Requesting `release` on a configuration therefore fails variant selection for any dependency that only selects a snapshot version; requesting `integration` fails for any dependency that only selects a release version.
 This applies to transitive dependencies as well.
 Prefer declaring the attribute on individual dependencies unless you intend every dependency in the graph to share the same status.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/component_metadata_rules.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/component_metadata_rules.adoc
@@ -361,6 +361,7 @@ To modify another attribute for all variants of a component `withAllVariants { a
 A module's status is taken into consideration when a <<dependency_versions.adoc#sec:single-version-declarations,_latest_ version selector>> is resolved.
 Specifically, `latest.someStatus` will resolve to the highest module version that has status `someStatus` or a more mature status.
 For example, `latest.integration` will select the highest module version regardless of its status (because `integration` is the least mature status as explained below), whereas `latest.release` will select the highest module version with status `release`.
+A status can also be requested as an attribute on the consumer, which <<dependency_versions.adoc#sec:dynamic-version-status,constrains dynamic versions>>.
 
 The interpretation of the status can be influenced by changing a module's _status scheme_ through the `setStatusScheme(valueList)` API.
 This concept models the different levels of maturity that a module transitions through over time with different publications.

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.0/lib-1.0.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.0/lib-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>1.0</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.1/lib-1.1.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.1/lib-1.1.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>1.1</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.2-SNAPSHOT/lib-1.2-SNAPSHOT.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/1.2-SNAPSHOT/lib-1.2-SNAPSHOT.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>1.2-SNAPSHOT</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/2.0/lib-2.0.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/2.0/lib-2.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>2.0</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/maven-metadata.xml
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/lib/maven-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.1</version>
+      <version>1.2-SNAPSHOT</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260101000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.0/other-1.0.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.0/other-1.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>other</artifactId>
+  <version>1.0</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.1/other-1.1.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.1/other-1.1.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>other</artifactId>
+  <version>1.1</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.2-SNAPSHOT/other-1.2-SNAPSHOT.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/1.2-SNAPSHOT/other-1.2-SNAPSHOT.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>other</artifactId>
+  <version>1.2-SNAPSHOT</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/2.0/other-2.0.pom
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/2.0/other-2.0.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>other</artifactId>
+  <version>2.0</version>
+</project>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/maven-metadata.xml
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/common/repo/com/example/other/maven-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.example</groupId>
+  <artifactId>other</artifactId>
+  <versioning>
+    <latest>2.0</latest>
+    <release>2.0</release>
+    <versions>
+      <version>1.0</version>
+      <version>1.1</version>
+      <version>1.2-SNAPSHOT</version>
+      <version>2.0</version>
+    </versions>
+    <lastUpdated>20260101000000</lastUpdated>
+  </versioning>
+</metadata>

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/perConfiguration/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/perConfiguration/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = file("../repo")
+    }
+}
+
+// tag::configuration-wide[]
+configurations.compileClasspath {
+    attributes.attribute(Attribute.of("org.gradle.status", String), "release")
+}
+
+configurations.runtimeClasspath {
+    attributes.attribute(Attribute.of("org.gradle.status", String), "release")
+}
+// end::configuration-wide[]
+
+dependencies {
+    implementation("com.example:lib:[1, 2)")
+    implementation("com.example:other:[1, 2)")
+}

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/prefixVersion/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/prefixVersion/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = file("../repo")
+    }
+}
+
+// tag::prefix-version[]
+dependencies {
+    implementation("com.example:lib:1.+") {
+        attributes {
+            attribute(Attribute.of("org.gradle.status", String), "release")
+        }
+    }
+}
+// end::prefix-version[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/range/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/range/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = file("../repo")
+    }
+}
+
+// tag::range[]
+dependencies {
+    implementation("com.example:lib:[1, 2)") {
+        attributes {
+            attribute(Attribute.of("org.gradle.status", String), "release")
+        }
+    }
+    implementation("com.example:other:[1, 2)")
+}
+// end::range[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/groovy/settings.gradle
@@ -1,0 +1,5 @@
+rootProject.name = "dynamic-version-status"
+
+include("range")
+include("prefixVersion")
+include("perConfiguration")

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/perConfiguration/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/perConfiguration/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = uri("../repo")
+    }
+}
+
+// tag::configuration-wide[]
+configurations.compileClasspath {
+    attributes.attribute(Attribute.of("org.gradle.status", String::class.java), "release")
+}
+
+configurations.runtimeClasspath {
+    attributes.attribute(Attribute.of("org.gradle.status", String::class.java), "release")
+}
+// end::configuration-wide[]
+
+dependencies {
+    implementation("com.example:lib:[1, 2)")
+    implementation("com.example:other:[1, 2)")
+}

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/prefixVersion/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/prefixVersion/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = uri("../repo")
+    }
+}
+
+// tag::prefix-version[]
+dependencies {
+    implementation("com.example:lib:1.+") {
+        attributes {
+            attribute(Attribute.of("org.gradle.status", String::class.java), "release")
+        }
+    }
+}
+// end::prefix-version[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/range/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/range/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("java-library")
+}
+
+repositories {
+    maven {
+        url = uri("../repo")
+    }
+}
+
+// tag::range[]
+dependencies {
+    implementation("com.example:lib:[1, 2)") {
+        attributes {
+            attribute(Attribute.of("org.gradle.status", String::class.java), "release")
+        }
+    }
+    implementation("com.example:other:[1, 2)")
+}
+// end::range[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/kotlin/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "dynamic-version-status"
+
+include("range")
+include("prefixVersion")
+include("perConfiguration")

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/dynamicVersionStatus.sample.conf
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/dynamicVersionStatus.sample.conf
@@ -1,0 +1,25 @@
+commands: [{
+    executable: gradle
+    args: ":range:dependencies --configuration compileClasspath"
+    expected-output-file: range.out
+    allow-additional-output: true
+    allow-disordered-output: true
+}, {
+    executable: gradle
+    args: ":prefixVersion:dependencies --configuration compileClasspath"
+    expected-output-file: prefixVersion.out
+    allow-additional-output: true
+    allow-disordered-output: true
+}, {
+    executable: gradle
+    args: ":perConfiguration:dependencies --configuration compileClasspath"
+    expected-output-file: perConfigurationCompileClasspath.out
+    allow-additional-output: true
+    allow-disordered-output: true
+}, {
+    executable: gradle
+    args: ":perConfiguration:dependencies --configuration runtimeClasspath"
+    expected-output-file: perConfigurationRuntimeClasspath.out
+    allow-additional-output: true
+    allow-disordered-output: true
+}]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/perConfigurationCompileClasspath.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/perConfigurationCompileClasspath.out
@@ -1,0 +1,3 @@
+compileClasspath - Compile classpath for source set 'main'.
++--- com.example:lib:[1, 2) -> 1.1
+\--- com.example:other:[1, 2) -> 1.1

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/perConfigurationRuntimeClasspath.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/perConfigurationRuntimeClasspath.out
@@ -1,0 +1,3 @@
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- com.example:lib:[1, 2) -> 1.1
+\--- com.example:other:[1, 2) -> 1.1

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/prefixVersion.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/prefixVersion.out
@@ -1,0 +1,2 @@
+compileClasspath - Compile classpath for source set 'main'.
+\--- com.example:lib:1.+ -> 1.1

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/range.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/declaringDependencies-dynamicVersionStatus/tests/range.out
@@ -1,0 +1,3 @@
+compileClasspath - Compile classpath for source set 'main'.
++--- com.example:lib:[1, 2) -> 1.1
+\--- com.example:other:[1, 2) -> 1.2-SNAPSHOT

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicVersionStatusAttributeIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicVersionStatusAttributeIntegrationTest.groovy
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/8126")
+class MavenDynamicVersionStatusAttributeIntegrationTest extends AbstractDependencyResolutionTest {
+
+    private static final String STATUS_ATTRIBUTE = "Attribute.of(\"${ProjectInternal.STATUS_ATTRIBUTE.name}\", String)"
+
+    private static String statusOf(String version) {
+        version.endsWith('-SNAPSHOT') ? 'integration' : 'release'
+    }
+
+    private static String rejectionReason(String version, String requestedStatus) {
+        "rejection: version $version:   - Attribute '${ProjectInternal.STATUS_ATTRIBUTE.name}' didn't match. Requested '$requestedStatus', was: '${statusOf(version)}'"
+    }
+
+    def resolve = new ResolveTestFixture(testDirectory)
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        buildFile << """
+            plugins {
+                id("jvm-ecosystem")
+            }
+
+            repositories {
+                maven {
+                    url = "${mavenRepo.uri}"
+                }
+            }
+
+            configurations {
+                compile
+            }
+
+            ${resolve.configureProject("compile")}
+        """
+
+        publishModule('releaseHead')
+    }
+
+    private void publishModule(String name) {
+        mavenRepo.module('com.example', name, '1.0').publish()
+        mavenRepo.module('com.example', name, '1.1').publish()
+        mavenRepo.module('com.example', name, '1.2-SNAPSHOT').withNonUniqueSnapshots().publish()
+        mavenRepo.module('com.example', name, '1.3').publish()
+        mavenRepo.module('com.example', name, '2.0').publish()
+    }
+
+    def "dynamic version #selector selects #selected regardless of status when none is requested"() {
+        given:
+        buildFile << """
+            dependencies {
+                compile("com.example:releaseHead:$selector")
+            }
+        """
+
+        when:
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.example:releaseHead:$selector", "com.example:releaseHead:$selected") {
+                    notRequested()
+                    byReason(rangeReason)
+                }
+            }
+        }
+
+        where:
+        selector   | selected       | rangeReason
+        '[1,2)'    | '1.3'          | "didn't match version 2.0"
+        '1.+'      | '1.3'          | "didn't match version 2.0"
+        '[1,1.3)'  | '1.2-SNAPSHOT' | "didn't match versions 2.0, 1.3"
+    }
+
+    def "#status status requested on a dependency skips the higher #rejected without affecting the other dependencies"() {
+        given:
+        publishModule('other')
+        buildFile << """
+            dependencies {
+                compile("com.example:releaseHead:$selector") {
+                    attributes {
+                        attribute($STATUS_ATTRIBUTE, "$status")
+                    }
+                }
+                compile("com.example:other:[1,2)")
+            }
+        """
+        def rejection = rejectionReason(rejected, status)
+
+        when:
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.example:releaseHead:$selector", "com.example:releaseHead:$selected") {
+                    notRequested()
+                    byReason(rangeReason)
+                    byReason(rejection)
+                }
+                edge("com.example:other:[1,2)", "com.example:other:1.3") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
+            }
+        }
+
+        where:
+        selector  | status        | selected       | rejected       | rangeReason
+        '[1,1.3)' | 'release'     | '1.1'          | '1.2-SNAPSHOT' | "didn't match versions 2.0, 1.3"
+        '[1,2)'   | 'integration' | '1.2-SNAPSHOT' | '1.3'          | "didn't match version 2.0"
+    }
+
+    def "#status status requested on a dependency with a prefix version skips the higher #rejected"() {
+        given:
+        publishModule('snapshotHead')
+        mavenRepo.module('com.example', 'snapshotHead', '1.4-SNAPSHOT').withNonUniqueSnapshots().publish()
+        buildFile << """
+            dependencies {
+                compile("com.example:$module:1.+") {
+                    attributes {
+                        attribute($STATUS_ATTRIBUTE, "$status")
+                    }
+                }
+            }
+        """
+        def rejection = rejectionReason(rejected, status)
+
+        when:
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.example:$module:1.+", "com.example:$module:$selected") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                    byReason(rejection)
+                }
+            }
+        }
+
+        where:
+        module          | status        | selected       | rejected
+        'snapshotHead'  | 'release'     | '1.3'          | '1.4-SNAPSHOT'
+        'releaseHead'   | 'integration' | '1.2-SNAPSHOT' | '1.3'
+    }
+
+    def "#status status requested on a configuration skips the higher #rejected for every dependency"() {
+        given:
+        publishModule('other')
+        buildFile << """
+            configurations.compile.attributes.attribute($STATUS_ATTRIBUTE, "$status")
+
+            dependencies {
+                compile("com.example:releaseHead:$selector")
+                compile("com.example:other:$selector")
+            }
+        """
+        def rejection = rejectionReason(rejected, status)
+
+        when:
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.example:releaseHead:$selector", "com.example:releaseHead:$selected") {
+                    notRequested()
+                    byReason(rangeReason)
+                    byReason(rejection)
+                }
+                edge("com.example:other:$selector", "com.example:other:$selected") {
+                    notRequested()
+                    byReason(rangeReason)
+                    byReason(rejection)
+                }
+            }
+        }
+
+        where:
+        selector  | status        | selected       | rejected       | rangeReason
+        '[1,1.3)' | 'release'     | '1.1'          | '1.2-SNAPSHOT' | "didn't match versions 2.0, 1.3"
+        '[1,2)'   | 'integration' | '1.2-SNAPSHOT' | '1.3'          | "didn't match version 2.0"
+    }
+
+    def "status requested on an extended configuration is not inherited by the resolving configuration"() {
+        given:
+        buildFile << """
+            configurations {
+                compileDeps
+                compile.extendsFrom(compileDeps)
+            }
+
+            configurations.compileDeps.attributes.attribute($STATUS_ATTRIBUTE, "release")
+
+            dependencies {
+                compileDeps("com.example:releaseHead:[1,2)")
+            }
+        """
+
+        when:
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.example:releaseHead:[1,2)", "com.example:releaseHead:1.3") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
+            }
+        }
+    }
+
+    def "requesting #status status on the configuration fails for a dependency on a static #version version"() {
+        given:
+        buildFile << """
+            configurations.compile.attributes.attribute($STATUS_ATTRIBUTE, "$status")
+
+            dependencies {
+                compile("com.example:releaseHead:$version")
+            }
+        """
+
+        when:
+        fails 'checkDeps'
+
+        then:
+        failure.assertHasCause("No matching variant of com.example:releaseHead:$version was found. The consumer was configured to find a component, with a $status status but:")
+        failure.assertThatCause(containsNormalizedString("Incompatible because this component declares a component, with a ${statusOf(version)} status and the consumer needed a component, with a $status status"))
+
+        where:
+        status        | version
+        'release'     | '1.2-SNAPSHOT'
+        'integration' | '1.1'
+    }
+}


### PR DESCRIPTION
Fixes #8126

Worth noting here that we explicitly chose this behavior to match Ivy. Maven does do something different here.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
