### PR TITLE
Handle missing exception method signature types during serialization

### DIFF
--- a/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
+++ b/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
@@ -190,6 +190,93 @@ class ExceptionPlaceholderIntegrationTest extends AbstractIntegrationSpec implem
         ]
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/34280")
+    def "preserves build failure when an exception method signature cannot be resolved"() {
+        given:
+        buildFile << '''
+            import javax.tools.ToolProvider
+            import java.util.concurrent.Callable
+
+            tasks.register('reproduce') {
+                doLast {
+                    def sourceDir = layout.buildDirectory.dir('reproducer/source/repro').get().asFile
+                    def classesDir = layout.buildDirectory.dir('reproducer/classes').get().asFile
+                    sourceDir.mkdirs()
+                    classesDir.mkdirs()
+
+                    def missingTypeSource = new File(sourceDir, 'MissingSignatureType.java')
+                    missingTypeSource.text = """
+                        package repro;
+
+                        public final class MissingSignatureType {
+                        }
+                    """.stripIndent()
+
+                    def brokenExceptionSource = new File(sourceDir, 'BrokenException.java')
+                    brokenExceptionSource.text = """
+                        package repro;
+
+                        public final class BrokenException extends RuntimeException {
+                            public BrokenException(String message) {
+                                super(message);
+                            }
+
+                            public MissingSignatureType methodWithMissingReturnType() {
+                                return null;
+                            }
+                        }
+                    """.stripIndent()
+
+                    def exceptionFactorySource = new File(sourceDir, 'BrokenExceptionFactory.java')
+                    exceptionFactorySource.text = """
+                        package repro;
+
+                        import java.util.concurrent.Callable;
+
+                        public final class BrokenExceptionFactory implements Callable<Throwable> {
+                            @Override
+                            public Throwable call() {
+                                return new BrokenException("Intentional task failure");
+                            }
+                        }
+                    """.stripIndent()
+
+                    def compiler = ToolProvider.systemJavaCompiler
+                    def compilationExitCode = compiler.run(
+                        null,
+                        null,
+                        null,
+                        '-d',
+                        classesDir.absolutePath,
+                        missingTypeSource.absolutePath,
+                        brokenExceptionSource.absolutePath,
+                        exceptionFactorySource.absolutePath
+                    )
+                    if (compilationExitCode != 0) {
+                        throw new GradleException("Fixture compilation failed with exit code ${compilationExitCode}")
+                    }
+
+                    def missingTypeClass = new File(classesDir, 'repro/MissingSignatureType.class')
+                    if (!missingTypeClass.delete()) {
+                        throw new GradleException("Could not delete ${missingTypeClass}")
+                    }
+
+                    def loader = new URLClassLoader([classesDir.toURI().toURL()] as URL[], ClassLoader.platformClassLoader)
+                    Callable<Throwable> exceptionFactory = Callable.class.cast(
+                        Class.forName('repro.BrokenExceptionFactory', true, loader).getDeclaredConstructor().newInstance()
+                    )
+                    throw exceptionFactory.call()
+                }
+            }
+        '''
+
+        when:
+        fails 'reproduce'
+
+        then:
+        failureCauseContains('Intentional task failure')
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/9487")
     def 'break cycles with suppressed and cause exceptions'() {
         given:

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/ExceptionSerializationUtil.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/ExceptionSerializationUtil.java
@@ -95,14 +95,18 @@ public final class ExceptionSerializationUtil {
     }
 
     private static @Nullable Method findCandidateGetCausesMethod(Throwable throwable) {
-        Method[] declaredMethods = throwable.getClass().getDeclaredMethods();
-        for (Method method : declaredMethods) {
-            if (CANDIDATE_GET_CAUSES.contains(method.getName())) {
-                Class<?> returnType = method.getReturnType();
-                if (Collection.class.isAssignableFrom(returnType)) {
-                    return method;
+        try {
+            Method[] declaredMethods = throwable.getClass().getDeclaredMethods();
+            for (Method method : declaredMethods) {
+                if (CANDIDATE_GET_CAUSES.contains(method.getName())) {
+                    Class<?> returnType = method.getReturnType();
+                    if (Collection.class.isAssignableFrom(returnType)) {
+                        return method;
+                    }
                 }
             }
+        } catch (Throwable ignored) {
+            return null;
         }
         return null;
     }

--- a/platforms/core-runtime/serialization/src/test/groovy/org/gradle/internal/serialize/ExceptionSerializationUtilTest.groovy
+++ b/platforms/core-runtime/serialization/src/test/groovy/org/gradle/internal/serialize/ExceptionSerializationUtilTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import javax.tools.ToolProvider
+import java.util.concurrent.Callable
+
+class ExceptionSerializationUtilTest extends Specification {
+    @Rule
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
+
+    def "falls back to the standard cause when an exception method signature cannot be resolved"() {
+        given:
+        TestFile sourceDir = temporaryFolder.createDir('src/repro')
+        TestFile classesDir = temporaryFolder.createDir('classes')
+        TestFile missingTypeSource = sourceDir.file('MissingSignatureType.java')
+        missingTypeSource.text = '''
+            package repro;
+
+            public final class MissingSignatureType {
+            }
+        '''.stripIndent()
+        TestFile brokenExceptionSource = sourceDir.file('BrokenException.java')
+        brokenExceptionSource.text = '''
+            package repro;
+
+            public final class BrokenException extends RuntimeException {
+                public BrokenException(String message, Throwable cause) {
+                    super(message, cause);
+                }
+
+                public MissingSignatureType methodWithMissingReturnType() {
+                    return null;
+                }
+            }
+        '''.stripIndent()
+        TestFile exceptionFactorySource = sourceDir.file('BrokenExceptionFactory.java')
+        exceptionFactorySource.text = '''
+            package repro;
+
+            import java.util.concurrent.Callable;
+
+            public final class BrokenExceptionFactory implements Callable<Throwable> {
+                @Override
+                public Throwable call() {
+                    return new BrokenException("broken", new IllegalStateException("actual cause"));
+                }
+            }
+        '''.stripIndent()
+        assert ToolProvider.systemJavaCompiler.run(
+            null,
+            null,
+            null,
+            '-d',
+            classesDir.absolutePath,
+            missingTypeSource.absolutePath,
+            brokenExceptionSource.absolutePath,
+            exceptionFactorySource.absolutePath
+        ) == 0
+        assert classesDir.file('repro/MissingSignatureType.class').delete()
+        URLClassLoader classLoader = new URLClassLoader([classesDir.toURI().toURL()] as URL[], ClassLoader.platformClassLoader)
+        Callable<Throwable> exceptionFactory = Callable.class.cast(
+            Class.forName('repro.BrokenExceptionFactory', true, classLoader).getDeclaredConstructor().newInstance()
+        )
+        Throwable exception = exceptionFactory.call()
+
+        when:
+        List<? extends Throwable> causes = ExceptionSerializationUtil.extractCauses(exception)
+
+        then:
+        causes*.message == ['actual cause']
+
+        cleanup:
+        classLoader?.close()
+    }
+}


### PR DESCRIPTION
Related to #34280.

### Context

Exception serialization performs a best-effort reflective search for external multi-cause exception methods named `getCauses` or `getFailures`. `Class.getDeclaredMethods()` eagerly resolves every declared method signature. When any signature references a class that is unavailable from the exception classloader, method discovery throws `NoClassDefFoundError` before the candidate methods can be inspected.

That error escapes serialization of the original build failure. In a daemon-backed build this can produce two `BUILD FAILED` reports while the Gradle client exits with status 0, allowing CI to treat a failed build as successful.

This change treats failed reflective method discovery as a best-effort miss. Serialization then uses the existing standard-cause fallback and preserves the original build failure.

The failure was reproduced with Gradle 7.6.6, 8.14.5, and 9.7.0. Please consider backporting the fix to the current release branch, `release8x`, and `release7x`.

### Testing

- Added a unit test that loads an exception with an unresolvable method return type and verifies fallback to its standard cause.
- Added an integration test that verifies the original build failure is preserved from a user perspective.
- Ran `./gradlew -q :serialization:quickTest :messaging:quickTest`.
- Ran the new test with both `embeddedIntegTest` and `forkingIntegTest`.
- Ran `./gradlew -q sanityCheck`.
- Built a patched distribution and verified that the reproducer exits with status 1 while retaining the original failure.

### AI assistance

Codex was used substantially to investigate the failure, build the deterministic reproducer, and prepare the code and tests. The contribution was validated locally, and I remain responsible for the change and follow-up discussion.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits are signed off according to the Developer Certificate of Origin.
- [x] All contributed code can be distributed under the Apache License 2.0.
- [x] Allow edits from maintainers.
- [x] Provide integration tests under `<subproject>/src/integTest`.
- [x] Provide unit tests under `<subproject>/src/test`.
- [x] Public-facing documentation is not required for this internal bug fix.
- [x] `./gradlew sanityCheck` passes.
- [x] Changed subproject `quickTest` tasks pass.