### PR TITLE
Verify file system watching is current before trusting the VFS

### DIFF
--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
@@ -67,4 +67,59 @@ class ContinuousBuildFileWatchingIntegrationTest extends AbstractContinuousInteg
         executedAndNotSkipped(":compileJava")
         executed(":build")
     }
+
+    def "arming the watch probe does not retrigger a continuous build"() {
+        given:
+        executer.withArgument(FileSystemWatchingHelper.getDropVfsArgument(false))
+        executer.beforeExecute {
+            withWatchFs()
+            // Outside the project directory, which is declared as an input below: <projectDir>/.gradle
+            // then holds nothing but the watch probe, and cache writes are not input changes either.
+            withArgument("--project-cache-dir")
+            withArgument(file("../project-cache").absolutePath)
+        }
+
+        def input = file("input.txt")
+        input.text = "original"
+
+        // The whole project directory is an input, unfiltered, so Gradle's own probe artifacts under
+        // .gradle count as inputs. The task writes nothing under the project directory, so anything
+        // that changes there is Gradle's doing.
+        buildFile << """
+            tasks.register("checkInput") {
+                inputs.dir(projectDir)
+                outputs.upToDateWhen { false }
+                doLast {
+                    println "input is " + file("input.txt").text
+                }
+            }
+        """
+
+        when:
+        succeeds("checkInput")
+
+        then:
+        outputContains("input is original")
+
+        when: "a real change arrives, and the build it triggers re-arms the probe at its start"
+        input.text = "changed"
+
+        then: "the build still reacts, so the filter did not silence everything"
+        buildTriggeredAndSucceeded()
+        outputContains("input is changed")
+
+
+        and: """no build follows. The first build of a session cannot re-arm - watchRegistry is read
+                before the lock and is null there - so this window, after a build that did rotate the
+                probe, is the only one that covers arming. The window is wider than the default because
+                the notification it must not see can take seconds to arrive here, and a window shorter
+                than that latency passes whether the filter works or not. It stays an ambiguous
+                assertion, as the fixture's own TODO at AbstractContinuousIntegrationTest:284 says, so
+                the results check below carries what it cannot."""
+        def buildsBeforeTheWindow = results.size()
+        noBuildTriggered(15)
+
+        and: "and none completed inside it either, which the output of the last one would hide"
+        results.size() == buildsBeforeTheWindow
+    }
 }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherProbeRegistry.java
@@ -48,6 +48,38 @@ public interface FileWatcherProbeRegistry {
 
     void armWatchProbe(File watchableHierarchy);
 
+    /**
+     * Arms the probe again, whatever state it is in, so a hierarchy proven once has to prove again that
+     * its events still arrive.
+     *
+     * <p>Each arming writes a file name no earlier arming used, and a probe accepts an event only for
+     * the name its current arming wrote, so an event still in flight from an earlier arming is
+     * ignored.</p>
+     */
+    void rearmWatchProbe(File watchableHierarchy);
+
+    /**
+     * Returns whether any hierarchy is still waiting for its probe event, without building the stream
+     * {@link #unprovenHierarchies()} returns.
+     */
+    boolean hasUnprovenHierarchies();
+
+    /**
+     * Returns whether the path is a probe file of any generation, live or superseded.
+     *
+     * <p>Answered by name rather than by the live path map, so an event still in flight for a
+     * generation that has already been replaced is recognized too.</p>
+     */
+    boolean isProbeFile(String path);
+
+    /**
+     * Returns whether the path is the probe directory of any registered hierarchy.
+     *
+     * <p>Answered across every probe, so a hierarchy nested inside another recognizes the outer one's
+     * directory and the other way round.</p>
+     */
+    boolean isProbeDirectory(String path);
+
     void disarmWatchProbe(File watchableHierarchy);
 
     void triggerWatchProbe(String path);

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -69,7 +69,25 @@ public interface FileWatcherRegistry extends Closeable {
      * For example, this method checks if watched hierarchies are where we left them after the previous build.
      */
     @CheckReturnValue
-    SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems);
+    SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems, WatcherVerificationResult verification);
+
+    /**
+     * Checks whether the watcher is still delivering, without holding the virtual file system lock.
+     *
+     * <p>Re-arms every probe and walks the retained state of the probed hierarchies, abandoning the walk
+     * as soon as a probe event arrives. The caller applies the result under the lock.</p>
+     */
+    WatcherVerificationResult verifyWatcherIsCurrent(SnapshotHierarchy root);
+
+    /**
+     * Returns whether the path is a watch probe file, of any generation.
+     */
+    boolean isProbeFile(String path);
+
+    /**
+     * Returns whether the path is the probe directory of any watched hierarchy.
+     */
+    boolean isProbeDirectory(String path);
 
     /**
      * Updates the VFS and the watchers before the build finishes.

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -93,10 +93,28 @@ public interface FileWatcherUpdater {
     /**
      * Remove watched hierarchies that have been moved.
      *
-     * @see FileWatcherRegistry#updateVfsOnBuildStarted(SnapshotHierarchy, WatchMode, java.util.List)
+     * @see FileWatcherRegistry#updateVfsOnBuildStarted(SnapshotHierarchy, WatchMode, java.util.List, WatcherVerificationResult)
      */
     @CheckReturnValue
-    SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems);
+    SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems, WatcherVerificationResult verification);
+
+    /**
+     * Checks whether the watcher is still delivering, without holding the virtual file system lock.
+     *
+     * <p>Re-arms every probe and walks the retained state of the probed hierarchies, abandoning the walk
+     * as soon as a probe event arrives. The caller applies the result under the lock.</p>
+     */
+    WatcherVerificationResult verifyWatcherIsCurrent(SnapshotHierarchy root);
+
+    /**
+     * Returns whether the path is a watch probe file, of any generation.
+     */
+    boolean isProbeFile(String path);
+
+    /**
+     * Returns whether the path is the probe directory of any watched hierarchy.
+     */
+    boolean isProbeDirectory(String path);
 
     /**
      * Remove everything from the root which can't be kept after the current build finished.

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/WatcherVerificationResult.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/WatcherVerificationResult.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.registry;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * What a scan of the retained virtual file system established about the hierarchies it walked.
+ *
+ * <p>The two parts carry different weight. An outdated path is an observation, so a scan cut short by
+ * its deadline still reports the ones it found. A verified hierarchy is a claim that its whole retained
+ * state agrees with the file system on file size, file modification time, and directory membership, so
+ * only a completed walk contributes one.</p>
+ */
+public class WatcherVerificationResult {
+    public static final WatcherVerificationResult EMPTY =
+        new WatcherVerificationResult(ImmutableList.of(), ImmutableSet.of());
+
+    private final List<String> outdatedPaths;
+    private final Set<File> verifiedHierarchies;
+
+    public WatcherVerificationResult(List<String> outdatedPaths, Set<File> verifiedHierarchies) {
+        this.outdatedPaths = outdatedPaths;
+        this.verifiedHierarchies = verifiedHierarchies;
+    }
+
+    /**
+     * Locations whose retained snapshot no longer matches the file system.
+     */
+    public List<String> getOutdatedPaths() {
+        return outdatedPaths;
+    }
+
+    /**
+     * Hierarchies the scan walked to the end, which therefore need no watch probe event to be trusted
+     * for this build.
+     *
+     * <p>The agreement covers file size, file modification time, and directory membership. It does not
+     * cover file content: a rewrite that preserves both the size and the modification time is invisible
+     * to the scan, and the retained content hash is then reused. Nor does it cover what the walk skips
+     * — the probe files Gradle writes for its own signalling, and everything
+     * {@code WatchableHierarchies.ignoredForWatching} covers, which is Gradle's immutable locations and
+     * every snapshot reached through a symlink.</p>
+     */
+    public Set<File> getVerifiedHierarchies() {
+        return verifiedHierarchies;
+    }
+}

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -24,26 +24,51 @@ import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
+import org.gradle.internal.snapshot.DirectorySnapshot;
+import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
+import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import org.gradle.internal.watch.registry.WatchMode;
+import org.gradle.internal.watch.registry.WatcherVerificationResult;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFileWatcherUpdater.class);
 
+    /**
+     * Bounds the whole verification step. Soft: a {@code stat} that blocks is not interrupted by it,
+     * since the walk runs on the build thread.
+     */
+    private static final long VERIFICATION_DEADLINE_MILLIS = 2000;
+
     protected final FileWatcherProbeRegistry probeRegistry;
     protected final WatchableHierarchies watchableHierarchies;
     private final MovedDirectoryHandler movedDirectoryHandler;
     protected FileHierarchySet watchedFiles = FileHierarchySet.empty();
