### PR TITLE
Allow S3 uploads larger than 128 KB to be retried

### DIFF
--- a/platforms/software/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/platforms/software/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -138,6 +138,7 @@ public class S3Client {
 
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, s3BucketKey, inputStream, objectMetadata)
                 .withCannedAcl(CannedAccessControlList.BucketOwnerFullControl);
+            putObjectRequest.getRequestClientOptions().setReadLimit(readLimitFor(contentLength));
             LOGGER.debug("Attempting to put resource:[{}] into s3 bucket [{}]", s3BucketKey, bucketName);
 
             amazonS3Client.putObject(putObjectRequest);
@@ -171,6 +172,7 @@ public class S3Client {
                         .withPartNumber(partNumber)
                         .withPartSize(partSize)
                         .withInputStream(inputStream);
+                    uploadPartRequest.getRequestClientOptions().setReadLimit(readLimitFor(partSize));
                     partETags.add(amazonS3Client.uploadPart(uploadPartRequest).getPartETag());
                     filePosition += partSize;
                 }
@@ -186,6 +188,16 @@ public class S3Client {
         } catch (AmazonClientException e) {
             throw ResourceExceptions.putFailed(destination, e);
         }
+    }
+
+    /**
+     * The SDK retries an upload by resetting the stream to a mark it placed before the first attempt,
+     * and abandons the mark once more than this many bytes have been read past it. Sizing the limit to
+     * the bytes a single attempt sends keeps a retryable error retryable; the SDK default of 128 KB
+     * would turn one into a ResetException for all but the smallest artifacts.
+     */
+    private static int readLimitFor(long attemptBytes) {
+        return (int) Math.min(attemptBytes + 1, Integer.MAX_VALUE);
     }
 
     public S3Object getMetaData(URI uri) {

--- a/platforms/software/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/platforms/software/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -58,6 +58,7 @@ class S3ClientTest extends Specification {
             assert putObjectRequest.key == 'maven/snapshot/myFile.txt'
             assert putObjectRequest.cannedAcl == CannedAccessControlList.BucketOwnerFullControl
             assert putObjectRequest.metadata.contentLength == 12
+            assert putObjectRequest.requestClientOptions.readLimit == 13
         }
     }
 
@@ -96,6 +97,7 @@ class S3ClientTest extends Specification {
             assert uploadPartRequest.partNumber == 1
             assert uploadPartRequest.fileOffset == 0
             assert uploadPartRequest.partSize == 7
+            assert uploadPartRequest.requestClientOptions.readLimit == 8
             uploadPartResult
         } >> { args ->
             UploadPartRequest uploadPartRequest = args[0]
@@ -104,6 +106,7 @@ class S3ClientTest extends Specification {
             assert uploadPartRequest.partNumber == 2
             assert uploadPartRequest.fileOffset == 0
             assert uploadPartRequest.partSize == 5
+            assert uploadPartRequest.requestClientOptions.readLimit == 6
             uploadPartResult
         }
         1 * amazonS3Client.completeMultipartUpload(*_) >> { args ->


### PR DESCRIPTION
Fixes #30965

### Context

`S3Client` sends every artifact under 100 MB through `putSingleObject`, which builds a `PutObjectRequest` from a raw `InputStream` and never calls `setReadLimit`. The SDK therefore falls back to `RequestClientOptions.DEFAULT_STREAM_BUFFER_SIZE`, which is 131073 bytes — 128 KB + 1.

The SDK retries a failed upload by resetting the request stream to a mark it places before the first attempt. For any object above that limit the mark is already invalid by the time a retry happens, so `reset()` throws `IOException: Resetting to invalid mark`, surfaced as `com.amazonaws.ResetException`:

```
> Could not write to resource 's3://…/rewrite-maven-8.92.0-20260829.161649-25.jar'.
   > The request to the service failed with a retryable reason, but resetting the
     request input stream has failed. See exception.getExtraInfo or debug-level
     logging for the original failure that caused this retry.
```

Two things make this hard to diagnose from a CI log: the upload is not retried, so a transient S3 error becomes a hard build failure, and `ResetException` discards the original retryable cause, which is then reachable only via `getExtraInfo` or `--debug`.

It also presents as intermittent in a way that hides the pattern. Artifacts at or below 128 KB retry successfully and silently, so only larger ones ever fail. In the build that prompted this, each module publishes 20 objects and exactly 3 exceed the limit (the jar, `-sources.jar` and `-javadoc.jar`); the pom, signatures and checksums are all far below it. The failure therefore lands on a different module each time and looks random.

`putMultiPartObject` has the same defect, which #30965 does not mention: each `UploadPartRequest` is built with `.withInputStream(inputStream)` against a 50 MB part, so no part can be retried either.

### The change

Set the read limit to the bytes a single attempt sends — `contentLength` for a single-part put, `partSize` for each part — following the SDK's own `size + 1` convention.

This is the in-code equivalent of the `-Dcom.amazonaws.sdk.s3.defaultStreamBufferSize` workaround suggested on the issue, but scoped per request rather than set globally, so it neither affects other AWS clients in the same JVM nor raises the limit for uploads that do not need it.

One trade-off worth stating plainly: permitting a rewind means the SDK retains the current attempt's bytes, bounded by `getMultipartThreshold()` (100 MB) for a single-part put and `getPartSize()` (50 MB) per part. The alternative that avoids buffering altogether is to pass a re-openable source down from `S3ResourceConnector`, which already holds a `ReadableContent` and calls `open()` on it, so that `reset()` re-opens instead of buffering. That is a larger change to `S3Client`'s internal API and I did not want to presume it — happy to take it that way if you prefer.

### Relationship to #29686

#29686 rewrites this class onto AWS SDK v2 and would, as currently written, preserve this behaviour: it passes the same forward-only `InputStream` to both paths via `RequestBody.fromInputStream(inputStream, contentLength)` and `RequestBody.fromInputStream(inputStream, partSize)`. This fix therefore is not superseded by that migration in its present form.

### Tests

The two existing `S3ClientTest` cases already assert on the constructed requests, so the read limit is asserted alongside them rather than in new near-duplicate tests: 13 for a 12-byte single-part put, and 8 and 6 for the two parts of a multipart upload. Both cases fail with `SpockComparisonFailure` without the production change and pass with it.

I did not add an integration test. Reproducing this end-to-end needs an `S3Server` stub that returns a retryable status on the first PUT and succeeds on the second, which the fixture does not currently have — `stubPutFileAuthFailure` and `stubMetaDataBroken` are both terminal. Glad to add one if you would like it in this PR.

### AI assistance

Claude Code was used substantially in producing this change: locating the defect, writing the fix and the test assertions, and drafting this description. Disclosing per [AI_POLICY.md](https://github.com/gradle/gradle/blob/master/AI_POLICY.md).

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — not included; see Tests above.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, internal class, no public API change.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`. — not run locally.
- [x] Ensure that tests pass locally: `./gradlew :resources-s3:quickTest`.
