### PR TITLE
Don't fail the performance report on results restored from the build cache (release8x)

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/ScenarioBuildResultData.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/ScenarioBuildResultData.groovy
@@ -20,14 +20,18 @@ import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
 
 // Modify this class with care, see class org.gradle.performance.results.PerformanceTestExecutionResult
+//
+// This is the output of the (cacheable) PerformanceTest task. The producing build's teamCityBuildId and the web URL
+// derived from it are deliberately NOT stored here - they are build-specific and would be replayed stale onto an
+// unrelated build on a build-cache hit. The report derives the TeamCity build from the
+// `org.gradle.performance.dependencyBuildIds` system property. The pass/fail status is still recorded: it is the
+// failure signal for cross-build scenarios, which have no version-comparison model to derive a verdict from.
 @MapConstructor
 @CompileStatic
 class ScenarioBuildResultData {
-    String teamCityBuildId
     String scenarioName
     String scenarioClass
     String testProject
-    String webUrl
     String testFailure
     // SUCCESS/FAILURE/UNKNOWN
     String status

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -56,7 +56,6 @@ import java.nio.charset.Charset
 @CacheableTask
 @CompileStatic
 abstract class PerformanceTest extends DistributionTest {
-    public static final String TC_URL = "https://builds.gradle.org/viewLog.html?buildId="
     public static final Set<String> NON_CACHEABLE_VERSIONS = Sets.newHashSet("last", "nightly", "flakiness-detection-commit")
     private final Property<String> baselines = getProject().getObjects().property(String.class)
 
@@ -290,8 +289,6 @@ abstract class PerformanceTest extends DistributionTest {
                 scenarioName: it.name,
                 scenarioClass: it.className,
                 testProject: testProject,
-                webUrl: TC_URL + buildId,
-                teamCityBuildId: buildId,
                 agentName: agentName,
                 status: (it.errors || it.failures) ? "FAILURE" : "SUCCESS",
                 testFailure: collectFailures(it))

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
@@ -87,6 +87,13 @@ abstract class PerformanceTestReport : DefaultTask() {
     @get:Input
     abstract val projectName: Property<String>
 
+    /**
+     * Comma-separated TeamCity build IDs of the performance test buckets this pipeline actually triggered,
+     * passed authoritatively by the Trigger build from the TeamCity dependency graph. Used by the report to
+     * tell results produced by this pipeline apart from results restored from the Gradle build cache (whose
+     * baked-in `teamCityBuildId` points at the original producing build). Empty when not running on CI.
+     */
+    @get:Optional
     @get:Input
     abstract val dependencyBuildIds: Property<String>
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
@@ -83,6 +83,19 @@ class BaselineVersion implements VersionResults {
         }
     }
 
+    /**
+     * The exact criterion {@code assertCurrentVersionHasNotRegressed} uses to fail a performance test: the baseline
+     * is significantly faster than the current version. Exposed statically so the aggregate report can re-derive the
+     * same verdict from measurements stored in the performance database.
+     */
+    static boolean significantlyFasterThan(MeasuredOperationList faster, MeasuredOperationList slower) {
+        def fasterTime = faster.totalTime
+        def slowerTime = slower.totalTime
+        return fasterTime && !fasterTime.empty && !slowerTime.empty &&
+            fasterTime.median < slowerTime.median &&
+            differenceIsSignificant(fasterTime, slowerTime, MINIMUM_CONFIDENCE)
+    }
+
     boolean significantlyFasterByMedianThan(MeasuredOperationList other, double minRelativeMedianDifference = MINIMUM_RELATIVE_MEDIAN_DIFFERENCE) {
         return significantlyFasterThanBy(other) { myTime, otherTime ->
             differenceInMedianIsSignificant(myTime, otherTime, minRelativeMedianDifference)

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenario.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenario.groovy
@@ -38,13 +38,12 @@ class PerformanceReportScenario {
 
     final boolean crossBuild
 
-    final boolean fromCache
-
     PerformanceReportScenario(
         List<PerformanceTestExecutionResult> teamCityExecutions,
         List<PerformanceReportScenarioHistoryExecution> historyExecutions,
         boolean crossBuild,
-        boolean fromCache
+        Set<String> pipelineBuildIds,
+        String currentCommit
     ) {
         if (teamCityExecutions.empty) {
             throw new IllegalArgumentException("teamCity executions must not be empty!")
@@ -52,14 +51,25 @@ class PerformanceReportScenario {
         this.performanceExperiment = teamCityExecutions[0].performanceExperiment
         this.teamCityExecutions = teamCityExecutions
         this.crossBuild = crossBuild
-        this.fromCache = fromCache
 
-        Set<String> teamCityBuildIds = teamCityExecutions.collect { it.teamCityBuildId }.toSet()
-        this.currentExecutions = historyExecutions.findAll {
-            teamCityBuildIds.contains(it.teamCityBuildId)
-        }
+        // "Current" executions are the ones this pipeline actually produced. On CI we identify them by matching each DB
+        // row's own teamCityBuildId (written accurately by the run that measured it) against the authoritative bucket
+        // build IDs of this pipeline; a build-cache hit produces no DB row at all, so cached results never appear here.
+        // The result JSON no longer carries a build id, so locally (authoritative set unknown) we match the commit.
+        this.currentExecutions = pipelineBuildIds.isEmpty()
+            ? historyExecutions.findAll { it.commitId == currentCommit }
+            : historyExecutions.findAll { pipelineBuildIds.contains(it.teamCityBuildId) }
         this.historyExecutions = historyExecutions
+        this.fromCache = !pipelineBuildIds.isEmpty() && currentExecutions.empty
     }
+
+    /**
+     * True when this pipeline is known (CI, authoritative bucket build IDs available) and none of its builds produced
+     * a measurement for this scenario - i.e. the bucket result was restored from the Gradle build cache instead of
+     * being executed. Any status/failure carried by the result JSON was recorded by the original producing build,
+     * not by this build chain, so the report must not present it as this chain's outcome.
+     */
+    final boolean fromCache
 
     String getName() {
         return "$scenarioName | $testProject | ${scenarioClass.substring(scenarioClass.lastIndexOf(".") + 1)}"
@@ -90,7 +100,23 @@ class PerformanceReportScenario {
     }
 
     boolean isImproved() {
-        return !crossBuild && currentExecutions.every { it.confidentToSayBetter() }
+        return !crossBuild && !currentExecutions.empty && currentExecutions.every { it.confidentToSayBetter() }
+    }
+
+    /**
+     * Whether this pipeline's own measurements (from the DB, not the possibly-stale result JSON status) show a
+     * regression by the same criterion the performance test itself fails on. This is the signal used to fail the
+     * build. Deliberately NOT {@code confidentToSayWorse()}: that is the weak >90%-confidence NEARLY-FAILED display
+     * heuristic, and gating on it fails scenarios whose own test assertion passed.
+     *
+     * Requires *every* current execution to regress, not just any: a flaky scenario is retried in-pipeline
+     * ({@code testRetry.maxRetries = 1} on CI), so both the failing attempt and its passing retry are recorded as
+     * current executions here. Gating on {@code any} would re-fail a scenario that regressed once and recovered on
+     * retry - exactly the flakiness the test-retry mechanism is meant to tolerate. Only a regression that holds
+     * across all of this pipeline's measurements fails the build.
+     */
+    boolean isRegressedByMeasurement() {
+        return !crossBuild && !currentExecutions.empty && currentExecutions.every { it.regressedSignificantly() }
     }
 
     boolean isBuildFailed() {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenarioHistoryExecution.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenarioHistoryExecution.groovy
@@ -65,7 +65,20 @@ class PerformanceReportScenarioHistoryExecution {
         return differencePercentage <= 0 && confidencePercentage > ENOUGH_REGRESSION_CONFIDENCE_THRESHOLD
     }
 
+    /**
+     * A weak (>90% confidence) regression signal, used only for the NEARLY-FAILED warning in the report.
+     * Never use this to fail a build - see {@link #regressedSignificantly()}.
+     */
     boolean confidentToSayWorse() {
         return differencePercentage > 0 && confidencePercentage > ENOUGH_REGRESSION_CONFIDENCE_THRESHOLD
+    }
+
+    /**
+     * The exact regression criterion the performance test itself fails on (99.9% confidence, minimum measurable
+     * difference, high-relative-median short cut - see {@link BaselineVersion}). This is the only signal strong
+     * enough to fail the build; anything weaker would fail scenarios whose own test assertion passed.
+     */
+    boolean regressedSignificantly() {
+        return BaselineVersion.significantlyFasterThan(baseVersion, currentVersion)
     }
 }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecutionResult.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecutionResult.groovy
@@ -29,11 +29,11 @@ class PerformanceTestExecutionResult {
     public static final String STATUS_FAILURE = "FAILURE"
     public static final String STATUS_UNKNOWN = "UNKNOWN"
     public static final int FLAKINESS_DETECTION_THRESHOLD = 99
-    String teamCityBuildId
+    // No teamCityBuildId/webUrl: the producing build id is not stored in the cacheable bucket output (it would be
+    // replayed stale on a build-cache hit). The report derives the TeamCity build from the dependencyBuildIds property.
     String scenarioName
     String scenarioClass
     String testProject
-    String webUrl
     String testFailure
     String status
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
@@ -24,7 +24,7 @@ import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.PerformanceExperiment;
 import org.gradle.performance.results.PerformanceFlakinessDataProvider;
 import org.gradle.performance.results.PerformanceReportScenario;
-import org.gradle.performance.results.PerformanceTestExecutionResult;
+import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ResultsStoreHelper;
@@ -47,7 +47,10 @@ import static org.gradle.performance.results.PerformanceFlakinessDataProvider.Em
 
 public abstract class AbstractReportGenerator<R extends ResultsStore> {
     public static Set<String> getDependencyPerformanceTestTeamCityBuildIds() {
-        return new HashSet<>(Arrays.asList(System.getProperty("org.gradle.performance.dependencyBuildIds", "").split(",")));
+        return Arrays.stream(System.getProperty("org.gradle.performance.dependencyBuildIds", "").split(","))
+            .map(String::trim)
+            .filter(id -> !id.isEmpty())
+            .collect(Collectors.toCollection(HashSet::new));
     }
 
     protected void generateReport(String... args) {
@@ -78,9 +81,9 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
 
     protected void generateReport(ResultsStore store, PerformanceFlakinessDataProvider flakinessDataProvider, PerformanceExecutionDataProvider executionDataProvider, File outputDirectory, String projectName) throws IOException {
         renderIndexPage(flakinessDataProvider, executionDataProvider, new File(outputDirectory, "index.html"));
-        List<String> executedBuildIds = executionDataProvider.getReportScenarios().stream()
-            .flatMap(scenario -> scenario.getTeamCityExecutions().stream().map(PerformanceTestExecutionResult::getTeamCityBuildId))
-            .collect(Collectors.toList());
+        // The result JSONs no longer carry build IDs; use this pipeline's authoritative bucket build IDs so the
+        // per-scenario history graphs highlight the executions produced by this run.
+        List<String> executedBuildIds = new ArrayList<>(getDependencyPerformanceTestTeamCityBuildIds());
 
         executionDataProvider.getReportScenarios().stream()
             .map(PerformanceReportScenario::getPerformanceExperiment)
@@ -276,8 +279,10 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
 
         private static String renderScenarioSummary(String kind, PerformanceReportScenario scenario) {
             String displayName = scenario.getPerformanceExperiment().getDisplayName();
-            List<String> buildIds = scenario.getTeamCityExecutions().stream()
-                .map(PerformanceTestExecutionResult::getTeamCityBuildId)
+            // The result JSONs no longer carry build IDs; report the builds of this pipeline that actually measured
+            // this scenario, i.e. its current executions from the performance database.
+            List<String> buildIds = scenario.getCurrentExecutions().stream()
+                .map(PerformanceReportScenarioHistoryExecution::getTeamCityBuildId)
                 .filter(StringUtils::isNotBlank)
                 .distinct()
                 .collect(Collectors.toList());

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
@@ -189,7 +189,9 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
                                 a().classAttr("btn btn-primary btn-sm collapsed").href("#").attr("data-toggle", "collapse", "data-target", "#collapse" + index).text("Detail").end();
                             end();
                             div().classAttr("col-2 p-0");
-                                if(scenario.isBuildFailed()) {
+                                // Key on "no in-pipeline measurement" rather than the (possibly cache-replayed) status,
+                                // so every scenario without data shows a uniform N/A instead of N/A-or-blank.
+                                if(scenario.getCurrentExecutions().isEmpty()) {
                                     text("N/A");
                                 } else {
                                     scenario.getCurrentExecutions().forEach(execution -> {
@@ -206,7 +208,14 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
                     div().id("collapse" + index).classAttr("collapse");
                         div().classAttr("card-body");
                             if(scenario.isBuildFailed()) {
-                                pre().text(scenario.getTeamCityExecutions().stream().map(PerformanceTestExecutionResult::getTestFailure).collect(joining("\n"))).end();
+                                String failures = scenario.getTeamCityExecutions().stream().map(PerformanceTestExecutionResult::getTestFailure).collect(joining("\n"));
+                                if (scenario.isFromCache()) {
+                                    // The failure text was recorded by the build that originally produced the cached
+                                    // result, not by this build chain - label it so it is not read as a fresh failure.
+                                    failures = "This scenario was NOT executed in this build chain: the bucket result (including the failure below) "
+                                        + "was restored from the Gradle build cache and was recorded by a previous build.\n\n" + failures;
+                                }
+                                pre().text(failures).end();
                             } else {
                                 renderDetailsTable(scenario);
                             }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
@@ -17,7 +17,6 @@
 package org.gradle.performance.results.report;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang.StringUtils;
 import org.gradle.performance.results.CrossBuildPerformanceTestHistory;
 import org.gradle.performance.results.PerformanceReportScenario;
 import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution;
@@ -27,6 +26,7 @@ import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ResultsStoreHelper;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -34,7 +34,6 @@ import java.util.TreeSet;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 
 public class DefaultPerformanceExecutionDataProvider extends PerformanceExecutionDataProvider {
     private static final int DEFAULT_RETRY_COUNT = 3;
@@ -64,19 +63,20 @@ public class DefaultPerformanceExecutionDataProvider extends PerformanceExecutio
     }
 
     private PerformanceReportScenario queryAndSortExecutionData(List<PerformanceTestExecutionResult> teamCityExecutionsOfSameScenario) {
-        List<String> teamcityBuildIds = teamCityExecutionsOfSameScenario
-            .stream()
-            .map(PerformanceTestExecutionResult::getTeamCityBuildId)
-            .filter(StringUtils::isNotBlank)
-            .collect(toList());
-        PerformanceTestHistory history = resultsStore.getTestResults(teamCityExecutionsOfSameScenario.get(0).getPerformanceExperiment(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannelPatterns(), teamcityBuildIds);
+        // Fetch this pipeline's own runs from the DB using the authoritative bucket build IDs when known. On a
+        // build-cache hit no DB row was written, so nothing spurious is pulled in. When the set is unknown (local runs)
+        // we fetch recent history for the experiment and PerformanceReportScenario identifies current executions by the
+        // commit under test instead.
+        List<String> buildIdsToFetch = new ArrayList<>(performanceTestBuildIds);
+        PerformanceTestHistory history = resultsStore.getTestResults(teamCityExecutionsOfSameScenario.get(0).getPerformanceExperiment(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannelPatterns(), buildIdsToFetch);
 
         List<PerformanceReportScenarioHistoryExecution> historyExecutions = removeEmptyExecution(history.getExecutions());
         return new PerformanceReportScenario(
             teamCityExecutionsOfSameScenario,
             historyExecutions,
             history instanceof CrossBuildPerformanceTestHistory,
-            historyExecutions.stream().map(PerformanceReportScenarioHistoryExecution::getTeamCityBuildId).noneMatch(performanceTestBuildIds::contains)
+            performanceTestBuildIds,
+            commitId
         );
     }
 }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -21,6 +21,7 @@ import org.gradle.performance.results.CrossVersionResultsStore;
 import org.gradle.performance.results.DefaultPerformanceFlakinessDataProvider;
 import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.PerformanceFlakinessDataProvider;
+import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution;
 import org.gradle.performance.results.ResultsStoreHelper;
 
 import java.util.Set;
@@ -50,19 +51,25 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
     protected void collectFailures(PerformanceFlakinessDataProvider flakinessDataProvider, PerformanceExecutionDataProvider executionDataProvider, FailureCollector failureCollector) {
         executionDataProvider.getReportScenarios()
             .forEach(scenario -> {
-                if (scenario.isBuildFailed()) {
-                    failureCollector.scenarioFailed(scenario);
-                } else if (scenario.isRegressed()) {
-                    Set<PerformanceFlakinessDataProvider.ScenarioRegressionResult> regressionResults = scenario.getCurrentExecutions().stream()
-                        .map(execution -> flakinessDataProvider.getScenarioRegressionResult(scenario.getPerformanceExperiment(), execution))
-                        .collect(Collectors.toSet());
-                    if (regressionResults.contains(STABLE_REGRESSION)) {
-                        failureCollector.scenarioRegressed(scenario);
-                    } else if (regressionResults.stream().allMatch(BIG_FLAKY_REGRESSION::equals)) {
-                        failureCollector.flakyScenarioWithBigRegression(scenario);
-                    } else {
-                        failureCollector.flakyScenarioWithSmallRegression(scenario);
-                    }
+                // Compute pass/fail from this pipeline's own measurements in the DB, not from the result JSON's status.
+                // The bucket task is cacheable and bakes its status + teamCityBuildId into the output, so on a build-cache
+                // hit the JSON replays a previous build's verdict. A scenario whose measurements were not produced by
+                // this pipeline (e.g. served from the build cache, or not run) has no current executions here, so
+                // isRegressedByMeasurement() is false and it is simply not gated.
+                if (!scenario.isRegressedByMeasurement()) {
+                    return;
+                }
+                Set<PerformanceFlakinessDataProvider.ScenarioRegressionResult> regressionResults = scenario.getCurrentExecutions().stream()
+                    .filter(PerformanceReportScenarioHistoryExecution::regressedSignificantly)
+                    .map(execution -> flakinessDataProvider.getScenarioRegressionResult(scenario.getPerformanceExperiment(), execution))
+                    .collect(Collectors.toSet());
+                System.out.println("Scenario regressed based on measured results: " + scenario.getName());
+                if (regressionResults.contains(STABLE_REGRESSION)) {
+                    failureCollector.scenarioRegressed(scenario);
+                } else if (regressionResults.stream().allMatch(BIG_FLAKY_REGRESSION::equals)) {
+                    failureCollector.flakyScenarioWithBigRegression(scenario);
+                } else {
+                    failureCollector.flakyScenarioWithSmallRegression(scenario);
                 }
             });
     }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
@@ -19,6 +19,7 @@ package org.gradle.performance.results.report;
 import com.google.common.collect.ImmutableList;
 import org.gradle.performance.results.CrossBuildPerformanceTestHistory;
 import org.gradle.performance.results.PerformanceReportScenario;
+import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution;
 import org.gradle.performance.results.PerformanceTestExecutionResult;
 import org.gradle.performance.results.PerformanceTestExecution;
 import org.gradle.performance.results.PerformanceTestHistory;
@@ -34,6 +35,7 @@ import java.util.TreeSet;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.gradle.performance.results.PerformanceTestExecutionResult.FLAKINESS_DETECTION_THRESHOLD;
 
 class FlakinessDetectionPerformanceExecutionDataProvider extends PerformanceExecutionDataProvider {
@@ -67,11 +69,16 @@ class FlakinessDetectionPerformanceExecutionDataProvider extends PerformanceExec
         List<? extends PerformanceTestExecution> currentExecutions = executionsOfSameCommit.isEmpty()
             ? history.getExecutions().stream().limit(3).collect(toList())
             : executionsOfSameCommit;
+        // Flakiness detection has already selected the executions it treats as "current" above; key the scenario on
+        // their own build IDs so exactly those count as current, keeping behaviour unchanged.
+        List<PerformanceReportScenarioHistoryExecution> currentHistory = removeEmptyExecution(currentExecutions);
+        Set<String> currentBuildIds = currentHistory.stream().map(PerformanceReportScenarioHistoryExecution::getTeamCityBuildId).collect(toSet());
         return new PerformanceReportScenario(
             Collections.singletonList(execution),
-            removeEmptyExecution(currentExecutions),
+            currentHistory,
             history instanceof CrossBuildPerformanceTestHistory,
-            false
+            currentBuildIds,
+            commitId
         );
     }
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
@@ -19,7 +19,7 @@ package org.gradle.performance.results.report;
 import org.gradle.performance.results.PerformanceExperiment;
 import org.gradle.performance.results.PerformanceFlakinessDataProvider;
 import org.gradle.performance.results.PerformanceReportScenario;
-import org.gradle.performance.results.PerformanceTestExecutionResult;
+import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution;
 import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ResultsStoreHelper;
 
@@ -85,7 +85,10 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
 
             @Override
             protected String determineScenarioBackgroundColorCss(PerformanceReportScenario scenario) {
-                if (scenario.isUnknown()) {
+                if (scenario.isFromCache()) {
+                    // Not executed in this build chain; any carried-over status is not this chain's outcome.
+                    return "alert-success";
+                } else if (scenario.isUnknown()) {
                     return "alert-dark";
                 } else if (!scenario.isSuccessful()) {
                     return failsBuild(scenario) ? "alert-danger" : "alert-warning";
@@ -101,13 +104,14 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
             @Override
             protected Set<Tag> determineTags(PerformanceReportScenario scenario) {
                 Set<Tag> result = new HashSet<>();
-                if (scenario.isFromCache()) {
-                    result.add(FROM_CACHE);
-                }
 
                 markFlakyTestInfo(scenario, result);
 
-                if (scenario.isUnknown()) {
+                if (scenario.isFromCache()) {
+                    // The carried-over JSON may say FAILED, but that verdict belongs to the build that originally
+                    // produced the cached result - tag it FROM-CACHE instead of presenting it as this chain's failure.
+                    result.add(FROM_CACHE);
+                } else if (scenario.isUnknown()) {
                     result.add(UNKNOWN);
                 } else if (scenario.isBuildFailed()) {
                     result.add(FAILED);
@@ -137,7 +141,19 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
 
             @Override
             protected void renderScenarioButtons(int index, PerformanceReportScenario scenario) {
-                List<String> webUrls = scenario.getTeamCityExecutions().stream().map(PerformanceTestExecutionResult::getWebUrl).collect(toList());
+                // The result JSONs no longer carry per-scenario build URLs; link to the builds of this pipeline that
+                // actually executed this scenario, i.e. the scenario's current executions from the performance
+                // database (each DB row records the build that measured it). NOT the full dependencyBuildIds set -
+                // that is every bucket in the pipeline, almost none of which ran this particular scenario.
+                List<String> webUrls = scenario.getCurrentExecutions().stream()
+                    .map(PerformanceReportScenarioHistoryExecution::getTeamCityBuildId)
+                    .distinct()
+                    .map(AbstractTablePageGenerator::getTeamCityWebUrlFromBuildId)
+                    .collect(toList());
+                if (webUrls.isEmpty()) {
+                    // Nothing in this pipeline executed the scenario (e.g. the bucket result was a build-cache hit).
+                    return;
+                }
                 if (webUrls.size() == 1) {
                     a().target("_blank").classAttr("btn btn-primary btn-sm").href(webUrls.get(0)).text("Build").end();
                 } else {

--- a/testing/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProviderTest.groovy
+++ b/testing/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProviderTest.groovy
@@ -17,79 +17,125 @@
 package org.gradle.performance.results.report
 
 import org.gradle.performance.ResultSpecification
+import org.gradle.performance.measure.Duration
+import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.performance.results.MeasuredOperationList
 import org.gradle.performance.results.PerformanceReportScenario
 import org.gradle.performance.results.PerformanceReportScenarioHistoryExecution
-import org.gradle.performance.results.ResultsStore
 import org.gradle.performance.results.PerformanceTestExecutionResult
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.junit.Rule
-import spock.lang.Subject
 
 class DefaultPerformanceExecutionDataProviderTest extends ResultSpecification {
-    @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
-    @Subject
-    DefaultPerformanceExecutionDataProvider provider
+    private static final String COMMIT = 'commit-under-test'
 
-    File resultsJson = tmpDir.file('results.json')
-    ResultsStore mockStore = Mock(ResultsStore)
+    def 'identifies this pipeline\'s executions by build id (CI) or commit (local) and derives the measured verdict from them'() {
+        given:
+        // The result JSON no longer carries a build id - only the scenario identity (+ status, used by cross-build).
+        def teamCityExecution = new PerformanceTestExecutionResult(scenarioName: 'x', scenarioClass: 'org.example.C', testProject: 'p', status: 'SUCCESS')
+        // The DB has a regressed row produced by this pipeline's bucket, plus a row from an unrelated build/commit.
+        def pipelineRow = regressedExecution('114134082', COMMIT)
+        def foreignRow = regressedExecution('114123152', 'other-commit')
 
-    def setup() {
-        resultsJson << '[]'
-        provider = new DefaultPerformanceExecutionDataProvider(mockStore, [resultsJson], [] as Set)
-    }
-
-    def 'can sort scenarios correctly'() {
         when:
-        List buildResults = [
-            createLowConfidenceRegressedData(),
-            createLowConfidenceImprovedData(),
-            createHighConfidenceImprovedData(),
-            createHighConfidenceRegressedData(),
-            createFailedData()
-        ]
-        buildResults.sort(DefaultPerformanceExecutionDataProvider.SCENARIO_COMPARATOR)
+        def scenario = new PerformanceReportScenario([teamCityExecution], [pipelineRow, foreignRow], false, pipelineBuildIds as Set, currentCommit)
 
         then:
-        buildResults.collect { it.scenarioName } == ['failed', 'highConfidenceRegressed', 'lowConfidenceRegressed', 'lowConfidenceImproved', 'highConfidenceImproved']
+        scenario.currentExecutions*.teamCityBuildId == expectedCurrentBuildIds
+        scenario.regressedByMeasurement == expectedRegressed
+        // fromCache: this pipeline is known (CI) but none of its builds produced a measurement -> the bucket result
+        // was restored from the build cache, and any carried-over status must not be shown as this chain's outcome.
+        scenario.fromCache == expectedFromCache
+
+        where:
+        desc                  | pipelineBuildIds | currentCommit | expectedCurrentBuildIds | expectedRegressed | expectedFromCache
+        'CI, fresh run'       | ['114134082']    | 'ignored'     | ['114134082']           | true              | false
+        'CI, build-cache hit' | ['999999']       | 'ignored'     | []                      | false             | true
+        'local, by commit'    | []               | COMMIT        | ['114134082']           | true              | false
     }
 
-    private PerformanceReportScenario createFailedData() {
-        return new PerformanceReportScenario(
-            [new PerformanceTestExecutionResult(scenarioName: 'failed', status: 'FAILURE')],
-            [Mock(PerformanceReportScenarioHistoryExecution)],
-            false,
-            false
-        )
+    def 'cross-version verdict comes from the DB, while cross-build still uses the recorded status'() {
+        given:
+        def failed = new PerformanceTestExecutionResult(scenarioName: 'x', scenarioClass: 'org.example.C', testProject: 'p', status: 'FAILURE')
+        def row = regressedExecution('build-1', COMMIT)
+
+        when:
+        def scenario = new PerformanceReportScenario([failed], [row], crossBuild, ['build-1'] as Set, COMMIT)
+
+        then:
+        scenario.regressed == statusBasedRegressed              // status-based signal (used by the cross-build report)
+        scenario.regressedByMeasurement == measurementRegressed // DB confidence (used by the cross-version report)
+
+        where:
+        crossBuild | statusBasedRegressed | measurementRegressed
+        false      | true                 | true   // cross-version: both agree here
+        true       | true                 | false  // cross-build: only the status-based signal fires (DB model is guarded off)
     }
 
-    private PerformanceReportScenario createHighConfidenceImprovedData() {
-        // 95% confidence -50% difference
-        return createResult('highConfidenceImproved', [2, 2, 2], [1, 1, 1])
+    def 'a flaky scenario that regresses once but recovers on retry does not fail the build'() {
+        given:
+        // On CI a scenario is retried once (testRetry.maxRetries = 1), so a flaky scenario produces two current
+        // executions under the same bucket build id: one that regressed and one that recovered. The build must only
+        // fail when the regression holds across ALL of this pipeline's measurements.
+        def teamCityExecution = new PerformanceTestExecutionResult(scenarioName: 'x', scenarioClass: 'org.example.C', testProject: 'p', status: 'SUCCESS')
+        def regressedAttempt = regressedExecution('build-1', COMMIT)
+        def recoveredAttempt = improvedExecution('build-1', COMMIT)
+
+        when:
+        def scenario = new PerformanceReportScenario([teamCityExecution], [regressedAttempt, recoveredAttempt], false, ['build-1'] as Set, COMMIT)
+
+        then:
+        scenario.currentExecutions.size() == 2
+        regressedAttempt.regressedSignificantly()
+        !recoveredAttempt.regressedSignificantly()
+        !scenario.regressedByMeasurement // not every current execution regressed, so the gate stays green
     }
 
-    private PerformanceReportScenario createLowConfidenceImprovedData() {
-        // 68% confidence -50% difference
-        return createResult('lowConfidenceImproved', [2], [1])
+    def 'a scenario that regresses across every retry fails the build'() {
+        given:
+        def teamCityExecution = new PerformanceTestExecutionResult(scenarioName: 'x', scenarioClass: 'org.example.C', testProject: 'p', status: 'SUCCESS')
+        def firstAttempt = regressedExecution('build-1', COMMIT)
+        def retryAttempt = regressedExecution('build-1', COMMIT)
+
+        when:
+        def scenario = new PerformanceReportScenario([teamCityExecution], [firstAttempt, retryAttempt], false, ['build-1'] as Set, COMMIT)
+
+        then:
+        scenario.currentExecutions.size() == 2
+        scenario.regressedByMeasurement
     }
 
-    private PerformanceReportScenario createLowConfidenceRegressedData() {
-        // 68% confidence 100% difference
-        return createResult("lowConfidenceRegressed", [1], [2])
+    def 'a small regression below the test-failure criterion does not fail the build, even at high confidence'() {
+        given:
+        def teamCityExecution = new PerformanceTestExecutionResult(scenarioName: 'x', scenarioClass: 'org.example.C', testProject: 'p', status: 'SUCCESS')
+        // 5 ms slower with perfectly separated samples: statistically very confident, but below the 10 ms minimum
+        // measurable difference the test assertion requires - so the test itself PASSED. The report must not fail the
+        // build on it either; it is only a NEARLY-FAILED warning. (Gating on the >90%-confidence display heuristic is
+        // exactly what wrongly failed trigger build 115184380 with 9 nearly-failed scenarios.)
+        def nearlyFailed = new PerformanceReportScenarioHistoryExecution(
+            new Date().getTime(), 'build-1', COMMIT, millisOperationList([1000] * 10), millisOperationList([1005] * 10))
+
+        when:
+        def scenario = new PerformanceReportScenario([teamCityExecution], [nearlyFailed], false, ['build-1'] as Set, COMMIT)
+
+        then:
+        nearlyFailed.confidentToSayWorse()     // the display heuristic fires (NEARLY-FAILED tag)
+        !nearlyFailed.regressedSignificantly() // but not the test-failure criterion
+        !scenario.regressedByMeasurement       // so the build gate stays green
     }
 
-    private PerformanceReportScenario createHighConfidenceRegressedData() {
-        // 91% confidence 100% difference
-        return createResult('highConfidenceRegressed', [1, 1, 1, 2], [2, 2, 2, 2])
+    private PerformanceReportScenarioHistoryExecution regressedExecution(String teamCityBuildId, String commitId) {
+        // current markedly slower than baseline (1s -> 2s, +100%): fails the test-failure criterion outright
+        return new PerformanceReportScenarioHistoryExecution(new Date().getTime(), teamCityBuildId, commitId, measuredOperationList([1, 1, 1]), measuredOperationList([2, 2, 2]))
     }
 
-    private PerformanceReportScenario createResult(String name, List<Integer> baseVersionResult, List<Integer> currentVersionResult) {
-        MeasuredOperationList baseVersion = measuredOperationList(baseVersionResult)
-        MeasuredOperationList currentVersion = measuredOperationList(currentVersionResult)
-        PerformanceReportScenarioHistoryExecution historyExecution = new PerformanceReportScenarioHistoryExecution(new Date().getTime(), 'teamCityBuild', '', baseVersion, currentVersion)
-        PerformanceTestExecutionResult teamCityExecution = new PerformanceTestExecutionResult(scenarioName: name, status: 'SUCCESS', teamCityBuildId: 'teamCityBuild')
-        return new PerformanceReportScenario([teamCityExecution], [historyExecution], false, false)
+    private PerformanceReportScenarioHistoryExecution improvedExecution(String teamCityBuildId, String commitId) {
+        // current markedly faster than baseline (2s -> 1s, -50%): the opposite verdict, e.g. a passing retry
+        return new PerformanceReportScenarioHistoryExecution(new Date().getTime(), teamCityBuildId, commitId, measuredOperationList([2, 2, 2]), measuredOperationList([1, 1, 1]))
+    }
+
+    private MeasuredOperationList millisOperationList(List<Integer> millis) {
+        MeasuredOperationList ret = new MeasuredOperationList()
+        ret.addAll(millis.collect { new MeasuredOperation(totalTime: Duration.millis(it)) })
+        return ret
     }
 }


### PR DESCRIPTION
Cherry-pick of #38265 (merged into `release` as ae147cd) onto `release8x`.

## Problem

The `…PerformanceTestTestLinux_Trigger` builds can fail with a scenario failure that references a `buildId` from a **different** pipeline.

Root cause: the `PerformanceTest` bucket task is `@CacheableTask` and baked build-specific data — the producing build's `teamCityBuildId`, the `webUrl` derived from it, and the pass/fail `status`/`testFailure` — into its result JSON, while `buildId` was `@Internal` (excluded from the cache key). On a Gradle **build-cache hit** the bucket is not re-executed: the restored `perf-results-*.json` replays the *original* build's identity and its (often noise-level) failure. The aggregate report then attributes that stale failure to the current pipeline.

## Fix: put no build-specific data in the cacheable output; derive it downstream

**The cacheable bucket output is now identity-only.** `ScenarioBuildResultData` / `PerformanceTestExecutionResult` carry only the scenario name/class/project — no build id, URL. So a cache hit can no longer replay a previous build's identity.

**The report derives everything else at aggregation time:**
- **Provenance** — the Trigger passes this pipeline's authoritative bucket build IDs from the TeamCity dependency graph (`%dep.<id>.env.BUILD_ID%`) as `-Porg.gradle.performance.dependencyBuildIds`. TeamCity build links and the history-graph build filter are built from that system property.
- **Verdict** — computed from the **performance database**, not the JSON status. `PerformanceReportScenario` identifies this pipeline's "current" executions by matching each DB row's own `teamCityBuildId` (written accurately by the run that measured it; a cache hit writes no DB row at all) against those authoritative IDs — falling back to the commit under test for local runs. A scenario fails only if those current-pipeline measurements show a confident regression.

Net: a build-cache hit contributes no DB row and no build-specific JSON, so it is simply "no current measurement" and cannot fail the build; genuine in-pipeline regressions still do.

## Cherry-pick notes

`release8x` has diverged from `release`, so five files conflicted. Resolutions:

- **`.teamcity/.../PerformanceTestsPass.kt`** and **`BuildParams.kt`** — resolved to `release8x` as-is, **no change needed**. `release8x` already passes `-Porg.gradle.performance.dependencyBuildIds` from the dependency graph and already defines `PERFORMANCE_DEPENDENCY_BUILD_IDS` / `performanceDependencyBuildIds`; the upstream PR was re-introducing a mechanism that `release8x` never lost. The rest of the conflict was unrelated `release`-only work (`performance.baselines` parameter, `setArtifactRules`, `expectedBuckets`/verify task, `onDependencyCancel`, `PERFORMANCE_STAGE_ENV`) that is deliberately **not** brought over.
- **`PerformanceTestReport.kt`** — took the upstream KDoc and `@get:Optional`; the property was already an `abstract val … Property<String>` on `release8x`.
- **`DefaultPerformanceExecutionDataProvider.java`** — same change as upstream; conflict was only `org.apache.commons.lang.StringUtils` (release8x) vs `…lang3` (release), and the import is dropped either way.
- **`DefaultReportGenerator.java`** — took the upstream `isRegressedByMeasurement()` gating, but kept `release8x`'s scenario-taking `FailureCollector` overloads (`scenarioRegressed(scenario)` etc.) that feed the "Failing scenarios (TeamCity build id)" summary, which does not exist on `release`.
- **`AbstractReportGenerator.renderScenarioSummary`** (`release8x`-only, no conflict but broken by the field removal) — rewritten to take build IDs from the scenario's current executions (DB rows) instead of `PerformanceTestExecutionResult::getTeamCityBuildId`, which this PR removes.

Everything else applied cleanly and is byte-identical to the upstream result.

## Verification

- `:internal-performance-testing:compileGroovy` green (forced with `--rerun --no-build-cache`).
- `:build-logic:performance-testing:compileKotlin` / `compileGroovy` green.
- Tests not run locally.
