### PR TITLE
Enforce the ClassLoaderScope recording invariants

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -54,42 +54,52 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
     val loaders = IdentityHashMap<ClassLoader, Pair<ClassLoaderScopeSpec, ClassLoaderRole>>()
 
     private
-    var disposed = false
+    var recording = false
 
+    /**
+     * Starts recording the [ClassLoaderScopeSpec]s of this build tree.
+     *
+     * Recording starts before any scope can be created, so that no scope is
+     * missed. A build that does not need the scope tree stops the recording
+     * again through [stopRecording].
+     */
     override fun afterBuildTreeStart() {
         synchronized(lock) {
-            assertNotDisposed("afterBuildTreeStart")
+            check(!recording) { "Recording has already started." }
             listenerManager.add(this)
+            recording = true
         }
     }
 
     /**
-     * Stops recording [ClassLoaderScopeSpec]s and releases any recorded state.
+     * Stops recording and releases the recorded state. Does nothing if the
+     * recording was already stopped.
+     *
+     * TODO:configuration-cache make this unnecessary by deciding the cache strategy
+     *  early, so the listener is only attached when the entry is stored.
      */
-    fun dispose() {
+    fun stopRecording() {
         synchronized(lock) {
-            if (disposed) {
-                return
+            resetState()
+            if (recording) {
+                listenerManager.remove(this)
+                recording = false
             }
-            // TODO:configuration-cache find a way to make `dispose` unnecessary;
-            //  maybe by extracting an `ConfigurationCacheBuildDefinition` service
-            //  from DefaultConfigurationCacheHost so a decision based on the configured
-            //  configuration cache strategy (none, store or load) can be taken early on.
-            //  The listener only needs to be attached in the `store` state.
-            scopeSpecs.clear()
-            loaders.clear()
-            listenerManager.remove(this)
-            disposed = true
         }
     }
 
+    private
+    fun resetState() {
+        scopeSpecs.clear()
+        loaders.clear()
+    }
+
     override fun close() {
-        dispose()
+        stopRecording()
     }
 
     override fun scopeFor(classLoader: ClassLoader?): Pair<ClassLoaderScopeSpec, ClassLoaderRole>? {
         synchronized(lock) {
-            assertNotDisposed("scopeFor")
             // TODO:configuration-cache assert the spec can no longer change after it has been observed
             return loaders[classLoader]
         }
@@ -102,7 +112,6 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
 
     override fun childScopeCreated(parentId: ClassLoaderScopeId, childId: ClassLoaderScopeId, origin: ClassLoaderScopeOrigin?) {
         synchronized(lock) {
-            assertNotDisposed("childScopeCreated")
             if (scopeSpecs.containsKey(childId)) {
                 // scope is being reused
                 return
@@ -132,7 +141,6 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
                 "Please report this error, run './gradlew --stop' and try again."
         }
         synchronized(lock) {
-            assertNotDisposed("classloaderCreated")
             val spec = scopeSpecs[scopeId]
             check(spec != null) {
                 "Spec for ClassLoaderScope '$scopeId' not found!"
@@ -147,13 +155,6 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
                 spec.exportClassPath = classPath
             }
             loaders[classLoader] = Pair(spec, ClassLoaderRole(local))
-        }
-    }
-
-    private
-    fun assertNotDisposed(method: String) {
-        check(!disposed) {
-            "${javaClass.simpleName}.$method cannot be used after being disposed of."
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -56,9 +56,9 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
     private
     var disposed = false
 
-    override fun afterStart() {
+    override fun afterBuildTreeStart() {
         synchronized(lock) {
-            assertNotDisposed("afterStart")
+            assertNotDisposed("afterBuildTreeStart")
             listenerManager.add(this)
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.initialization.ClassLoaderScopeIdentifier
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderId
 import org.gradle.initialization.ClassLoaderScopeId
@@ -28,13 +27,13 @@ import org.gradle.internal.cc.impl.serialize.ClassLoaderRole
 import org.gradle.internal.cc.impl.serialize.ClassLoaderScopeSpec
 import org.gradle.internal.cc.impl.serialize.ScopeLookup
 import org.gradle.internal.cc.impl.serialize.describeClassLoader
-import org.gradle.internal.cc.impl.serialize.describeKnownClassLoaders
 import org.gradle.internal.classloader.DelegatingClassLoader
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
 import java.io.Closeable
+import java.util.Collections
 import java.util.IdentityHashMap
 
 
@@ -53,65 +52,123 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
     private
     val loaders = IdentityHashMap<ClassLoader, Pair<ClassLoaderScopeSpec, ClassLoaderRole>>()
 
+    /**
+     * The class loaders that [scopeFor] reported as having no scope. A scope
+     * must not arrive for one of these afterwards: the class was already
+     * encoded against the Gradle runtime, which does not have it.
+     */
     private
-    var recording = false
+    val reportedAsUnknown = Collections.newSetFromMap(IdentityHashMap<ClassLoader, Boolean>())
+
+    private
+    var state = State.IDLE
+
+    private
+    enum class State {
+        /** Before the build tree starts. No event was received. */
+        IDLE,
+
+        /** Registered as a listener. Events are received and recorded. */
+        ACTIVE,
+
+        /** Unregistered and the recorded state released. Terminal. */
+        DISPOSED
+    }
 
     /**
      * Starts recording the [ClassLoaderScopeSpec]s of this build tree.
      *
-     * Recording starts before any scope can be created, so that no scope is
-     * missed. A build that does not need the scope tree stops the recording
-     * again through [stopRecording].
+     * This runs before any scope of the build tree can be created, so that no
+     * scope is missed. A build that does not need the scope tree stops the
+     * recording again through [stopRecording].
      */
     override fun afterBuildTreeStart() {
+        startRecording()
+    }
+
+    private
+    fun startRecording() {
         synchronized(lock) {
-            check(!recording) { "Recording has already started." }
+            check(state == State.IDLE) {
+                "Cannot start recording ClassLoaderScopes in state $state."
+            }
             listenerManager.add(this)
-            recording = true
+            state = State.ACTIVE
         }
     }
 
     /**
-     * Stops recording and releases the recorded state. Does nothing if the
-     * recording was already stopped.
+     * Unregisters the listener and releases the recorded state.
+     *
+     * Callers invoke this more than once per build tree, so a call in
+     * [State.DISPOSED] returns without doing anything. The state is terminal:
+     * recording cannot start again for this build tree.
      *
      * TODO:configuration-cache make this unnecessary by deciding the cache strategy
      *  early, so the listener is only attached when the entry is stored.
      */
     fun stopRecording() {
         synchronized(lock) {
-            resetState()
-            if (recording) {
-                listenerManager.remove(this)
-                recording = false
+            if (state == State.DISPOSED) {
+                return
+            }
+            check(state == State.ACTIVE) {
+                "Cannot stop recording ClassLoaderScopes in state $state."
+            }
+            dispose()
+        }
+    }
+
+    /**
+     * Releases the state of a listener that the build tree no longer needs.
+     *
+     * Unlike [stopRecording] this accepts every state, because the services of
+     * a build tree are closed even when the tree failed before it started.
+     */
+    override fun close() {
+        synchronized(lock) {
+            if (state != State.DISPOSED) {
+                dispose()
             }
         }
     }
 
     private
-    fun resetState() {
+    fun dispose() {
+        if (state == State.ACTIVE) {
+            listenerManager.remove(this)
+        }
         scopeSpecs.clear()
         loaders.clear()
-    }
-
-    override fun close() {
-        stopRecording()
+        reportedAsUnknown.clear()
+        state = State.DISPOSED
     }
 
     override fun scopeFor(classLoader: ClassLoader?): Pair<ClassLoaderScopeSpec, ClassLoaderRole>? {
         synchronized(lock) {
+            check(state == State.ACTIVE) {
+                "Cannot look up a ClassLoaderScope in state $state."
+            }
             // TODO:configuration-cache assert the spec can no longer change after it has been observed
-            return loaders[classLoader]
+            val scopeAndRole = loaders[classLoader]
+            if (scopeAndRole == null && classLoader != null) {
+                reportedAsUnknown.add(classLoader)
+            }
+            return scopeAndRole
         }
     }
 
-    override val knownClassLoaders: Set<ClassLoader>
-        get() = synchronized(lock) {
-            ImmutableSet.copyOf(loaders.keys)
+    override fun describeKnownClassLoaders(): String =
+        synchronized(lock) {
+            if (loaders.isEmpty()) "No class loaders are currently known."
+            else "These are the known class loaders:\n${loaders.keys.joinToString("\n") { "\t- $it" }}\n"
         }
 
     override fun childScopeCreated(parentId: ClassLoaderScopeId, childId: ClassLoaderScopeId, origin: ClassLoaderScopeOrigin?) {
         synchronized(lock) {
+            check(state == State.ACTIVE) {
+                "Received a ClassLoaderScope event for $childId in state $state."
+            }
             if (scopeSpecs.containsKey(childId)) {
                 // scope is being reused
                 return
@@ -122,7 +179,7 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
                 null
             } else {
                 val lookupParent = scopeSpecs[parentId]
-                require(lookupParent != null) {
+                check(lookupParent != null) {
                     "Cannot find parent $parentId for child scope $childId"
                 }
                 lookupParent
@@ -141,6 +198,15 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
                 "Please report this error, run './gradlew --stop' and try again."
         }
         synchronized(lock) {
+            check(state == State.ACTIVE) {
+                "Received a ClassLoader event for scope '$scopeId' in state $state."
+            }
+            check(classLoader !in reportedAsUnknown) {
+                "ClassLoaderScope '$scopeId' was created for ${describeClassLoader(classLoader)} " +
+                    "after that loader was reported as having no scope.\n" +
+                    describeKnownClassLoaders() +
+                    "Please report this error, run './gradlew --stop' and try again."
+            }
             val spec = scopeSpecs[scopeId]
             check(spec != null) {
                 "Spec for ClassLoaderScope '$scopeId' not found!"

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -229,6 +229,11 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun initializeCacheEntrySideEffects(cacheAction: ConfigurationCacheAction) {
+        if (cacheAction.isReadOnly) {
+            // The scope tree is only needed to store an entry, and recording it
+            // has already started for this build tree.
+            scopeRegistryListener.stopRecording()
+        }
         when (cacheAction) {
             is Load -> {
                 val entryDetails = readEntryDetails()
@@ -303,6 +308,7 @@ class DefaultConfigurationCache internal constructor(
     }
 
     override fun loadRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): BuildTreeConfigurationCache.LoadRequestedTasksResult {
+        scopeRegistryListener.stopRecording()
         return loadWorkGraph(graph, graphBuilder, true)
     }
 
@@ -403,7 +409,7 @@ class DefaultConfigurationCache internal constructor(
         try {
             cacheFingerprintController.stop()
         } finally {
-            scopeRegistryListener.dispose()
+            scopeRegistryListener.stopRecording()
         }
     }
 
@@ -650,9 +656,6 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun loadModel(): Any = runAtConfigurationTime {
-        // No need to record the `ClassLoaderScope` tree when loading
-        scopeRegistryListener.dispose()
-
         buildOperationRunner.withModelLoadOperation {
             val storeLoadResult = entryStore.useForStateLoad(StateType.Model) { stateFile: ConfigurationCacheStateFile ->
                 cacheIO.readModelFrom(stateFile)
@@ -668,10 +671,6 @@ class DefaultConfigurationCache internal constructor(
         graphBuilder: BuildTreeWorkGraphBuilder?,
         loadAfterStore: Boolean
     ): BuildTreeConfigurationCache.LoadRequestedTasksResult = runAtConfigurationTime {
-
-        // No need to record the `ClassLoaderScope` tree
-        // when loading the task graph.
-        scopeRegistryListener.dispose()
 
         val finalizedGraph = buildOperationRunner.withWorkGraphLoadOperation {
             val storeLoadResult = entryStore.useForStateLoad(StateType.Work) { stateFile: ConfigurationCacheStateFile ->

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
@@ -30,7 +30,13 @@ import org.gradle.internal.serialize.graph.WriteIdentities
 internal
 interface ScopeLookup {
     fun scopeFor(classLoader: ClassLoader?): Pair<ClassLoaderScopeSpec, ClassLoaderRole>?
-    val knownClassLoaders: Set<ClassLoader>
+
+    /**
+     * Describes the recorded class loaders for a failure message. Available in
+     * any state, because a failure must be reported even when a lookup is not
+     * permitted.
+     */
+    fun describeKnownClassLoaders(): String
 }
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
@@ -98,10 +98,3 @@ class DefaultClassEncoder(
         }
     }
 }
-
-
-internal
-fun ScopeLookup.describeKnownClassLoaders(): String = knownClassLoaders.let { classLoaders ->
-    if (classLoaders.isEmpty()) "No class loaders are currently known."
-    else "These are the known class loaders:\n${classLoaders.joinToString("\n") { "\t- $it" }}"
-}

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListenerTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListenerTest.groovy
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.api.internal.initialization.ClassLoaderScopeIdentifier
+import org.gradle.initialization.ClassLoaderScopeRegistryListenerManager
+import org.gradle.internal.classpath.DefaultClassPath
+import spock.lang.Specification
+
+class ConfigurationCacheClassLoaderScopeRegistryListenerTest extends Specification {
+
+    def listenerManager = Mock(ClassLoaderScopeRegistryListenerManager)
+    def listener = new ConfigurationCacheClassLoaderScopeRegistryListener(listenerManager)
+
+    def rootId = new ClassLoaderScopeIdentifier(null, "root")
+    def scopeId = rootId.child("scope")
+
+    def "registers when the build tree starts and unregisters when recording stops"() {
+        when:
+        listener.afterBuildTreeStart()
+
+        then:
+        1 * listenerManager.add(listener)
+
+        when:
+        listener.stopRecording()
+
+        then:
+        1 * listenerManager.remove(listener)
+    }
+
+    def "records the scope of a class loader"() {
+        given:
+        listener.afterBuildTreeStart()
+        def classLoader = classLoader()
+
+        when:
+        listener.childScopeCreated(rootId, scopeId, null)
+        listener.classloaderCreated(scopeId, scopeId.localId(), classLoader, DefaultClassPath.of(), null)
+
+        then:
+        def scopeAndRole = listener.scopeFor(classLoader)
+        scopeAndRole.first.name == "scope"
+        scopeAndRole.second.local
+    }
+
+    def "rejects a second start, so that recorded scopes cannot be discarded"() {
+        given:
+        listener.afterBuildTreeStart()
+
+        when:
+        listener.afterBuildTreeStart()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot start recording ClassLoaderScopes in state ACTIVE."
+    }
+
+    def "rejects stopping a recording that never started"() {
+        when:
+        listener.stopRecording()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.startsWith("Cannot stop recording ClassLoaderScopes in state IDLE.")
+    }
+
+    def "cannot look up a scope once recording stopped"() {
+        given:
+        listener.afterBuildTreeStart()
+        def classLoader = classLoader()
+        listener.childScopeCreated(rootId, scopeId, null)
+        listener.classloaderCreated(scopeId, scopeId.localId(), classLoader, DefaultClassPath.of(), null)
+        listener.stopRecording()
+
+        when:
+        listener.scopeFor(classLoader)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.startsWith("Cannot look up a ClassLoaderScope in state DISPOSED.")
+    }
+
+    def "stopping an already stopped recording does nothing"() {
+        given:
+        listener.afterBuildTreeStart()
+        listener.stopRecording()
+
+        when:
+        listener.stopRecording()
+
+        then:
+        noExceptionThrown()
+        0 * listenerManager.remove(_)
+    }
+
+    def "rejects a scope for a class loader already reported as having none"() {
+        given:
+        listener.afterBuildTreeStart()
+        def classLoader = classLoader()
+        listener.childScopeCreated(rootId, scopeId, null)
+
+        and:
+        assert listener.scopeFor(classLoader) == null
+
+        when:
+        listener.classloaderCreated(scopeId, scopeId.localId(), classLoader, DefaultClassPath.of(), null)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("after that loader was reported as having no scope")
+    }
+
+    def "rejects an event once recording stopped"() {
+        given:
+        listener.afterBuildTreeStart()
+        listener.stopRecording()
+
+        when:
+        listener.childScopeCreated(rootId, scopeId, null)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Received a ClassLoaderScope event for $scopeId in state DISPOSED."
+    }
+
+    def "can be closed before the build tree started"() {
+        when:
+        listener.close()
+
+        then:
+        noExceptionThrown()
+        0 * listenerManager.remove(_)
+    }
+
+    def "closing while recording unregisters the listener"() {
+        given:
+        listener.afterBuildTreeStart()
+
+        when:
+        listener.close()
+
+        then:
+        1 * listenerManager.remove(listener)
+    }
+
+    def "can be closed after the recording stopped"() {
+        given:
+        listener.afterBuildTreeStart()
+        listener.stopRecording()
+
+        when:
+        listener.close()
+
+        then:
+        noExceptionThrown()
+        0 * listenerManager.remove(_)
+    }
+
+    private static ClassLoader classLoader() {
+        new URLClassLoader(new URL[0], null)
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IdeaIoSystemPropertyInitializer.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IdeaIoSystemPropertyInitializer.kt
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.ServiceScope
 internal
 class IdeaIoSystemPropertyInitializer : BuildTreeLifecycleListener {
 
-    override fun afterStart() {
+    override fun afterBuildTreeStart() {
         org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutor.java
@@ -89,7 +89,7 @@ public class RootBuildLifecycleBuildActionExecutor {
 
         projectParallelExecutionController.startProjectExecution(buildModelParameters.isParallelProjectExecution());
         try {
-            lifecycleListener.afterStart();
+            lifecycleListener.afterBuildTreeStart();
             StartParameterInternal startParameter = action.getStartParameter();
             try {
                 initDeprecationLogging(startParameter);
@@ -100,7 +100,7 @@ public class RootBuildLifecycleBuildActionExecutor {
             } finally {
                 // Since continuous builds reuse the same StartParameter for multiple build trees.
                 startParameter.clearMutationListener();
-                lifecycleListener.beforeStop();
+                lifecycleListener.beforeBuildTreeStop();
             }
         } finally {
             projectParallelExecutionController.finishProjectExecution();

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/exec/RootBuildLifecycleBuildActionExecutorTest.groovy
@@ -62,11 +62,11 @@ class RootBuildLifecycleBuildActionExecutorTest extends Specification {
         executor.execute(buildAction)
 
         then:
-        1 * listener.afterStart()
+        1 * listener.afterBuildTreeStart()
         then:
         1 * buildActionRunner.run(buildAction, _)
         then:
-        1 * listener.beforeStop()
+        1 * listener.beforeBuildTreeStop()
         0 * listener._
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
@@ -39,7 +39,7 @@ public class BuildOptionBuildOperationProgressEventsEmitter implements BuildTree
     }
 
     @Override
-    public void afterStart() {
+    public void afterBuildTreeStart() {
         eventEmitter.emitNowForCurrent(new ConfigurationCacheSettingsFinalizedProgressDetails() {
             @Override
             public boolean isEnabled() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleListener.java
@@ -29,7 +29,7 @@ public interface BuildTreeLifecycleListener {
      * This method is called before the root build operation has started, so implementations should not perform any expensive work
      * and should not run any user code.
      */
-    default void afterStart() {
+    default void afterBuildTreeStart() {
     }
 
     /**
@@ -38,6 +38,6 @@ public interface BuildTreeLifecycleListener {
      * This method is called after the root build operation has completed, so implementations should not perform any expensive work
      * and should not run any user code.
      */
-    default void beforeStop() {
+    default void beforeBuildTreeStop() {
     }
 }


### PR DESCRIPTION
Split out of the refactor in #38811, stacked on #39027 — review that one first.

Turns the rules the `ClassLoaderScope` listener depends on into checks, and keeps recording tied to the build tree lifecycle.

### Why

The listener records the `ClassLoaderScope` tree so the configuration cache can store a reference to a class loader instead of the loader itself. A missing record is silent: the encoder writes the same byte for "no loader" and "no scope for this loader", so the class is stored as one of the Gradle runtime and, on load, resolved from a class loader that does not have it.

The class guarded none of that. It held a single `Boolean`, so a repeated start discarded every recorded scope and continued, a lookup after release was indistinguishable from a class with no scope, and the `assertNotDisposed` guards that had made misuse fail were dropped when `dispose()` was replaced.

### What

- `BuildTreeLifecycleListener.afterStart`/`beforeStop` → `afterBuildTreeStart`/`beforeBuildTreeStop`. Three unrelated listener interfaces each declared a method called `afterStart`.
- `IDLE`, `ACTIVE` and `DISPOSED` replace the `Boolean`. Every transition and query the design does not use is rejected.
- Recording is driven by the build tree callback again, rather than by the cache action, so it cannot start after the scopes it records.
- `ScopeLookup` declares what the encoder needs — a lookup and a description for failure messages — instead of exposing the recorded loaders.

### Verification

- `ConfigurationCacheClassLoaderScopeRegistryListenerTest` covers the state machine: registration and unregistration, recording and looking up a scope, and each rejected case — a second start, a stop that never started, a lookup or an event after the state is released, and a scope arriving for a class loader already reported as having none. `close` is covered in each state, since it is teardown and must not fail.
- The rejected cases are asserted through the production entry points, so they cover the wiring as well as the checks.
- Each commit compiles on its own.

### Details

- **The invariants are now stated in code.** Four held only by the order of calls: recording starts once per build tree, no event precedes it, no lookup outside recording, and the records are read before they are released. Each is a `check` on the state.

- **A scope arriving for a loader already reported as having none now fails.** `scopeFor` records the loaders it reported as unknown, and a later event for one of them raises an error. Whether that order can occur is not established — the check is how we would find out. It fails rather than reporting a configuration cache problem because no build can cause or correct it; if it proves reachable, the case has to be modelled.

- **`stopRecording` and `close` are separate operations.** Stopping is part of the protocol, so it rejects a state where recording never started. Closing is teardown, invoked when the build tree services close even after a failure, so it accepts every state. Both release through the same private step.

- **Starting is no longer callable from outside.** The build tree callback is the only entry, so the transition that discarded records is unreachable rather than merely unused.

- **Not addressed here: the recorded specifications are mutable.** A scope owns a local and an export class loader, each arriving as a separate event, so a specification is completed in two steps. The encoder writes a specification once and refers back to it, so one encoded before the second event stores an empty local classpath and no implementation hash. Whether that order can occur is likewise not established. The TODO in the class covers it.
