### PR TITLE
Update Documentation: Fix service injection page

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -179,12 +179,12 @@ These bounds are enforced at compile time in the Kotlin DSL and Java plugin code
 | <<providerfactory,`ProviderFactory`>>           | ✓ | ✓   | ✓ | ✓
 | <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓   | ✓ | ✓
 | <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓   | ✓ | ✓
-| <<execoperations,`ExecOperations`>>             |   | ✓ * |   |
+| <<execoperations,`ExecOperations`>>             |   | ✓ † |   |
 | <<sec:projectlayout,`ProjectLayout`>>           | ✓ | ✓   |   |
 | <<buildlayout,`BuildLayout`>>                   |   |     | ✓ |
 |===
 
-*`ExecOperations` is the only lookup restricted to task actions (via `Task.service`, not from a project, settings, or init script).
+† `ExecOperations` is the only lookup restricted to task actions (via `Task.service`, not from a project, settings, or init script).
 
 Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.
 
@@ -192,7 +192,7 @@ Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperation
 
 In the Kotlin DSL and Java plugin code, requesting a service outside its scope, or a type that is not a Gradle service at all, is a compile error.
 
-In the Groovy DSL, and whenever the type is supplied reflectively as a `Class`, that bound is not enforced statically.
+In the Groovy DSL — and whenever the type is supplied reflectively as a `Class` — that bound is not enforced statically.
 The request instead fails at runtime with an `InvalidUserDataException`.
 The message adapts to the failure:
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle-types/service_injection.adoc
@@ -142,47 +142,66 @@ The following services are available for injection in settings plugins, extensio
 |===
 
 [[looking_up_services]]
-== Looking up services in scripts incubating-label:[]
+== Looking up services in scripts and task actions incubating-label:[]
 
 Instead of declaring an `@Inject` point, build, settings, and init scripts, as well as task actions, can look up a curated set of Gradle services directly with `service(Class)` in the Groovy DSL or `service<Type>()` in the Kotlin DSL.
-This avoids the ad-hoc `objects.newInstance(...)` ceremony shown in the per-service sections below, while remaining compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>.
+This avoids the ad-hoc `objects.newInstance(...)` pattern shown in the per-service sections below, while remaining compatible with the <<configuration_cache.adoc#config_cache,Configuration Cache>> and <<isolated_projects.adoc#isolated_projects,Isolated Projects>>.
 
-The most common use is from a task action:
+`service<T>()` can be called in two places, and the choice matters for when the lookup runs.
+
+*Inside a task action*. The lookup runs each time the task executes.
+This is the most common form:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=service-lookup]"]
 include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=service-lookup]"]
 ====
 
-A looked-up service can also be captured at configuration time and used later from a task action; the captured instance is safe to store in the Configuration Cache:
+*At configuration time, captured for later use*. The lookup runs once, when the build is configured, and the captured reference is safe to store in the Configuration Cache:
 
 ====
 include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=service-lookup-capture]"]
 include::sample[dir="snippets/reference/gradle-types/services/groovy",files="build.gradle[tags=service-lookup-capture]"]
 ====
 
+NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, and the captured instance is preserved when that task runs from the Configuration Cache.
+
 === Services available for lookup
 
-The set of services you can look up depends on where the lookup happens:
+The set of services you can look up depends on where the lookup happens.
+These bounds are enforced at compile time in the Kotlin DSL and Java plugin code, and at runtime in the Groovy DSL:
 
 [%header,cols="2,1,1,1,1"]
 |===
 | Service | Project scripts & project plugins | Tasks | Settings scripts & settings plugins | Init scripts & init plugins
 
-| <<objectfactory,`ObjectFactory`>>               | ✓ | ✓ | ✓ | ✓
-| <<providerfactory,`ProviderFactory`>>           | ✓ | ✓ | ✓ | ✓
-| <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓ | ✓ | ✓
-| <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓ | ✓ | ✓
-| <<execoperations,`ExecOperations`>>             |   | ✓ |   |
-| <<sec:projectlayout,`ProjectLayout`>>           | ✓ | ✓ |   |
-| <<buildlayout,`BuildLayout`>>                   |   |   | ✓ |
+| <<objectfactory,`ObjectFactory`>>               | ✓ | ✓   | ✓ | ✓
+| <<providerfactory,`ProviderFactory`>>           | ✓ | ✓   | ✓ | ✓
+| <<filesystemoperations,`FileSystemOperations`>> | ✓ | ✓   | ✓ | ✓
+| <<archiveoperations,`ArchiveOperations`>>       | ✓ | ✓   | ✓ | ✓
+| <<execoperations,`ExecOperations`>>             |   | ✓ * |   |
+| <<sec:projectlayout,`ProjectLayout`>>           | ✓ | ✓   |   |
+| <<buildlayout,`BuildLayout`>>                   |   |     | ✓ |
 |===
 
