### PR TITLE
Fix flaky ScalaConcurrencyIntegrationTest

### DIFF
--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
@@ -18,13 +18,11 @@ package org.gradle.scala
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ScalaCoverage
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Issue
 
 
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/4636")
 class ScalaConcurrencyIntegrationTest extends AbstractIntegrationSpec {
     @Rule BlockingHttpServer httpServer = new BlockingHttpServer()
 
@@ -90,7 +88,14 @@ class ScalaConcurrencyIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        // Compile everything before the concurrency barrier below. Project 'a' depends on 'b', 'c'
+        // and 'd', so ':a:compileScala' cannot start until their jars exist. In the measured build,
+        // ':b:test', ':c:test' and ':d:test' block on the barrier holding 3 of the 4 worker leases,
+        // leaving ':a' a single lease on which to run two forked Scala compilations before ':a:test'
+        // can reach the barrier -- regularly longer than BlockingHttpServer's 120s timeout.
+        succeeds(":a:testClasses", ":b:testClasses", ":c:testClasses", ":d:testClasses")
+
+        and:
         succeeds("build", "--parallel", "--max-workers", "4")
-        true
     }
 }

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaConcurrencyIntegrationTest.groovy
@@ -96,6 +96,9 @@ class ScalaConcurrencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds(":a:testClasses", ":b:testClasses", ":c:testClasses", ":d:testClasses")
 
         and:
-        succeeds("build", "--parallel", "--max-workers", "4")
+        // 8 workers, not 4: all four ':test' tasks must be in flight at once, so demanding
+        // exactly max-workers leaves zero tolerance for any other lease holder (e.g. ':a:jar').
+        // Headroom removes that ceiling; expectConcurrent still asserts all four run concurrently.
+        succeeds("build", "--parallel", "--max-workers", "8")
     }
 }


### PR DESCRIPTION
## Problem

`ScalaConcurrencyIntegrationTest` fails on its first attempt roughly **47%** of the time it runs. Over 2026-08-10 → 2026-09-01 Develocity records **135 flaky vs 153 passed** executions (0 hard failures — it always recovers on retry). Since June: 403 flaky / 519 passed.

The failure signature is always the same:

```
Failed to handle GET /:d:test due to a timeout waiting for other requests.
Waiting for 1 further requests, received [GET /:d:test, GET /:b:test, GET /:c:test],
released [], not yet received [GET /:a:test]
```

### Root cause

`BlockingHttpServer` allows 120s from the last-arriving request. From a representative failure ([scan](https://ge.gradle.org/s/zh7jzysx2ypmw)):

| Time | Event |
|---|---|
| 05:27:24.494 | `:d:test` reaches barrier, blocks |
| 05:27:25.952 | `:b:test` reaches barrier, blocks |
| 05:27:26.831 | `:c:test` reaches barrier, blocks — **120s clock starts** |
| 05:27:53 | `:a:compileScala` finally *starts* (26s spent queuing for a free lease) |
| 05:29:26.831 | **Timeout at exactly +120.000s**, `:a:compileScala` still running |

Two compounding causes, both about worker leases:

1. **The compile is inside the timed window.** `a` depends on `b`, `c` and `d`, so `:a:compileScala` cannot start until their jars exist — `:a:test` is necessarily **last** to the barrier. Meanwhile `:b:test`, `:c:test` and `:d:test` block inside their `doLast` holding 3 of the 4 worker leases, leaving `a` a **single lease** on which to serially run two `options.fork = true` Scala compilations (forked compiler-daemon JVM startup included). For scale: `b`/`c`/`d`'s own `compileScala` each took ~30s *with 3 workers available*; `a`'s got >93s on one lease and still didn't finish.

2. **The test sits exactly at the lease ceiling.** Four `:test` tasks must be in flight simultaneously for the barrier to release, while `--max-workers` was also 4. That leaves zero tolerance for any other lease holder — the same pattern documented for `ParallelDownloadsIntegrationTest`.

The retry passes in ~10s purely because the Gradle daemon, dependency cache and Scala compiler daemon are all warm — which is exactly why this presents as flaky rather than broken.

## Fix

1. Compile all four projects in a separate build first, so the measured build has only the four `test` tasks left to run and all of them reach the barrier promptly.
2. Raise `--max-workers` from 4 to 8, so the demanded concurrency no longer equals the lease ceiling.

`expectConcurrent` is unchanged, so the test still proves what gradle/gradle#14434 was about.

Also removes the `@Flaky` quarantine annotation, since the test is no longer flaky.

A timeout bump was considered and rejected: it just moves the goalposts and still flakes on a slower agent.

## Verification

Ran locally on JDK 21 (`-PtestJavaVersion=21`) — **7 runs, 7 passes, 0 failures** (4 before the headroom change, 3 after), 12–50s each with no timeouts. This also confirms all four `test` tasks still overlap after the warm-up build, so the concurrency assertion is genuinely still exercised rather than trivially satisfied.

Note for reviewers: this test is silently **skipped** on JDK 24+ (`ScalaCoverage` requires Scala >= 2.13.17 there, but `SCALA_2` tops out at 2.13.16), and a skip still reports `BUILD SUCCESSFUL`. An explicit older test JDK is needed to exercise it locally.

Fixes gradle/gradle-private#4636