### PR TITLE
Keep the escaping of a redirect location

### DIFF
--- a/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -33,12 +33,14 @@ import org.gradle.internal.resource.transport.http.DefaultSslContextFactory
 import org.gradle.internal.resource.transport.http.HttpClientFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.server.http.AuthScheme
+import org.gradle.test.fixtures.server.http.HttpResourceHandler
 import org.gradle.test.fixtures.server.http.HttpResourceInteraction
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.util.concurrent.CopyOnWriteArrayList
 
 class HttpBuildCacheServiceTest extends Specification {
     public static final List<Integer> FATAL_HTTP_ERROR_CODES = [
@@ -154,6 +156,27 @@ class HttpBuildCacheServiceTest extends Specification {
 
         then:
         receivedInput == "Data"
+    }
+
+    def "loading from cache keeps the escaping of a redirect location"() {
+        def srcFile = tempDir.file("cached.zip")
+        srcFile.text = "Data"
+        def requested = new CopyOnWriteArrayList<String>()
+        server.addHandler({ target, request, response ->
+            requested.add(request.rawPath)
+        } as HttpResourceHandler)
+        server.expectGetRedirected("/cache/${key.hashCode}", "/redirect%2Bed/cache/${key.hashCode}")
+        server.expectGet("/redirect+ed/cache/${key.hashCode}", srcFile)
+
+        when:
+        def receivedInput = null
+        cache.load(key) { input ->
+            receivedInput = input.text
+        }
+
+        then:
+        receivedInput == "Data"
+        requested.contains("/redirect%2Bed/cache/${key.hashCode}".toString())
     }
 
     def "reports cache miss on 404"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractRedirectResolveIntegrationTest.groovy
@@ -15,10 +15,17 @@
  */
 package org.gradle.integtests.resolve.http
 
+import org.gradle.test.fixtures.server.http.HttpResourceHandler
+import org.gradle.test.fixtures.server.http.HttpServer
+
+import java.util.concurrent.CopyOnWriteArrayList
 
 import static org.gradle.internal.resource.transport.http.JavaSystemPropertiesHttpTimeoutSettings.SOCKET_TIMEOUT_SYSTEM_PROPERTY
 
 abstract class AbstractRedirectResolveIntegrationTest extends AbstractRedirectResolveBaseIntegrationTest {
+
+    private static final String VERSION = '1.0-dev01+abc'
+    private static final String ESCAPED = '1.0-dev01%2Babc'
 
     def "resolves module artifacts via HTTP redirect"() {
         given:
@@ -66,5 +73,79 @@ abstract class AbstractRedirectResolveIntegrationTest extends AbstractRedirectRe
         failureCauseContains("Could not get resource '${server.uri}/repo/group/projectA/1.0/ivy-1.0.xml'")
         failureCauseContains("Could not GET '${backingServer.uri}/redirected/group/projectA/1.0/ivy-1.0.xml'")
         failureCauseContains("Read timed out")
+    }
+
+    def "keeps the escaping of an absolute redirect location while resolving"() {
+        given:
+        def published = publishVersionWithAPlus()
+        def requested = recordRawPathsOf(backingServer)
+
+        when:
+        server.expectGetRedirected(
+            "/repo/group/projectA/${VERSION}/ivy-${VERSION}.xml",
+            "${backingServer.uri}/redirected/group/projectA/${ESCAPED}/ivy-${ESCAPED}.xml"
+        )
+        backingServer.expectGet(
+            "/redirected/group/projectA/${VERSION}/ivy-${VERSION}.xml", published.ivyFile
+        )
+        server.expectGetRedirected(
+            "/repo/group/projectA/${VERSION}/projectA-${VERSION}.jar",
+            "${backingServer.uri}/redirected/group/projectA/${ESCAPED}/projectA-${ESCAPED}.jar"
+        )
+        backingServer.expectGet(
+            "/redirected/group/projectA/${VERSION}/projectA-${VERSION}.jar", published.jarFile
+        )
+
+        then:
+        succeeds('listJars')
+        requested == [
+            "/redirected/group/projectA/${ESCAPED}/ivy-${ESCAPED}.xml".toString(),
+            "/redirected/group/projectA/${ESCAPED}/projectA-${ESCAPED}.jar".toString()
+        ]
+    }
+
+    def "keeps the escaping of a relative redirect location while resolving"() {
+        given:
+        def published = publishVersionWithAPlus()
+        def requested = recordRawPathsOf(server)
+
+        when:
+        server.expectGetRedirected(
+            "/repo/group/projectA/${VERSION}/ivy-${VERSION}.xml",
+            "/relocated/group/projectA/${ESCAPED}/ivy-${ESCAPED}.xml"
+        )
+        server.expectGet(
+            "/relocated/group/projectA/${VERSION}/ivy-${VERSION}.xml", published.ivyFile
+        )
+        server.expectGetRedirected(
+            "/repo/group/projectA/${VERSION}/projectA-${VERSION}.jar",
+            "/relocated/group/projectA/${ESCAPED}/projectA-${ESCAPED}.jar"
+        )
+        server.expectGet(
+            "/relocated/group/projectA/${VERSION}/projectA-${VERSION}.jar", published.jarFile
+        )
+
+        then:
+        succeeds('listJars')
+        // This server also saw the request it redirected, which carries a literal '+'.
+        requested.containsAll([
+            "/relocated/group/projectA/${ESCAPED}/ivy-${ESCAPED}.xml".toString(),
+            "/relocated/group/projectA/${ESCAPED}/projectA-${ESCAPED}.jar".toString()
+        ])
+    }
+
+    private publishVersionWithAPlus() {
+        buildFile << configurationWithIvyDependencyAndExpectedArtifact(
+            "group:projectA:$VERSION", "projectA-${VERSION}.jar"
+        )
+        ivyRepo().module('group', 'projectA', VERSION).publish()
+    }
+
+    private List<String> recordRawPathsOf(HttpServer target) {
+        def paths = new CopyOnWriteArrayList<String>()
+        target.addHandler({ t, request, response ->
+            paths.add(request.rawPath)
+        } as HttpResourceHandler)
+        paths
     }
 }

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/AllowFollowForMutatingMethodRedirectStrategy.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/AllowFollowForMutatingMethodRedirectStrategy.java
@@ -16,9 +16,8 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import org.apache.http.impl.client.DefaultRedirectStrategy;
-
-public class AllowFollowForMutatingMethodRedirectStrategy extends DefaultRedirectStrategy {
+public class AllowFollowForMutatingMethodRedirectStrategy
+    extends EncodingPreservingRedirectStrategy {
 
     public AllowFollowForMutatingMethodRedirectStrategy() {
     }

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/AlwaysFollowAndPreserveMethodRedirectStrategy.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/AlwaysFollowAndPreserveMethodRedirectStrategy.java
@@ -21,7 +21,6 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolException;
 import org.apache.http.client.methods.*;
-import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.protocol.HttpContext;
 
 import java.net.URI;
@@ -31,7 +30,8 @@ import java.net.URI;
  * This has been introduced to overcome a regression caused by switching to apache httpclient as the transport mechanism for publishing (https://issues.gradle.org/browse/GRADLE-3312)
  * The rational for httpclient not following redirects, by default, can be found here: https://issues.apache.org/jira/browse/HTTPCLIENT-860
  */
-public class AlwaysFollowAndPreserveMethodRedirectStrategy extends DefaultRedirectStrategy {
+public class AlwaysFollowAndPreserveMethodRedirectStrategy
+    extends EncodingPreservingRedirectStrategy {
 
     public AlwaysFollowAndPreserveMethodRedirectStrategy() {
     }

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/EncodingPreservingRedirectStrategy.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/EncodingPreservingRedirectStrategy.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.CircularRedirectException;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URIUtils;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.RedirectLocations;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.Asserts;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Follows a redirect to the location the server gave, without re-encoding it.
+ *
+ * <p>httpclient 4.5.14 runs the {@code Location} header through
+ * {@link URIUtils#normalizeSyntax(URI)}, which decodes the path into segments and encodes them
+ * again, escaping only what RFC 3986 requires. A server that answered {@code %2B} is then asked
+ * for {@code +}.
+ *
+ * <p>Skipping that call also skips what else it did: an absolute location keeps its dot segments
+ * and the case of its scheme and host. A relative one goes through {@link URI#resolve(URI)},
+ * which removes dot segments under RFC 3986.
+ */
+@NullMarked
+class EncodingPreservingRedirectStrategy extends DefaultRedirectStrategy {
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(EncodingPreservingRedirectStrategy.class);
+
+    @Override
+    public URI getLocationURI(
+        HttpRequest request,
+        HttpResponse response,
+        HttpContext context
+    ) throws ProtocolException {
+        HttpClientContext clientContext = HttpClientContext.adapt(context);
+        Header location = response.getFirstHeader(HttpHeaders.LOCATION);
+        if (location == null) {
+            throw new ProtocolException(
+                "Received redirect response " + response.getStatusLine() + " but no location header"
+            );
+        }
+        LOGGER.debug("Redirect requested to location '{}'", location.getValue());
+
+        RequestConfig requestConfig = clientContext.getRequestConfig();
+        URI targetUri = createLocationURI(location.getValue());
+        if (!targetUri.isAbsolute()) {
+            targetUri = resolveAgainstRequest(targetUri, request, clientContext, requestConfig);
+        }
+
+        recordVisit(targetUri, clientContext, requestConfig);
+        return targetUri;
+    }
+
+    private URI resolveAgainstRequest(
+        URI location, HttpRequest request,
+        HttpClientContext clientContext,
+        RequestConfig requestConfig
+    ) throws ProtocolException {
+        if (!requestConfig.isRelativeRedirectsAllowed()) {
+            throw new ProtocolException(
+                "Relative redirect location '" + location + "' not allowed"
+            );
+        }
+        HttpHost host = clientContext.getTargetHost();
+        Asserts.notNull(host, "Target host");
+        try {
+            URI requestedUri = new URI(request.getRequestLine().getUri());
+            // URIUtils.resolve is where a relative location loses its escaping.
+            URI base = URIUtils.rewriteURI(requestedUri, host, URIUtils.NO_FLAGS);
+            return resolveReference(base, location);
+        } catch (URISyntaxException e) {
+            throw new ProtocolException(e.getMessage(), e);
+        }
+    }
+
+    private static URI resolveReference(URI base, URI reference) {
+        String ref = reference.toASCIIString();
+        if (!ref.isEmpty() && !ref.startsWith("?")) {
+            return base.resolve(reference);
+        }
+        String target = truncateAt(base.toASCIIString(), '#');
+        return URI.create(ref.isEmpty() ? target : truncateAt(target, '?') + ref);
+    }
+
+    private static String truncateAt(String uri, char marker) {
+        int index = uri.indexOf(marker);
+        return index < 0 ? uri : uri.substring(0, index);
+    }
+
+    private void recordVisit(
+        URI target,
+        HttpClientContext clientContext,
+        RequestConfig config
+    ) throws ProtocolException {
+        RedirectLocations visited =
+            (RedirectLocations) clientContext.getAttribute(HttpClientContext.REDIRECT_LOCATIONS);
+        if (visited == null) {
+            visited = new RedirectLocations();
+            clientContext.setAttribute(HttpClientContext.REDIRECT_LOCATIONS, visited);
+        }
+        if (!config.isCircularRedirectsAllowed() && visited.contains(target)) {
+            throw new CircularRedirectException("Circular redirect to '" + target + "'");
+        }
+        visited.add(target);
+    }
+}

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/AllowFollowForMutatingMethodRedirectStrategyTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/AllowFollowForMutatingMethodRedirectStrategyTest.groovy
@@ -16,7 +16,10 @@
 
 package org.gradle.internal.resource.transport.http
 
+import org.apache.http.HttpHeaders
 import org.apache.http.HttpRequest
+import org.apache.http.HttpStatus
+import org.apache.http.HttpVersion
 import org.apache.http.ProtocolVersion
 import org.apache.http.RequestLine
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -50,7 +53,8 @@ class AllowFollowForMutatingMethodRedirectStrategyTest extends Specification {
         HttpRequest request = Mock()
         CloseableHttpResponse response = Mock()
         HttpContext context = Mock()
-        response.getFirstHeader("location") >> new BasicHeader('location', 'http://redirectTo')
+        response.getFirstHeader(HttpHeaders.LOCATION) >>
+            new BasicHeader(HttpHeaders.LOCATION, 'http://redirectTo')
         response.getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), redirect, "ignored")
         request.getRequestLine() >> Mock(RequestLine) {
             getMethod() >> httpMethod
@@ -66,6 +70,29 @@ class AllowFollowForMutatingMethodRedirectStrategyTest extends Specification {
 
         where:
         [httpMethod, redirect] << [HTTP_METHODS, REDIRECTS].combinations()
+    }
+
+    def "should keep the escaping of the location"() {
+        setup:
+        def location = 'http://redirectTo/module/1.0%2Bdev/module.pom'
+        HttpRequest request = Mock()
+        CloseableHttpResponse response = Mock()
+        HttpContext context = Mock()
+        response.getFirstHeader(HttpHeaders.LOCATION) >>
+            new BasicHeader(HttpHeaders.LOCATION, location)
+        response.getStatusLine() >> new BasicStatusLine(
+            HttpVersion.HTTP_1_1, HttpStatus.SC_MOVED_TEMPORARILY, "ignored"
+        )
+        request.getRequestLine() >> Mock(RequestLine) {
+            getMethod() >> "GET"
+            getUri() >> "http://original.com"
+        }
+
+        when:
+        def redirectRequest = strategy.getRedirect(request, response, context)
+
+        then:
+        redirectRequest.URI.toASCIIString() == location
     }
 
 }

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/AlwaysFollowAndPreserveMethodRedirectStrategyTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/AlwaysFollowAndPreserveMethodRedirectStrategyTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.resource.transport.http
 
+import org.apache.http.HttpHeaders
 import org.apache.http.HttpRequest
 import org.apache.http.RequestLine
 import org.apache.http.client.methods.CloseableHttpResponse
@@ -30,7 +31,7 @@ class AlwaysFollowAndPreserveMethodRedirectStrategyTest extends Specification {
 
     def "should consider all requests redirectable"() {
         expect:
-        new AllowFollowForMutatingMethodRedirectStrategy().isRedirectable(method)
+        new AlwaysFollowAndPreserveMethodRedirectStrategy().isRedirectable(method)
 
         where:
         method << HTTP_METHODS
@@ -41,7 +42,8 @@ class AlwaysFollowAndPreserveMethodRedirectStrategyTest extends Specification {
         HttpRequest request = Mock()
         CloseableHttpResponse response = Mock()
         HttpContext context = Mock()
-        response.getFirstHeader("location") >> new BasicHeader('location', 'http://redirectTo')
+        response.getFirstHeader(HttpHeaders.LOCATION) >>
+            new BasicHeader(HttpHeaders.LOCATION, 'http://redirectTo')
         request.getRequestLine() >> Mock(RequestLine) {
             getMethod() >> httpMethod
         }
@@ -55,5 +57,29 @@ class AlwaysFollowAndPreserveMethodRedirectStrategyTest extends Specification {
 
         where:
         httpMethod << HTTP_METHODS + HTTP_METHODS.collect { it.toLowerCase() }
+    }
+
+    def "should keep the escaping of the location for http method [#httpMethod]"() {
+        setup:
+        def location = 'http://redirectTo/module/1.0%2Bdev/module.pom'
+        HttpRequest request = Mock()
+        CloseableHttpResponse response = Mock()
+        HttpContext context = Mock()
+        response.getFirstHeader(HttpHeaders.LOCATION) >>
+            new BasicHeader(HttpHeaders.LOCATION, location)
+        request.getRequestLine() >> Mock(RequestLine) {
+            getMethod() >> httpMethod
+        }
+        request.getParams() >> Mock(HttpParams)
+
+        when:
+        def redirect = new AlwaysFollowAndPreserveMethodRedirectStrategy()
+            .getRedirect(request, response, context)
+
+        then:
+        redirect.URI.toASCIIString() == location
+
+        where:
+        httpMethod << HTTP_METHODS
     }
 }

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/EncodingPreservingRedirectStrategyTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/EncodingPreservingRedirectStrategyTest.groovy
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Gradle and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.apache.http.HttpHeaders
+import org.apache.http.HttpHost
+import org.apache.http.HttpRequest
+import org.apache.http.HttpResponse
+import org.apache.http.HttpStatus
+import org.apache.http.HttpVersion
+import org.apache.http.ProtocolException
+import org.apache.http.RequestLine
+import org.apache.http.client.CircularRedirectException
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.protocol.HttpClientContext
+import org.apache.http.message.BasicHeader
+import org.apache.http.message.BasicStatusLine
+import spock.lang.Specification
+
+class EncodingPreservingRedirectStrategyTest extends Specification {
+
+    private static final String HOST = "https://repo.example.com"
+    private static final String REQUEST_URI = "/m2/g/m/1.0/m-1.0.jar"
+
+    def strategy = new EncodingPreservingRedirectStrategy()
+    def context = HttpClientContext.create()
+
+    def setup() {
+        context.targetHost = new HttpHost("repo.example.com", -1, "https")
+    }
+
+    def "keeps the escaping the server sent for #escaped"() {
+        given:
+        def location = "$HOST/module/1.0-dev01${escaped}abc/module.pom"
+
+        expect:
+        follow(location) == location
+
+        where:
+        escaped << ['%2B', '%3A', '%40', '%2C', '%3B', '%3D', '%21', '%24', '%26',
+                    '%2F', '%20', '%25', '%3F', '%23']
+    }
+
+    def "keeps the escaping whether or not the client asks for normalisation"() {
+        given:
+        def location = "$HOST/module/1.0%2Bdev/module.pom"
+
+        expect:
+        follow(location, RequestConfig.custom().setNormalizeUri(normalize).build()) == location
+
+        where:
+        normalize << [true, false]
+    }
+
+    def "keeps the escaping of a query"() {
+        given:
+        def location = "$HOST/module.jar?sig=ab%2Bcd%3D"
+
+        expect:
+        follow(location) == location
+    }
+
+    def "resolves a relative location against the request"() {
+        expect:
+        follow(location) == "$HOST/$expected"
+
+        where:
+        location               | expected
+        '/other/1.0%2Bdev/pom' | 'other/1.0%2Bdev/pom'
+        'sub/1.0%2Bdev/pom'    | 'm2/g/m/1.0/sub/1.0%2Bdev/pom'
+    }
+
+    def "resolves a relative location against an escaped request path"() {
+        expect:
+        follow('sub/2.0%2Bdev/pom', RequestConfig.DEFAULT, '/a/1.0%2Bdev/m.pom') ==
+            "$HOST/a/1.0%2Bdev/sub/2.0%2Bdev/pom"
+    }
+
+    def "resolves a location that carries only a query against the request path"() {
+        expect:
+        follow('?token=a%2Bb') == "$HOST$REQUEST_URI?token=a%2Bb"
+    }
+
+    def "resolves an empty location to the request itself"() {
+        expect:
+        follow('') == "$HOST$REQUEST_URI"
+    }
+
+    def "passes an absolute location through as it arrived"() {
+        expect:
+        follow(location) == location
+
+        where:
+        location << [
+            "$HOST/module/1.0/../2.0/module.pom",
+            "$HOST//module//1.0/module.pom",
+            "HTTPS://REPO.EXAMPLE.COM/module/1.0/module.pom"
+        ]
+    }
+
+    def "removes the dot segments of a relative location while resolving it"() {
+        expect:
+        follow('../2.0%2Bdev/module.pom') == "$HOST/m2/g/m/2.0%2Bdev/module.pom"
+    }
+
+    def "fails when the redirect response carries no location"() {
+        when:
+        strategy.getLocationURI(request(REQUEST_URI), responseWithoutLocation(), context)
+
+        then:
+        thrown(ProtocolException)
+    }
+
+    def "fails on a relative location when the client forbids one"() {
+        given:
+        def config = RequestConfig.custom()
+            .setRelativeRedirectsAllowed(false)
+            .build()
+
+        when:
+        follow('/other/module.pom', config)
+
+        then:
+        thrown(ProtocolException)
+    }
+
+    def "fails when the same location is visited twice"() {
+        given:
+        def location = "$HOST/module/1.0/module.pom"
+
+        when:
+        follow(location)
+        follow(location)
+
+        then:
+        thrown(CircularRedirectException)
+    }
+
+    def "visits the same location twice when the client allows it"() {
+        given:
+        def location = "$HOST/module/1.0/module.pom"
+        def config = RequestConfig.custom()
+            .setCircularRedirectsAllowed(true)
+            .build()
+
+        expect:
+        follow(location, config) == location
+        follow(location, config) == location
+    }
+
+    private String follow(
+        String location,
+        RequestConfig config = RequestConfig.DEFAULT,
+        String requestUri = REQUEST_URI
+    ) {
+        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config)
+        strategy.getLocationURI(request(requestUri), redirectTo(location), context).toASCIIString()
+    }
+
+    private HttpRequest request(String requestUri) {
+        Stub(HttpRequest) {
+            getRequestLine() >> Stub(RequestLine) { getUri() >> requestUri }
+        }
+    }
+
+    private HttpResponse redirectTo(String location) {
+        Stub(HttpResponse) {
+            getFirstHeader(HttpHeaders.LOCATION) >> new BasicHeader(HttpHeaders.LOCATION, location)
+        }
+    }
+
+    private HttpResponse responseWithoutLocation() {
+        Stub(HttpResponse) {
+            getFirstHeader(HttpHeaders.LOCATION) >> null
+            getStatusLine() >> new BasicStatusLine(
+                HttpVersion.HTTP_1_1, HttpStatus.SC_MOVED_TEMPORARILY, 'Found'
+            )
+        }
+    }
+}

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpRequest.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpRequest.groovy
@@ -38,6 +38,10 @@ class HttpRequest {
         return exchange.requestURI.path
     }
 
+    String getRawPath() {
+        return exchange.requestURI.rawPath
+    }
+
     String getRequestURI() {
         return exchange.requestURI.path
     }


### PR DESCRIPTION
Fixes #12873

### Context

Resolving a module whose version contains `+` fails with `Could not find`, while `curl` fetches the exact URL from the error message and gets 200. The issue has been open since 2020, and both its title and the diagnosis in the comments point away from the cause: the search has been for how Gradle encodes its own outgoing URLs. That part is fine. What breaks is the handling of the answer.

#### Reproducer

```groovy
repositories { maven { url = 'https://plugins.gradle.org/m2' } }
configurations { probe }
dependencies { probe 'org.danilopianini:gradle-latex:0.2.0-dev04+c9758cc' }
```

#### Before

```
* What went wrong:
Execution failed for task ':probe'.
> Could not resolve all files for configuration ':probe'.
   > Could not find org.danilopianini:gradle-latex:0.2.0-dev04+c9758cc.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/org/danilopianini/gradle-latex/0.2.0-dev04+c9758cc/gradle-latex-0.2.0-dev04+c9758cc.pom
```

`curl -sL` on that same URL returns 200. Running with `--debug` shows why:

```
[DEBUG] [DefaultRedirectStrategy] Redirect requested to location '...0.2.0-dev04%2Bc9758cc/...'
[DEBUG] [RedirectExec]            Redirecting to             '...0.2.0-dev04+c9758cc/...'
[INFO]  [HttpClientHelper]        Resource missing. [HTTP GET: ...0.2.0-dev04+c9758cc/...]
```

The server answers `303` with a correctly escaped `Location`, and the client asks for something else.

#### After

```
[DEBUG] [EncodingPreservingRedirectStrategy] Redirect requested to location '...%2Bc9758cc/...'
[DEBUG] [RedirectExec]                       Redirecting to             '...%2Bc9758cc/...'

RESOLVED: [gradle-latex-0.2.0-dev04+c9758cc.jar, kotlin-stdlib-jdk8-1.3.71.jar, ...]
```

Both runs went against the live plugin portal, the first on Gradle 9.3.1 and the second on a distribution built from this branch.

#### Cause

`DefaultRedirectStrategy.getLocationURI` in httpclient 4.5.14 runs the `Location` header through `URIUtils.normalizeSyntax`. That method removes dot segments and lowercases the scheme and host, and to work with segments it parses the path through `URIBuilder.getPathSegments()`, which decodes them. Rebuilding escapes only what RFC 3986 requires, and the decoding cannot be undone: `a%2Bb` and `a+b` both decode to `a+b`, so the shorter form wins.

I measured fourteen escaped characters against 4.5.14. Nine come back unescaped:

```
%2B → +    %3A → :    %40 → @    %2C → ,    %3B → ;
%3D → =    %21 → !    %24 → $    %26 → &

%2F, %20, %25, %3F, %23 unaffected
```

A 404 is the mild outcome. `%3B`, `%3D` and `%26` arrive literal, and a server is then free to read them as separators.

A relative `Location` is hit too, by a different route. `URIUtils.resolve` calls `normalizeSyntax` at the end unconditionally, so `RequestConfig.setNormalizeUri(false)` would fix the absolute case and leave that one broken.

httpclient 5 does not have this problem: its `URIBuilder` keeps the raw path, and `normalizeSyntax` no longer touches segments. #37296 attempted that upgrade and was closed after CI failures, so this fixes 4.5.14, where Gradle is today.

#### Implementation

`AlwaysFollowAndPreserveMethodRedirectStrategy` and `AllowFollowForMutatingMethodRedirectStrategy` now extend a common base that overrides `getLocationURI`. An absolute location is used as it arrived. A relative one goes through `java.net.URI.resolve`, which merges under RFC 3986 and leaves the raw path alone. The relative-redirects check, the target-host assertion, and the `RedirectLocations` bookkeeping that circular-redirect detection depends on all came across with it.

`URIUtils.resolve` covers two cases that `java.net.URI.resolve` gets wrong, since the latter follows RFC 2396 and drops the last path segment when the reference brings no path of its own. Both are reproduced: an empty `Location` resolves to the request itself, and a `Location` that is only a query keeps the request path.

#### Notes for review

Four things that are easier to argue about now than later.

**Absolute locations are no longer normalised.** Dropping `normalizeSyntax` drops its other effects with it, and bringing those back over a raw path would mean hand-rolling `remove_dot_segments`. Dot segments in an absolute `Location` now go to the server as they came, and the scheme and host keep their case. `GUtil.isSecureUrl` compares case-insensitively and `URI.equals` does the same for scheme and host, so neither the insecure-redirect check nor circular-redirect detection changes. The class javadoc says all of this.

**The debug line is back on purpose.** The inherited implementation logs the raw `Location` before touching it, and the field it logs through is private. That single line is how this bug can be diagnosed at all, so the override logs it again under its own category.

**The test fixture needed one accessor.** `HttpServer` matches requests on the decoded path, so it cannot tell `a%2Bb` from `a+b`, and an integration test written against it would pass with or without the fix. `HttpRequest.getRawPath()` exposes `exchange.requestURI.rawPath`, next to `getQueryString()`, which already returns the raw query.

**Every new test was checked by reverting the fix under it.** Restoring `normalizeSyntax` fails the character matrix, restoring `URIUtils.resolve` fails the relative cases, and reverting `extends` on either strategy fails that strategy's own case. One test, on keeping an escaped query, survives every mutation I could write: nothing on this path touches the query today, and it is there to catch a later change that does.

One limitation on the live check. The end-to-end run covers `+`, because that is the only character I could find a published artifact for. The other eight are covered by unit tests, and the fix is not per-character in any case, since nothing decodes the path any more.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :resources-http:quickTest`.