### PR TITLE
Update Documentation: Distribution Plugin

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/application_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/application_plugin.adoc
@@ -111,7 +111,9 @@ include::sample[dir="snippets/reference/platforms/jvm/application/groovy",files=
 
 By specifying that the distribution should include the task's output files (see <<incremental_build.adoc#sec:task_inputs_outputs, incremental builds>>), Gradle knows that the task that produces the files must be invoked before the distribution can be assembled and will take care of this for you.
 
-You can run `gradle installDist` to create an image of the application in `build/install/__projectName__`. You can run `gradle distZip` to create a ZIP containing the distribution, `gradle distTar` to create an application TAR or `gradle assemble` to build both.
+You can run `gradle installDist` to create an image of the application in `build/install/__projectName__`.
+You can run `gradle distZip` to create a ZIP containing the distribution, `gradle distTar` to create an application TAR or `gradle assembleDist` to build both.
+Because the distribution archives are wired into the build-wide `assemble` task, running `assemble` (and therefore `build`) also produces them; see <<distribution_plugin.adoc#sec:distribution_tasks,the Distribution plugin reference>>.
 
 [[sec:customizing_start_script_generation]]
 === Customizing start script generation

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
@@ -44,6 +44,13 @@ The files will be created at `__layout.buildDirectory.dir__("distributions/__${p
 
 You can run `gradle installDist` to assemble the uncompressed distribution into `__layout.buildDirectory.dir__("install/__${project.name}__")`.
 
+[NOTE]
+====
+Applying the plugin also wires `distZip` and `distTar` — along with the `__distributionName__DistZip` and `__distributionName__DistTar` tasks of any additional distributions — into the build-wide `assemble` task.
+As a result, running `assemble` (and therefore `build`) creates *all* distribution archives, not only the ones you request explicitly.
+To produce just one archive, run its task directly (for example `distZip` or `distTar`); to build a single distribution's archives without the others, run its `assembleDist` (or `assemble__DistributionName__Dist`) task; to run verification without building any distributions, use `check` instead of `build`.
+====
+
 [[sec:distribution_tasks]]
 == Tasks
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
  - Fix #32757

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description