-    private ImmutableSet<File> probedHierarchies = ImmutableSet.of();
+    /**
+     * Hierarchies whose probes are armed. Replaced wholesale rather than mutated, and read by the build
+     * thread outside the update lock, so the write has to publish the whole set.
+     */
+    private volatile ImmutableSet<File> probedHierarchies = ImmutableSet.of();
 
     public AbstractFileWatcherUpdater(
         FileWatcherProbeRegistry probeRegistry,
@@ -63,13 +88,221 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public final SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems) {
-        SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchableContentOnBuildStart(root, createInvalidator(), watchMode, unsupportedFileSystems);
+    public final SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems, WatcherVerificationResult verification) {
+        SnapshotHierarchy invalidatedRoot = root;
+        WatchableHierarchies.Invalidator invalidator = createInvalidator();
+        for (String outdatedPath : verification.getOutdatedPaths()) {
+            invalidatedRoot = invalidator.invalidate(outdatedPath, invalidatedRoot);
+        }
+        SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchableContentOnBuildStart(
+            invalidatedRoot, createInvalidator(), watchMode, unsupportedFileSystems, verification.getVerifiedHierarchies());
         newRoot = invalidateMovedDirectoriesOnBuildStarted(newRoot);
         if (root != newRoot) {
             update(newRoot);
         }
         return newRoot;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The root is read outside the virtual file system's update lock and the result is applied to
+     * whatever root the caller holds once it takes it. That is safe because of what can arrive in
+     * between: the only paths that add a snapshot are {@code store} and {@code storeWithAction}, and
+     * both store a location that was just read from disk. This scan exists to decide whether state
+     * retained from an <em>earlier</em> build can still be trusted, and a snapshot taken after the scan
+     * started is not such state. The watcher's own thread never adds — it only invalidates, or empties
+     * the whole hierarchy after an error.</p>
+     */
+    @Override
+    public WatcherVerificationResult verifyWatcherIsCurrent(SnapshotHierarchy root) {
+        ImmutableSet<File> hierarchiesToProve = probedHierarchies;
+        if (hierarchiesToProve.isEmpty()) {
+            return WatcherVerificationResult.EMPTY;
+        }
+        // The deadline covers the preparation as well as the walk: arming sweeps a directory, creates
+        // it and writes a file, per hierarchy, and on a stalled file system that is unbounded. It does
+        // not govern the preparation: every hierarchy is re-armed regardless. Skipping one
+        // would leave its probe TRIGGERED from the previous build, out of unprovenHierarchies(), and
+        // its retained state kept on that stale evidence, which is the failure this step exists to
+        // prevent. A slow arming instead eats the walk's share, so nothing is verified and everything
+        // is dropped.
+        // Elapsed time is measured as a difference rather than against a precomputed instant:
+        // System.nanoTime() has an arbitrary origin and may overflow, so only the subtraction is
+        // ordered correctly. Its own javadoc says as much.
+        long startedAt = System.nanoTime();
+        long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(VERIFICATION_DEADLINE_MILLIS);
+        hierarchiesToProve.forEach(probeRegistry::rearmWatchProbe);
+
+        // Computed once per verification, after re-arming, because arming can create the directory.
+        // The walk asks about Gradle's own artifacts once per snapshot child and once per on-disk
+        // name, so both questions have to be set lookups rather than file system calls.
+        ImmutableSet<File> probeDirectories = hierarchiesToProve.stream()
+            .map(probeRegistry::getProbeDirectory)
+            .collect(ImmutableSet.toImmutableSet());
+        List<String> outdatedPaths = new ArrayList<>();
+        ImmutableSet.Builder<File> verifiedHierarchies = ImmutableSet.builder();
+        for (File hierarchy : hierarchiesToProve) {
+            if (!probeRegistry.hasUnprovenHierarchies() || System.nanoTime() - startedAt > timeoutNanos) {
+                // The probe answered, or the deadline passed, before this hierarchy was entered.
+                break;
+            }
+            RetainedStateVerifier verifier = new RetainedStateVerifier(startedAt, timeoutNanos, probeDirectories);
+            Iterator<FileSystemLocationSnapshot> rootSnapshots =
+                root.rootSnapshotsUnder(hierarchy.getAbsolutePath()).iterator();
+            while (rootSnapshots.hasNext() && !verifier.isAbandoned()) {
+                rootSnapshots.next().accept(verifier);
+            }
+            outdatedPaths.addAll(verifier.getOutdatedPaths());
+            if (verifier.isAbandoned()) {
+                // The probe answered, or the deadline passed. Either way no later hierarchy is entered.
+                break;
+            }
+            verifiedHierarchies.add(hierarchy);
+        }
+        return new WatcherVerificationResult(outdatedPaths, verifiedHierarchies.build());
+    }
+
+    /**
+     * Compares each retained snapshot against the file system, collecting the locations that no longer
+     * match.
+     *
+     * <p>Regular files are compared by size and modification time, directories by the names of their
+     * children; no content is hashed, so the walk costs one {@code stat} per entry. The probe directory
+     * is walked like any other. What is dropped from both sides of a listing comparison is the
+     * artifacts Gradle writes for its own signalling, since a name Gradle just wrote is not evidence
+     * about an external change.</p>
+     */
+    private class RetainedStateVerifier implements FileSystemSnapshotHierarchyVisitor {
+        private static final int ENTRIES_BETWEEN_PROBE_CHECKS = 1024;
+
+        private final long startedAt;
+        private final long timeoutNanos;
+        private final ImmutableSet<File> probeDirectories;
+        private final List<String> outdatedPaths = new ArrayList<>();
+        private int entriesVisited;
+        private boolean abandoned;
+
+        RetainedStateVerifier(long startedAt, long timeoutNanos, ImmutableSet<File> probeDirectories) {
+            this.startedAt = startedAt;
+            this.timeoutNanos = timeoutNanos;
+            this.probeDirectories = probeDirectories;
+        }
+
+        @Override
+        public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
+            if (abandoned) {
+                return SnapshotVisitResult.TERMINATE;
+            }
+            if (++entriesVisited % ENTRIES_BETWEEN_PROBE_CHECKS == 0
+                && (!probeRegistry.hasUnprovenHierarchies() || System.nanoTime() - startedAt > timeoutNanos)) {
+                abandoned = true;
+                return SnapshotVisitResult.TERMINATE;
+            }
+            String path = snapshot.getAbsolutePath();
+            if (watchableHierarchies.ignoredForWatching(snapshot)) {
+                return SnapshotVisitResult.SKIP_SUBTREE;
+            }
+            if (matchesFileSystem(snapshot)) {
+                return SnapshotVisitResult.CONTINUE;
+            }
+            outdatedPaths.add(path);
+            return SnapshotVisitResult.SKIP_SUBTREE;
+        }
+
+        /**
+         * Returns whether the child is one Gradle writes for its own signalling: a probe file inside a
+         * probe directory, or a probe directory in the listing of the directory that contains it.
+         *
+         * <p>Excluding the directory unconditionally accepts one stale claim: a parent snapshotted
+         * before Gradle created the directory keeps a children set that no longer names it, and a
+         * {@code DirectorySnapshot} asserts a <em>complete</em> listing, so the virtual file system
+         * answers "missing" from memory for any path beneath it. The bound on that is a scope — paths
+         * under one directory Gradle owns — rather than a time. It is taken because the alternative,
+         * reporting the parent when the directory appears, invalidates the whole hierarchy's retained
+         * state over a directory Gradle itself just made.</p>
+         *
+         * <p>It does not outlive a working watcher. The probe filter suppresses only the broadcast leg,
+         * so {@code InvalidateVfsChangeHandler} still invalidates for a probe path, and
+         * {@code DirectorySnapshot.invalidate} degrades the node to a partial one even when the path
+         * matches no child — which is exactly this case. Gradle writes such an event itself every build
+         * when it re-arms.</p>
+         */
+        private boolean isGradlesOwnChild(File directory, String name) {
+            File child = new File(directory, name);
+            if (probeDirectories.contains(directory)) {
+                return isProbeFile(child.getAbsolutePath());
+            }
+            return probeDirectories.contains(child);
+        }
+
+        private boolean matchesFileSystem(FileSystemLocationSnapshot snapshot) {
+            File file = new File(snapshot.getAbsolutePath());
+            BasicFileAttributes attributes = readAttributes(file);
+            if (attributes != null && attributes.isSymbolicLink()) {
+                // The retained snapshot recorded direct access, so a link that has appeared since is a
+                // change whatever it points at. Comparing through it would compare the target, and a
+                // matching target would vouch for content reached by a route Gradle does not watch.
+                return false;
+            }
+            switch (snapshot.getType()) {
+                case RegularFile:
+                    if (attributes == null || !attributes.isRegularFile()) {
+                        return false;
+                    }
+                    FileMetadata metadata = ((RegularFileSnapshot) snapshot).getMetadata();
+                    return attributes.size() == metadata.getLength()
+                        && attributes.lastModifiedTime().toMillis() == metadata.getLastModified();
+                case Directory:
+                    if (attributes == null || !attributes.isDirectory()) {
+                        return false;
+                    }
+                    String[] namesOnDisk = file.list();
+                    if (namesOnDisk == null) {
+                        return false;
+                    }
+                    Set<String> expected = new HashSet<>();
+                    for (FileSystemLocationSnapshot child : ((DirectorySnapshot) snapshot).getChildren()) {
+                        if (child.getType() != FileType.Missing && !isGradlesOwnChild(file, child.getName())) {
+                            expected.add(child.getName());
+                        }
+                    }
+                    Set<String> found = new HashSet<>();
+                    for (String name : namesOnDisk) {
+                        if (!isGradlesOwnChild(file, name)) {
+                            found.add(name);
+                        }
+                    }
+                    // Both directions: a name only on disk makes the retained listing stale just as a
+                    // missing one does.
+                    return expected.equals(found);
+                case Missing:
+                    return attributes == null;
+                default:
+                    return false;
+            }
+        }
+
+        List<String> getOutdatedPaths() {
+            return outdatedPaths;
+        }
+
+        boolean isAbandoned() {
+            return abandoned;
+        }
+    }
+
+    /**
+     * Reads the attributes of the path itself rather than of whatever it may link to, so a path that
+     * has become a symlink is visible as one.
+     */
+    @Nullable
+    private static BasicFileAttributes readAttributes(File file) {
+        try {
+            return Files.readAttributes(file.toPath(), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @CheckReturnValue
@@ -130,6 +363,16 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     @Override
     public void removeProbeFiles() {
         probeRegistry.removeProbeFiles();
+    }
+
+    @Override
+    public boolean isProbeFile(String path) {
+        return probeRegistry.isProbeFile(path);
+    }
+
+    @Override
+    public boolean isProbeDirectory(String path) {
+        return probeRegistry.isProbeDirectory(path);
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistry.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -36,6 +37,7 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
     private final Map<String, WatchProbe> watchProbesByPath = new ConcurrentHashMap<>();
 
     private final Function<File, File> probeLocationResolver;
+    private final AtomicLong nextProbeGeneration = new AtomicLong();
 
     public DefaultFileWatcherProbeRegistry(Function<File, File> probeLocationResolver) {
         this.probeLocationResolver = probeLocationResolver;
@@ -59,6 +61,49 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
         return watchProbesByHierarchy.values().stream()
             .filter(WatchProbe::leftArmed)
             .map(WatchProbe::getWatchableHierarchy);
+    }
+
+    @Override
+    public boolean isProbeFile(String path) {
+        File file = new File(path);
+        File directory = file.getParentFile();
+        if (directory == null) {
+            return false;
+        }
+        return watchProbesByHierarchy.values().stream()
+            .anyMatch(probe -> probe.ownsProbeFile(directory, file.getName()));
+    }
+
+    @Override
+    public boolean isProbeDirectory(String path) {
+        File directory = new File(path);
+        return watchProbesByHierarchy.values().stream().anyMatch(probe -> probe.ownsProbeDirectory(directory));
+    }
+
+    @Override
+    public boolean hasUnprovenHierarchies() {
+        return watchProbesByHierarchy.values().stream().anyMatch(WatchProbe::leftArmed);
+    }
+
+    @Override
+    public void rearmWatchProbe(File watchableHierarchy) {
+        WatchProbe probe = watchProbesByHierarchy.get(watchableHierarchy);
+        if (probe == null) {
+            LOGGER.debug("Did not find watchable hierarchy to re-arm probe for: {}", watchableHierarchy);
+            return;
+        }
+        File previousProbeFile = probe.getProbeFile();
+        File probeFile = new File(previousProbeFile.getParentFile(),
+            probe.nameForGeneration(nextProbeGeneration.incrementAndGet()));
+        // Both mappings move before the file is written: no event for the new name is dropped because
+        // the map was not ready, and none for the old name still resolves to this probe.
+        watchProbesByPath.remove(previousProbeFile.getAbsolutePath());
+        watchProbesByPath.put(probeFile.getAbsolutePath(), probe);
+        try {
+            probe.rearm(probeFile);
+        } catch (IOException e) {
+            LOGGER.debug("Could not re-arm watch probe for hierarchy {}", watchableHierarchy, e);
+        }
     }
 
     @Override
@@ -93,7 +138,7 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
         WatchProbe probe = watchProbesByPath.get(path);
         if (probe != null) {
             LOGGER.debug("Triggering watch probe for {}", probe.getWatchableHierarchy());
-            probe.trigger();
+            probe.trigger(path);
         }
     }
 
@@ -130,13 +175,65 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
         }
 
         private final File watchableHierarchy;
-        private final File probeFile;
-        private State state = State.UNARMED;
+        /**
+         * Name every probe file of this hierarchy starts with, before the generation suffix. The probe
+         * directory holds unrelated files, so {@link #rearm(File)} sweeps by this prefix rather than
+         * emptying the directory.
+         */
+        private final String baseName;
+        private final String extension;
+        private volatile File probeFile;
+        private volatile State state = State.UNARMED;
 
         public WatchProbe(File watchableHierarchy, File probeFile) {
             this.watchableHierarchy = watchableHierarchy;
             this.probeFile = probeFile;
+            String name = probeFile.getName();
+            int dot = name.lastIndexOf('.');
+            this.baseName = dot < 0 ? name : name.substring(0, dot);
+            this.extension = dot < 0 ? "" : name.substring(dot);
         }
+
+        /**
+         * Names the given generation of this probe. The generation is a suffix on the original name, so
+         * a base name that itself contains a hyphen keeps it.
+         */
+        public String nameForGeneration(long generation) {
+            return baseName + "-" + generation + extension;
+        }
+
+        /**
+         * Returns whether the name is one this probe writes: the name it was registered with, or any
+         * generation of it. The sweep and {@link DefaultFileWatcherProbeRegistry#isProbeFile} share
+         * this so they cannot drift apart.
+         */
+        boolean isOwnProbeFileName(String name) {
+            if (!name.startsWith(baseName) || !name.endsWith(extension)) {
+                return false;
+            }
+            String generation = name.substring(baseName.length(), name.length() - extension.length());
+            if (generation.isEmpty()) {
+                return true;
+            }
+            if (generation.length() < 2 || generation.charAt(0) != '-') {
+                return false;
+            }
+            for (int i = 1; i < generation.length(); i++) {
+                if (!Character.isDigit(generation.charAt(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        boolean ownsProbeFile(File directory, String name) {
+            return directory.equals(probeFile.getParentFile()) && isOwnProbeFileName(name);
+        }
+
+        boolean ownsProbeDirectory(File directory) {
+            return directory.equals(probeFile.getParentFile());
+        }
+
 
         public synchronized void arm() throws IOException {
             switch (state) {
@@ -175,27 +272,43 @@ public class DefaultFileWatcherProbeRegistry implements FileWatcherProbeRegistry
             }
         }
 
-        public synchronized void trigger() {
+        public synchronized void trigger(String eventPath) {
+            if (!probeFile.getAbsolutePath().equals(eventPath)) {
+                // An event for a generation this probe has already superseded.
+                LOGGER.debug("Ignoring watch probe event for a superseded generation: {}", eventPath);
+                return;
+            }
             if (state != State.TRIGGERED) {
                 LOGGER.debug("Watch probe in state {} has been triggered for hierarchy: {}", state, watchableHierarchy);
                 state = State.TRIGGERED;
             }
         }
 
-        public synchronized boolean leftArmed() {
+        public synchronized void rearm(File newProbeFile) throws IOException {
+            File[] previousGenerations = probeFile.getParentFile()
+                .listFiles((directory, name) -> isOwnProbeFileName(name));
+            if (previousGenerations != null) {
+                for (File file : previousGenerations) {
+                    //noinspection ResultOfMethodCallIgnored
+                    file.delete();
+                }
+            }
+            probeFile = newProbeFile;
+            state = State.UNARMED;
+            arm();
+        }
+
+        public boolean leftArmed() {
             return state == State.ARMED;
         }
 
         public synchronized void deleteProbeFile() {
             if (!probeFile.delete() && probeFile.exists()) {
                 LOGGER.debug("Could not delete probe file: {}", probeFile);
-                return;
             }
-            File probeDirectory = probeFile.getParentFile();
-            String[] remaining = probeDirectory.list();
-            if (remaining != null && remaining.length == 0 && !probeDirectory.delete()) {
-                LOGGER.debug("Could not delete empty probe directory: {}", probeDirectory);
-            }
+            // The directory stays. Arming re-creates it at the start of every build, so removing it
+            // here would make Gradle emit a create and a remove for it per build, in a location a
+            // continuous build can be watching.
         }
 
         public File getProbeFile() {

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -23,6 +23,7 @@ import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
 import org.gradle.internal.watch.registry.WatchMode;
+import org.gradle.internal.watch.registry.WatcherVerificationResult;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,8 +149,23 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
     }
 
     @Override
-    public SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems) {
-        return fileWatcherUpdater.updateVfsOnBuildStarted(root, watchMode, unsupportedFileSystems);
+    public SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode, List<File> unsupportedFileSystems, WatcherVerificationResult verification) {
+        return fileWatcherUpdater.updateVfsOnBuildStarted(root, watchMode, unsupportedFileSystems, verification);
+    }
+
+    @Override
+    public WatcherVerificationResult verifyWatcherIsCurrent(SnapshotHierarchy root) {
+        return fileWatcherUpdater.verifyWatcherIsCurrent(root);
+    }
+
+    @Override
+    public boolean isProbeFile(String path) {
+        return fileWatcherUpdater.isProbeFile(path);
+    }
+
+    @Override
+    public boolean isProbeDirectory(String path) {
+        return fileWatcherUpdater.isProbeDirectory(path);
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -37,6 +37,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -220,17 +221,19 @@ public class WatchableHierarchies {
     }
 
     @CheckReturnValue
-    public SnapshotHierarchy removeUnwatchableContentOnBuildStart(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode, List<File> unsupportedFileSystems) {
+    public SnapshotHierarchy removeUnwatchableContentOnBuildStart(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode, List<File> unsupportedFileSystems, Set<File> verifiedHierarchies) {
         SnapshotHierarchy newRoot = root;
-        newRoot = removeUnprovenHierarchies(newRoot, invalidator, watchMode);
+        newRoot = removeUnprovenHierarchies(newRoot, invalidator, watchMode, verifiedHierarchies);
         newRoot = updateUnwatchableFilesOnBuildStart(newRoot, invalidator, unsupportedFileSystems);
         return newRoot;
     }
 
     @CheckReturnValue
-    private SnapshotHierarchy removeUnprovenHierarchies(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode) {
-        // Remove hierarchies that did not respond to a watch probe
+    private SnapshotHierarchy removeUnprovenHierarchies(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode, Set<File> verifiedHierarchies) {
+        // Remove hierarchies that neither responded to a watch probe nor were verified against the
+        // file system by a completed scan.
         return probeRegistry.unprovenHierarchies()
+            .filter(unprovenHierarchy -> !verifiedHierarchies.contains(unprovenHierarchy))
             .reduce(root, (currentRoot, unprovenHierarchy) -> {
                 if (hierarchies.remove(unprovenHierarchy)) {
                     watchMode.loggerForWarnings(LOGGER).warn(INVALIDATING_HIERARCHY_MESSAGE + " {}", unprovenHierarchy);

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -35,6 +35,7 @@ import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.WatchMode;
+import org.gradle.internal.watch.registry.WatcherVerificationResult;
 import org.gradle.internal.watch.registry.impl.FileSystemWatchingDocumentationIndex;
 import org.gradle.internal.watch.registry.impl.SnapshotCollectingDiffListener;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
@@ -120,6 +121,16 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
         warningLogger = watchMode.loggerForWarnings(LOGGER);
         stateInvalidatedAtStartOfBuild = false;
         reasonForNotWatchingFiles = null;
+        // Outside the lock on purpose: the watcher consumer thread needs the same lock to deliver the
+        // probe event, so waiting for it here would starve the proof this asks for.
+        // One observation of the field: the consumer thread nulls it on a watching error, so a
+        // second read could hand a null to a call this one has already null-checked. A registry
+        // closed just after this read still verifies; the result is then discarded by the checks
+        // inside the lock, which costs a scan rather than an answer.
+        FileWatcherRegistry registryToVerify = watchRegistry;
+        WatcherVerificationResult verification = registryToVerify == null || !watchMode.isEnabled()
+            ? WatcherVerificationResult.EMPTY
+            : registryToVerify.verifyWatcherIsCurrent(root);
         updateRootUnderLock(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
             public SnapshotHierarchy call(BuildOperationContext context) {
@@ -150,7 +161,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         if (hasDroppedStateBecauseOfErrorsReceivedWhileWatching(statistics) || !couldDetectUnsupportedFileSystems) {
                             newRoot = stopWatchingAndInvalidateHierarchyAfterError(currentRoot);
                         } else {
-                            newRoot = watchRegistry.updateVfsOnBuildStarted(currentRoot, watchMode, unsupportedFileSystems);
+                            newRoot = watchRegistry.updateVfsOnBuildStarted(currentRoot, watchMode, unsupportedFileSystems, verification);
                         }
                         stateInvalidatedAtStartOfBuild = newRoot != currentRoot;
                         statisticsSinceLastBuild = new DefaultFileSystemWatchingStatistics(statistics, newRoot);
@@ -329,7 +340,8 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                     new InvalidateVfsChangeHandler(),
                     new BroadcastingChangeHandler()
                 )));
-            SnapshotHierarchy newRoot = watchRegistry.updateVfsOnBuildStarted(currentRoot.empty(), watchMode, unsupportedFileSystems);
+            // Watching has just started over an empty root, so there is no retained state to verify.
+            SnapshotHierarchy newRoot = watchRegistry.updateVfsOnBuildStarted(currentRoot.empty(), watchMode, unsupportedFileSystems, WatcherVerificationResult.EMPTY);
             watchableHierarchiesRegisteredEarly.forEach(watchableHierarchy -> watchRegistry.registerWatchableHierarchy(watchableHierarchy, newRoot));
             watchableHierarchiesRegisteredEarly.clear();
             return newRoot;
@@ -388,6 +400,17 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     private class BroadcastingChangeHandler implements FileWatcherRegistry.ChangeHandler {
         @Override
         public void handleChange(FileWatcherRegistry.Type type, Path path) {
+            FileWatcherRegistry registry = watchRegistry;
+            String location = path.toString();
+            if (registry != null && (registry.isProbeFile(location) || registry.isProbeDirectory(location))) {
+                // Gradle arms a probe at the start of every build, so broadcasting its own write
+                // would let a continuous build retrigger itself. The virtual file system is still
+                // invalidated for it, which is why this filter sits on the broadcast leg alone.
+                // Logged because a silent drop is indistinguishable from an event that never came,
+                // both when diagnosing a build and when testing this filter.
+                LOGGER.debug("{} to watch probe artifact {} not broadcast to file change listeners", type, location);
+                return;
+            }
             fileChangeListeners.broadcastChange(type, path);
         }
 

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry
 import org.gradle.internal.watch.registry.FileWatcherUpdater
 import org.gradle.internal.watch.registry.WatchMode
+import org.gradle.internal.watch.registry.WatcherVerificationResult
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -440,6 +441,280 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         0 * _
     }
 
+    def "a file added to a snapshotted directory makes it outdated"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def sourceDirectory = watchableHierarchy.createDir("src")
+        sourceDirectory.file("Foo.java").createFile()
+        addSnapshot(snapshotDirectory(sourceDirectory))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+
+        when: "a file appears that the watcher never reported"
+        sourceDirectory.file("Bar.java").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then:
+        verification.outdatedPaths == [sourceDirectory.absolutePath]
+
+        when:
+        virtualFileSystem.root = updater.updateVfsOnBuildStarted(virtualFileSystem.root, WatchMode.DEFAULT, [], verification)
+
+        then:
+        !vfsHasSnapshotsAt(sourceDirectory)
+    }
+
+    def "a file added under the probe directory is still detected"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def probeDirectory = watchableHierarchy.createDir(".gradle")
+        probeDirectory.file("file-watching.probe").createFile()
+        addSnapshot(snapshotDirectory(probeDirectory))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "real state appears under .gradle without the watcher reporting it"
+        probeDirectory.file("configuration-cache.bin").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "skipping the probe directory wholesale would have missed this"
+        verification.outdatedPaths == [probeDirectory.absolutePath]
+    }
+
+    def "creating the probe directory does not make its parent outdated"() {
+        given: "the hierarchy is snapshotted before the probe directory exists"
+        def watchableHierarchy = file("hierarchy").createDir()
+        watchableHierarchy.file("build.gradle").createFile()
+        registerWatchableHierarchies([watchableHierarchy])
+        addSnapshot(snapshotDirectory(watchableHierarchy))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "arming creates it"
+        watchableHierarchy.createDir(".gradle").file("file-watching-1.probe").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "the parent listing gained a name Gradle wrote for itself, which is not a change to report"
+        verification.outdatedPaths.isEmpty()
+    }
+
+    def "removing the probe directory does not make its parent outdated"() {
+        given: "the hierarchy is snapshotted while the probe directory exists"
+        def watchableHierarchy = file("hierarchy").createDir()
+        watchableHierarchy.file("build.gradle").createFile()
+        def probeDirectory = watchableHierarchy.createDir(".gradle")
+        probeDirectory.file("file-watching-1.probe").createFile()
+        registerWatchableHierarchies([watchableHierarchy])
+        addSnapshot(snapshotDirectory(watchableHierarchy))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "it is gone from disk while the retained listing still names it"
+        probeDirectory.deleteDir()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "the exclusion has to hold on the snapshot side as well as the disk side"
+        !verification.outdatedPaths.contains(watchableHierarchy.absolutePath)
+    }
+
+    def "a file added under a probe directory the parent snapshot names is reported"() {
+        given: "the parent is snapshotted while its probe directory already exists"
+        def watchableHierarchy = file("hierarchy").createDir()
+        watchableHierarchy.file("build.gradle").createFile()
+        def probeDirectory = watchableHierarchy.createDir(".gradle")
+        probeDirectory.file("file-watching-1.probe").createFile()
+        registerWatchableHierarchies([watchableHierarchy])
+        addSnapshot(snapshotDirectory(watchableHierarchy))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "content the watcher never reported appears under it"
+        probeDirectory.file("configuration-cache.bin").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "the directory is a child of the parent snapshot, so its own comparison catches it"
+        verification.outdatedPaths == [probeDirectory.absolutePath]
+    }
+
+    def "a file replaced by a symlink to identical content is reported"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def watched = watchableHierarchy.file("watched.txt")
+        watched.text = "same bytes"
+        addSnapshot(snapshotRegularFile(watched))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "the path becomes a link to a file the metadata cannot tell apart"
+        def target = watchableHierarchy.file("target.txt")
+        target.text = "same bytes"
+        target.lastModified = watched.lastModified()
+        watched.delete()
+        java.nio.file.Files.createSymbolicLink(watched.toPath(), target.toPath())
+
+        and:
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "following the link would vouch for content reached by a route Gradle does not watch"
+        verification.outdatedPaths == [watched.absolutePath]
+    }
+
+    def "a nested hierarchy's probe directory is not reported by the outer walk"() {
+        given: "the outer hierarchy is snapshotted before the inner hierarchy has a probe directory"
+        def outer = file("outer").createDir()
+        def inner = outer.createDir("inner")
+        inner.file("build.gradle").createFile()
+        registerWatchableHierarchies([outer, inner])
+        addSnapshot(snapshotDirectory(inner))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(outer, inner)
+
+        when: "arming the inner hierarchy creates its probe directory"
+        inner.createDir(".gradle").file("file-watching-1.probe").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "an exclusion scoped to one hierarchy's probe directory would report the inner listing"
+        verification.outdatedPaths.isEmpty()
+    }
+
+    def "retained state under a deleted probe directory is reported"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def probeDirectory = watchableHierarchy.createDir(".gradle")
+        probeDirectory.file("configuration-cache.bin").createFile()
+        // The directory itself is retained, which is the shape an absence guard would skip whole.
+        addSnapshot(snapshotDirectory(probeDirectory))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "the directory goes away with real state retained under it"
+        probeDirectory.deleteDir()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "skipping the subtree here would vouch for state that is gone"
+        verification.outdatedPaths == [probeDirectory.absolutePath]
+    }
+
+    def "a verified hierarchy survives the drop and an unverified one does not"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        addSnapshot(snapshotRegularFile(watchableHierarchy.file("kept.txt").createFile()))
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probeRegistry.unprovenHierarchies() >> { Stream.of(watchableHierarchy) }
+
+        when: "the probe never fires and no scan vouched for the hierarchy"
+        buildStarted(WatchMode.DEFAULT, [], WatcherVerificationResult.EMPTY)
+
+        then:
+        !vfsHasSnapshotsAt(watchableHierarchy)
+    }
+
+    def "a hierarchy the scan verified is kept even though its probe never fired"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        addSnapshot(snapshotRegularFile(watchableHierarchy.file("kept.txt").createFile()))
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probeRegistry.unprovenHierarchies() >> { Stream.of(watchableHierarchy) }
+
+        when:
+        def verified = new WatcherVerificationResult([], [watchableHierarchy] as Set)
+        buildStarted(WatchMode.DEFAULT, [], verified)
+
+        then:
+        vfsHasSnapshotsAt(watchableHierarchy)
+    }
+
+    def "re-arming the probe does not make its own directory outdated"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def probeDirectory = watchableHierarchy.createDir(".gradle")
+        probeDirectory.file("file-watching.probe").createFile()
+        addSnapshot(snapshotDirectory(probeDirectory))
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        probePredicatesFrom(watchableHierarchy)
+
+        when: "arming writes a file name the snapshot has never seen"
+        probeDirectory.file("file-watching-1.probe").createFile()
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then:
+        verification.outdatedPaths.isEmpty()
+    }
+
+    def "content in an immutable location is not scanned"() {
+        given:
+        def watchableHierarchy = file("hierarchy").createDir()
+        registerWatchableHierarchies([watchableHierarchy])
+        def cacheDirectory = watchableHierarchy.createDir("caches")
+        def cachedFile = cacheDirectory.file("artifact.jar").createFile()
+        addSnapshot(snapshotRegularFile(cachedFile))
+        ignoredForWatching.add(cachedFile.absolutePath)
+        probeRegistry.hasUnprovenHierarchies() >> true
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+
+        when: "the immutable location changes behind the watcher's back"
+        cachedFile.text = "rewritten"
+        cachedFile.lastModified = cachedFile.lastModified() + 2000
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "Gradle manages that location itself, so the scan does not spend a stat on it"
+        verification.outdatedPaths.isEmpty()
+    }
+
+    def "a hierarchy is not entered once the probe has answered"() {
+        given: "two watchable hierarchies, each holding a file that changed behind the watcher's back"
+        def hierarchies = [file("one").createDir(), file("two").createDir()]
+        registerWatchableHierarchies(hierarchies)
+        def changedFiles = hierarchies.collect { it.file("changed.txt").createFile() }
+        changedFiles.each { it.text = "before" }
+        changedFiles.each { addSnapshot(snapshotRegularFile(it)) }
+        probeRegistry.getProbeDirectory(_) >> { File it -> new File(it, ".gradle") }
+        // Unproven when the walk starts, answered before the next hierarchy is entered.
+        probeRegistry.hasUnprovenHierarchies() >>> [true, false]
+
+        when:
+        changedFiles.each {
+            it.text = "after"
+            it.lastModified = it.lastModified() + 2000
+        }
+        def verification = updater.verifyWatcherIsCurrent(virtualFileSystem.root)
+
+        then: "the walk stopped after one hierarchy, whichever the iteration reached first"
+        verification.verifiedHierarchies.size() == 1
+        verification.outdatedPaths.size() == 1
+
+        and: "the hierarchy that was never entered is not vouched for"
+        def skipped = hierarchies.find { !verification.verifiedHierarchies.contains(it) }
+        verification.outdatedPaths.every { !it.startsWith(skipped.absolutePath) }
+    }
+
+    /**
+     * Answers the probe predicates the way production does, by delegating to a real registry built
+     * with this fixture's resolver. Re-stating the rule in a stub is how the earlier ones drifted
+     * wider than the code they stood in for.
+     */
+    void probePredicatesFrom(File... hierarchies) {
+        def real = new DefaultFileWatcherProbeRegistry(probeLocationResolver)
+        hierarchies.each { real.registerProbe(it) }
+        probeRegistry.isProbeFile(_) >> { String path -> real.isProbeFile(path) }
+        probeRegistry.isProbeDirectory(_) >> { String path -> real.isProbeDirectory(path) }
+    }
+
     TestFile file(Object... path) {
         temporaryFolder.testDirectory.file(path)
     }
@@ -502,8 +777,8 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         probeLocationResolver.apply(watchableHierarchy)
     }
 
-    SnapshotHierarchy buildStarted(WatchMode watchMode = WatchMode.DEFAULT, List<File> unsupportedFileSystems = []) {
-        virtualFileSystem.root = updater.updateVfsOnBuildStarted(virtualFileSystem.root, watchMode, unsupportedFileSystems)
+    SnapshotHierarchy buildStarted(WatchMode watchMode = WatchMode.DEFAULT, List<File> unsupportedFileSystems = [], WatcherVerificationResult verification = WatcherVerificationResult.EMPTY) {
+        virtualFileSystem.root = updater.updateVfsOnBuildStarted(virtualFileSystem.root, watchMode, unsupportedFileSystems, verification)
         return virtualFileSystem.root
     }
 

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistryTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/DefaultFileWatcherProbeRegistryTest.groovy
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.registry.impl
+
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.util.function.Function
+
+@CleanupTestDirectory
+class DefaultFileWatcherProbeRegistryTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
+
+    def hierarchy = temporaryFolder.testDirectory.file("hierarchy").createDir()
+    def probeDirectory = hierarchy.file(".gradle")
+    def registry = new DefaultFileWatcherProbeRegistry(
+        { File it -> new File(new File(it, ".gradle"), "file-system.probe") } as Function<File, File>)
+
+    def probeFiles() {
+        (probeDirectory.list() ?: [] as String[])
+            .findAll { it.startsWith("file-system") }
+            .sort()
+    }
+
+    def "re-arming keeps a base name that contains a hyphen"() {
+        given:
+        registry.registerProbe(hierarchy)
+
+        when:
+        registry.rearmWatchProbe(hierarchy)
+
+        then: "the generation is a suffix, not a replacement for everything after the last hyphen"
+        probeFiles() == ["file-system-1.probe"]
+    }
+
+    def "each re-arming leaves exactly one probe file behind"() {
+        given:
+        registry.registerProbe(hierarchy)
+
+        when:
+        5.times { registry.rearmWatchProbe(hierarchy) }
+
+        then:
+        probeFiles() == ["file-system-5.probe"]
+    }
+
+    def "a probe file left by an earlier daemon is swept"() {
+        given:
+        registry.registerProbe(hierarchy)
+        probeDirectory.createDir().file("file-system-97.probe").text = "left by a crashed daemon"
+
+        when:
+        registry.rearmWatchProbe(hierarchy)
+
+        then:
+        probeFiles() == ["file-system-1.probe"]
+    }
+
+    def "an unrelated file in the probe directory is not swept"() {
+        given:
+        registry.registerProbe(hierarchy)
+        // The second name shares the probe's prefix, which is what a prefix-only sweep deletes.
+        probeDirectory.createDir().file("configuration-cache").text = "not ours"
+        probeDirectory.file("file-system-cache.bin").text = "not ours either"
+        // A suffix that is not a generation: only digits after the hyphen make one.
+        probeDirectory.file("file-system-x.probe").text = "not a generation"
+
+        when:
+        registry.rearmWatchProbe(hierarchy)
+
+        then:
+        probeDirectory.file("configuration-cache").exists()
+        probeDirectory.file("file-system-cache.bin").exists()
+        probeDirectory.file("file-system-x.probe").exists()
+    }
+
+    def "a probe file of any generation is recognized, live or superseded"() {
+        given:
+        registry.registerProbe(hierarchy)
+        registry.armWatchProbe(hierarchy)
+
+        when:
+        registry.rearmWatchProbe(hierarchy)
+
+        then:
+        registry.isProbeFile(probeDirectory.file("file-system-1.probe").absolutePath)
+        registry.isProbeFile(probeDirectory.file("file-system.probe").absolutePath)
+        registry.isProbeFile(probeDirectory.file("file-system-97.probe").absolutePath)
+
+        and:
+        !registry.isProbeFile(probeDirectory.file("file-system-cache.bin").absolutePath)
+        !registry.isProbeFile(probeDirectory.file("file-system-x.probe").absolutePath)
+        !registry.isProbeFile(probeDirectory.file("configuration-cache").absolutePath)
+        !registry.isProbeFile(hierarchy.file("file-system-1.probe").absolutePath)
+    }
+
+    def "the probe directory is left in place when the probe file is removed"() {
+        given:
+        registry.registerProbe(hierarchy)
+        registry.armWatchProbe(hierarchy)
+
+        when:
+        registry.removeProbeFiles()
+
+        then: "arming re-creates it every build, so removing it here would churn a watched location"
+        !probeDirectory.file("file-system.probe").exists()
+        probeDirectory.isDirectory()
+    }
+
+    def "a probe directory is recognized whichever hierarchy registered it"() {
+        given:
+        def nested = hierarchy.createDir("nested")
+        registry.registerProbe(hierarchy)
+        registry.registerProbe(nested)
+
+        expect: "the outer registry answers for the inner hierarchy's probe directory too"
+        registry.isProbeDirectory(probeDirectory.absolutePath)
+        registry.isProbeDirectory(nested.file(".gradle").absolutePath)
+
+        and: "and not for a .gradle belonging to no registered hierarchy"
+        !registry.isProbeDirectory(temporaryFolder.testDirectory.file("elsewhere/.gradle").absolutePath)
+        !registry.isProbeDirectory(hierarchy.absolutePath)
+    }
+
+    def "an event for a superseded generation does not prove the hierarchy"() {
+        given:
+        registry.registerProbe(hierarchy)
+        registry.armWatchProbe(hierarchy)
+        def supersededPath = probeDirectory.file("file-system.probe").absolutePath
+
+        when: "the event for the previous generation arrives after the probe was re-armed"
+        registry.rearmWatchProbe(hierarchy)
+        registry.triggerWatchProbe(supersededPath)
+
+        then:
+        registry.hasUnprovenHierarchies()
+
+        when: "the event for the current generation arrives"
+        registry.triggerWatchProbe(probeDirectory.file("file-system-1.probe").absolutePath)
+
+        then:
+        !registry.hasUnprovenHierarchies()
+    }
+}

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -24,11 +24,16 @@ import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory
 import org.gradle.internal.watch.registry.WatchMode
+import org.gradle.internal.watch.registry.WatcherVerificationResult
 import org.gradle.internal.watch.registry.impl.FileSystemWatchingDocumentationIndex
 import org.gradle.internal.watch.vfs.FileChangeListeners
 import org.gradle.internal.watch.vfs.VfsLogging
 import org.gradle.internal.watch.vfs.WatchableFileSystemDetector
 import spock.lang.Specification
+
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class WatchingVirtualFileSystemTest extends Specification {
     def watcherRegistryFactory = Mock(FileWatcherRegistryFactory)
@@ -56,6 +61,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.updateRootUnderLock { root -> nonEmptySnapshotHierarchy }
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.DISABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         watchingVirtualFileSystem.root == emptySnapshotHierarchy
@@ -65,6 +71,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.beforeBuildFinished(WatchMode.DISABLED, VfsLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         watchingVirtualFileSystem.afterBuildFinished()
         then:
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         watchingVirtualFileSystem.root == emptySnapshotHierarchy
@@ -75,7 +82,8 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _) >> watchingVirtualFileSystem.root
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -83,12 +91,14 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.updateVfsBeforeBuildFinished(_, Integer.MAX_VALUE, []) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.afterBuildFinished()
         then:
         1 * watcherRegistry.updateVfsAfterBuildFinished(_) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -96,9 +106,71 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.DISABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistry.close()
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         watchingVirtualFileSystem.root == emptySnapshotHierarchy
+    }
+
+    def "a probe file event is not broadcast to file change listeners"() {
+        given:
+        FileWatcherRegistry.ChangeHandler handler = null
+
+        when: "watching starts, so the handler chain exists"
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
+        then:
+        1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> { FileWatcherRegistry.ChangeHandler it ->
+            handler = it
+            watcherRegistry
+        }
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
+        0 * _
+
+        when: "an event arrives for Gradle's own probe file"
+        handler.handleChange(FileWatcherRegistry.Type.MODIFIED, Paths.get("/project/.gradle/file-system-1.probe"))
+        then: "arming the probe every build must not make a continuous build retrigger itself"
+        _ * watcherRegistry.isProbeFile("/project/.gradle/file-system-1.probe") >> true
+        _ * locationsUpdatedByCurrentBuild.shouldWatchLocation(_) >> true
+        0 * fileChangeListeners.broadcastChange(_, _)
+
+        when: "an ordinary event arrives"
+        handler.handleChange(FileWatcherRegistry.Type.MODIFIED, Paths.get("/project/src/Foo.java"))
+        then:
+        _ * watcherRegistry.isProbeFile("/project/src/Foo.java") >> false
+        _ * locationsUpdatedByCurrentBuild.shouldWatchLocation(_) >> true
+        1 * fileChangeListeners.broadcastChange(_, _)
+    }
+
+    def "the watcher is verified before the virtual file system is locked"() {
+        given:
+        def lockTaken = new CountDownLatch(1)
+
+        when: "watching starts"
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
+        then:
+        1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
+        0 * _
+
+        when: "the next build verifies the watcher"
+        watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
+
+        then: "another thread can still take the update lock while the verification runs"
+        1 * watcherRegistry.verifyWatcherIsCurrent(_) >> {
+            // The watcher consumer thread needs this same lock to deliver a probe event. Holding it
+            // here is what starved the probe, so the verification must run outside it.
+            Thread.start {
+                watchingVirtualFileSystem.updateRootUnderLock { root -> root }
+                lockTaken.countDown()
+            }
+            assert lockTaken.await(10, TimeUnit.SECONDS)
+            return WatcherVerificationResult.EMPTY
+        }
+        1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
+        0 * _
     }
 
     def "retains the virtual file system when watching is enabled"() {
@@ -106,7 +178,8 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _) >> watchingVirtualFileSystem.root
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -114,20 +187,23 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.updateVfsBeforeBuildFinished(_, Integer.MAX_VALUE, []) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.afterBuildFinished()
         then:
         1 * watcherRegistry.updateVfsAfterBuildFinished(_) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.updateRootUnderLock { root -> nonEmptySnapshotHierarchy }
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
-        1 * watcherRegistry.updateVfsOnBuildStarted(_ as SnapshotHierarchy, WatchMode.ENABLED, []) >> { SnapshotHierarchy root, watchMode, unsupportedFileSystems -> root }
+        1 * watcherRegistry.updateVfsOnBuildStarted(_ as SnapshotHierarchy, WatchMode.ENABLED, [], _) >> { SnapshotHierarchy root, watchMode, unsupportedFileSystems, verification -> root }
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         watchingVirtualFileSystem.root == nonEmptySnapshotHierarchy
@@ -144,14 +220,16 @@ class WatchingVirtualFileSystemTest extends Specification {
         when:
         watchingVirtualFileSystem.registerWatchableHierarchy(watchableHierarchy)
         then:
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _) >> watchingVirtualFileSystem.root
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, _, _) >> watchingVirtualFileSystem.root
         1 * watcherRegistry.registerWatchableHierarchy(watchableHierarchy, _)
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -164,6 +242,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.updateVfsBeforeBuildFinished(_, Integer.MAX_VALUE, []) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -171,6 +250,7 @@ class WatchingVirtualFileSystemTest extends Specification {
 
         then:
         1 * watcherRegistry.updateVfsAfterBuildFinished(_) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -187,7 +267,8 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watchableFileSystemDetector.detectUnsupportedFileSystems() >> unsupportedFileSystems.stream()
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, unsupportedFileSystems) >> watchingVirtualFileSystem.root
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, unsupportedFileSystems, _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -195,12 +276,14 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.updateVfsBeforeBuildFinished(_, Integer.MAX_VALUE, unsupportedFileSystems) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.afterBuildFinished()
         then:
         1 * watcherRegistry.updateVfsAfterBuildFinished(_) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -208,8 +291,9 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.DEFAULT, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watchableFileSystemDetector.detectUnsupportedFileSystems() >> unsupportedFileSystems.stream()
-        1 * watcherRegistry.updateVfsOnBuildStarted(_ as SnapshotHierarchy, WatchMode.DEFAULT, unsupportedFileSystems) >> { SnapshotHierarchy root, watchMode, it -> root }
+        1 * watcherRegistry.updateVfsOnBuildStarted(_ as SnapshotHierarchy, WatchMode.DEFAULT, unsupportedFileSystems, _) >> { SnapshotHierarchy root, watchMode, it, verification -> root }
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
     }
 
@@ -219,6 +303,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         !result
         1 * watchableFileSystemDetector.detectUnsupportedFileSystems() >> { throw new NativeException("Failed") }
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
     }
 
@@ -227,7 +312,8 @@ class WatchingVirtualFileSystemTest extends Specification {
         watchingVirtualFileSystem.afterBuildStarted(WatchMode.ENABLED, VfsLogging.NORMAL, buildOperationRunner)
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
-        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, []) >> watchingVirtualFileSystem.root
+        1 * watcherRegistry.updateVfsOnBuildStarted(_, _, [], _) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -235,12 +321,14 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.updateVfsBeforeBuildFinished(_, Integer.MAX_VALUE, []) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
         watchingVirtualFileSystem.afterBuildFinished()
         then:
         1 * watcherRegistry.updateVfsAfterBuildFinished(_) >> watchingVirtualFileSystem.root
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
 
         when:
@@ -250,6 +338,7 @@ class WatchingVirtualFileSystemTest extends Specification {
         1 * watchableFileSystemDetector.detectUnsupportedFileSystems() >> { throw new NativeException("Failed") }
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
         1 * watcherRegistry.close()
+        _ * watcherRegistry.verifyWatcherIsCurrent(_) >> WatcherVerificationResult.EMPTY
         0 * _
     }
 }


### PR DESCRIPTION
## Why

Gradle's virtual file system keeps snapshots between builds and treats "no file system event arrived for this path" as "this path did not change". **Nothing verifies that assumption.** There is no liveness check on the notification channel, and no way for Gradle to notice the channel has fallen behind.

On macOS the assumption does not hold. FSEvents delivery has no upper bound on latency, and while it is behind it reports no loss at all. The result is a silently wrong build: the task is declared `UP-TO-DATE` from a source file that changed seconds earlier, the build is green, and the log gives no hint. Two neighbouring builds of the same series, with `-Dorg.gradle.vfs.verbose=true`:

```text
stale:   Received 0 file system events   ->  Hashed 0 files   ->  > Task :compileJava UP-TO-DATE
correct: Received 8 file system events   ->  Hashed 3 files   ->  > Task :compileJava
```

`Stat: Executed stat() x 0` in both. Gradle never looks at the file; the decision rests entirely on the event stream.

This is hard to diagnose from the outside. The build succeeds, the task is up to date, and the produced artifact does not match the source. Whoever hits it suspects their build script, their caching setup, or their editor long before they suspect the watcher.

### Measurements

macOS 15 (Darwin 25.5, APFS, 10 cores), Gradle 9.6.1 and 9.7.1 behave identically. A three-file Java project; a script rewrites one source file and immediately runs `compileJava`, then checks whether the produced `.class` contains the new content.

| Condition | Stale builds |
| --- | --- |
| No added file system activity | 7/12 |
| ~3 file writes per second in the project tree | 11/12 |
| ~200 file writes per second | 11/12, 10/12 |
| ~200 file writes per second, on a **different volume** | 7/15 |
| `--no-watch-fs` under the same load | 0/20 |
| A 5-second pause between the edit and the build | 15/15 |

Two of these matter more than the rest. Churn on an unrelated volume still breaks it, because `fseventsd` is one system-wide service. And a five-second pause does not help, so this is not a matter of waiting a little longer.

**An existing Gradle test already reproduces this.** `ContinuousBuildFileWatchingIntegrationTest.file system watching picks up changes causing a continuous build to rebuild` fails 2 times in 5 on unmodified `master` on this machine, and 0 times in 5 with this change applied. Small samples, but the direction is not subtle: what looks like a flaky test is the same lost-notification defect seen from the continuous-build side.

### The delivery stall is upstream of Gradle

A standalone C program with its own run loop and a trivial callback — no JVM, no Gradle — misses the same notification under the same conditions. In one run it received **13325 events with zero `mustScanSubDirs`, `userDropped` or `kernelDropped` flags** while the notification for the one file it was waiting on took 43 seconds to arrive. The stream is honest and in order; it is simply far behind, and never says so.

Two things checked before blaming the OS, both negative:

- The `FSEventStreamCreate` latency Gradle passes (20 µs, with a `TODO Figure out a good value for this` next to it) makes no difference. 20 µs, 20 ms, 100 ms and 1 s all behave the same.
- `FSEventStreamFlushSync`, the OS primitive for "deliver what you have", does not fix it: 0 of 10 notifications arrived within 15 s when the churn was inside the watched tree.

### Why the watch probe does not catch it

`DefaultFileWatcherProbeRegistry` arms a probe once per hierarchy and, once triggered, never re-arms. Its javadoc states the goal it was built for: to avoid trusting locations where the OS silently sends no events. That is a capability check, and it works — a daemon started while the channel is already saturated never proves the probe and drops its retained state every build, correctly. The dangerous state is the ordinary one: a daemon that caught a probe event during a calm moment holds the hierarchy proven for its whole life, and then produces 11 of 12 stale builds under the same load.

### This matters more with coding agents

An AI agent writes a file and reruns the build immediately, from a script, in a loop — hundreds of times per session, with no human pause anywhere. That is precisely the timing that loses this race, and the setting where the failure does the most damage: the agent reads a green build and a stale artifact, concludes its change had no effect or that a test it just wrote is passing, and proceeds from a false result.

Every measurement above came out of exactly that loop. This seems directly relevant to gradle/build-tool-roadmap#126 — an agent cannot be satisfied with results a build tool reports incorrectly, and cannot diagnose a wrong answer that arrives labelled `UP-TO-DATE`.

## What

At the start of each build, before the virtual file system lock is taken, every watched hierarchy re-arms its probe and the probe event races a scan of the retained state.

- The probe event proves the watcher is current, and the retained state stands as it is.
- The scan reaches the same conclusion by comparing each retained snapshot against the file system — regular files by size and modification time, directories by the names of their children, in both directions. No content is hashed, so it costs one `stat` per entry. Whatever no longer matches is invalidated; the rest of the retained state survives. It is scoped to the probed hierarchies, skips what `ignoredForWatching` covers, re-checks the probe as it walks so a probe event abandons it, and rejects a path that has become a symbolic link rather than following it.
- If neither finishes within the deadline, the hierarchy is left unproven and the existing `removeUnprovenHierarchies` drops it, as it does today.

**The wait cannot run under the virtual file system lock.** `afterBuildStarted` used to hold it across the whole callback, and the only thread that can trigger a probe — the watcher's consumer — needs that same lock for every event it processes. Events are consumed serially, so any other event ahead of the probe parked the consumer, and the probe could never arrive while the build waited for it. The verification therefore runs before the lock and its result is applied inside it.

**Each arming writes a file name no earlier arming used**, so a notification still in flight for a superseded generation cannot trigger the probe, and the probe file is no longer deleted along with its directory, which would otherwise churn a watched location once per build. Events for Gradle's own probe artifacts are kept off the broadcast leg — the virtual file system is still invalidated for them — so a continuous build does not retrigger itself.

There is no new thread, executor or timeout property: the scan runs on the build thread and is abandoned between entries.

Measured on a backport of an earlier revision of this change to 9.6.1, so that stock and patched daemons could run side by side under one load, with an isolated `GRADLE_USER_HOME` per daemon:

| | Stale builds | Median build | Builds stalled ≥ 1.5 s |
| --- | --- | --- | --- |
| 9.6.1 as released | 22/24 | 374 ms | 0 |
| Wait for the probe, no scan | 0/24 | 2000 ms | 12 |
| Race the two | **0/24** | 403 ms | **0** |

The scan is what keeps the cost down: 1 ms over 40 retained entries, 30 ms over 6028, 355 ms over 100201 — roughly 3.5 µs per entry, unchanged under file system churn.

<details>
<summary>Alternatives measured and rejected</summary>

**Wait for the probe under the virtual file system lock.** The watcher's consumer thread needs that same lock to deliver the event being waited for, so the probe cannot arrive while the build waits for it. Measured on a backport: with the wait moved out of the lock the probe still timed out 6 times out of 6 under churn, and the hierarchy oscillated between registered and unregistered on alternate builds.

**Run the scan on an executor rather than the build thread.** The race needs no concurrency once the scan re-checks the probe between entries. Taking `ExecutorFactory` would add a dependency on `:concurrent`, which `:file-watching` does not declare, and thread the service through three platform-specific factories, for work that does not need a thread.

**Tune the `FSEventStreamCreate` latency.** 20 µs, 20 ms, 100 ms and 1 s behave identically under churn, so the `TODO Figure out a good value for this` next to the current 20 µs is not what causes this.

**Use `FSEventStreamFlushSync`.** The OS primitive for "deliver what you have" does not help: 0 of 10 notifications arrived within 15 s when the churn was inside the watched tree.

**Drop the retained state instead of scanning it.** Correct, and 3.2 times the build time: 0 of 24 stale builds at a median of 2000 ms, against 403 ms for the race.

**Stop deleting the probe directory instead of filtering its events.** This removes the REMOVE but not the CREATE, because `update()` registers the hierarchy watch before its `mkdirs` loop, so the filter is still needed. Done anyway, for the halved churn.

**Hash file content during the scan.** The only way to close the metadata bound above, and the cost the scan exists to avoid: metadata alone is 355 ms over 100201 entries.
</details>

## How to verify

```bash
./gradlew :file-watching:checkstyleMain :file-watching:test :file-watching:embeddedIntegTest --tests '*ContinuousBuildFileWatchingIntegrationTest*'
```

`DefaultFileWatcherProbeRegistryTest` is new and covers probe rotation, the sweep, and an event for a superseded generation. `AbstractFileWatcherUpdaterTest` gains cases for a file added to a snapshotted directory, an addition under the probe directory, a nested hierarchy's probe directory, immutable locations, a symbolic link that replaced a regular file, the walk stopping once the probe answers, and both directions of the verified-hierarchy decision. `WatchingVirtualFileSystemTest` asserts that another thread can take the update lock while verification runs, and that a probe event is not broadcast. The continuous-build test asserts that a build which re-armed the probe is followed by no further build, and that none completed inside the window either. That assertion is a wall-clock one and its window is calibrated to a machine whose watcher lags, so a green run means the filter held **or** the notification had not arrived; the fixture's own TODO at `AbstractContinuousIntegrationTest:284` says the same about `noBuildTriggered`. Making it unambiguous needs a trigger observation this fixture does not offer — running the whole build under `--debug` to read the drop back was tried and is not worth its cost.

Every one of these was checked by reverting its own production change and watching it fail.

## Scope, and what I could not establish

- **Only macOS is measured.** Linux and Windows signal queue overflow to Gradle, so the balance there may differ, and the deadline may deserve a different default or none at all.
- **The scan compares metadata, not content.** A change that preserves both size and modification time is invisible to it, and the retained hash is then reused. Closing that means hashing every retained file, which is the cost the scan exists to avoid. `isContentAndMetadataUpToDate` already works this way, but that bound is only safe while events arrive, so this is a real weakening against dropping the state outright and a real strengthening against `master`, which checks nothing. Stated in `WatcherVerificationResult`'s javadoc; worth a maintainer's opinion on which baseline Gradle should promise.
- **Excluding the probe directory from its parent's listing is a tolerance, not a no-op.** A parent snapshotted before Gradle created that directory keeps a children set that does not name it, and a `DirectorySnapshot` asserts a complete listing. The bound is a scope rather than a time, and any delivered event under the parent clears it. Stated in the javadoc where the exclusion lives.
- **The broadcast filter is a bare path test**, so an external event at `<hierarchy>/.gradle` is dropped too. That path exists only because `update()` registers the hierarchy watch before its `mkdirs` loop; doing the `mkdirs` first would leave nothing to filter, and is the better fix if you want it.
- **The deadline is soft.** With the scan on the build thread, a `stat` that blocks is not interrupted by it. The daemon has the same exposure wherever it snapshots, and the alternative is a thread per build.
- **The machine these numbers come from runs a background process that keeps `fseventsd` near 100% CPU.** I did not measure with it stopped, so I cannot say how often this happens on an otherwise idle machine. What the added-churn rows show is that a few writes per second suffice once the channel is loaded, and that a fully independent C client fails the same way.

Separately and outside this change: `MutableFileWatchingStatistics.errorWhileReceivingFileChanges` guards on `!= null` before assigning, so the first error is never recorded. Happy to open that as its own issue.




## AI disclosure

Per `AI_POLICY.md`: this change was developed with Claude Code, which produced the investigation, the measurements quoted above, the implementation and the tests. I directed that work and can explain any part of it.
