### PR TITLE
Make BuildIdentity the source of build identity

### DIFF
--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -305,7 +305,7 @@ public class ProjectBuilderImpl {
     private static class TestRootBuild extends AbstractBuildState implements RootBuildState {
 
         public TestRootBuild(File rootProjectDir, StartParameterInternal startParameter, BuildTreeServices buildTreeServices) {
-            super(buildTreeServices, BuildDefinition.fromStartParameter(startParameter, rootProjectDir, null), null);
+            super(buildTreeServices, BuildDefinition.fromStartParameter(startParameter, rootProjectDir, null), Path.ROOT, null);
         }
 
         @Override
@@ -319,11 +319,6 @@ public class ProjectBuilderImpl {
 
         @Override
         public void ensureProjectsConfigured() {
-        }
-
-        @Override
-        public Path getIdentityPath() {
-            return Path.ROOT;
         }
 
         @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AbstractCompositeParticipantBuildState.java
@@ -29,6 +29,7 @@ import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.buildtree.BuildTreeServices;
+import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +43,8 @@ public abstract class AbstractCompositeParticipantBuildState extends AbstractBui
 
     private @Nullable Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules;
 
-    public AbstractCompositeParticipantBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, @Nullable BuildState parent) {
-        super(buildTreeServices, buildDefinition, parent);
+    public AbstractCompositeParticipantBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, Path identityPath, @Nullable BuildState parent) {
+        super(buildTreeServices, buildDefinition, identityPath, parent);
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -36,7 +36,6 @@ import java.io.File;
 
 public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState implements IncludedBuildState {
 
-    private final Path identityPath;
     private final BuildDefinition buildDefinition;
     private final boolean isImplicit;
 
@@ -48,10 +47,9 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
         BuildTreeServices buildTreeServices
     ) {
         // Use a defensive copy of the build definition, as it may be mutated during build execution
-        super(buildTreeServices, buildDefinition.newInstance(), owner);
+        super(buildTreeServices, buildDefinition.newInstance(), identityPath, owner);
         assert !identityPath.equals(Path.ROOT) : "An included build must not be located at the root path";
 
-        this.identityPath = identityPath;
         this.buildDefinition = buildDefinition;
         this.isImplicit = isImplicit;
     }
@@ -64,11 +62,6 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
     @Override
     public File getRootDirectory() {
         return buildDefinition.getBuildRootDir();
-    }
-
-    @Override
-    public Path getIdentityPath() {
-        return identityPath;
     }
 
     @Override
@@ -98,7 +91,7 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
 
     @Override
     public String getName() {
-        return identityPath.getName();
+        return getIdentityPath().getName();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 
 class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild {
 
-    private final Path identityPath;
     private final BuildState owner;
     private final BuildDefinition buildDefinition;
     private final BuildTreeLifecycleController buildTreeLifecycleController;
@@ -52,8 +51,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         BuildState owner,
         BuildTreeServices buildTreeServices
     ) {
-        super(buildTreeServices, buildDefinition, owner);
-        this.identityPath = identityPath;
+        super(buildTreeServices, buildDefinition, identityPath, owner);
         this.buildDefinition = buildDefinition;
         this.owner = owner;
 
@@ -75,11 +73,6 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     @Override
     public BuildDefinition getBuildDefinition() {
         return buildDefinition;
-    }
-
-    @Override
-    public Path getIdentityPath() {
-        return identityPath;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -58,7 +58,7 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
         BuildTreeServices buildTreeServices,
         ListenerManager listenerManager
     ) {
-        super(buildTreeServices, buildDefinition, null);
+        super(buildTreeServices, buildDefinition, Path.ROOT, null);
         this.listenerManager = listenerManager;
 
         CloseableServiceRegistry buildScopeServices = getBuildServices();
@@ -76,11 +76,6 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
             CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
-    }
-
-    @Override
-    public Path getIdentityPath() {
-        return Path.ROOT;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -53,7 +53,6 @@ import java.util.function.Function;
 @SuppressWarnings("this-escape")
 public class RootOfNestedBuildTree extends AbstractBuildState implements NestedRootBuild {
 
-    private final Path identityPath;
     private final BuildTreeLifecycleController buildTreeLifecycleController;
 
     public RootOfNestedBuildTree(
@@ -62,8 +61,7 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
         BuildState owner,
         BuildTreeServices buildTreeServices
     ) {
-        super(buildTreeServices, buildDefinition, owner);
-        this.identityPath = identityPath;
+        super(buildTreeServices, buildDefinition, identityPath, owner);
 
         CloseableServiceRegistry buildServices = getBuildServices();
         try {
@@ -87,11 +85,6 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
     @Override
     public StartParameterInternal getStartParameter() {
         return getBuildController().getGradle().getStartParameter();
-    }
-
-    @Override
-    public Path getIdentityPath() {
-        return identityPath;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -22,14 +22,13 @@ import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.buildtree.BuildTreeServices;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.internal.service.scopes.Scope;
+import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Closeable;
@@ -38,6 +37,7 @@ import java.util.function.Function;
 
 public abstract class AbstractBuildState implements BuildState, Closeable {
 
+    private final BuildIdentity buildIdentity;
     private final @Nullable BuildState parent;
     private final CloseableServiceRegistry buildServices;
     private final Lazy<BuildLifecycleController> buildLifecycleController;
@@ -45,7 +45,8 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     private final Lazy<BuildWorkGraphController> workGraphController;
 
     @SuppressWarnings("this-escape")
-    public AbstractBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, @Nullable BuildState parent) {
+    public AbstractBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, Path identityPath, @Nullable BuildState parent) {
+        this.buildIdentity = new BuildIdentity(identityPath);
         this.parent = parent;
 
         buildServices = ServiceRegistryBuilder.builder()
@@ -75,8 +76,8 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     }
 
     @Override
-    public DisplayName getDisplayName() {
-        return Describables.of(getBuildIdentifier());
+    public BuildIdentity getBuildIdentity() {
+        return buildIdentity;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
+import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Identifies a single build within the build tree.
+ * <p>
+ * This is the immutable identity of a build, as opposed to {@link BuildState}, which also
+ * owns the build's mutable model and service scope. Prefer this type over {@code BuildState}
+ * wherever only the identity of a build is required.
+ */
+@ServiceScope(Scope.Build.class)
+public final class BuildIdentity implements DisplayName {
+
+    private final Path buildPath;
+
+    private final BuildIdentifier buildIdentifier;
+    private final DisplayName displayName;
+
+    public BuildIdentity(Path buildPath) {
+        if (!buildPath.isAbsolute()) {
+            throw new IllegalArgumentException("Build path must be absolute: " + buildPath);
+        }
+
+        this.buildPath = buildPath;
+
+        this.buildIdentifier = new DefaultBuildIdentifier(buildPath);
+        this.displayName = Describables.memoize(Describables.of(buildIdentifier));
+    }
+
+    /**
+     * The identity of the build within the build tree. This path is fixed for the lifetime of the build.
+     */
+    public Path getBuildPath() {
+        return buildPath;
+    }
+
+    /**
+     * The public identifier for this build.
+     */
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName.getDisplayName();
+    }
+
+    @Override
+    public String getCapitalizedDisplayName() {
+        return displayName.getCapitalizedDisplayName();
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BuildIdentity that = (BuildIdentity) o;
+        return buildPath.equals(that.buildPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return buildPath.hashCode();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
@@ -47,6 +47,7 @@ public final class BuildIdentity implements DisplayName {
 
         this.buildPath = buildPath;
 
+        // TODO: avoid BuildIdentifier for core logic, and eventually wrap its implementation around BuildIdentity
         this.buildIdentifier = new DefaultBuildIdentifier(buildPath);
         this.displayName = Describables.memoize(Describables.of(buildIdentifier));
     }
@@ -65,6 +66,9 @@ public final class BuildIdentity implements DisplayName {
         return buildIdentifier;
     }
 
+    /**
+     * Returns the display name of this build, such as {@code build ':'} or {@code build ':included'}.
+     */
     @Override
     public String getDisplayName() {
         return displayName.getDisplayName();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -18,7 +18,6 @@ package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.DisplayName;
@@ -38,7 +37,14 @@ import java.util.function.Function;
 @ServiceScope(Scope.Build.class)
 public interface BuildState {
 
-    DisplayName getDisplayName();
+    /**
+     * Returns the immutable identity of this build.
+     */
+    BuildIdentity getBuildIdentity();
+
+    default DisplayName getDisplayName() {
+        return getBuildIdentity();
+    }
 
     /**
      * Returns the identifier for this build. The identifier is fixed for the lifetime of the build.
@@ -46,13 +52,15 @@ public interface BuildState {
      * Prefer {@link #getIdentityPath()}.
      */
     default BuildIdentifier getBuildIdentifier() {
-        return new DefaultBuildIdentifier(getIdentityPath());
+        return getBuildIdentity().getBuildIdentifier();
     }
 
     /**
      * Returns an identifying path for this build in the build tree. This path is fixed for the lifetime of the build.
      */
-    Path getIdentityPath();
+    default Path getIdentityPath() {
+        return getBuildIdentity().getBuildPath();
+    }
 
     /**
      * Get the parent build of this build, if any.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -42,6 +42,11 @@ public interface BuildState {
      */
     BuildIdentity getBuildIdentity();
 
+    /**
+     * Returns the display name of this build.
+     *
+     * @see BuildIdentity#getDisplayName()
+     */
     default DisplayName getDisplayName() {
         return getBuildIdentity();
     }
@@ -49,7 +54,7 @@ public interface BuildState {
     /**
      * Returns the identifier for this build. The identifier is fixed for the lifetime of the build.
      * <p>
-     * Prefer {@link #getIdentityPath()}.
+     * Prefer {@link #getBuildIdentity()} or plain {@link #getIdentityPath()}.
      */
     default BuildIdentifier getBuildIdentifier() {
         return getBuildIdentity().getBuildIdentifier();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildDomainObjectContext.java
@@ -18,7 +18,7 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
-import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
 
@@ -27,15 +27,15 @@ import org.gradle.util.Path;
  */
 public class BuildDomainObjectContext implements DomainObjectContext {
 
-    private final BuildState buildState;
+    private final BuildIdentity buildIdentity;
 
-    public BuildDomainObjectContext(BuildState buildState) {
-        this.buildState = buildState;
+    public BuildDomainObjectContext(BuildIdentity buildIdentity) {
+        this.buildIdentity = buildIdentity;
     }
 
     @Override
     public Path getBuildPath() {
-        return buildState.getIdentityPath();
+        return buildIdentity.getBuildPath();
     }
 
     @Override
@@ -47,7 +47,7 @@ public class BuildDomainObjectContext implements DomainObjectContext {
 
     @Override
     public String getDisplayName() {
-        return buildState.getDisplayName().getDisplayName();
+        return buildIdentity.getDisplayName();
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -177,6 +177,7 @@ import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ResolvedBuildLayout;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.BuildIncluder;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.BuildLifecycleControllerFactory;
@@ -271,7 +272,10 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     void configure(ServiceRegistration registration, ServiceRegistry buildScopeServices, List<GradleModuleServices> serviceProviders) {
         registration.add(BuildDefinition.class, buildDefinition);
         registration.add(BuildState.class, buildState);
-        registration.add(DomainObjectContext.class, new BuildDomainObjectContext(buildState));
+
+        BuildIdentity buildIdentity = buildState.getBuildIdentity();
+        registration.add(BuildIdentity.class, buildIdentity);
+        registration.add(DomainObjectContext.class, new BuildDomainObjectContext(buildIdentity));
 
         registration.addProvider(new BuildCacheServices());
 
@@ -325,7 +329,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     ExecutionPlanFactory createExecutionPlanFactory(
-        BuildState build,
+        BuildIdentity build,
         TaskNodeFactory taskNodeFactory,
         OrdinalGroupFactory ordinalGroupFactory,
         TaskDependencyResolver dependencyResolver,
@@ -333,7 +337,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         ResourceLockCoordinationService lockCoordinationService
     ) {
         return new ExecutionPlanFactory(
-            build.getDisplayName().getDisplayName(),
+            build.getDisplayName(),
             taskNodeFactory,
             ordinalGroupFactory,
             dependencyResolver,
@@ -376,8 +380,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected PublicBuildPath createPublicBuildPath(BuildState buildState) {
-        return new DefaultPublicBuildPath(buildState.getIdentityPath());
+    protected PublicBuildPath createPublicBuildPath(BuildIdentity buildIdentity) {
+        return new DefaultPublicBuildPath(buildIdentity.getBuildPath());
     }
 
     @Provides
@@ -411,10 +415,10 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected GradleProperties createGradleProperties(
-        BuildState buildState,
+        BuildIdentity buildIdentity,
         GradlePropertiesController gradlePropertiesController
     ) {
-        return gradlePropertiesController.getGradleProperties(buildState.getBuildIdentifier());
+        return gradlePropertiesController.getGradleProperties(buildIdentity.getBuildIdentifier());
     }
 
     @Provides
@@ -785,7 +789,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
 
     @Provides({BuildServiceRegistryInternal.class, HoldsProjectState.class})
     protected DefaultBuildServicesRegistry createSharedServiceRegistry(
-        BuildState buildState,
+        BuildIdentity buildIdentity,
         Instantiator instantiator,
         DomainObjectCollectionFactory factory,
         InstantiatorFactory instantiatorFactory,
@@ -804,7 +808,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         // Instantiate via `instantiator` for the DSL decorations to the `BuildServiceRegistry` API
         return instantiator.newInstance(
             DefaultBuildServicesRegistry.class,
-            buildState.getBuildIdentifier(),
+            buildIdentity.getBuildIdentifier(),
             factory,
             instantiatorFactory,
             services,

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build
+
+import org.gradle.util.Matchers
+import org.gradle.util.Path
+import spock.lang.Specification
+
+class BuildIdentityTest extends Specification {
+
+    // This display name format is what BuildState.toString() and BuildState.getDisplayName() produce.
+    // Changing it affects user-visible output in logs and error messages.
+
+    def "root build has display name with root path"() {
+        def identity = new BuildIdentity(Path.ROOT)
+
+        expect:
+        identity.buildPath == Path.ROOT
+        identity.displayName == "build ':'"
+        identity.toString() == "build ':'"
+    }
+
+    def "nested build has display name with its build path"() {
+        def identity = new BuildIdentity(Path.path(":included"))
+
+        expect:
+        identity.buildPath == Path.path(":included")
+        identity.displayName == "build ':included'"
+        identity.toString() == "build ':included'"
+    }
+
+    def "exposes a build identifier for the same path"() {
+        def identity = new BuildIdentity(Path.path(":included:nested"))
+
+        expect:
+        identity.buildIdentifier.buildPath == ":included:nested"
+    }
+
+    def "rejects a relative build path"() {
+        when:
+        new BuildIdentity(Path.path("relative"))
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Build path must be absolute: relative"
+    }
+
+    def "has equals"() {
+        expect:
+        def identity = new BuildIdentity(Path.path(":one"))
+        def same = new BuildIdentity(Path.path(":one"))
+        def different = new BuildIdentity(Path.path(":two"))
+
+        Matchers.strictlyEquals(identity, same)
+        identity != different
+    }
+}


### PR DESCRIPTION
Introduces `BuildIdentity`, an immutable value type that carries a build's identity, and makes it the source of a build's path, identifier and display name.

### Why

`BuildState` is two things in one object: the identity of a build, and the owner of that build's mutable model and service scope. Consumers that need only a build path or an identifier must therefore depend on the whole live object.

A survey of the 21 places that inject `BuildState` as a service found that about half never touch the model: six read only cheap identity data, and six use the instance purely as a comparison token. `BuildIdentity` gives those consumers a type that matches what they actually use.

Each implementation also carried its own identity path field or hard-coded `Path.ROOT`, so the same identity was expressed five different ways.

### What

- Add `BuildIdentity`: a final value type over a build path, modelled on `ProjectIdentity`. It derives the `BuildIdentifier` and the display name, and rejects a relative path.
- Make `getBuildIdentity()` the single abstract identity member of `BuildState`. The path, identifier and display name become defaults that delegate to it.
- Hold the identity in `AbstractBuildState`, built from a new constructor parameter, and remove the per-implementation path fields.
- Move five build-scope consumers from `BuildState` to `BuildIdentity`.

### Verification

- New `BuildIdentityTest` pins the display name format, the derived identifier, path validation and equality.
- The existing build-state and composite-build unit tests cover the identity plumbing through all five implementations.

### Details

**`getIdentityPath()` is now a default method.** A `BuildState` test double that stubs neither `getBuildIdentity()` nor the path accessors will throw rather than return `null`. No existing test relies on that, but new doubles should stub the identity.
