### PR TITLE
[WIP] Trim fetch result stacktraces

### DIFF
--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
@@ -19,7 +19,9 @@ import org.gradle.api.problems.internal.ProblemInternal;
 import org.gradle.internal.exceptions.MultiCauseException;
 import org.gradle.internal.problems.failure.DefaultFailureFactory;
 import org.gradle.internal.problems.failure.Failure;
+import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.internal.problems.failure.FailurePrinter;
+import org.gradle.internal.problems.failure.StackTraceMode;
 import org.gradle.tooling.internal.protocol.FailureDescriptionReconstructor;
 import org.gradle.tooling.internal.protocol.InternalBasicProblemDetailsVersion3;
 import org.gradle.tooling.internal.protocol.InternalFailure;
@@ -110,26 +112,31 @@ public class DefaultFailure implements Serializable, InternalFailure {
         return fromThrowable(t, mapper, FailureCache.NONE, StackTraceMode.INCLUDE);
     }
 
-    public static InternalFailure fromThrowable(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
-        Failure failure = DefaultFailureFactory.withDefaultClassifier().create(t);
+    public static InternalFailure fromThrowableWithoutStackTrace(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache) {
+        return fromThrowable(t, mapper, cache, StackTraceMode.OMIT);
+    }
+
+    private static InternalFailure fromThrowable(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
+        InternalFailure cached = cache.get(t);
+        if (cached != null) {
+            return cached;
+        }
+        FailureFactory failureFactory = DefaultFailureFactory.withDefaultClassifier();
+        Failure failure = stackTraceMode == StackTraceMode.OMIT
+            ? failureFactory.createWithoutStackTrace(t)
+            : failureFactory.create(t);
         return fromFailure(failure, mapper, cache, stackTraceMode);
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
-        return fromFailure(buildFailure, mapper, FailureCache.NONE);
+        return fromFailure(buildFailure, mapper, FailureCache.NONE, StackTraceMode.INCLUDE);
     }
 
-    public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache) {
-        return fromFailure(buildFailure, mapper, cache, StackTraceMode.INCLUDE);
+    public static InternalFailure fromFailureWithoutStackTrace(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache) {
+        return fromFailure(buildFailure, mapper, cache, StackTraceMode.OMIT);
     }
 
-    /**
-     * Converts a failure tree, rendering each node's own description with or without its stack frames.
-     * <p>
-     * A given {@code cache} must always be used with the same {@link StackTraceMode}: conversions are interned by the
-     * identity of the original throwable, so mixing modes would hand a caller the other mode's rendering.
-     */
-    public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
+    private static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
         // Reuse the conversion of a throwable already seen, e.g. a configuration failure shared across per-project fetches.
         InternalFailure cached = cache.get(buildFailure.getOriginal());
         if (cached != null) {

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
@@ -107,8 +107,12 @@ public class DefaultFailure implements Serializable, InternalFailure {
     }
 
     public static InternalFailure fromThrowable(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
+        return fromThrowable(t, mapper, FailureCache.NONE, StackTraceMode.INCLUDE);
+    }
+
+    public static InternalFailure fromThrowable(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
         Failure failure = DefaultFailureFactory.withDefaultClassifier().create(t);
-        return fromFailure(failure, mapper);
+        return fromFailure(failure, mapper, cache, stackTraceMode);
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
@@ -116,6 +120,16 @@ public class DefaultFailure implements Serializable, InternalFailure {
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache) {
+        return fromFailure(buildFailure, mapper, cache, StackTraceMode.INCLUDE);
+    }
+
+    /**
+     * Converts a failure tree, rendering each node's own description with or without its stack frames.
+     * <p>
+     * A given {@code cache} must always be used with the same {@link StackTraceMode}: conversions are interned by the
+     * identity of the original throwable, so mixing modes would hand a caller the other mode's rendering.
+     */
+    public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper, FailureCache cache, StackTraceMode stackTraceMode) {
         // Reuse the conversion of a throwable already seen, e.g. a configuration failure shared across per-project fetches.
         InternalFailure cached = cache.get(buildFailure.getOriginal());
         if (cached != null) {
@@ -124,8 +138,8 @@ public class DefaultFailure implements Serializable, InternalFailure {
         // Build the failure tree in a single pass: each node carries only its own description. The full description (the
         // whole cause subtree) is reconstructed lazily from these on demand, so no node prints its subtree here. Children
         // are interned before the parent, so the cache is never re-entered while a single mapping is being computed.
-        String ownDescription = FailurePrinter.printNodeToString(buildFailure);
-        List<InternalFailure> causeFailures = convertCausesToFailures(buildFailure.getCauses(), mapper, cache);
+        String ownDescription = renderOwnDescription(buildFailure, stackTraceMode);
+        List<InternalFailure> causeFailures = convertCausesToFailures(buildFailure.getCauses(), mapper, cache, stackTraceMode);
         List<InternalBasicProblemDetailsVersion3> problemDetails = buildFailure.getProblems().stream()
             .map(mapper)
             .collect(toList());
@@ -134,10 +148,17 @@ public class DefaultFailure implements Serializable, InternalFailure {
         return cache.intern(buildFailure.getOriginal(), converted);
     }
 
+    private static String renderOwnDescription(Failure buildFailure, StackTraceMode stackTraceMode) {
+        return stackTraceMode == StackTraceMode.OMIT
+            ? FailurePrinter.printNodeWithoutFramesToString(buildFailure)
+            : FailurePrinter.printNodeToString(buildFailure);
+    }
+
     private static List<InternalFailure> convertCausesToFailures(
         List<Failure> causes,
         Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper,
-        FailureCache cache
+        FailureCache cache,
+        StackTraceMode stackTraceMode
     ) {
         return causes.stream()
             // Multi cause exceptions are dropped from the cause structure (the reason predates this code); for example
@@ -147,7 +168,7 @@ public class DefaultFailure implements Serializable, InternalFailure {
             .flatMap(cause -> cause.getOriginal() instanceof MultiCauseException
                 ? cause.getCauses().stream()
                 : Stream.of(cause))
-            .map(cause -> fromFailure(cause, mapper, cache))
+            .map(cause -> fromFailure(cause, mapper, cache, stackTraceMode))
             .collect(toList());
     }
 

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/FailureCache.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/FailureCache.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Deduplicates failure conversion by the identity of the original {@link Throwable}.
+ * Deduplicates stackless failure conversion by the identity of the original {@link Throwable}.
  * <p>
  * A failed Isolated Projects sync attaches the same configuration failure to every per-project fetch, so the same
  * {@code Throwable} (the whole tree or a shared deep cause) is converted many times. Keying by {@code Throwable}

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/StackTraceMode.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/StackTraceMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.build.event.types;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Whether a converted failure's description carries the stack frames of the original exception.
+ * <p>
+ * A failure carries its stack trace as text inside its description, so the frames dominate both the cost of converting
+ * it and the size of what is sent to the client. {@link #OMIT} drops them, leaving the headers and the failure
+ * structure.
+ *
+ * @see DefaultFailure
+ */
+@NullMarked
+public enum StackTraceMode {
+
+    /**
+     * Describe each failure the way {@link Throwable#printStackTrace()} would, frames included.
+     */
+    INCLUDE,
+
+    /**
+     * Describe failures and their suppressed exceptions without rendering stack frames, so neither a frame line nor the
+     * "... n more" line that elides a common frame tail appears anywhere in the failure tree.
+     */
+    OMIT
+}

--- a/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
+++ b/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
@@ -124,7 +124,7 @@ class DefaultFailureTest extends Specification {
         def source = DefaultFailureFactory.withDefaultClassifier().create(deepChain())
 
         when:
-        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT)
+        def converted = DefaultFailure.fromFailureWithoutStackTrace(source, { p -> null } as Function, FailureCache.NONE)
 
         then: "the node's own description is its header, with nothing below it"
         converted.ownDescription == "java.lang.RuntimeException: root" + System.lineSeparator()
@@ -146,7 +146,7 @@ class DefaultFailureTest extends Specification {
             new DefaultMultiCauseException("multi", suppressing, new RuntimeException("two")))
 
         when:
-        def text = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT).getDescription()
+        def text = DefaultFailure.fromFailureWithoutStackTrace(source, { p -> null } as Function, FailureCache.NONE).getDescription()
 
         then:
         text.contains("Cause 1: java.lang.RuntimeException: outer")
@@ -159,7 +159,7 @@ class DefaultFailureTest extends Specification {
 
     def "omitting stack traces preserves messages and survives serialization"() {
         def source = DefaultFailureFactory.withDefaultClassifier().create(new RuntimeException("boom", new IllegalStateException("inner")))
-        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT)
+        def converted = DefaultFailure.fromFailureWithoutStackTrace(source, { p -> null } as Function, FailureCache.NONE)
 
         when:
         def restored = roundTrip(converted)

--- a/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
+++ b/platforms/core-runtime/daemon-messaging/src/test/groovy/org/gradle/internal/build/event/types/DefaultFailureTest.groovy
@@ -120,6 +120,57 @@ class DefaultFailureTest extends Specification {
         FailurePrinter.printToString(source).contains("INTERIOR-MULTI")
     }
 
+    def "omitting stack traces keeps the cause chain but renders no frames"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(deepChain())
+
+        when:
+        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT)
+
+        then: "the node's own description is its header, with nothing below it"
+        converted.ownDescription == "java.lang.RuntimeException: root" + System.lineSeparator()
+
+        and: "the full description still walks the whole cause chain"
+        def text = converted.getDescription()
+        text.contains("java.lang.RuntimeException: root")
+        text.contains("Caused by: java.lang.RuntimeException: level1")
+        text.contains("Caused by: java.lang.RuntimeException: level2-DEEP")
+
+        and: "no frames anywhere, so no common tail elision either"
+        !containsRenderedStackTrace(text)
+    }
+
+    def "omitting stack traces renders multiple causes and drops the frames of suppressed exceptions"() {
+        def suppressing = new RuntimeException("outer")
+        suppressing.addSuppressed(new IllegalStateException("suppressed-one"))
+        def source = DefaultFailureFactory.withDefaultClassifier().create(
+            new DefaultMultiCauseException("multi", suppressing, new RuntimeException("two")))
+
+        when:
+        def text = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT).getDescription()
+
+        then:
+        text.contains("Cause 1: java.lang.RuntimeException: outer")
+        text.contains("Cause 2: java.lang.RuntimeException: two")
+        text.contains("Suppressed: java.lang.IllegalStateException: suppressed-one")
+
+        and:
+        !containsRenderedStackTrace(text)
+    }
+
+    def "omitting stack traces preserves messages and survives serialization"() {
+        def source = DefaultFailureFactory.withDefaultClassifier().create(new RuntimeException("boom", new IllegalStateException("inner")))
+        def converted = DefaultFailure.fromFailure(source, { p -> null } as Function, FailureCache.NONE, StackTraceMode.OMIT)
+
+        when:
+        def restored = roundTrip(converted)
+
+        then:
+        restored.message == "boom"
+        restored.causes[0].message == "inner"
+        restored.getDescription() == converted.getDescription()
+        !containsRenderedStackTrace(restored.getDescription())
+    }
+
     def "converted failure survives serialization and reconstructs its description"() {
         def source = DefaultFailureFactory.withDefaultClassifier().create(new RuntimeException("boom", new IllegalStateException("inner")))
         def expected = FailurePrinter.printToString(source)
@@ -131,6 +182,14 @@ class DefaultFailureTest extends Specification {
         then:
         restored.getOwnDescription() == converted.getOwnDescription()
         restored.getDescription() == expected
+    }
+
+    /**
+     * Whether the text renders a stack trace: a frame line, or the line that elides a tail of frames shared with the
+     * parent. Both are indented, and a suppressed exception's own lines carry one further level of indentation.
+     */
+    private static boolean containsRenderedStackTrace(String text) {
+        return text.readLines().any { it ==~ /\t+(at .+|\.\.\. \d+ more)/ }
     }
 
     private static InternalFailure roundTrip(InternalFailure failure) {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
@@ -50,32 +50,42 @@ public class DefaultFailureFactory implements FailureFactory {
 
     @Override
     public Failure create(Throwable failure) {
-        return new Job(stackTraceClassifier, ProblemLocator.EMPTY_LOCATOR)
+        return create(failure, ProblemLocator.EMPTY_LOCATOR, StackTraceMode.INCLUDE);
+    }
+
+    @Override
+    public Failure createWithoutStackTrace(Throwable failure) {
+        return create(failure, ProblemLocator.EMPTY_LOCATOR, StackTraceMode.OMIT);
+    }
+
+    private Failure create(Throwable failure, ProblemLocator problemLocator, StackTraceMode stackTraceMode) {
+        return new Job(stackTraceClassifier, problemLocator, stackTraceMode)
             .convert(failure);
     }
 
     @Override
     public Failure create(Throwable failure, ProblemLocator problemLocator) {
-        return new Job(stackTraceClassifier, problemLocator)
-            .convert(failure);
+        return create(failure, problemLocator, StackTraceMode.INCLUDE);
     }
 
     private static final class Job {
 
         private final StackTraceClassifier stackTraceClassifier;
         private final ProblemLocator problemLocator;
+        private final StackTraceMode stackTraceMode;
 
         private final Set<Throwable> seen;
 
         private final Function<Throwable, Failure> recursiveConverter = this::convertRecursively;
 
-        private Job(StackTraceClassifier stackTraceClassifier, ProblemLocator problemLocator) {
-            this(stackTraceClassifier, problemLocator, null);
+        private Job(StackTraceClassifier stackTraceClassifier, ProblemLocator problemLocator, StackTraceMode stackTraceMode) {
+            this(stackTraceClassifier, problemLocator, stackTraceMode, null);
         }
 
-        private Job(StackTraceClassifier stackTraceClassifier, ProblemLocator problemLocator, @Nullable Set<Throwable> parentSeen) {
+        private Job(StackTraceClassifier stackTraceClassifier, ProblemLocator problemLocator, StackTraceMode stackTraceMode, @Nullable Set<Throwable> parentSeen) {
             this.stackTraceClassifier = stackTraceClassifier;
             this.problemLocator = problemLocator;
+            this.stackTraceMode = stackTraceMode;
             this.seen = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
             if (parentSeen != null) {
                 this.seen.addAll(parentSeen);
@@ -93,12 +103,18 @@ public class DefaultFailureFactory implements FailureFactory {
             }
             if (!seen.add(failure)) {
                 Throwable replacement = new Throwable("[CIRCULAR REFERENCE: " + failure + "]");
-                replacement.setStackTrace(failure.getStackTrace());
+                replacement.setStackTrace(
+                    stackTraceMode == StackTraceMode.INCLUDE ? failure.getStackTrace() : new StackTraceElement[0]
+                );
                 failure = replacement;
             }
 
-            ImmutableList<StackTraceElement> stackTrace = ImmutableList.copyOf(failure.getStackTrace());
-            List<StackTraceRelevance> relevances = classify(stackTrace, stackTraceClassifier);
+            ImmutableList<StackTraceElement> stackTrace = stackTraceMode == StackTraceMode.INCLUDE
+                ? ImmutableList.copyOf(failure.getStackTrace())
+                : ImmutableList.of();
+            List<StackTraceRelevance> relevances = stackTraceMode == StackTraceMode.INCLUDE
+                ? classify(stackTrace, stackTraceClassifier)
+                : ImmutableList.of();
             SuppressedAndCauses suppressedAndCauses = getSuppressedAndCauses(failure);
             List<Failure> suppressed = convertSuppressed(suppressedAndCauses);
             List<Failure> causes = convertCauses(suppressedAndCauses);
@@ -181,7 +197,7 @@ public class DefaultFailureFactory implements FailureFactory {
         }
 
         private Failure multiChildTransformer(Throwable throwable) {
-            return new Job(stackTraceClassifier, problemLocator, seen).convert(throwable);
+            return new Job(stackTraceClassifier, problemLocator, stackTraceMode, seen).convert(throwable);
         }
 
         private static class SuppressedAndCauses {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/FailurePrinter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/FailurePrinter.java
@@ -47,8 +47,20 @@ public class FailurePrinter {
      * The node's own frames are printed as if it had no parent, so no common tail elision is applied to them.
      */
     public static String printNodeToString(Failure failure) {
+        return printNodeToString(failure, true);
+    }
+
+    /**
+     * Prints a single node like {@link #printNodeToString(Failure)}, but without any stack frames: only its header and
+     * any suppressed exceptions, themselves printed without frames.
+     */
+    public static String printNodeWithoutFramesToString(Failure failure) {
+        return printNodeToString(failure, false);
+    }
+
+    private static String printNodeToString(Failure failure, boolean printFrames) {
         StringBuilder output = new StringBuilder();
-        new Job(output, FailurePrinterListener.NO_OP).printNode(failure);
+        new Job(output, FailurePrinterListener.NO_OP, printFrames).printNode(failure);
         return output.toString();
     }
 
@@ -57,11 +69,17 @@ public class FailurePrinter {
         private final FailurePrinterListener listener;
 
         private final Appendable builder;
+        private final boolean printFrames;
         private final String lineSeparator = SystemProperties.getInstance().getLineSeparator();
 
         private Job(Appendable builder, FailurePrinterListener listener) {
+            this(builder, listener, true);
+        }
+
+        private Job(Appendable builder, FailurePrinterListener listener, boolean printFrames) {
             this.listener = listener;
             this.builder = builder;
+            this.printFrames = printFrames;
         }
 
         public void print(Failure failure) {
@@ -116,6 +134,10 @@ public class FailurePrinter {
         }
 
         private void appendFrames(String prefix, @Nullable Failure parent, Failure failure) throws IOException {
+            if (!printFrames) {
+                return;
+            }
+
             List<StackTraceElement> stackTrace = failure.getStackTrace();
 
             int commonTailSize = parent == null ? 0 : countCommonTailFrames(stackTrace, parent.getStackTrace());

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/failure/FailurePrinterTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/failure/FailurePrinterTest.groovy
@@ -91,6 +91,57 @@ class FailurePrinterTest extends Specification {
         !node.contains(cause.stackTrace[0].toString())
     }
 
+    def "printNodeWithoutFramesToString prints only the node header"() {
+        def cause = SimulatedJavaException.simulateDeeperException()
+        def e = new RuntimeException("BOOM", cause)
+        def f = toFailure(e)
+
+        when:
+        def node = FailurePrinter.printNodeWithoutFramesToString(f)
+
+        then:
+        node == "java.lang.RuntimeException: BOOM" + System.lineSeparator()
+
+        and:
+        !containsRenderedStackTrace(node)
+        !node.contains("Caused by:")
+    }
+
+    def "printNodeWithoutFramesToString keeps suppressed exceptions but drops their frames"() {
+        def e = new RuntimeException("BOOM")
+        e.addSuppressed(new RuntimeException("SUPPRESSED", SimulatedJavaException.simulateDeeperException()))
+        def f = toFailure(e)
+
+        when:
+        def node = FailurePrinter.printNodeWithoutFramesToString(f)
+
+        then:
+        node.contains("java.lang.RuntimeException: BOOM")
+        node.contains("\tSuppressed: java.lang.RuntimeException: SUPPRESSED")
+        node.contains("\tCaused by: ")
+
+        and:
+        !containsRenderedStackTrace(node)
+    }
+
+    def "printNodeWithoutFramesToString does not read the frames it would not print"() {
+        // The point of the frameless print is to skip the frame work, not to render frames and then drop the result.
+        def failure = Mock(Failure) {
+            getHeader() >> "java.lang.RuntimeException: BOOM"
+            getSuppressed() >> []
+        }
+
+        when:
+        def node = FailurePrinter.printNodeWithoutFramesToString(failure)
+
+        then:
+        node == "java.lang.RuntimeException: BOOM" + System.lineSeparator()
+
+        and:
+        0 * failure.getStackTrace()
+        0 * failure.getStackTraceRelevance(_)
+    }
+
     def "notifies the listener"() {
         def e = new RuntimeException("BOOM")
         def firstFrame = e.stackTrace[0]
@@ -110,6 +161,14 @@ class FailurePrinterTest extends Specification {
         1 * listener.beforeFrames()
         1 * listener.beforeFrame(firstFrame, USER_CODE)
         1 * listener.afterFrames()
+    }
+
+    /**
+     * Whether the text renders a stack trace: a frame line, or the line that elides a tail of frames shared with the
+     * parent. Both are indented, and a suppressed exception's own lines carry one further level of indentation.
+     */
+    private static boolean containsRenderedStackTrace(String text) {
+        return text.readLines().any { it ==~ /\t+(at .+|\.\.\. \d+ more)/ }
     }
 
     private static Failure toFailure(Throwable t) {

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
@@ -114,4 +114,43 @@ class DefaultFailureFactoryTest extends Specification {
         failure.causes.empty
     }
 
+    def "omitting stack traces does not read or classify frames anywhere in the failure tree"() {
+        def cause = new StackTraceReadCountingException("cause")
+        def suppressed = new StackTraceReadCountingException("suppressed")
+        def root = new StackTraceReadCountingException("root", cause)
+        root.addSuppressed(suppressed)
+        def classifier = Mock(StackTraceClassifier)
+
+        when:
+        def failure = new DefaultFailureFactory(classifier).createWithoutStackTrace(root)
+
+        then:
+        root.stackTraceReads == 0
+        cause.stackTraceReads == 0
+        suppressed.stackTraceReads == 0
+        0 * classifier._
+
+        and:
+        failure.stackTrace.empty
+        failure.causes[0].stackTrace.empty
+        failure.suppressed[0].stackTrace.empty
+        failure.header == "${StackTraceReadCountingException.name}: root"
+        failure.causes[0].header == "${StackTraceReadCountingException.name}: cause"
+        failure.suppressed[0].header == "${StackTraceReadCountingException.name}: suppressed"
+    }
+
+    private static class StackTraceReadCountingException extends RuntimeException {
+        int stackTraceReads
+
+        StackTraceReadCountingException(String message, Throwable cause = null) {
+            super(message, cause)
+        }
+
+        @Override
+        StackTraceElement[] getStackTrace() {
+            stackTraceReads++
+            return super.getStackTrace()
+        }
+    }
+
 }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -103,7 +103,9 @@ A resilient sync reports a failure for every model it fetches, and a single brok
 Until now each of those failures carried the full stack trace of the underlying exception, so the same trace was rendered and transferred once per model, delaying the moment an IDE could show the error.
 
 The failures returned by [`FetchModelResult.getFailures()`](javadoc/org/gradle/tooling/FetchModelResult.html) now describe themselves by message and cause chain only.
-Clients that need the stack traces read them from the failure the build reports when it fails at the end of the sync, which is unchanged.
+Gradle omits the frames when it first converts these failures, avoiding the cost of reading, copying, and classifying each repeated stack trace as well as rendering and transferring it.
+When the same underlying failure also fails the sync, clients can read its complete stack trace from the failure the build reports at the end.
+Failures reported only by a fetch result intentionally have no stack trace.
 
 See [`getModel`/`findModel` versus `fetch`](userguide/tooling_api.html#sec:embedding_get_find_vs_fetch) in the user manual.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -97,6 +97,16 @@ Gradle provides robust [security features and underlying infrastructure](usergui
 ### Tooling and IDE integration
 Gradle provides [Tooling APIs](userguide/third_party_integration.html) that facilitate deep integration with modern IDEs and CI/CD pipelines.
 
+#### Fetch results report failures without stack traces
+
+A resilient sync reports a failure for every model it fetches, and a single broken build script commonly fails all of them.
+Until now each of those failures carried the full stack trace of the underlying exception, so the same trace was rendered and transferred once per model, delaying the moment an IDE could show the error.
+
+The failures returned by [`FetchModelResult.getFailures()`](javadoc/org/gradle/tooling/FetchModelResult.html) now describe themselves by message and cause chain only.
+Clients that need the stack traces read them from the failure the build reports when it fails at the end of the sync, which is unchanged.
+
+See [`getModel`/`findModel` versus `fetch`](userguide/tooling_api.html#sec:embedding_get_find_vs_fetch) in the user manual.
+
 ### Performance improvements
 Gradle continuously improves [build performance](userguide/performance.html) through caching, parallelism, and reduced overhead across all phases of the build.
 

--- a/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
@@ -122,6 +122,10 @@ Each `fetch(...)` call returns a link:{javadocPath}/org/gradle/tooling/FetchMode
 * The fetched model — accessible via `FetchModelResult.getModel()`, or `null` if the model could not be built.
 * Any failures encountered while building the model — accessible via `FetchModelResult.getFailures()` as a collection of link:{javadocPath}/org/gradle/tooling/Failure.html[`Failure`] values.
 
+Starting with Gradle 9.9, these failures describe themselves by message and cause chain, without stack traces.
+A resilient sync reports a failure per fetched model, and the same configuration failure is commonly attached to every one of them, so their stack traces would be rendered and transferred once per model.
+A client that needs the stack traces reads them from the failure the build reports when it fails at the end of the sync, which is unaffected.
+
 Unlike `getModel`/`findModel`, `fetch(...)` does not throw when the build-side fails to produce the model.
 The build action can inspect the failures, decide whether to continue, and request more models.
 This is the recommended API for IDEs and tools that want to deliver a partial sync result when part of the build is broken, rather than failing the whole operation on the first error:
@@ -163,6 +167,7 @@ Resilient sync requires Tooling API 9.3.0 or later and a target Gradle version t
 * Gradle 9.3.0: The `fetch(...)` methods and `FetchModelResult` are available.
 * Gradle 9.4.0: Partial build models, returned when a settings script or a settings plugin fails.
 * Gradle 9.7.0: Reporting a resilient sync that partially failed as a failed operation. In earlier versions, such an operation could complete successfully, with the failures reported only through `FetchModelResult.getFailures()`.
+* Gradle 9.9.0: Reporting the failures of a fetch result without stack traces. Earlier versions include the stack trace of every failure in its description.
 
 [[sec:embedding_phased_action_example]]
 === Reading intermediate models with a phased build action

--- a/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
@@ -124,7 +124,8 @@ Each `fetch(...)` call returns a link:{javadocPath}/org/gradle/tooling/FetchMode
 
 Starting with Gradle 9.9, these failures describe themselves by message and cause chain, without stack traces.
 A resilient sync reports a failure per fetched model, and the same configuration failure is commonly attached to every one of them, so their stack traces would be rendered and transferred once per model.
-A client that needs the stack traces reads them from the failure the build reports when it fails at the end of the sync, which is unaffected.
+When the same underlying failure also fails the sync, a client can read its complete stack trace from the failure the build reports at the end.
+Failures reported only by a fetch result intentionally have no stack trace.
 
 Unlike `getModel`/`findModel`, `fetch(...)` does not throw when the build-side fails to produce the model.
 The build action can inspect the failures, decide whether to continue, and request more models.

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -125,7 +125,8 @@ public class GradleBuildBuilder implements BuildScopeModelBuilder {
             try {
                 target.ensureProjectsLoaded();
             } catch (GradleException e) {
-                failures.add(failureFactory.create(e));
+                // The failure retains the original exception, which the tooling model controller reports at the build boundary.
+                failures.add(failureFactory.createWithoutStackTrace(e));
             }
         }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/FailureFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/FailureFactory.java
@@ -30,6 +30,11 @@ public interface FailureFactory {
 
     Failure create(Throwable failure);
 
+    /**
+     * Converts an exception without reading or retaining its stack frames.
+     */
+    Failure createWithoutStackTrace(Throwable failure);
+
     Failure create(Throwable failure, ProblemLocator problemLocator);
 
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/StackTraceMode.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/StackTraceMode.java
@@ -13,30 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.build.event.types;
+package org.gradle.internal.problems.failure;
 
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Whether a converted failure's description carries the stack frames of the original exception.
+ * Whether a converted failure carries the stack frames of the original exception.
  * <p>
- * A failure carries its stack trace as text inside its description, so the frames dominate both the cost of converting
- * it and the size of what is sent to the client. {@link #OMIT} drops them, leaving the headers and the failure
- * structure.
+ * Stack frames dominate both the cost of converting a failure and the size of its serialized description.
+ * {@link #OMIT} leaves the failure headers and structure intact without reading, copying, or classifying frames.
  *
- * @see DefaultFailure
+ * @see FailureFactory
  */
 @NullMarked
 public enum StackTraceMode {
 
     /**
-     * Describe each failure the way {@link Throwable#printStackTrace()} would, frames included.
+     * Convert each failure with all of its stack frames.
      */
     INCLUDE,
 
     /**
-     * Describe failures and their suppressed exceptions without rendering stack frames, so neither a frame line nor the
-     * "... n more" line that elides a common frame tail appears anywhere in the failure tree.
+     * Convert failures and their suppressed exceptions without stack frames.
      */
     OMIT
 }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.build.event.types.DefaultFailure;
 import org.gradle.internal.buildtree.BuildTreeModelController;
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor;
 import org.gradle.internal.buildtree.BuildTreeModelTarget;
@@ -179,7 +178,7 @@ class DefaultBuildController implements
             List<InternalFailure> failures = toInternalFailures(resultInternal.getFailures());
             return new DefaultInternalFetchModelResult<>(uncheckedNonnullCast(resultInternal.getModel()), failures);
         } catch (Exception e) {
-            List<InternalFailure> failures = ImmutableList.of(DefaultFailure.fromThrowable(e));
+            List<InternalFailure> failures = ImmutableList.of(failureConverter.convert(e));
             return new DefaultInternalFetchModelResult<>(null, failures);
         }
     }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -178,7 +178,7 @@ class DefaultBuildController implements
             List<InternalFailure> failures = toInternalFailures(resultInternal.getFailures());
             return new DefaultInternalFetchModelResult<>(uncheckedNonnullCast(resultInternal.getModel()), failures);
         } catch (Exception e) {
-            List<InternalFailure> failures = ImmutableList.of(failureConverter.convert(e));
+            List<InternalFailure> failures = ImmutableList.of(failureConverter.convertWithoutStackTrace(e));
             return new DefaultInternalFetchModelResult<>(null, failures);
         }
     }
@@ -186,7 +186,7 @@ class DefaultBuildController implements
     private List<InternalFailure> toInternalFailures(List<Failure> failures) {
         return failures
             .stream()
-            .map(failureConverter::convert)
+            .map(failureConverter::convertWithoutStackTrace)
             .collect(toImmutableList());
     }
 }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
@@ -19,7 +19,6 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.api.problems.internal.ProblemInternal;
 import org.gradle.internal.build.event.types.DefaultFailure;
 import org.gradle.internal.build.event.types.FailureCache;
-import org.gradle.internal.build.event.types.StackTraceMode;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -37,9 +36,9 @@ import java.util.concurrent.ConcurrentMap;
  * {@link FailureCache} for why this reuse matters). Its lifetime is this build tree, so it is freed when the model
  * phase ends and never retains failure graphs across syncs.
  * <p>
- * Fetch failures are converted without stack frames, which the client still receives from the failure the build fails
- * with. Holding that policy here is what keeps every value in this converter's cache rendered the same way (see
- * {@link DefaultFailure#fromFailure(Failure, java.util.function.Function, FailureCache, StackTraceMode)}).
+ * Fetch failures are converted without stack frames. When the same underlying failure also fails the operation as a
+ * whole, the client receives its complete stack trace from that terminal failure. Failures reported only by a fetch
+ * result intentionally have no full-stack equivalent.
  */
 @ServiceScope(Scope.BuildTree.class)
 @NullMarked
@@ -47,12 +46,12 @@ public class FetchFailureConverter implements FailureCache {
 
     private final ConcurrentMap<IdentityKey, InternalFailure> cache = new ConcurrentHashMap<>();
 
-    InternalFailure convert(Failure failure) {
-        return DefaultFailure.fromFailure(failure, FetchFailureConverter::noProblemDetails, this, StackTraceMode.OMIT);
+    InternalFailure convertWithoutStackTrace(Failure failure) {
+        return DefaultFailure.fromFailureWithoutStackTrace(failure, FetchFailureConverter::noProblemDetails, this);
     }
 
-    InternalFailure convert(Throwable throwable) {
-        return DefaultFailure.fromThrowable(throwable, FetchFailureConverter::noProblemDetails, this, StackTraceMode.OMIT);
+    InternalFailure convertWithoutStackTrace(Throwable throwable) {
+        return DefaultFailure.fromThrowableWithoutStackTrace(throwable, FetchFailureConverter::noProblemDetails, this);
     }
 
     @Nullable

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
@@ -19,6 +19,7 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.api.problems.internal.ProblemInternal;
 import org.gradle.internal.build.event.types.DefaultFailure;
 import org.gradle.internal.build.event.types.FailureCache;
+import org.gradle.internal.build.event.types.StackTraceMode;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -35,15 +36,23 @@ import java.util.concurrent.ConcurrentMap;
  * {@link InternalFailure} values, interning by {@link Throwable} identity at every recursion step (see
  * {@link FailureCache} for why this reuse matters). Its lifetime is this build tree, so it is freed when the model
  * phase ends and never retains failure graphs across syncs.
+ * <p>
+ * Fetch failures are converted without stack frames, which the client still receives from the failure the build fails
+ * with. Holding that policy here is what keeps every value in this converter's cache rendered the same way (see
+ * {@link DefaultFailure#fromFailure(Failure, java.util.function.Function, FailureCache, StackTraceMode)}).
  */
 @ServiceScope(Scope.BuildTree.class)
 @NullMarked
 public class FetchFailureConverter implements FailureCache {
 
-    private final ConcurrentMap<Throwable, InternalFailure> cache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<IdentityKey, InternalFailure> cache = new ConcurrentHashMap<>();
 
     InternalFailure convert(Failure failure) {
-        return DefaultFailure.fromFailure(failure, FetchFailureConverter::noProblemDetails, this);
+        return DefaultFailure.fromFailure(failure, FetchFailureConverter::noProblemDetails, this, StackTraceMode.OMIT);
+    }
+
+    InternalFailure convert(Throwable throwable) {
+        return DefaultFailure.fromThrowable(throwable, FetchFailureConverter::noProblemDetails, this, StackTraceMode.OMIT);
     }
 
     @Nullable
@@ -54,12 +63,30 @@ public class FetchFailureConverter implements FailureCache {
     @Override
     @Nullable
     public InternalFailure get(Throwable original) {
-        return cache.get(original);
+        return cache.get(new IdentityKey(original));
     }
 
     @Override
     public InternalFailure intern(Throwable original, InternalFailure converted) {
-        InternalFailure previous = cache.putIfAbsent(original, converted);
+        InternalFailure previous = cache.putIfAbsent(new IdentityKey(original), converted);
         return previous != null ? previous : converted;
+    }
+
+    private static final class IdentityKey {
+        private final Throwable throwable;
+
+        private IdentityKey(Throwable throwable) {
+            this.throwable = throwable;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object other) {
+            return this == other || (other instanceof IdentityKey && throwable == ((IdentityKey) other).throwable);
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(throwable);
+        }
     }
 }

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
@@ -28,6 +28,37 @@ class FetchFailureConverterTest extends Specification {
 
     def converter = new FetchFailureConverter()
 
+    def "converts without stack frames, keeping the messages and the cause chain"() {
+        def throwable = new RuntimeException("top", new IllegalStateException("bottom"))
+
+        when:
+        def converted = converter.convert(failureOf(throwable))
+
+        then:
+        converted.message == "top"
+        converted.causes[0].message == "bottom"
+
+        and:
+        def description = converted.description
+        description.contains("java.lang.RuntimeException: top")
+        description.contains("Caused by: java.lang.IllegalStateException: bottom")
+        !containsRenderedStackTrace(description)
+    }
+
+    def "converts a throwable without stack frames and interns it like a failure"() {
+        def throwable = new RuntimeException("boom")
+
+        when:
+        def fromThrowable = converter.convert(throwable)
+        def fromFailure = converter.convert(failureOf(throwable))
+
+        then: "the throwable and the failure wrapping it convert to the same instance"
+        fromThrowable.is(fromFailure)
+
+        and:
+        !containsRenderedStackTrace(fromThrowable.description)
+    }
+
     def "reuses the converted failure when two failures share the same original throwable"() {
         def throwable = new RuntimeException("boom")
 
@@ -46,6 +77,17 @@ class FetchFailureConverterTest extends Specification {
 
         then:
         !first.is(second)
+    }
+
+    def "uses throwable identity rather than equality for cache keys"() {
+        when:
+        def first = converter.convert(failureOf(new EqualException("one")))
+        def second = converter.convert(failureOf(new EqualException("two")))
+
+        then:
+        !first.is(second)
+        first.message == "one"
+        second.message == "two"
     }
 
     def "reuses the whole converted tree when two failures share the same throwable tree"() {
@@ -97,6 +139,14 @@ class FetchFailureConverterTest extends Specification {
         executor.shutdownNow()
     }
 
+    /**
+     * Whether the text renders a stack trace: a frame line, or the line that elides a tail of frames shared with the
+     * parent. Both are indented, and a suppressed exception's own lines carry one further level of indentation.
+     */
+    private static boolean containsRenderedStackTrace(String text) {
+        return text.readLines().any { it ==~ /\t+(at .+|\.\.\. \d+ more)/ }
+    }
+
     private static Failure failureOf(Throwable throwable) {
         DefaultFailureFactory.withDefaultClassifier().create(throwable)
     }
@@ -105,5 +155,20 @@ class FetchFailureConverterTest extends Specification {
         Throwable t = new RuntimeException("leaf")
         (1..(depth - 1)).each { t = new RuntimeException("level-$it", t) }
         t
+    }
+    private static class EqualException extends RuntimeException {
+        EqualException(String message) {
+            super(message)
+        }
+
+        @Override
+        boolean equals(Object other) {
+            return other instanceof EqualException
+        }
+
+        @Override
+        int hashCode() {
+            return 0
+        }
     }
 }

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
@@ -32,7 +32,7 @@ class FetchFailureConverterTest extends Specification {
         def throwable = new RuntimeException("top", new IllegalStateException("bottom"))
 
         when:
-        def converted = converter.convert(failureOf(throwable))
+        def converted = converter.convertWithoutStackTrace(failureOf(throwable))
 
         then:
         converted.message == "top"
@@ -49,8 +49,8 @@ class FetchFailureConverterTest extends Specification {
         def throwable = new RuntimeException("boom")
 
         when:
-        def fromThrowable = converter.convert(throwable)
-        def fromFailure = converter.convert(failureOf(throwable))
+        def fromThrowable = converter.convertWithoutStackTrace(throwable)
+        def fromFailure = converter.convertWithoutStackTrace(failureOf(throwable))
 
         then: "the throwable and the failure wrapping it convert to the same instance"
         fromThrowable.is(fromFailure)
@@ -63,17 +63,29 @@ class FetchFailureConverterTest extends Specification {
         def throwable = new RuntimeException("boom")
 
         when:
-        def first = converter.convert(failureOf(throwable))
-        def second = converter.convert(failureOf(throwable))
+        def first = converter.convertWithoutStackTrace(failureOf(throwable))
+        def second = converter.convertWithoutStackTrace(failureOf(throwable))
 
         then:
         first.is(second)
     }
 
+    def "consults the identity cache before converting a throwable to a failure"() {
+        def throwable = new CauseAccessGuardException("boom")
+        def first = converter.convertWithoutStackTrace(failureOf(throwable))
+        throwable.causeAccessAllowed = false
+
+        when:
+        def second = converter.convertWithoutStackTrace(throwable)
+
+        then: "the factory is bypassed, so it never tries to inspect the throwable again"
+        second.is(first)
+    }
+
     def "converts failures with distinct originals into distinct instances"() {
         when:
-        def first = converter.convert(failureOf(new RuntimeException("one")))
-        def second = converter.convert(failureOf(new RuntimeException("two")))
+        def first = converter.convertWithoutStackTrace(failureOf(new RuntimeException("one")))
+        def second = converter.convertWithoutStackTrace(failureOf(new RuntimeException("two")))
 
         then:
         !first.is(second)
@@ -81,8 +93,8 @@ class FetchFailureConverterTest extends Specification {
 
     def "uses throwable identity rather than equality for cache keys"() {
         when:
-        def first = converter.convert(failureOf(new EqualException("one")))
-        def second = converter.convert(failureOf(new EqualException("two")))
+        def first = converter.convertWithoutStackTrace(failureOf(new EqualException("one")))
+        def second = converter.convertWithoutStackTrace(failureOf(new EqualException("two")))
 
         then:
         !first.is(second)
@@ -94,8 +106,8 @@ class FetchFailureConverterTest extends Specification {
         def shared = chainOfDepth(4)
 
         when:
-        def first = converter.convert(failureOf(shared))
-        def second = converter.convert(failureOf(shared))
+        def first = converter.convertWithoutStackTrace(failureOf(shared))
+        def second = converter.convertWithoutStackTrace(failureOf(shared))
 
         then:
         first.is(second)
@@ -108,8 +120,8 @@ class FetchFailureConverterTest extends Specification {
         def topB = new RuntimeException("project :b failed", sharedCause)
 
         when:
-        def a = converter.convert(failureOf(topA))
-        def b = converter.convert(failureOf(topB))
+        def a = converter.convertWithoutStackTrace(failureOf(topA))
+        def b = converter.convertWithoutStackTrace(failureOf(topB))
 
         then: "the per-project wrappers differ but the shared deep cause is converted once"
         !a.is(b)
@@ -126,7 +138,7 @@ class FetchFailureConverterTest extends Specification {
         def futures = (1..threads).collect {
             executor.submit({
                 start.await()
-                converter.convert(failureOf(shared))
+                converter.convertWithoutStackTrace(failureOf(shared))
             } as Callable)
         }
         start.countDown()
@@ -156,6 +168,23 @@ class FetchFailureConverterTest extends Specification {
         (1..(depth - 1)).each { t = new RuntimeException("level-$it", t) }
         t
     }
+
+    private static class CauseAccessGuardException extends RuntimeException {
+        boolean causeAccessAllowed = true
+
+        CauseAccessGuardException(String message) {
+            super(message)
+        }
+
+        @Override
+        synchronized Throwable getCause() {
+            if (!causeAccessAllowed) {
+                throw new AssertionError("cause should not be read after the throwable has been cached")
+            }
+            return super.getCause()
+        }
+    }
+
     private static class EqualException extends RuntimeException {
         EqualException(String message) {
             super(message)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
@@ -77,13 +77,16 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
     def "can request unknown model"() {
         when:
-        def causes = succeeds {
+        def result = succeeds {
             action(new FetchUnknownModelAction())
                 .run()
         }
 
         then:
-        causes == ["No builders are available to build a model of type 'org.gradle.integtests.tooling.r930.UnknownModel'."]
+        result.causes == ["No builders are available to build a model of type 'org.gradle.integtests.tooling.r930.UnknownModel'."]
+        if (targetVersion >= GradleVersion.version("9.9")) {
+            assert !containsRenderedStackTrace(result.failureDescription)
+        }
     }
 
     def "can request a custom model with #dsl DSL"() {
@@ -330,5 +333,9 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
                 }
             }
             """
+    }
+
+    private static boolean containsRenderedStackTrace(String text) {
+        return text.readLines().any { it ==~ /\t+(at .+|\.\.\. \d+ more)/ }
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r990/ResilientFetchFailureStackTraceCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r990/ResilientFetchFailureStackTraceCrossVersionSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r990
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.integtests.tooling.r16.CustomModel
+import org.gradle.integtests.tooling.r970.FetchFailureTreeAction
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.IntermediateResultHandler
+
+/**
+ * A resilient sync reports a failure per fetched model, so a shared configuration failure would otherwise have its
+ * stack trace rendered and sent once per project. From Gradle 9.9 onwards the failures a fetch result carries describe
+ * themselves without stack frames; the client still receives the complete failure, frames included, from the
+ * {@link BuildException} the build fails with at the end of the sync.
+ */
+@ToolingApiVersion('>=9.3.0')
+@TargetGradleVersion('>=9.9.0')
+class ResilientFetchFailureStackTraceCrossVersionSpec extends ToolingApiSpecification {
+
+    private FetchFailureTreeAction.Result fetchResult
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'a', 'b'
+        """
+        file('a/build.gradle') << "// intentionally clean\n"
+        file('b/build.gradle') << """throw new RuntimeException("FAILURE(:b)")\n"""
+        file('init.gradle') << """
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import javax.inject.Inject
+
+gradle.lifecycle.beforeProject {
+    it.plugins.apply(CustomPlugin)
+}
+
+class CustomModel implements Serializable {
+    String getValue() { 'greetings' }
+}
+
+class CustomBuilder implements ToolingModelBuilder {
+    boolean canBuild(String modelName) {
+        return modelName == '${CustomModel.name}'
+    }
+    Object buildAll(String modelName, Project project) {
+        return new CustomModel()
+    }
+}
+
+class CustomPlugin implements Plugin<Project> {
+    @Inject
+    CustomPlugin(ToolingModelBuilderRegistry registry) {
+        registry.register(new CustomBuilder())
+    }
+
+    void apply(Project project) {
+    }
+}
+"""
+    }
+
+    def "fetch failures carry no stack frames while the build failure still does"() {
+        when:
+        fails {
+            action()
+                .buildFinished(new FetchFailureTreeAction(CustomModel), { fetchResult = it } as IntermediateResultHandler)
+                .build()
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then: "the whole build fails to configure, so every project fails to be queried and the build fails"
+        def e = thrown(BuildException)
+        fetchResult != null
+        fetchResult.failedToQueryProjects.toSet() == ['root', 'a', 'b'] as Set
+
+        and: "no failure description carries a stack frame, nor the elision line that only frames produce"
+        fetchResult.rootDescriptionByProject.each { project, description ->
+            assert !containsRenderedStackTrace(description): "Unexpected stack trace for project '$project':\n$description"
+        }
+
+        and: "the failing project is still named by its own failure, with its cause chain below it"
+        fetchResult.failureTreeByProject['b'].message.contains(":b")
+        fetchResult.rootDescriptionByProject['b'].contains("Caused by: ")
+        fetchResult.rootDescriptionByProject['b'].contains("FAILURE(:b)")
+
+        and: "the same failure reaches the client with its stack trace when the build fails at the end of the sync"
+        def cause = collectCauses(e).find { it.message?.contains("FAILURE(:b)") }
+        cause != null
+        cause.stackTrace.length > 0
+    }
+
+    /**
+     * Whether the text renders a stack trace: a frame line, or the line that elides a tail of frames shared with the
+     * parent. Both are indented, and a suppressed exception's own lines carry one further level of indentation.
+     */
+    private static boolean containsRenderedStackTrace(String text) {
+        return text.readLines().any { it ==~ /\t+(at .+|\.\.\. \d+ more)/ }
+    }
+
+    private static List<Throwable> collectCauses(Throwable throwable, int depth = 0) {
+        if (throwable == null || depth > 50) {
+            return []
+        }
+        def causes = throwable.respondsTo('getCauses')
+            ? throwable.causes
+            : (throwable.cause != null ? [throwable.cause] : [])
+        return [throwable] + causes.collectMany { collectCauses(it as Throwable, depth + 1) }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r990/ResilientFetchFailureStackTraceCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r990/ResilientFetchFailureStackTraceCrossVersionSpec.groovy
@@ -21,7 +21,11 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r16.CustomModel
 import org.gradle.integtests.tooling.r970.FetchFailureTreeAction
+import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildException
+import org.gradle.tooling.BuildController
+import org.gradle.tooling.Failure
+import org.gradle.tooling.FetchModelResult
 import org.gradle.tooling.IntermediateResultHandler
 
 /**
@@ -35,6 +39,7 @@ import org.gradle.tooling.IntermediateResultHandler
 class ResilientFetchFailureStackTraceCrossVersionSpec extends ToolingApiSpecification {
 
     private FetchFailureTreeAction.Result fetchResult
+    private FetchStackTraceReadCountAction.Result stackTraceReadResult
 
     def setup() {
         settingsFile << """
@@ -106,6 +111,122 @@ class CustomPlugin implements Plugin<Project> {
         def cause = collectCauses(e).find { it.message?.contains("FAILURE(:b)") }
         cause != null
         cause.stackTrace.length > 0
+    }
+
+    def "fetch failure conversion does not read stack frames before final build failure reporting"() {
+        given:
+        file('b/build.gradle').text = ''
+        file('init.gradle').text = """
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+
+gradle.lifecycle.beforeProject {
+    it.plugins.apply(StackTraceCountingPlugin)
+}
+
+class StackTraceCountingException extends RuntimeException {
+    static final AtomicInteger STACK_TRACE_READS = new AtomicInteger()
+
+    StackTraceCountingException(String message) {
+        super(message)
+    }
+
+    @Override
+    StackTraceElement[] getStackTrace() {
+        STACK_TRACE_READS.incrementAndGet()
+        return super.getStackTrace()
+    }
+}
+
+class StackTraceReadCountModel {
+    int getCount() {
+        return StackTraceCountingException.STACK_TRACE_READS.get()
+    }
+}
+
+class StackTraceCountingBuilder implements ToolingModelBuilder {
+    boolean canBuild(String modelName) {
+        return modelName in [
+            '${FetchStackTraceReadCountAction.FailingModel.name}',
+            '${FetchStackTraceReadCountAction.StackTraceReadCountModel.name}'
+        ]
+    }
+
+    Object buildAll(String modelName, Project project) {
+        if (modelName == '${FetchStackTraceReadCountAction.FailingModel.name}') {
+            throw new StackTraceCountingException('FRAME-COUNTED-FAILURE')
+        }
+        return new StackTraceReadCountModel()
+    }
+}
+
+class StackTraceCountingPlugin implements Plugin<Project> {
+    @Inject
+    StackTraceCountingPlugin(ToolingModelBuilderRegistry registry) {
+        registry.register(new StackTraceCountingBuilder())
+    }
+
+    void apply(Project project) {
+    }
+}
+"""
+
+        when:
+        fails {
+            action()
+                .buildFinished(new FetchStackTraceReadCountAction(), { stackTraceReadResult = it } as IntermediateResultHandler)
+                .build()
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then: "the client-facing failure is converted without materializing its frames"
+        def e = thrown(BuildException)
+        stackTraceReadResult != null
+        stackTraceReadResult.stackTraceReadsBeforeFinalFailure == 0
+        stackTraceReadResult.failureDescription.contains('FRAME-COUNTED-FAILURE')
+        !containsRenderedStackTrace(stackTraceReadResult.failureDescription)
+
+        and: "the original throwable is retained and still has frames when the build failure is reported"
+        def cause = collectCauses(e).find { it.message?.contains('FRAME-COUNTED-FAILURE') }
+        cause != null
+        cause.stackTrace.length > 0
+    }
+
+    static class FetchStackTraceReadCountAction implements BuildAction<FetchStackTraceReadCountAction.Result>, Serializable {
+
+        @Override
+        Result execute(BuildController controller) {
+            FetchModelResult<FailingModel> failed = controller.fetch(FailingModel)
+            assert failed.model == null
+            assert failed.failures.size() == 1
+            Failure failure = failed.failures.iterator().next()
+
+            FetchModelResult<StackTraceReadCountModel> count = controller.fetch(StackTraceReadCountModel)
+            assert count.failures.empty
+            StackTraceReadCountModel countModel = count.model
+            assert countModel != null
+            return new Result(failure.description, countModel.count)
+        }
+
+        interface FailingModel {
+        }
+
+        interface StackTraceReadCountModel {
+            int getCount()
+        }
+
+        static class Result implements Serializable {
+            final String failureDescription
+            final int stackTraceReadsBeforeFinalFailure
+
+            Result(String failureDescription, int stackTraceReadsBeforeFinalFailure) {
+                this.failureDescription = failureDescription
+                this.stackTraceReadsBeforeFinalFailure = stackTraceReadsBeforeFinalFailure
+            }
+        }
     }
 
     /**

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r930/FetchUnknownModelAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r930/FetchUnknownModelAction.java
@@ -21,17 +21,30 @@ import org.gradle.tooling.BuildController;
 import org.gradle.tooling.Failure;
 import org.gradle.tooling.FetchModelResult;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class FetchUnknownModelAction implements BuildAction<List<String>> {
+class FetchUnknownModelAction implements BuildAction<FetchUnknownModelAction.Result> {
     @Override
-    public List<String> execute(BuildController controller) {
+    public Result execute(BuildController controller) {
         FetchModelResult<UnknownModel> result = controller.fetch(null, UnknownModel.class, null, null);
         assert result.getModel() == null;
-        return result.getFailures().stream()
-            .flatMap(f -> f.getCauses().stream())
+        assert result.getFailures().size() == 1;
+        Failure failure = result.getFailures().iterator().next();
+        List<String> causes = failure.getCauses().stream()
             .map(Failure::getMessage)
             .collect(Collectors.toList());
+        return new Result(causes, failure.getDescription());
+    }
+
+    public static class Result implements Serializable {
+        public final List<String> causes;
+        public final String failureDescription;
+
+        public Result(List<String> causes, String failureDescription) {
+            this.causes = causes;
+            this.failureDescription = failureDescription;
+        }
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
@@ -44,6 +44,10 @@ public interface FetchModelResult<M> {
 
     /**
      * Returns the failures that occurred during the fetch operation.
+     * <p>
+     * From Gradle 9.9 onwards, failure descriptions keep their messages and cause structure but omit stack frames. When
+     * such a failure also fails the operation as a whole, its complete stack trace is available from the failure the
+     * operation reports.
      *
      * @return a collection of failures, empty if the fetch operation was successful
      * @since 9.3.0

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
@@ -45,9 +45,9 @@ public interface FetchModelResult<M> {
     /**
      * Returns the failures that occurred during the fetch operation.
      * <p>
-     * From Gradle 9.9 onwards, failure descriptions keep their messages and cause structure but omit stack frames. When
-     * such a failure also fails the operation as a whole, its complete stack trace is available from the failure the
-     * operation reports.
+     * From Gradle 9.9 onwards, failure descriptions keep their messages and cause structure but omit stack frames. If
+     * the same underlying failure also fails the operation as a whole, its complete stack trace is available from the
+     * failure the operation reports. A failure reported only by this fetch result has no companion stack trace.
      *
      * @return a collection of failures, empty if the fetch operation was successful
      * @since 9.3.0

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
@@ -87,7 +87,7 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
     }
 
     private static ToolingModelScopeResult configurationFailureResult(FailureFactory failureFactory, Throwable clientFailure, Throwable buildFailure, @Nullable Object model) {
-        ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.attachFailures(model, ImmutableList.of(failureFactory.create(clientFailure)));
+        ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.attachFailures(model, ImmutableList.of(failureFactory.createWithoutStackTrace(clientFailure)));
         return ToolingModelScopeResult.withConfigurationFailure(clientResult, buildFailure);
     }
 
@@ -141,7 +141,7 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
                 if (failure instanceof UnknownModelException) {
                     throw (UnknownModelException) failure;
                 }
-                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.create(failure)));
+                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.createWithoutStackTrace(failure)));
                 return ToolingModelScopeResult.withModelBuilderFailure(clientResult, failure);
             });
         }
@@ -180,7 +180,7 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
         @Override
         public ToolingModelScopeResult getModel(ToolingModelRequestContext modelRequestContext, @Nullable ToolingModelParameterCarrier parameter) {
             return Try.ofFailable(() -> buildScopeResult(parameter)).getOrMapFailure(failure -> {
-                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.create(failure)));
+                ToolingModelBuilderResultInternal clientResult = ToolingModelBuilderResultInternal.of(null, ImmutableList.of(failureFactory.createWithoutStackTrace(failure)));
                 return ToolingModelScopeResult.withModelBuilderFailure(clientResult, failure);
             });
         }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
@@ -127,7 +127,7 @@ public class DefaultIntermediateToolingModelProvider implements IntermediateTool
                 } catch (Throwable t) {
                     // Safety net for an unexpected throw; the resilient controller normally
                     // captures configuration failures into the result itself.
-                    return ToolingModelBuilderResultInternal.of(ImmutableList.of(failureFactory.create(t)));
+                    return ToolingModelBuilderResultInternal.of(ImmutableList.of(failureFactory.createWithoutStackTrace(t)));
                 }
             })
             .collect(toList());


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/38983

### Context

Resilient Tooling API syncs can return the same configuration failure in many `FetchModelResult` instances. Rendering, serializing, and transferring the complete stack trace for every occurrence adds unnecessary sync overhead.

Configuration failures still fail the build at the end of the sync, where the client receives the complete stack trace.

### Changes

- Return failures attached to `FetchModelResult` without stack frames.
- Preserve failure messages, causes, suppressed exceptions, problems, and reconstructed descriptions.
- Avoid materializing stack traces when creating failures for the fetch path.
- Reuse converted failures through a build-tree-scoped cache keyed by `Throwable` identity.
- Keep terminal build failures unchanged so their complete stack traces remain available.
- Document the stackless `FetchModelResult` behavior.

### Example

For a failed model fetch, the failure description previously included every stack frame:

```text
java.lang.RuntimeException: Could not create model for project ':b'
    at com.example.ModelBuilder.buildAll(ModelBuilder.java:42)
    at org.gradle.tooling.provider.model.internal...
Caused by: java.lang.IllegalStateException: Project configuration failed
    at build_abc123.run(build.gradle:10)
    ... 25 more
```

The same `FetchModelResult` now reports the failure structure without frames:

```text
java.lang.RuntimeException: Could not create model for project ':b'
Caused by: java.lang.IllegalStateException: Project configuration failed
```

Messages, causes, suppressed exceptions, and problem information remain available. If the same failure also fails the build, the terminal `BuildException` still contains its complete stack trace.

### Testing

Added unit and cross-version coverage verifying that:

- fetch-result failures contain no rendered stack frames;
- failure structure and descriptions remain intact;
- shared failures are converted once and cached by identity;
- stack traces are not accessed while producing fetch results;
- terminal build failures still contain the complete failure information.
