### PR TITLE
WIP: Record build scope invariants that had to be rediscovered

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
@@ -19,6 +19,17 @@ package gradlebuild.basics.testing
 import org.gradle.api.tasks.testing.Test
 
 
+/**
+ * The executers run the same tests under different conditions, so which one you need
+ * depends on what the change affects:
+ *
+ * - `embedded` runs the build in the test process. This is the executer wired into `check`.
+ * - `forking` and `noDaemon` run a real build process, so they cover daemon and startup behaviour.
+ * - `parallel` runs with parallel execution enabled.
+ * - `configCache` stores and reloads the configuration cache, so it is the only executer that
+ *   exercises serialization. A change to a codec is not covered by any of the others.
+ * - `isolatedProjects` runs with isolated projects enabled.
+ */
 enum class TestType(val prefix: String, val executers: List<String>) {
     INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "configCache", "isolatedProjects")),
     CROSSVERSION("crossVersion", listOf("embedded", "forking"))

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuild.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuild.kt
@@ -16,9 +16,9 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildState
 import org.gradle.util.Path
 import java.io.File
@@ -41,5 +41,5 @@ interface ConfigurationCacheBuild {
 
     fun addImplicitIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild
 
-    fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild
+    fun getBuildSrcOf(ownerId: BuildIdentity): ConfigurationCacheBuild
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -489,7 +489,7 @@ class ConfigurationCacheState(
     suspend fun WriteContext.writeBuildSrcBuild(state: StandAloneNestedBuild, buildTreeState: StoredBuildTreeState) {
         val gradle = state.mutableModel
         withGradleIsolate(gradle, userTypesCodec) {
-            write(state.owner.buildIdentifier)
+            write(state.owner.buildIdentity)
         }
         // Encode the build state using the contextualized IO service for the nested build
         gradle.serviceOf<ConfigurationCacheIncludedBuildIO>().run {
@@ -503,8 +503,8 @@ class ConfigurationCacheState(
     private
     suspend fun ReadContext.readBuildSrcBuild(rootBuild: ConfigurationCacheBuild): CachedBuildState {
         val build = withGradleIsolate(rootBuild.gradle, userTypesCodec) {
-            val ownerIdentifier = readNonNull<BuildIdentifier>()
-            rootBuild.getBuildSrcOf(ownerIdentifier)
+            val ownerIdentity = readNonNull<BuildIdentity>()
+            rootBuild.getBuildSrcOf(ownerIdentity)
         }
         return readNestedBuildState(build)
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -47,6 +47,7 @@ import org.gradle.initialization.BuildStructureOperationProject
 import org.gradle.initialization.ProjectsIdentifiedProgressDetails
 import org.gradle.initialization.RootBuildCacheControllerSettingsProcessor
 import org.gradle.internal.Actions
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildProjectRegistry
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.IncludedBuildState
@@ -344,7 +345,7 @@ class ConfigurationCacheState(
 
     private
     suspend fun WriteContext.writeBuildsInTree(buildEventListeners: List<RegisteredBuildServiceProvider<*, *>>) {
-        val requiredBuildServicesPerBuild = buildEventListeners.groupBy { it.buildIdentifier }
+        val requiredBuildServicesPerBuild = buildEventListeners.groupBy { it.buildIdentity }
         val builds = mutableMapOf<BuildState, BuildToStore>()
         val scheduledWorkPerBuild = mutableMapOf<BuildIdentifier, ScheduledWork>()
         host.visitBuilds { state ->
@@ -674,7 +675,7 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writeRequiredBuildServicesOf(build: BuildState, buildTreeState: StoredBuildTreeState) {
         withGradleIsolate(build.mutableModel, userTypesCodec) {
-            val providers = buildTreeState.requiredBuildServicesPerBuild[build.buildIdentifier] ?: emptyList()
+            val providers = buildTreeState.requiredBuildServicesPerBuild[build.buildIdentity] ?: emptyList()
             writeCollection(providers) { listener ->
                 writeBuildEventListenerSubscription(listener)
             }
@@ -1060,13 +1061,13 @@ class ConfigurationCacheState(
 
     private
     fun isRelevantBuildEventListener(provider: RegisteredBuildServiceProvider<*, *>) =
-        Path.path(provider.buildIdentifier.buildPath).name != BUILD_SRC
+        provider.buildIdentity.buildPath.name != BUILD_SRC
 }
 
 
 internal
 class StoredBuildTreeState(
-    val requiredBuildServicesPerBuild: Map<BuildIdentifier, List<BuildServiceProvider<*, *>>>,
+    val requiredBuildServicesPerBuild: Map<BuildIdentity, List<BuildServiceProvider<*, *>>>,
     private val scheduledWorkPerBuild: Map<BuildIdentifier, ScheduledWork>,
     val idForNode: IdForNode,
     val transformedProjectsPerBuild: Map<BuildIdentifier, Set<Path>>

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -33,6 +33,7 @@ import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.ProjectDescriptorInternal
 import org.gradle.initialization.SettingsState
 import org.gradle.initialization.layout.BuildLayout
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.service
@@ -150,8 +151,8 @@ class DefaultConfigurationCacheHost internal constructor(
             return DefaultConfigurationCacheBuild(buildStateRegistry.addImplicitIncludedBuild(buildDefinition, buildPath), fileResolver, buildStateRegistry, settingsFile)
         }
 
-        override fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild {
-            return DefaultConfigurationCacheBuild(buildStateRegistry.getBuildSrcNestedBuild(buildStateRegistry.getBuild(ownerId))!!, fileResolver, buildStateRegistry, null)
+        override fun getBuildSrcOf(ownerId: BuildIdentity): ConfigurationCacheBuild {
+            return DefaultConfigurationCacheBuild(buildStateRegistry.getBuildSrcNestedBuild(buildStateRegistry.getBuild(ownerId.buildPath))!!, fileResolver, buildStateRegistry, null)
         }
 
         private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -516,7 +516,7 @@ class ConfigurationCacheFingerprintController internal constructor(
             when (propertyScope) {
                 is GradlePropertyScope.Build -> {
                     propertiesController.loadGradleProperties(
-                        propertyScope.buildIdentifier,
+                        propertyScope.buildIdentity,
                         propertiesDir,
                         true
                     )

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -1064,7 +1064,7 @@ class ConfigurationCacheFingerprintWriter(
     ) = PropertyTrace.Project(
         path = when (propertyScope) {
             is GradlePropertyScope.Project -> propertyScope.projectIdentity.buildTreePath.asString()
-            is GradlePropertyScope.Build -> propertyScope.buildIdentifier.buildPath
+            is GradlePropertyScope.Build -> propertyScope.buildIdentity.buildPath.asString()
             else -> error("Unexpected property scope $propertyScope")
         },
         trace = location

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     api(projects.stdlibJavaExtensions)
     api(projects.logging)
     api(projects.modelCore)
+    api(projects.serialization)
     api(projects.snapshots)
 
     api(libs.kotlinStdlib)
@@ -54,7 +55,6 @@ dependencies {
     implementation(projects.modelReflect)
     implementation(projects.platformJvm)
     implementation(projects.publish)
-    implementation(projects.serialization)
     implementation(projects.serviceLookup)
     implementation(projects.stdlibSerializationCodecs)
     implementation(projects.stdlibKotlinExtensions)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/BuildIdentitySerializer.java
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/BuildIdentitySerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.codecs.core;
+
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.PathSerializer;
+import org.gradle.internal.build.BuildIdentity;
+import org.gradle.internal.serialize.AbstractSerializer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import java.io.IOException;
+
+/**
+ * A thread-safe and reusable serializer for {@link BuildIdentity}.
+ * <p>
+ * Only the build path is written, as the rest of the identity is derived from it.
+ */
+public class BuildIdentitySerializer extends AbstractSerializer<BuildIdentity> {
+
+    private final PathSerializer pathSerializer = new PathSerializer();
+
+    @Override
+    public BuildIdentity read(Decoder decoder) throws IOException {
+        return new BuildIdentity(pathSerializer.read(decoder));
+    }
+
+    @Override
+    public void write(Encoder encoder, BuildIdentity value) throws IOException {
+        pathSerializer.write(encoder, value.getBuildPath());
+    }
+
+}

--- a/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/BuildIdentitySerializer.java
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/BuildIdentitySerializer.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.serialize.codecs.core;
 
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.PathSerializer;
 import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.util.Path;
 
 import java.io.IOException;
 
@@ -28,19 +28,25 @@ import java.io.IOException;
  * A thread-safe and reusable serializer for {@link BuildIdentity}.
  * <p>
  * Only the build path is written, as the rest of the identity is derived from it.
+ * The path is encoded inline rather than by delegating to a {@code Path} serializer,
+ * as the existing one lives in a platform this one must not depend on.
  */
 public class BuildIdentitySerializer extends AbstractSerializer<BuildIdentity> {
 
-    private final PathSerializer pathSerializer = new PathSerializer();
-
     @Override
     public BuildIdentity read(Decoder decoder) throws IOException {
-        return new BuildIdentity(pathSerializer.read(decoder));
+        boolean isRoot = decoder.readBoolean();
+        return new BuildIdentity(isRoot ? Path.ROOT : Path.path(decoder.readString()));
     }
 
     @Override
     public void write(Encoder encoder, BuildIdentity value) throws IOException {
-        pathSerializer.write(encoder, value.getBuildPath());
+        Path buildPath = value.getBuildPath();
+        boolean isRoot = buildPath.equals(Path.ROOT);
+        encoder.writeBoolean(isRoot);
+        if (!isRoot) {
+            encoder.writeString(buildPath.asString());
+        }
     }
 
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/package-info.java
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/java/org/gradle/internal/serialize/codecs/core/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.gradle.internal.serialize.codecs.core;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BaseTypes.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/BaseTypes.kt
@@ -28,4 +28,5 @@ fun BindingsBuilder.baseTypes(objectOpener: ObjectOpener) {
     guavaTypes()
     bind(JavaRecordCodec(objectOpener))
     bind(BuildIdentifierSerializer())
+    bind(BuildIdentitySerializer())
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.serialize.codecs.core
 
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.flow.FlowAction
@@ -43,6 +42,7 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.services.internal.BuildServiceDetails
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.configuration.problems.PropertyTrace
@@ -238,7 +238,7 @@ class BuildServiceProviderCodec(
     override suspend fun WriteContext.encode(value: BuildServiceProvider<*, *>) =
         encodePreservingSharedIdentityOf(value) {
             val serviceDetails: BuildServiceDetails<*, *> = value.serviceDetails
-            write(serviceDetails.buildIdentifier)
+            write(serviceDetails.buildIdentity)
             writeString(serviceDetails.name)
             writeClass(serviceDetails.implementationType)
             writeBoolean(serviceDetails.isResolved)
@@ -250,22 +250,22 @@ class BuildServiceProviderCodec(
 
     override suspend fun ReadContext.decode(): BuildServiceProvider<*, *> =
         decodePreservingSharedIdentity<BuildServiceProvider<*, *>> {
-            val buildIdentifier = readNonNull<BuildIdentifier>()
+            val buildIdentity = readNonNull<BuildIdentity>()
             val name = readString()
             val implementationType = readClassOf<BuildService<*>>()
             val isResolved = readBoolean()
             if (isResolved) {
                 val parameters = readNonNull<BuildServiceParameters>()
                 val maxUsages = readInt()
-                buildServiceRegistryOf(buildIdentifier).registerIfAbsent(name, implementationType, parameters, maxUsages)
+                buildServiceRegistryOf(buildIdentity).registerIfAbsent(name, implementationType, parameters, maxUsages)
             } else {
-                buildServiceRegistryOf(buildIdentifier).consume(name, implementationType)
+                buildServiceRegistryOf(buildIdentity).consume(name, implementationType)
             }
         }
 
     private
-    fun buildServiceRegistryOf(buildIdentifier: BuildIdentifier) =
-        buildStateRegistry.getBuild(buildIdentifier).mutableModel.serviceOf<BuildServiceRegistryInternal>()
+    fun buildServiceRegistryOf(buildIdentity: BuildIdentity) =
+        buildStateRegistry.getBuild(buildIdentity.buildPath).mutableModel.serviceOf<BuildServiceRegistryInternal>()
 }
 
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskInAnotherBuildCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskInAnotherBuildCodec.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.serialize.codecs.core
 
-import org.gradle.api.artifacts.component.BuildIdentifier
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
@@ -38,7 +38,7 @@ class TaskInAnotherBuildCodec(
 
     override suspend fun ReadContext.decode(): TaskInAnotherBuild {
         val taskPath = readString()
-        val targetBuild = readNonNull<BuildIdentifier>()
+        val targetBuild = readNonNull<BuildIdentity>()
         return TaskInAnotherBuild.restored(
             taskPath,
             targetBuild,

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -192,7 +192,7 @@ public class ProjectBuilderImpl {
         gradle.setIncludedBuilds(Collections.emptyList());
 
         GradlePropertiesController gradlePropertiesController = buildServices.get(GradlePropertiesController.class);
-        gradlePropertiesController.loadGradleProperties(build.getBuildIdentifier(), build.getBuildRootDir(), false);
+        gradlePropertiesController.loadGradleProperties(build.getBuildIdentity(), build.getBuildRootDir(), false);
 
         ClassLoaderScope baseScope = gradle.getClassLoaderScope();
         ClassLoaderScope rootProjectScope = baseScope.createChild("root-project", null);

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class MultiProjectProjectDependencyConflictResolutionIntegrationTest extends Abs
 
     @Override
     String getBuildId() {
-        "((${ProjectInternal.name}) project).getOwner().getOwner().getBuildIdentifier()"
+        "((${ProjectInternal.name}) project).getOwner().getOwner().getIdentityPath()"
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
@@ -18,10 +18,9 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
-import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.Cast;
 import org.gradle.util.Path;
 
@@ -32,7 +31,7 @@ import java.util.List;
 
 public class DefaultProjectPublicationRegistry implements ProjectPublicationRegistry, HoldsProjectState {
     private final SetMultimap<Path, ProjectPublication> publicationsByProjectId = LinkedHashMultimap.create();
-    private final SetMultimap<BuildIdentifier, PublicationForProject<?>> publicationsByBuildId = LinkedHashMultimap.create();
+    private final SetMultimap<BuildIdentity, PublicationForProject<?>> publicationsByBuildId = LinkedHashMultimap.create();
 
     @Override
     @SuppressWarnings("MixedMutabilityReturnType")
@@ -54,7 +53,7 @@ public class DefaultProjectPublicationRegistry implements ProjectPublicationRegi
 
     @Override
     @SuppressWarnings("MixedMutabilityReturnType")
-    public <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentifier buildIdentity) {
+    public <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentity buildIdentity) {
         synchronized (publicationsByBuildId) {
             Collection<PublicationForProject<?>> buildPublications = publicationsByBuildId.get(buildIdentity);
             if (buildPublications.isEmpty()) {
@@ -77,7 +76,7 @@ public class DefaultProjectPublicationRegistry implements ProjectPublicationRegi
         }
         synchronized (publicationsByBuildId) {
             DefaultPublicationForProject publicationReference = new DefaultPublicationForProject(publication, projectIdentity);
-            publicationsByBuildId.put(new DefaultBuildIdentifier(projectIdentity.getBuildPath()), publicationReference);
+            publicationsByBuildId.put(new BuildIdentity(projectIdentity.getBuildPath()), publicationReference);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
@@ -49,7 +49,7 @@ public interface ProjectPublicationRegistry {
     /**
      * Returns all known publications for the given build.
      */
-    <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentifier buildIdentity);
+    <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentity buildIdentity);
 
     interface PublicationForProject<T extends ProjectPublication> {
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.Providers
 import org.gradle.execution.ProjectConfigurer
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.Describables
 import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.Path
@@ -414,7 +415,7 @@ Found the following publications in <project>:
         }
 
         @Override
-        <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentifier buildIdentity) {
+        <T extends ProjectPublication> Collection<PublicationForProject<T>> getPublicationsForBuild(Class<T> type, BuildIdentity buildIdentity) {
             throw new UnsupportedOperationException()
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ModuleVersionIdentifier
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.SoftwareComponentInternal

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -112,9 +112,9 @@ $includeMechanism 'ProjectA'
             }
 
             def projectId(String projectName) {
-                def buildId = $buildId
+                def buildPath = $buildId
                 def projectPath = $projectPath
-                return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).projects.getProject(${Path.name}.path(projectPath)).componentIdentifier
+                return project.services.get(${BuildStateRegistry.name}).getBuild(buildPath).projects.getProject(${Path.name}.path(projectPath)).componentIdentifier
             }
 
             repositories { maven { url = "${mavenRepo.uri}" } }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -53,7 +53,7 @@ class CompositeBuildIncludesMultiProjectProjectDependencyConflictResolutionInteg
 
     @Override
     String getBuildId() {
-        "((${ProjectInternal.name}) project).getServices().get(${BuildState.name}.class).getBuildIdentifier()"
+        "((${ProjectInternal.name}) project).getServices().get(${BuildState.name}.class).getIdentityPath()"
     }
 
     @Override

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class CompositeBuildProjectDependencyConflictResolutionIntegrationTest extends A
 
     @Override
     String getBuildId() {
-        "new org.gradle.api.internal.artifacts.DefaultBuildIdentifier(org.gradle.util.Path.path(':' + projectName))"
+        "org.gradle.util.Path.path(':' + projectName)"
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
@@ -17,15 +17,16 @@
 package org.gradle.composite.internal;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.execution.plan.PlanExecutor;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.work.WorkerLeaseService;
+
+import org.gradle.util.Path;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class DefaultBuildControllers implements BuildControllers {
     // Always iterate over the controllers in a fixed order
-    private final Map<BuildIdentifier, BuildController> controllers = new TreeMap<>(idComparator());
+    private final Map<BuildIdentity, BuildController> controllers = new TreeMap<>(idComparator());
     private final ManagedExecutor executorService;
     private final WorkerLeaseService workerLeaseService;
     private final PlanExecutor planExecutor;
@@ -54,13 +55,13 @@ class DefaultBuildControllers implements BuildControllers {
 
     @Override
     public BuildController getBuildController(BuildState build) {
-        BuildController buildController = controllers.get(build.getBuildIdentifier());
+        BuildController buildController = controllers.get(build.getBuildIdentity());
         if (buildController != null) {
             return buildController;
         }
 
         BuildController newBuildController = new DefaultBuildController(build, workerLeaseService);
-        controllers.put(build.getBuildIdentifier(), newBuildController);
+        controllers.put(build.getBuildIdentity(), newBuildController);
         return newBuildController;
     }
 
@@ -129,17 +130,15 @@ class DefaultBuildControllers implements BuildControllers {
         CompositeStoppable.stoppable(controllers.values()).stop();
     }
 
-    private static Comparator<BuildIdentifier> idComparator() {
+    private static Comparator<BuildIdentity> idComparator() {
         return (id1, id2) -> {
             // Root is always last
-            if (id1.equals(DefaultBuildIdentifier.ROOT)) {
-                if (id2.equals(DefaultBuildIdentifier.ROOT)) {
-                    return 0;
-                } else {
-                    return 1;
-                }
+            boolean isRoot1 = id1.getBuildPath().equals(Path.ROOT);
+            boolean isRoot2 = id2.getBuildPath().equals(Path.ROOT);
+            if (isRoot1) {
+                return isRoot2 ? 0 : 1;
             }
-            if (id2.equals(DefaultBuildIdentifier.ROOT)) {
+            if (isRoot2) {
                 return -1;
             }
             return id1.getBuildPath().compareTo(id2.getBuildPath());

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
@@ -18,7 +18,6 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
@@ -144,7 +143,7 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
                 // TODO: This check should not be necessary. `ensureProjectsConfigured` should
                 //       be able to handle the case where the source build ensures that itself is configured, but
                 //       at the moment it deadlocks in that case.
-                BuildState buildState = buildStateRegistry.getBuild(new DefaultBuildIdentifier(targetBuild));
+                BuildState buildState = buildStateRegistry.getBuild(targetBuild);
                 buildState.ensureProjectsConfigured();
             }
             configuredBuilds.add(targetBuild);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -18,10 +18,8 @@ package org.gradle.composite.internal;
 
 import com.google.common.base.MoreObjects;
 import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.initialization.buildsrc.BuildSrcDetector;
 import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.build.BuildState;
@@ -103,7 +101,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     private void addBuild(BuildState build) {
         BuildState before = buildsByPath.put(build.getIdentityPath(), build);
         if (before != null) {
-            throw new IllegalArgumentException("Build is already registered: " + build.getBuildIdentifier());
+            throw new IllegalArgumentException("Build is already registered: " + build.getBuildIdentity());
         }
         buildAddedBroadcaster.buildAdded(build);
         maybeAddBuildSrcBuild(build);
@@ -137,17 +135,6 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     @Override
     public Collection<IncludedBuildState> getIncludedBuilds() {
         return includedBuildsByRootDir.values();
-    }
-
-    @Override
-    public BuildState getBuild(BuildIdentifier buildIdentifier) {
-        return getBuild(((DefaultBuildIdentifier) buildIdentifier).getIdentityPath());
-    }
-
-    @Nullable
-    @Override
-    public BuildState findBuild(BuildIdentifier buildIdentifier) {
-        return findBuild(((DefaultBuildIdentifier) buildIdentifier).getIdentityPath());
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -124,7 +124,7 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
     @Override
     public IncludedBuildTaskResource locateTask(TaskIdentifier taskIdentifier) {
         return withState(workGraph -> {
-            BuildState build = buildRegistry.getBuild(taskIdentifier.getBuildIdentifier());
+            BuildState build = buildRegistry.getBuild(taskIdentifier.getBuildIdentity().getBuildPath());
             ExportedTaskNode taskNode = build.getWorkGraph().locateTask(taskIdentifier);
             return new TaskBackedResource(workGraph, build, taskNode);
         });

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/plugins/CompositeBuildPluginResolverContributor.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/plugins/CompositeBuildPluginResolverContributor.java
@@ -16,11 +16,11 @@
 
 package org.gradle.composite.internal.plugins;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.project.HoldsProjectState;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.BuildIncluder;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
@@ -125,7 +125,7 @@ public class CompositeBuildPluginResolverContributor implements PluginResolverCo
                 return PluginResult.NO_INCLUDED_BUILDS;
             }
             for (IncludedBuildState build : includedBuilds) {
-                PluginResolution pluginResolution = resolvePlugin(requestedPluginId, build.getBuildIdentifier());
+                PluginResolution pluginResolution = resolvePlugin(requestedPluginId, build.getBuildIdentity());
                 if (pluginResolution != null) {
                     return new ResolvedPlugin(pluginResolution);
                 }
@@ -136,7 +136,7 @@ public class CompositeBuildPluginResolverContributor implements PluginResolverCo
         private PluginResolution resolveFromIncludedPluginBuilds(PluginId requestedPluginId) {
             for (IncludedBuildState build : buildIncluder.getRegisteredPluginBuilds()) {
                 buildIncluder.prepareForPluginResolution(build);
-                PluginResolution pluginResolution = resolvePlugin(requestedPluginId, build.getBuildIdentifier());
+                PluginResolution pluginResolution = resolvePlugin(requestedPluginId, build.getBuildIdentity());
                 if (pluginResolution != null) {
                     return pluginResolution;
                 }
@@ -145,7 +145,7 @@ public class CompositeBuildPluginResolverContributor implements PluginResolverCo
         }
 
         @Nullable
-        private PluginResolution resolvePlugin(PluginId requestedPluginId, BuildIdentifier buildIdentity) {
+        private PluginResolution resolvePlugin(PluginId requestedPluginId, BuildIdentity buildIdentity) {
             Collection<ProjectPublicationRegistry.PublicationForProject<PluginPublication>> publicationsForBuild =
                 publicationRegistry.getPublicationsForBuild(PluginPublication.class, buildIdentity);
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/AbstractIncludedBuildTaskGraphTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.TaskInternal
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.BuildWorkGraphController
@@ -27,15 +27,15 @@ import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 abstract class AbstractIncludedBuildTaskGraphTest extends ConcurrentSpec {
     def buildStateRegistry = Mock(BuildStateRegistry)
 
-    BuildState build(BuildIdentifier id, BuildWorkGraphController workGraph = null) {
+    BuildState build(BuildIdentity id, BuildWorkGraphController workGraph = null) {
         def build = Mock(IncludedBuildState)
-        _ * build.buildIdentifier >> id
+        _ * build.buildIdentity >> id
         _ * build.workGraph >> (workGraph ?: Stub(BuildWorkGraphController))
-        _ * buildStateRegistry.getBuild(id) >> build
+        _ * buildStateRegistry.getBuild(id.buildPath) >> build
         return build
     }
 
-    TaskIdentifier taskIdentifier(BuildIdentifier id, String taskPath) {
+    TaskIdentifier taskIdentifier(BuildIdentity id, String taskPath) {
         def task = Stub(TaskInternal) {
             getPath() >> taskPath
         }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -20,11 +20,9 @@ import org.gradle.api.Action
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.plugins.PluginManagerInternal
@@ -53,6 +51,7 @@ import org.gradle.execution.plan.TaskDependencyResolver
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.initialization.DefaultBuildCancellationToken
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildToolingModelController
@@ -128,7 +127,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "runs scheduled work"() {
         def services = new TreeServices(workers)
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def node = new TestNode()
 
         when:
@@ -149,8 +148,8 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "runs scheduled unrelated work across multiple builds"() {
         def services = new TreeServices(workers)
-        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childBuild = build(services, new BuildIdentity(Path.path(":child")))
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def childNode = new TestNode("child build node")
         def node = new TestNode("main build node")
 
@@ -177,8 +176,8 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "runs the work of each build under the operation of that build"() {
         def services = new TreeServices(workers)
-        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childBuild = build(services, new BuildIdentity(Path.path(":child")))
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def childNode = new TestNode("child build node")
         def node = new TestNode("main build node")
 
@@ -207,8 +206,8 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "runs scheduled related work across multiple builds"() {
         def services = new TreeServices(workers)
-        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childBuild = build(services, new BuildIdentity(Path.path(":child")))
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def childNode = new TestNode("child build node")
         def node = new DelegateNode("main build node", [childNode])
 
@@ -235,8 +234,8 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "stops running work and fails with exception when build is cancelled"() {
         def services = new TreeServices(workers)
-        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childBuild = build(services, new BuildIdentity(Path.path(":child")))
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def childNode = new CancellingNode("child build node", cancellationToken)
         def node = new DelegateNode("main build node", [childNode])
 
@@ -267,7 +266,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "fails when no further nodes can be selected"() {
         def services = new TreeServices(manyWorkers)
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def node = new DependenciesStuckNode()
 
         when:
@@ -293,8 +292,8 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     def "fails when no further nodes can be selected across multiple builds"() {
         def services = new TreeServices(manyWorkers)
-        def childBuild = build(services, new DefaultBuildIdentifier(Path.path(":child")))
-        def build = build(services, DefaultBuildIdentifier.ROOT)
+        def childBuild = build(services, new BuildIdentity(Path.path(":child")))
+        def build = build(services, new BuildIdentity(Path.ROOT))
         def node = new DependenciesStuckNode("main build node")
         def childNode = new DependenciesStuckNode("child build node")
 
@@ -343,20 +342,20 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         return result
     }
 
-    BuildServices build(TreeServices services, BuildIdentifier identifier) {
+    BuildServices build(TreeServices services, BuildIdentity identifier) {
         def identityPath = Stub(Path)
         def gradle = Stub(GradleInternal) {
             getIdentityPath() >> identityPath
         }
         def buildOperation = Stub(BuildOperationRef) {
-            getId() >> new OperationIdentifier(identifier.buildPath.hashCode())
+            getId() >> new OperationIdentifier(identifier.buildPath.asString().hashCode())
         }
         return new BuildServices(services, identifier, gradle, buildOperation)
     }
 
     TaskInternal task(BuildServices services, Node dependsOn) {
         def projectState = Stub(ProjectState)
-        def buildId = Path.path(services.identifier.buildPath)
+        def buildId = services.identifier.buildPath
         def projectId = ProjectIdentity.forRootProject(buildId, "root")
         def project = Stub(ProjectInternal) {
             getProjectIdentity() >> projectId
@@ -535,10 +534,10 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         final TreeServices services
         final GradleInternal gradle
         final BuildState state
-        final BuildIdentifier identifier
+        final BuildIdentity identifier
         final BuildOperationRef buildOperation
 
-        BuildServices(TreeServices services, BuildIdentifier identifier, GradleInternal gradle, BuildOperationRef buildOperation) {
+        BuildServices(TreeServices services, BuildIdentity identifier, GradleInternal gradle, BuildOperationRef buildOperation) {
             this.identifier = identifier
             this.services = services
             this.gradle = gradle

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.execution.plan.PlanExecutor
+import org.gradle.internal.build.BuildIdentity
+import org.gradle.util.Path
 import org.gradle.internal.build.BuildWorkGraph
 import org.gradle.internal.build.BuildWorkGraphController
 import org.gradle.internal.build.ExecutionResult
@@ -46,7 +46,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "finalizes graph for a build when something scheduled"() {
         given:
-        def id = Stub(BuildIdentifier)
+        def id = new BuildIdentity(Path.path(":b1"))
         def workGraphController = Mock(BuildWorkGraphController)
         def workGraph = Mock(BuildWorkGraph)
         def build = build(id, workGraphController)
@@ -69,7 +69,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "cannot schedule tasks when graph has not been created"() {
         when:
-        graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
+        graph.locateTask(taskIdentifier(new BuildIdentity(Path.ROOT), ":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -79,7 +79,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
     def "cannot schedule tasks when after graph has finished execution"() {
         when:
         graph.withNewWorkGraph { 12 }
-        graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
+        graph.locateTask(taskIdentifier(new BuildIdentity(Path.ROOT), ":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -88,7 +88,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "cannot schedule tasks when graph is not yet being prepared for execution"() {
         given:
-        def id = Stub(BuildIdentifier)
+        def id = new BuildIdentity(Path.path(":b2"))
         build(id)
 
         when:
@@ -103,7 +103,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "cannot schedule tasks when graph has been prepared for execution"() {
         given:
-        def id = Stub(BuildIdentifier)
+        def id = new BuildIdentity(Path.path(":b3"))
         build(id)
 
         when:
@@ -120,14 +120,14 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "cannot schedule tasks when graph has started task execution"() {
         given:
-        def id = Stub(BuildIdentifier)
+        def id = new BuildIdentity(Path.path(":b4"))
         def workGraphController = Mock(BuildWorkGraphController)
         def workGraph = Mock(BuildWorkGraph)
         def build = build(id, workGraphController)
 
         workGraphController.newWorkGraph() >> workGraph
         workGraph.runWork() >> {
-            graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
+            graph.locateTask(taskIdentifier(new BuildIdentity(Path.ROOT), ":task")).queueForExecution()
         }
 
         when:
@@ -145,7 +145,7 @@ class DefaultIncludedBuildTaskGraphTest extends AbstractIncludedBuildTaskGraphTe
 
     def "cannot schedule tasks when graph has completed task execution"() {
         given:
-        def id = Stub(BuildIdentifier)
+        def id = new BuildIdentity(Path.path(":b5"))
         build(id)
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
@@ -94,7 +94,7 @@ public class DefaultBuildLogicBuilder implements BuildLogicBuilder {
             if (targetBuild == currentBuild) {
                 throw new InvalidUserDataException("Script classpath dependencies must reside in a separate build from the script itself.");
             }
-            tasksToBuild.add(new TaskIdentifier(targetBuild.getBuildIdentifier(), (TaskInternal) task));
+            tasksToBuild.add(new TaskIdentifier(targetBuild.getBuildIdentity(), (TaskInternal) task));
         }
         return tasksToBuild;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -17,10 +17,10 @@ package org.gradle.api.internal.project;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.initialization.ProjectDescriptorInternal;
 import org.gradle.initialization.ProjectDescriptorRegistry;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.AllProjectsAccess;
 import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
@@ -55,7 +55,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     private final Object lock = new Object();
     private final Map<Path, ProjectState> projectsByPath = new LinkedHashMap<>();
     private final Map<ProjectComponentIdentifier, ProjectState> projectsById = new HashMap<>();
-    private final Map<BuildIdentifier, DefaultBuildProjectRegistry> projectsByBuild = new HashMap<>();
+    private final Map<BuildIdentity, DefaultBuildProjectRegistry> projectsByBuild = new HashMap<>();
 
     public DefaultProjectStateRegistry(WorkerLeaseService workerLeaseService) {
         this.workerLeaseService = workerLeaseService;
@@ -117,10 +117,10 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     private DefaultBuildProjectRegistry getBuildProjectRegistry(BuildState owner) {
-        DefaultBuildProjectRegistry buildProjectRegistry = projectsByBuild.get(owner.getBuildIdentifier());
+        DefaultBuildProjectRegistry buildProjectRegistry = projectsByBuild.get(owner.getBuildIdentity());
         if (buildProjectRegistry == null) {
             buildProjectRegistry = new DefaultBuildProjectRegistry(owner, workerLeaseService);
-            projectsByBuild.put(owner.getBuildIdentifier(), buildProjectRegistry);
+            projectsByBuild.put(owner.getBuildIdentity(), buildProjectRegistry);
         }
         return buildProjectRegistry;
     }
@@ -135,7 +135,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public void discardProjectsFor(BuildState build) {
-        DefaultBuildProjectRegistry registry = projectsByBuild.get(build.getBuildIdentifier());
+        DefaultBuildProjectRegistry registry = projectsByBuild.get(build.getBuildIdentity());
         if (registry != null) {
             for (ProjectState project : registry.projectsByPath.values()) {
                 projectsById.remove(project.getComponentIdentifier());
@@ -201,11 +201,11 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     @Override
-    public BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException {
+    public BuildProjectRegistry projectsFor(BuildIdentity buildIdentity) throws IllegalArgumentException {
         synchronized (lock) {
-            BuildProjectRegistry registry = projectsByBuild.get(buildIdentifier);
+            BuildProjectRegistry registry = projectsByBuild.get(buildIdentity);
             if (registry == null) {
-                throw new IllegalArgumentException("Projects for " + buildIdentifier + " have not been registered yet.");
+                throw new IllegalArgumentException("Projects for " + buildIdentity + " have not been registered yet.");
             }
             return registry;
         }
@@ -213,9 +213,9 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Nullable
     @Override
-    public BuildProjectRegistry findProjectsFor(BuildIdentifier buildIdentifier) {
+    public BuildProjectRegistry findProjectsFor(BuildIdentity buildIdentity) {
         synchronized (lock) {
-            return projectsByBuild.get(buildIdentifier);
+            return projectsByBuild.get(buildIdentity);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -16,9 +16,9 @@
 package org.gradle.api.internal.project;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.initialization.ProjectDescriptorRegistry;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
@@ -53,13 +53,13 @@ public interface ProjectStateRegistry extends ProjectStateLookup {
     /**
      * Locates the state objects for all projects of the given build.
      */
-    BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
+    BuildProjectRegistry projectsFor(BuildIdentity buildIdentity) throws IllegalArgumentException;
 
     /**
      * Locates the state objects for all projects of the given build, or {@code null} if these are not available yet.
      */
     @Nullable
-    BuildProjectRegistry findProjectsFor(BuildIdentifier buildIdentifier);
+    BuildProjectRegistry findProjectsFor(BuildIdentity buildIdentity);
 
     /**
      * Registers the projects of a build.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/properties/DefaultGradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/properties/DefaultGradlePropertiesController.java
@@ -17,9 +17,8 @@
 package org.gradle.api.internal.properties;
 
 import com.google.common.collect.ImmutableMap;
-import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.initialization.properties.DefaultGradleProperties;
 import org.gradle.initialization.properties.GradlePropertiesLoader;
 import org.gradle.initialization.properties.SystemPropertiesInstaller;
@@ -37,7 +36,7 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
     private final SystemPropertiesInstaller systemPropertiesInstaller;
     private final GradlePropertiesListener listener;
 
-    private final ConcurrentMap<BuildIdentifier, BuildScopedGradleProperties> buildProperties = new ConcurrentHashMap<>();
+    private final ConcurrentMap<BuildIdentity, BuildScopedGradleProperties> buildProperties = new ConcurrentHashMap<>();
     private final ConcurrentMap<ProjectIdentity, ProjectScopedGradleProperties> projectProperties = new ConcurrentHashMap<>();
 
     public DefaultGradlePropertiesController(
@@ -59,17 +58,17 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
     }
 
     @Override
-    public GradleProperties getGradleProperties(BuildIdentifier buildId) {
+    public GradleProperties getGradleProperties(BuildIdentity buildId) {
         return getOrCreateGradleProperties(buildId);
     }
 
     @Override
-    public void loadGradleProperties(BuildIdentifier buildId, File buildRootDir, boolean setSystemProperties) {
+    public void loadGradleProperties(BuildIdentity buildId, File buildRootDir, boolean setSystemProperties) {
         getOrCreateGradleProperties(buildId).loadProperties(buildRootDir, setSystemProperties);
     }
 
     @Override
-    public void unloadGradleProperties(BuildIdentifier buildId) {
+    public void unloadGradleProperties(BuildIdentity buildId) {
         if (!projectProperties.isEmpty()) {
             throw new IllegalStateException("Cannot unload Gradle properties after loading project properties.");
         }
@@ -84,7 +83,7 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
     @Override
     public GradleProperties getGradleProperties(GradlePropertyScope propertyScope) {
         if (propertyScope instanceof GradlePropertyScope.Build) {
-            return getGradleProperties(((GradlePropertyScope.Build) propertyScope).getBuildIdentifier());
+            return getGradleProperties(((GradlePropertyScope.Build) propertyScope).getBuildIdentity());
         }
         if (propertyScope instanceof GradlePropertyScope.Project) {
             return getGradleProperties(((GradlePropertyScope.Project) propertyScope).getProjectIdentity());
@@ -94,12 +93,12 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
 
     @Override
     public void loadGradleProperties(ProjectIdentity projectId, File projectDir) {
-        LoadedBuildScopedState loadedBuildProperties = getOrCreateGradleProperties(new DefaultBuildIdentifier(projectId.getBuildPath()))
+        LoadedBuildScopedState loadedBuildProperties = getOrCreateGradleProperties(new BuildIdentity(projectId.getBuildPath()))
             .checkLoaded();
         getOrCreateGradleProperties(projectId).loadProperties(loadedBuildProperties, projectDir);
     }
 
-    private BuildScopedGradleProperties getOrCreateGradleProperties(BuildIdentifier buildId) {
+    private BuildScopedGradleProperties getOrCreateGradleProperties(BuildIdentity buildId) {
         return buildProperties.computeIfAbsent(buildId, id ->
             new BuildScopedGradleProperties(gradlePropertiesLoader, systemPropertiesInstaller, id, listener));
     }
@@ -175,14 +174,14 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
 
         private final GradlePropertiesLoader loader;
         private final SystemPropertiesInstaller systemPropertiesInstaller;
-        private final BuildIdentifier buildId;
+        private final BuildIdentity buildId;
         @Nullable
         private volatile LoadedBuildScopedState loaded;
 
         private BuildScopedGradleProperties(
             GradlePropertiesLoader loader,
             SystemPropertiesInstaller systemPropertiesInstaller,
-            BuildIdentifier buildId,
+            BuildIdentity buildId,
             GradlePropertiesListener listener
         ) {
             super(new BuildPropertyScope(buildId), listener);
@@ -373,14 +372,14 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
     }
 
     private static class BuildPropertyScope implements GradlePropertyScope.Build {
-        private final BuildIdentifier buildId;
+        private final BuildIdentity buildId;
 
-        public BuildPropertyScope(BuildIdentifier buildId) {
+        public BuildPropertyScope(BuildIdentity buildId) {
             this.buildId = buildId;
         }
 
         @Override
-        public BuildIdentifier getBuildIdentifier() {
+        public BuildIdentity getBuildIdentity() {
             return buildId;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/properties/GradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/properties/GradlePropertiesController.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.properties;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -33,7 +33,7 @@ import java.io.File;
  * This is useful when the properties need to be injected as a service in the corresponding scope.
  * Accessing the values of the unloaded properties, however, will result in an exception.
  * <p>
- * After the build properties have been loaded, it is possible to {@link #unloadGradleProperties(BuildIdentifier) unload} them.
+ * After the build properties have been loaded, it is possible to {@link #unloadGradleProperties(BuildIdentity) unload} them.
  * It is only possible to unload build properties before any project properties have been loaded.
  * The support for unloading is currently required by Configuration Cache, where properties are loaded before checking
  * the fingerprint and unloaded in case the fingerprint is rejected.
@@ -55,10 +55,10 @@ public interface GradlePropertiesController {
      * </ul>
      * <p>
      * The instance of {@code GradleProperties} can be obtained before the corresponding properties
-     * have been {@link #loadGradleProperties(BuildIdentifier, File, boolean) loaded}.
+     * have been {@link #loadGradleProperties(BuildIdentity, File, boolean) loaded}.
      * However, accessing of property values will fail with an exception if the properties have not been loaded by then.
      */
-    GradleProperties getGradleProperties(BuildIdentifier buildId);
+    GradleProperties getGradleProperties(BuildIdentity buildId);
 
     /**
      * Returns project-scoped {@link GradleProperties} for the specified project.
@@ -81,7 +81,7 @@ public interface GradlePropertiesController {
      * as the one in the build root directory.
      * <p>
      * The instance of {@code GradleProperties} can be obtained before the corresponding properties
-     * have been {@link #loadGradleProperties(BuildIdentifier, File, boolean) loaded}.
+     * have been {@link #loadGradleProperties(BuildIdentity, File, boolean) loaded}.
      * However, accessing of property values will fail with an exception if the properties have not been loaded by then.
      */
     GradleProperties getGradleProperties(ProjectIdentity projectId);
@@ -94,7 +94,7 @@ public interface GradlePropertiesController {
     /**
      * Loads build-scoped {@link GradleProperties} from the specified build root directory.
      * <p>
-     * See {@link #getGradleProperties(BuildIdentifier) build-scoped properties} on which sources are considered.
+     * See {@link #getGradleProperties(BuildIdentity) build-scoped properties} on which sources are considered.
      * <p>
      * If {@code setSystemProperties} is true, properties with {@code systemProp.} prefix are set as system properties.
      * However, the <strong>system properties are only sourced from {@code gradle.properties} files</strong>:
@@ -107,18 +107,18 @@ public interface GradlePropertiesController {
      * @param buildRootDir directory containing the {@code gradle.properties} file
      * @param setSystemProperties whether to set system properties from loaded properties
      */
-    void loadGradleProperties(BuildIdentifier buildId, File buildRootDir, boolean setSystemProperties);
+    void loadGradleProperties(BuildIdentity buildId, File buildRootDir, boolean setSystemProperties);
 
     /**
      * Unloads build-scoped properties.
      * <p>
-     * Subsequent calls to {@link #loadGradleProperties(BuildIdentifier, File, boolean)} will
+     * Subsequent calls to {@link #loadGradleProperties(BuildIdentity, File, boolean)} will
      * reload properties and re-evaluate system property assignments.
      * <p>
      * Build-scoped properties can't be unloaded if any {@link #loadGradleProperties(ProjectIdentity, File) project-scoped}
      * properties have been loaded.
      */
-    void unloadGradleProperties(BuildIdentifier buildId);
+    void unloadGradleProperties(BuildIdentity buildId);
 
     /**
      * Loads project-scoped {@link GradleProperties} from the specified project directory.
@@ -134,7 +134,7 @@ public interface GradlePropertiesController {
     /**
      * Unloads all project-scoped and build-scoped properties.
      * <p>
-     * Subsequent calls to {@link #loadGradleProperties(BuildIdentifier, File, boolean)} will
+     * Subsequent calls to {@link #loadGradleProperties(BuildIdentity, File, boolean)} will
      * reload properties and re-evaluate system property assignments.
      */
     void unloadAll();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/properties/GradlePropertyScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/properties/GradlePropertyScope.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.properties;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.build.BuildIdentity;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -37,7 +37,7 @@ import org.jspecify.annotations.Nullable;
     String toString();
 
     interface Build extends GradlePropertyScope {
-        BuildIdentifier getBuildIdentifier();
+        BuildIdentity getBuildIdentity();
     }
 
     interface Project extends GradlePropertyScope {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceDetails.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.services.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.jspecify.annotations.Nullable;
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
  * Details about a service registration.
  */
 public class BuildServiceDetails<T extends BuildService<P>, P extends BuildServiceParameters> {
-    private final BuildIdentifier buildIdentifier;
+    private final BuildIdentity buildIdentity;
     private final String name;
     private final Class<T> implementationType;
     @Nullable
@@ -34,8 +34,8 @@ public class BuildServiceDetails<T extends BuildService<P>, P extends BuildServi
     private final int maxUsages;
     private final boolean resolved;
 
-    public BuildServiceDetails(BuildIdentifier buildIdentifier, String name, Class<T> implementationType, P parameters, @Nullable Integer maxUsages) {
-        this.buildIdentifier = buildIdentifier;
+    public BuildServiceDetails(BuildIdentity buildIdentity, String name, Class<T> implementationType, P parameters, @Nullable Integer maxUsages) {
+        this.buildIdentity = buildIdentity;
         this.name = name;
         this.implementationType = implementationType;
         this.parameters = parameters;
@@ -43,8 +43,8 @@ public class BuildServiceDetails<T extends BuildService<P>, P extends BuildServi
         this.resolved = true;
     }
 
-    public BuildServiceDetails(BuildIdentifier buildIdentifier, String name, Class<T> implementationType) {
-        this.buildIdentifier = buildIdentifier;
+    public BuildServiceDetails(BuildIdentity buildIdentity, String name, Class<T> implementationType) {
+        this.buildIdentity = buildIdentity;
         this.name = name;
         this.implementationType = implementationType;
         this.parameters = null;
@@ -52,8 +52,8 @@ public class BuildServiceDetails<T extends BuildService<P>, P extends BuildServi
         this.resolved = false;
     }
 
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
+    public BuildIdentity getBuildIdentity() {
+        return buildIdentity;
     }
 
     public String getName() {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.services.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
@@ -25,6 +24,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.Cast;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.service.ServiceLookup;
@@ -94,7 +94,7 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
     /**
      * Returns the identifier for the build that owns this service.
      */
-    public abstract BuildIdentifier getBuildIdentifier();
+    public abstract BuildIdentity getBuildIdentity();
 
     /**
      * Are the given providers referring to the same service provider?
@@ -118,7 +118,7 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
         if (!isCompatibleServiceType(thisBuildServiceProvider, otherBuildServiceProvider)) {
             return false;
         }
-        return thisBuildServiceProvider.getBuildIdentifier().equals(otherBuildServiceProvider.getBuildIdentifier());
+        return thisBuildServiceProvider.getBuildIdentity().equals(otherBuildServiceProvider.getBuildIdentity());
     }
 
     private static boolean isCompatibleServiceType(BuildServiceProvider thisBuildServiceProvider, BuildServiceProvider otherBuildServiceProvider) {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
@@ -16,12 +16,12 @@
 
 package org.gradle.api.services.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistration;
 import org.gradle.api.services.BuildServiceRegistry;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.Cast;
 import org.gradle.internal.service.ServiceRegistry;
 import org.jspecify.annotations.NonNull;
@@ -37,16 +37,16 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     protected final ServiceRegistry internalServices;
     private final String serviceName;
     private final Class<T> serviceType;
-    private final BuildIdentifier buildIdentifier;
+    private final BuildIdentity buildIdentity;
     private volatile RegisteredBuildServiceProvider<T, BuildServiceParameters> resolvedProvider;
 
     public ConsumedBuildServiceProvider(
-        BuildIdentifier buildIdentifier,
+        BuildIdentity buildIdentity,
         String serviceName,
         Class<T> serviceType,
         ServiceRegistry internalServices
     ) {
-        this.buildIdentifier = buildIdentifier;
+        this.buildIdentity = buildIdentity;
         this.serviceName = serviceName;
         this.serviceType = serviceType;
         this.internalServices = internalServices;
@@ -102,14 +102,14 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     }
 
     @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
+    public BuildIdentity getBuildIdentity() {
+        return buildIdentity;
     }
 
     @Override
     public BuildServiceDetails<T, BuildServiceParameters> getServiceDetails() {
         BuildServiceProvider<T, BuildServiceParameters> resolvedProvider = resolve(true);
-        return resolvedProvider != null ? resolvedProvider.getServiceDetails() : new BuildServiceDetails<>(buildIdentifier, serviceName, serviceType);
+        return resolvedProvider != null ? resolvedProvider.getServiceDetails() : new BuildServiceDetails<>(buildIdentity, serviceName, serviceType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -25,7 +25,6 @@ import org.gradle.BuildResult;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.NonExtensible;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.DelegatingNamedDomainObjectSet;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.project.HoldsProjectState;
@@ -34,6 +33,7 @@ import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistration;
 import org.gradle.api.services.BuildServiceSpec;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.Cast;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.buildtree.BuildModelParameters;
@@ -65,7 +65,7 @@ import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public class DefaultBuildServicesRegistry implements BuildServiceRegistryInternal, HoldsProjectState {
 
-    private final BuildIdentifier buildIdentifier;
+    private final BuildIdentity buildIdentity;
     private final Lock registrationsLock = new ReentrantLock();
     private NamedDomainObjectSet<BuildServiceRegistration<?, ?>> internalRegistrations;
     private IsolatedProjectsReportingRegistrationsContainer publicRegistrations;
@@ -83,7 +83,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
     private final BuildModelParameters buildModelParameters;
 
     public DefaultBuildServicesRegistry(
-        BuildIdentifier buildIdentifier,
+        BuildIdentity buildIdentity,
         DomainObjectCollectionFactory collectionFactory,
         InstantiatorFactory instantiatorFactory,
         ServiceRegistry services,
@@ -94,7 +94,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         IsolatedProjectsProblemsReporter problems,
         BuildModelParameters buildModelParameters
     ) {
-        this.buildIdentifier = buildIdentifier;
+        this.buildIdentity = buildIdentity;
         this.internalRegistrations = uncheckedCast(collectionFactory.newNamedDomainObjectSet(BuildServiceRegistration.class));
         this.problems = problems;
         this.buildModelParameters = buildModelParameters;
@@ -286,7 +286,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
     }
 
     private <T extends BuildService<BuildServiceParameters>> BuildServiceProvider<T, BuildServiceParameters> doConsume(String name, Class<T> implementationType) {
-        return new ConsumedBuildServiceProvider<>(buildIdentifier, name, implementationType, services);
+        return new ConsumedBuildServiceProvider<>(buildIdentity, name, implementationType, services);
     }
 
     private <T extends BuildService<P>, P extends BuildServiceParameters> BuildServiceProvider<T, P> doRegister(
@@ -297,7 +297,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         NamedDomainObjectSet<BuildServiceRegistration<?, ?>> registrations
     ) {
         RegisteredBuildServiceProvider<T, P> provider = new RegisteredBuildServiceProvider<>(
-            buildIdentifier,
+            buildIdentity,
             name,
             implementationType,
             parameters,

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
@@ -17,10 +17,10 @@
 package org.gradle.api.services.internal;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.Try;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.collect.PersistentList;
@@ -58,7 +58,7 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
     private boolean keepAlive;
 
     public RegisteredBuildServiceProvider(
-        BuildIdentifier buildIdentifier,
+        BuildIdentity buildIdentity,
         String name,
         Class<T> implementationType,
         P parameters,
@@ -69,7 +69,7 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
         Listener listener,
         @Nullable Integer maxUsages
     ) {
-        this.serviceDetails = new BuildServiceDetails<>(buildIdentifier, name, implementationType, parameters, maxUsages);
+        this.serviceDetails = new BuildServiceDetails<>(buildIdentity, name, implementationType, parameters, maxUsages);
         this.internalServices = internalServices;
         this.isolationScheme = isolationScheme;
         this.instantiationScheme = instantiationScheme;
@@ -83,8 +83,8 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
     }
 
     @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return serviceDetails.getBuildIdentifier();
+    public BuildIdentity getBuildIdentity() {
+        return serviceDetails.getBuildIdentity();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
@@ -16,21 +16,21 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.internal.build.BuildIdentity;
 
 public class TaskIdentifier {
 
-    private final BuildIdentifier buildIdentifier;
+    private final BuildIdentity buildIdentity;
     private final TaskInternal task;
 
-    public TaskIdentifier(BuildIdentifier buildIdentifier, TaskInternal task) {
-        this.buildIdentifier = buildIdentifier;
+    public TaskIdentifier(BuildIdentity buildIdentity, TaskInternal task) {
+        this.buildIdentity = buildIdentity;
         this.task = task;
     }
 
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
+    public BuildIdentity getBuildIdentity() {
+        return buildIdentity;
     }
 
     public TaskInternal getTask() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -17,13 +17,13 @@
 package org.gradle.execution.plan;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.composite.internal.IncludedBuildTaskResource;
 import org.gradle.composite.internal.TaskIdentifier;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
@@ -38,7 +38,7 @@ public abstract class TaskInAnotherBuild extends TaskNode {
         TaskInternal task,
         BuildTreeWorkGraphController taskGraph
     ) {
-        BuildIdentifier targetBuild = buildIdentifierOf(task);
+        BuildIdentity targetBuild = buildIdentityOf(task);
         TaskIdentifier taskIdentifier = new TaskIdentifier(targetBuild, task);
         IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild) {
@@ -62,10 +62,10 @@ public abstract class TaskInAnotherBuild extends TaskNode {
      */
     public static Restored restored(
         String taskPath,
-        BuildIdentifier targetBuild,
+        BuildIdentity targetBuild,
         BuildTreeWorkGraphController taskGraph
     ) {
-        Path taskIdentityPath = Path.path(targetBuild.getBuildPath()).append(Path.path(taskPath));
+        Path taskIdentityPath = targetBuild.getBuildPath().append(Path.path(taskPath));
         return new Restored(taskIdentityPath, taskPath, targetBuild, taskGraph);
     }
 
@@ -82,7 +82,7 @@ public abstract class TaskInAnotherBuild extends TaskNode {
         private Restored(
             Path taskIdentityPath,
             String taskPath,
-            BuildIdentifier targetBuild,
+            BuildIdentity targetBuild,
             BuildTreeWorkGraphController taskGraph
         ) {
             super(taskIdentityPath, taskPath, targetBuild);
@@ -115,15 +115,15 @@ public abstract class TaskInAnotherBuild extends TaskNode {
     private IncludedBuildTaskResource.State taskState = IncludedBuildTaskResource.State.Scheduled;
     private final Path taskIdentityPath;
     private final String taskPath;
-    private final BuildIdentifier targetBuild;
+    private final BuildIdentity targetBuild;
 
-    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild) {
+    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentity targetBuild) {
         this.taskIdentityPath = taskIdentityPath;
         this.taskPath = taskPath;
         this.targetBuild = targetBuild;
     }
 
-    public BuildIdentifier getTargetBuild() {
+    public BuildIdentity getTargetBuild() {
         return targetBuild;
     }
 
@@ -242,8 +242,8 @@ public abstract class TaskInAnotherBuild extends TaskNode {
         // This node does not do anything itself
     }
 
-    private static BuildIdentifier buildIdentifierOf(TaskInternal task) {
-        return ((ProjectInternal) task.getProject()).getOwner().getOwner().getBuildIdentifier();
+    private static BuildIdentity buildIdentityOf(TaskInternal task) {
+        return ((ProjectInternal) task.getProject()).getOwner().getOwner().getBuildIdentity();
     }
 
     protected abstract IncludedBuildTaskResource getTarget();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -18,7 +18,6 @@ package org.gradle.initialization;
 
 import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
@@ -36,6 +35,7 @@ import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.buildsrc.BuildSrcDetector;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.BuildLayoutFactory;
+import org.gradle.internal.build.BuildIdentity;
 import org.gradle.internal.build.BuildIncluder;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
@@ -185,7 +185,7 @@ public class DefaultSettingsPreparer implements SettingsPreparer {
 
     private void loadGradlePropertiesForBuild(GradleInternal gradle) {
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(gradle.getStartParameter().toBuildLayoutConfiguration());
-        BuildIdentifier buildId = gradle.getOwner().getBuildIdentifier();
+        BuildIdentity buildId = gradle.getOwner().getBuildIdentity();
         gradlePropertiesController.loadGradleProperties(buildId, settingsLocation.getSettingsDir(), true);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -16,7 +16,9 @@
 
 package org.gradle.internal.build;
 
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
@@ -38,6 +40,7 @@ import java.util.function.Function;
 public abstract class AbstractBuildState implements BuildState, Closeable {
 
     private final BuildIdentity buildIdentity;
+    private final BuildIdentifier buildIdentifier;
     private final @Nullable BuildState parent;
     private final CloseableServiceRegistry buildServices;
     private final Lazy<BuildLifecycleController> buildLifecycleController;
@@ -47,6 +50,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     @SuppressWarnings("this-escape")
     public AbstractBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, Path identityPath, @Nullable BuildState parent) {
         this.buildIdentity = new BuildIdentity(identityPath);
+        this.buildIdentifier = new DefaultBuildIdentifier(identityPath);
         this.parent = parent;
 
         buildServices = ServiceRegistryBuilder.builder()
@@ -78,6 +82,11 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     @Override
     public BuildIdentity getBuildIdentity() {
         return buildIdentity;
+    }
+
+    @Override
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -119,7 +119,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
 
     @Override
     public BuildProjectRegistry getProjects() {
-        return getProjectStateRegistry().projectsFor(getBuildIdentifier());
+        return getProjectStateRegistry().projectsFor(getBuildIdentity());
     }
 
     protected BuildLifecycleController getBuildController() {
@@ -133,12 +133,12 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
 
     @Override
     public boolean isProjectsLoaded() {
-        return getProjectStateRegistry().findProjectsFor(getBuildIdentifier()) != null;
+        return getProjectStateRegistry().findProjectsFor(getBuildIdentity()) != null;
     }
 
     @Override
     public boolean isProjectsCreated() {
-        BuildProjectRegistry projectsForThisBuild = getProjectStateRegistry().findProjectsFor(getBuildIdentifier());
+        BuildProjectRegistry projectsForThisBuild = getProjectStateRegistry().findProjectsFor(getBuildIdentity());
         return projectsForThisBuild != null && projectsForThisBuild.getRootProject().isCreated();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -47,6 +47,15 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     private final Lazy<ProjectStateRegistry> projectStateRegistry;
     private final Lazy<BuildWorkGraphController> workGraphController;
 
+    /**
+     * The build-scoped services are created here, rather than being passed in, because
+     * this build is itself one of those services. Subclasses also read the registry in their
+     * own constructors, so it is already in use by the time this constructor returns.
+     * <p>
+     * Note that a registry's own services take precedence over those of its parents, so
+     * adding a build-scoped service to the parent registry has no effect on lookups made
+     * against this one. See {@link ServiceRegistryBuilder}.
+     */
     @SuppressWarnings("this-escape")
     public AbstractBuildState(BuildTreeServices buildTreeServices, BuildDefinition buildDefinition, Path identityPath, @Nullable BuildState parent) {
         this.buildIdentity = new BuildIdentity(identityPath);

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
@@ -36,7 +36,6 @@ import org.jspecify.annotations.Nullable;
 public final class BuildIdentity implements DisplayName {
 
     private final Path buildPath;
-
     private final BuildIdentifier buildIdentifier;
     private final DisplayName displayName;
 
@@ -46,10 +45,9 @@ public final class BuildIdentity implements DisplayName {
         }
 
         this.buildPath = buildPath;
-
-        // TODO: avoid BuildIdentifier for core logic, and eventually wrap its implementation around BuildIdentity
         this.buildIdentifier = new DefaultBuildIdentifier(buildPath);
-        this.displayName = Describables.memoize(Describables.of(buildIdentifier));
+        // TODO: ensure the display name logic is shared with BuildIdentifier for consistency
+        this.displayName = Describables.memoize(Describables.withTypeAndName("build", buildPath.asString()));
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildIdentity.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.service.scopes.Scope;
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
 public final class BuildIdentity implements DisplayName {
 
     private final Path buildPath;
-    private final BuildIdentifier buildIdentifier;
     private final DisplayName displayName;
 
     public BuildIdentity(Path buildPath) {
@@ -45,7 +42,6 @@ public final class BuildIdentity implements DisplayName {
         }
 
         this.buildPath = buildPath;
-        this.buildIdentifier = new DefaultBuildIdentifier(buildPath);
         // TODO: ensure the display name logic is shared with BuildIdentifier for consistency
         this.displayName = Describables.memoize(Describables.withTypeAndName("build", buildPath.asString()));
     }
@@ -55,13 +51,6 @@ public final class BuildIdentity implements DisplayName {
      */
     public Path getBuildPath() {
         return buildPath;
-    }
-
-    /**
-     * The public identifier for this build.
-     */
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -56,9 +56,7 @@ public interface BuildState {
      * <p>
      * Prefer {@link #getBuildIdentity()} or plain {@link #getIdentityPath()}.
      */
-    default BuildIdentifier getBuildIdentifier() {
-        return getBuildIdentity().getBuildIdentifier();
-    }
+    BuildIdentifier getBuildIdentifier();
 
     /**
      * Returns an identifying path for this build in the build tree. This path is fixed for the lifetime of the build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -33,6 +33,9 @@ import java.util.function.Function;
  * Encapsulates the identity and state of a particular build in a build tree.
  *
  * Implementations are not yet entirely thread-safe, but should be.
+ * <p>
+ * The hierarchy this sits in — build process, session, tree, build, project — is described
+ * in {@code architecture/build-state-model.md}.
  */
 @ServiceScope(Scope.Build.class)
 public interface BuildState {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.buildtree.NestedBuildTree;
 import org.gradle.internal.classpath.ClassPath;
@@ -55,21 +54,6 @@ public interface BuildStateRegistry {
      * Returns all included builds.
      */
     Collection<? extends IncludedBuildState> getIncludedBuilds();
-
-    /**
-     * Locates a build. Fails if not present.
-     * <p>
-     * Prefer {@link #getBuild(Path)}.
-     */
-    BuildState getBuild(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
-
-    /**
-     * Finds a build. Returns null if there's no build with the given identifier.
-     * <p>
-     * Prefer {@link #findBuild(Path)}.
-     */
-    @Nullable
-    BuildState findBuild(BuildIdentifier buildIdentifier);
 
     /**
      * Locates a build. Fails if not present.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -21,7 +21,6 @@ import org.gradle.BuildResult;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
@@ -296,7 +295,7 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
 
         @Nullable
         private BuildState findBuild(Path buildPath) {
-            return getBuildStateRegistry().findBuild(new DefaultBuildIdentifier(buildPath));
+            return getBuildStateRegistry().findBuild(buildPath);
         }
 
         private BuildStateRegistry getBuildStateRegistry() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -257,6 +257,9 @@ import java.util.List;
 
 /**
  * Contains the services for a single build invocation inside a build tree.
+ * <p>
+ * See {@code architecture/build-state-model.md} for how this scope relates to the
+ * surrounding build tree, session and process scopes.
  */
 public class BuildScopeServices implements ServiceRegistrationProvider {
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -418,7 +418,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         BuildIdentity buildIdentity,
         GradlePropertiesController gradlePropertiesController
     ) {
-        return gradlePropertiesController.getGradleProperties(buildIdentity.getBuildIdentifier());
+        return gradlePropertiesController.getGradleProperties(buildIdentity);
     }
 
     @Provides
@@ -808,7 +808,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         // Instantiate via `instantiator` for the DSL decorations to the `BuildServiceRegistry` API
         return instantiator.newInstance(
             DefaultBuildServicesRegistry.class,
-            buildIdentity.getBuildIdentifier(),
+            buildIdentity,
             factory,
             instantiatorFactory,
             services,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.api.internal.project
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.problems.ProblemReporter
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultProjectDescriptorRegistry
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.model.DefaultCalculatedModelValue
 import org.gradle.internal.operations.BuildOperationsParameters
@@ -97,7 +97,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         registry.stateFor(p1.componentIdentifier).is(p1)
         registry.stateFor(p2.componentIdentifier).is(p2)
 
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
         projects.rootProject.is(root)
         projects.getProject(Path.ROOT).is(root)
         projects.getProject(Path.path(":p1")).is(p1)
@@ -265,7 +265,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         given:
         def build = build("p1", "p2")
         def state = registry.stateFor(projectId("p1"))
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         expect:
         !state.hasMutableState()
@@ -291,7 +291,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createRootProject()
         def state = registry.stateFor(projectId("p1"))
         createProject(state, project)
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -330,7 +330,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createRootProject()
         def state = registry.stateFor(projectId("p1"))
         createProject(state, project("p1"))
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -359,7 +359,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createRootProject()
         def state = registry.stateFor(projectId("p1"))
         createProject(state, project("p1"))
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -390,7 +390,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createProject(state1, project("p1"))
         def state2 = registry.stateFor(projectId("p2"))
         createProject(state2, project("p2"))
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -420,7 +420,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createProject(state1, project("p1"))
         def state2 = registry.stateFor(projectId("p2"))
         createProject(state2, project("p2"))
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -450,7 +450,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createRootProject(otherBuildPath)
         def state = registry.stateFor(projectId(otherBuildPath, "p1"))
         createProject(state, project("p1"))
-        def rootProjects = registry.projectsFor(rootBuild.buildIdentifier)
+        def rootProjects = registry.projectsFor(rootBuild.buildIdentity)
 
         when:
         async {
@@ -481,7 +481,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         createRootProject()
         def state = registry.stateFor(projectId("p1"))
         createProject(state, project("p1"))
-        def otherProjects = registry.projectsFor(otherBuild.buildIdentifier)
+        def otherProjects = registry.projectsFor(otherBuild.buildIdentity)
 
         when:
         async {
@@ -507,7 +507,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
     def "releases lock for all projects while running blocking operation"() {
         given:
         def build = build("p1", "p2")
-        def projects = registry.projectsFor(build.buildIdentifier)
+        def projects = registry.projectsFor(build.buildIdentity)
 
         when:
         async {
@@ -871,7 +871,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
 
         def build = Stub(BuildState)
         build.loadedSettings >> settings
-        build.buildIdentifier >> (identityPath == Path.ROOT ? DefaultBuildIdentifier.ROOT : new DefaultBuildIdentifier(identityPath))
+        build.buildIdentity >> new BuildIdentity(identityPath)
         build.identityPath >> identityPath
         def services = new DefaultServiceRegistry()
         services.add(projectFactory)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/properties/DefaultGradlePropertiesControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/properties/DefaultGradlePropertiesControllerTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.properties
 
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.initialization.properties.GradlePropertiesLoader
 import org.gradle.initialization.properties.SystemPropertiesInstaller
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class DefaultGradlePropertiesControllerTest extends Specification {
 
-    private final rootBuildId = DefaultBuildIdentifier.ROOT
+    private final rootBuildId = new BuildIdentity(Path.ROOT)
     private final rootProjectId = ProjectIdentity.forRootProject(Path.ROOT, "root")
     private final buildRootDir = new File("buildRootDir")
 
@@ -293,7 +293,7 @@ class DefaultGradlePropertiesControllerTest extends Specification {
         def controller = newDefaultGradlePropertiesController()
 
         def rootBuildId = this.rootBuildId
-        def includedBuildId = new DefaultBuildIdentifier(Path.path(":included"))
+        def includedBuildId = new BuildIdentity(Path.path(":included"))
 
         def rootProperties = controller.getGradleProperties(rootBuildId)
         def includedProperties = controller.getGradleProperties(includedBuildId)

--- a/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.BuildListener
 import org.gradle.BuildResult
 import org.gradle.api.Action
 import org.gradle.api.GradleException
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -29,6 +28,7 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.services.BuildServiceRegistry
 import org.gradle.api.services.BuildServiceSpec
 import org.gradle.api.services.ServiceReference
+import org.gradle.internal.build.BuildIdentity
 import org.gradle.internal.Actions
 import org.gradle.internal.Try
 import org.gradle.internal.buildtree.BuildModelParameters
@@ -45,6 +45,7 @@ import org.gradle.internal.service.ServiceRegistrationProvider
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.snapshot.impl.DefaultIsolatableFactory
 import org.gradle.util.TestUtil
+import org.gradle.util.Path
 import spock.lang.Specification
 
 import java.util.function.Consumer
@@ -56,7 +57,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
     }
     def isolatableFactory = new DefaultIsolatableFactory(classLoaderHasher, TestUtil.managedFactoryRegistry())
     def leaseRegistry = Stub(SharedResourceLeaseRegistry)
-    def buildIdentifier = Mock(BuildIdentifier)
+    def buildIdentity = new BuildIdentity(Path.ROOT)
     def ipProblemsReporter = new DefaultIsolatedProjectsProblemsReporter(
         Stub(ProblemFactory),
         Stub(IsolatedProjectsProblemsListener)
@@ -67,7 +68,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
             @Provides
             BuildServiceRegistry createBuildServiceRegistry() {
                 return new DefaultBuildServicesRegistry(
-                    buildIdentifier,
+                    buildIdentity,
                     services.get(DomainObjectCollectionFactory),
                     services.get(InstantiatorFactory),
                     services,

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.build
 
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.util.Matchers
 import org.gradle.util.Path
 import spock.lang.Specification
@@ -33,6 +32,7 @@ class BuildIdentityTest extends Specification {
         identity.buildPath == Path.ROOT
         identity.displayName == "build ':'"
         identity.toString() == "build ':'"
+        identity.capitalizedDisplayName == "Build ':'"
     }
 
     def "nested build has display name with its build path"() {
@@ -42,13 +42,7 @@ class BuildIdentityTest extends Specification {
         identity.buildPath == Path.path(":included")
         identity.displayName == "build ':included'"
         identity.toString() == "build ':included'"
-    }
-
-    def "exposes a build identifier for the same path"() {
-        def identity = new BuildIdentity(Path.path(":included:nested"))
-
-        expect:
-        identity.buildIdentifier.buildPath == ":included:nested"
+        identity.capitalizedDisplayName == "Build ':included'"
     }
 
     def "rejects a relative build path"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildIdentityTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.build
 
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.util.Matchers
 import org.gradle.util.Path
 import spock.lang.Specification


### PR DESCRIPTION
> [!WARNING]
> **WIP — do not review as a finished change.** These comments came out of a retrospective on #39009, not from a plan. Their value is unproven, and the claims in them have not been checked by anyone who knows this code well. At least two statements were already softened once because they asserted more than had been verified. Treat every sentence as a proposal to be corrected or dropped.

Adds comments in three places where working on #39009 meant reconstructing something that was not written down.

### Why

Migrating `BuildIdentifier` to `BuildIdentity` across the build scope took several wrong turns, and each one came from an invariant that the code knows but does not state:

- The build-scope service registry is built inside `AbstractBuildState`'s constructor, and a `this-escape` suppression sits there with no explanation. Working out why it cannot be avoided meant reading `BuildScopeServices`, then every subclass constructor.
- `architecture/build-state-model.md` describes the scope hierarchy these types implement. Nothing in the code references it, so the model gets rebuilt from the source instead. That file was last touched in May 2024.
- The integration test executers are a bare list of names. Only the `configCache` one stores and reloads the cache, which is what makes it the only executer that covers serialization — a change that had to be established by instrumenting a codec and counting calls.

### What

- Comment the `this-escape` suppression in `AbstractBuildState`, and note the service lookup rule that surprises callers.
- Point `BuildState` and `BuildScopeServices` at the architecture doc.
- Describe on `TestType` what each integration test executer exercises.

### Details

**These are three separate commits because their value differs.** The constructor comment is the one I would defend: it records a constraint that rules out a refactoring which looks obvious and is not. The doc pointers are weaker — they make an already-stale document reachable, which surfaces the rot rather than fixing it. The executer descriptions sit on the enum, so adding an executer without describing it shows up in the same diff.

**The most valuable idea from the retrospective is not here.** A round-trip test over the registered serializers, requiring a sample per binding, would have caught the deserialization bug in #39009 before CI — and would fail on absence rather than rotting. It is not included because a naive version of it would have passed on that bug: `BuildIdentity`'s equality compares only the build path, while the corruption was in a derived field. Writing it needs a spike first to confirm the assertion actually catches that.

**Nothing here is enforced.** Every claim in these comments can drift out of date without anything failing. That is the main argument against the change as it stands.
