### PR TITLE
Decide TAPI download reuse under the lock, not on jar existence

### DIFF
--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolverTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolverTest.groovy
@@ -26,6 +26,7 @@ import spock.lang.Specification
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
+import java.util.zip.ZipFile
 
 /**
  * Tests {@link ToolingApiDistributionResolver}.
@@ -108,6 +109,26 @@ class ToolingApiDistributionResolverTest extends Specification {
         otherDownloadedToolingApiJar == downloadedToolingApiJar
         Files.getLastModifiedTime(downloadedToolingApiJar.toPath()) == someTime
         downloadedToolingApiJar.toPath().startsWith(destination.canonicalFile.toPath())
+    }
+
+    def "re-downloads a jar left behind by an interrupted download"() {
+        given:
+        System.setProperty("integTest.tmpDir", tempFolder.root.toString())
+        // What an interrupted download leaves behind: the jar exists, but the marker file
+        // that records a completed download does not.
+        def partialJar = new TestFile(tempFolder.root, "gradle-tooling-api-8.14.jar")
+        partialJar.text = "not a jar"
+
+        when:
+        def result = underTest.resolve("8.14")
+
+        then:
+        def downloadedToolingApiJar = result.classpath.find {
+            it.name == "gradle-tooling-api-8.14.jar"
+        }
+        new ZipFile(downloadedToolingApiJar).withCloseable {
+            it.getEntry("org/gradle/util/GradleVersion.class") != null
+        }
     }
 
     def "can download multiple distribution versions"() {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -78,10 +78,7 @@ class ToolingApiDistributionResolver {
         }
 
         TestFile destination = buildContext.tmpDir.file("gradle-tooling-api-${version}.jar")
-        if (!destination.exists()) {
-            def url = repoUrl + "/" + relativePath
-            download(url, destination)
-        }
+        download(repoUrl + "/" + relativePath, destination)
         return destination
     }
 
@@ -95,6 +92,15 @@ class ToolingApiDistributionResolver {
         location
     }
 
+    /**
+     * Downloads the jar, unless an earlier download of it already ran to completion.
+     *
+     * <p>Whether the download can be skipped is decided by the marker file, and only while holding
+     * the lock. The jar itself is not a safe signal: it is written in place, so it exists on disk
+     * while still incomplete, and a concurrent test worker that checked for its existence would
+     * hand a truncated archive to the tooling API ClassLoader. That surfaces much later as a
+     * {@code NoClassDefFoundError} for a class the jar does contain.
+     */
     private void download(String url, TestFile destination) {
         def markerFile = destination.withExtension("ok")
         fileAccessManager.access(destination) {


### PR DESCRIPTION
### Context

`ToolingApiDistributionResolver.locateToolingApi` skipped the download when the tooling API jar was already on disk:

```groovy
TestFile destination = buildContext.tmpDir.file("gradle-tooling-api-${version}.jar")
if (!destination.exists()) {
    download(url, destination)
}
return destination
```

That check ran **outside** the exclusive file lock, and `download` writes the jar in place via `destination.copyFrom(url)`. The lock is held on a separate `.lck` file, so the jar is visible on disk while it is still being written. With `maxParallelForks=4` all racing to resolve the same version, one worker can observe the half-written jar, skip the download, and hand a truncated archive to the tooling API `ClassLoader`.

`URLClassLoader` fails silently on a truncated jar, so this does not surface as an I/O error. It surfaces much later, during test discovery, as a `NoClassDefFoundError` for a class the jar does contain:

```
Caused by: java.lang.NoClassDefFoundError: org/gradle/util/GradleVersion
	at org.spockframework.runtime.SpecInfoBuilder.buildFeatures(SpecInfoBuilder.java:106)
Caused by: java.lang.ClassNotFoundException: org.gradle.util.GradleVersion
```

(`SpecInfoBuilder.buildFeatures` calls `Class.getDeclaredMethods()`, which has to resolve `GradleVersion` because `ToolingApiSpecification` declares `setTargetDistAndToolingApiVersion(GradleDistribution, GradleVersion)` and `getTargetVersion()`.)

The fix moves the decision into `download`, where it is made while holding the lock and keyed on the completion marker file rather than on the jar itself. The marker is only created after `copyFrom` returns, so a jar left behind by an interrupted download is correctly re-fetched instead of being reused.

### How this was found, and what is actually proven

This came out of investigating [`Ready for Release` #2647](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Stage_ReadyforRelease_Trigger/116835217), where `:tooling-api:gradle6.9.4CrossVersionTest` failed at discovery with the `NoClassDefFoundError` above ([scan](https://ge.gradle.org/s/d3mqgzcglr4u2)). That was the first failure of that config in 19 runs.

To be precise about the evidence:

- **Proven:** the TOCTOU is real and is visible in the code. The added unit test fails against the previous implementation and passes against this one — verified in both directions.
- **Not proven:** that this race caused that specific CI failure. The agent's disk state was not captured, and a poisoned entry in the local repo or a bad artifact from the mirror would produce an identical symptom. The fix is worth making on its own merits; treat the causal link as suspected rather than confirmed.

### Verification

- `:tooling-api:test --tests "*ToolingApiDistributionResolverTest"` — 6/6 green; the new test fails without the production change.
- [Flaky Test Quarantine / QuickFeedbackCrossVersion Java17 Linux #116842943](https://builds.gradle.org/build/116842943) on this branch with `-PrerunAllTests` (to disable Predictive Test Selection, so the test set is comparable to a `master` run): **128/128 passed**, an identical test set to the `master` run, with `:tooling-api:gradle6.9.4CrossVersionTest` completing rather than dying at discovery.

Note that a single green cross-version run is weak evidence here — the failure this addresses occurred once in 19 runs, so the old code would very likely have been green too. The unit test is the discriminating check.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/). — not signed off; `.github/dco.yml` sets `require.members: false`, so sign-off is waived for org members
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — n/a, this is build/test infrastructure
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, no public-facing change
