### PR TITLE
Split the AllVersionsCrossVersion flaky quarantine across agents

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -86,6 +86,11 @@ class FlakyTestQuarantine(
         val timeout = if (testCoverage.testType == TestType.ALL_VERSIONS_CROSS_VERSION) 240 else 120
         applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = timeout)
 
+        if (testCoverage.testType == TestType.ALL_VERSIONS_CROSS_VERSION) {
+            // Split the biggest quarantine coverage across agents to get it away from the timeout.
+            tcParallelTests(4)
+        }
+
         if (os == Os.LINUX) {
             steps {
                 script {

--- a/testing/internal-distribution-testing/src/main/resources/parallel-tests-experiment-cache-buster.txt
+++ b/testing/internal-distribution-testing/src/main/resources/parallel-tests-experiment-cache-buster.txt
@@ -1,0 +1,1 @@
+Marker resource to invalidate distribution test cache keys for the parallel-tests experiment on this branch (PR #38994). Not intended to be merged. 2026-08-31

--- a/testing/internal-distribution-testing/src/main/resources/parallel-tests-experiment-cache-buster.txt
+++ b/testing/internal-distribution-testing/src/main/resources/parallel-tests-experiment-cache-buster.txt
@@ -1,1 +1,0 @@
-Marker resource to invalidate distribution test cache keys for the parallel-tests experiment on this branch (PR #38994). Not intended to be merged. 2026-08-31


### PR DESCRIPTION
## Why

Closing https://github.com/gradle/gradle-private/issues/5331

`Flaky Test Quarantine - AllVersionsCrossVersion` runs every cross-version test task of its coverage on a single agent. The coverage contains ~146 minutes of quarantined test execution (61% of it from the class-level `@Flaky` on `ResolveArtifactsProgressCrossVersionSpec`), which lands Windows right at the timeout - it recently got 240 minutes of headroom for exactly this reason.

## What

Enable the TeamCity Parallel Tests build feature (4 batches) for the AllVersionsCrossVersion quarantine coverage, the same `tcParallelTests` mechanism the regular functional test builds use. Each batch runs a quarter of the test classes, so wall-clock time should drop to batch overhead plus ~35 minutes of test execution.

## Verification

`.teamcity` DSL generates (`./mvnw teamcity-configs:generate`). Experiment builds on an isolated pipeline from branch `parallelquarantine`: results to be added below.