### PR TITLE
Update Documentation: War Plugin

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/war_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/war_plugin.adoc
@@ -78,6 +78,20 @@ Because this is a "provided" configuration, this means that neither of these dep
 If you don't want this transitive behavior, simply declare your `provided` dependencies like `commons-httpclient:commons-httpclient:3.0@jar`.
 ====
 
+[[sec:war_provided_vs_compileonly]]
+=== `providedCompile` versus `compileOnly`
+
+The War plugin's `provided` configurations are not the same as the <<java_plugin.adoc#tab:configurations,`compileOnly`>> configuration added by the <<java_plugin.adoc#java_plugin,Java plugin>>, and the two are not interchangeable:
+
+`compileOnly`::
+Dependencies are available on the compile classpath only.
+They are _not_ on any runtime classpath (including the test runtime classpath) and are never packaged.
+Use it for dependencies that are needed solely to compile, such as annotation-only libraries.
+
+`providedCompile` (and `providedRuntime`)::
+Dependencies are available on the runtime classpath as well (including the test runtime classpath), so your tests can run against them, but they are excluded from the WAR archive.
+Use these for dependencies that the servlet container or application server supplies at deployment time, such as the Servlet API.
+
 [[sec:war_plugin_publishing]]
 == Publishing
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
  - Fix #1171

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [x] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description