-In the Kotlin and Java DSLs each `service(...)` is bounded to the scopes above, so requesting a service that is not available in the current scope — or a type that is not a Gradle service at all — is a compile error.
-In the Groovy DSL, where the bound is not enforced (or when the type is supplied reflectively as a `Class`), the same request instead fails at runtime with an `InvalidUserDataException`: for a service requested outside its scope the message names the scopes where it _is_ available, and for a type that is not a Gradle service at all it lists the services available in the current scope; for a <<build_services.adoc#build_services,shared build service>> it points you to `@ServiceReference` and `gradle.sharedServices` instead.
-This check covers only _where_ a service can be looked up; it does not distinguish configuration-time from execution-time use, nor does it police cross-project access (see below).
+*`ExecOperations` is the only lookup restricted to task actions (via `Task.service`, not from a project, settings, or init script).
 
 Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperations` are resolved the same way as for the enclosing scope: against the project directory for a project script or task action, and against the build's root directory for a settings or init script.
+
+=== Error messages
+
+In the Kotlin DSL and Java plugin code, requesting a service outside its scope, or a type that is not a Gradle service at all, is a compile error.
+
+In the Groovy DSL, and whenever the type is supplied reflectively as a `Class`, that bound is not enforced statically.
+The request instead fails at runtime with an `InvalidUserDataException`.
+The message adapts to the failure:
+
+* For a service requested outside its scope, it names the scopes where the service _is_ available.
+* For a type that is not a Gradle service at all, it lists the services available in the current scope.
+* For a <<build_services.adoc#build_services,shared build service>>, it points you to `@ServiceReference` and `gradle.sharedServices` instead.
+
+This check covers only _where_ a service can be looked up.
+It does not distinguish configuration-time from execution-time use, nor does it police cross-project access (see below).
 
 === Cross-project access and Isolated Projects
 
@@ -190,14 +209,27 @@ Relative paths passed to a looked-up `FileSystemOperations` or `ArchiveOperation
 Calling it on another project — for example `project(":other").service(ObjectFactory)` — reaches across the project boundary and is reported as a problem under <<isolated_projects.adoc#isolated_projects,Isolated Projects>>, exactly like `project(":other").getObjects()`.
 Look services up from the owning project instead.
 
-NOTE: A service that is only available in the settings scope (such as `BuildLayout`) can be captured in a settings script and referenced from a task action, and the captured instance is preserved when that task runs from the Configuration Cache.
-
 === When to use a lookup
 
-Prefer a looked-up `FileSystemOperations`, `ArchiveOperations`, or `ExecOperations` over hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)`.
-The Gradle services give you path resolution, copy and sync specs, and robust deletion, and they keep your code compatible with the Configuration Cache.
+Three patterns get you a Gradle service.
+Pick by where you are:
 
-`ExecOperations` can be looked up only through a task (via `Task.service`), not from a project, settings, or init script.
+[%header,cols="1,2"]
+|===
+| Pattern | Use when
+
+| `service<T>()`
+| Writing a script or task action; the service is in the lookup table above.
+
+| `@Inject`
+| You own a task, plugin, or extension type; you want the type unit-testable.
+
+| `objects.newInstance(...)`
+| You need a service not in the lookup table (for example, `DependencyFactory` or `SoftwareComponentFactory`).
+|===
+
+Any of these is preferable to hand-rolled `java.io`/`java.nio` code or `Runtime.exec(...)`.
+The Gradle services give you path resolution, copy and sync specs, and robust deletion, and they keep your code compatible with the Configuration Cache.
 
 [[objectfactory]]
 == `ObjectFactory`
@@ -352,7 +384,7 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `FileSystemOperations` service is injected into the `MyFileSystemOperationsTask` task's constructor using the `@Inject` annotation.
 
-To use `FileSystemOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
+To use `FileSystemOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts and task actions>>.
 
 It can also be obtained through an injection point created with `ObjectFactory.newInstance`.
 This is more verbose, but works for any injectable service, including those not available through `service()`:
@@ -382,7 +414,7 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `ArchiveOperations` service is injected into the `MyArchiveOperationsTask` task's constructor using the `@Inject` annotation.
 
-To use `ArchiveOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts>>.
+To use `ArchiveOperations` in an ad-hoc task without writing a dedicated class, look it up with `service()` — see <<looking_up_services,Looking up services in scripts and task actions>>.
 
 ====
 include::sample[dir="snippets/reference/gradle-types/services/kotlin",files="build.gradle.kts[tags=archive-op-lookup]"]
@@ -404,7 +436,7 @@ include::sample[dir="snippets/reference/gradle-types/services/groovy",files="bui
 
 The `ExecOperations` is injected into the `MyExecOperationsTask` task's constructor using the `@Inject` annotation.
 
-To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts>>.
+To run an external process from an ad-hoc task, look `ExecOperations` up with `service()` from the task action — see <<looking_up_services,Looking up services in scripts and task actions>>.
 To run one at configuration time instead, use `providers.exec` or a `ValueSource`, which are compatible with the Configuration Cache.
 
 ====

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -67,7 +67,7 @@ Groovy has been updated to link:https://groovy-lang.org/changelogs/changelog-4.0
 ==== New `service(Class)` method on `Project`, `Settings`, `Gradle`, and `Task`
 
 Gradle 9.8.0 adds an incubating `service(Class)` method to link:{javadocPath}/org/gradle/api/Project.html[`Project`], link:{javadocPath}/org/gradle/api/initialization/Settings.html[`Settings`], link:{javadocPath}/org/gradle/api/invocation/Gradle.html[`Gradle`], and link:{javadocPath}/org/gradle/api/Task.html[`Task`], along with reified `service<T>()` extensions in the Kotlin DSL.
-See <<service_injection.adoc#looking_up_services,Looking up services in scripts>> for details.
+See <<service_injection.adoc#looking_up_services,Looking up services in scripts and task actions>> for details.
 
 If your build, plugin, or convention already exposes a member called `service` on one of these types (for example, a user-defined extension, a Groovy dynamic property, or a Kotlin extension function), the new built-in member may shadow it or make calls ambiguous.
 Rename your member (for example, to `myService`) to disambiguate:


### PR DESCRIPTION
### Details
This is a Documentation infrastructure change ONLY.

### Context
Clean up services page

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description     