### PR TITLE
Split loading and scheduling of requested tasks

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
@@ -82,10 +82,6 @@ class ConfigurationCacheCleanupIntegrationTest
         return configurationCacheDir.file('gc.properties')
     }
 
-    private TestFile getConfigurationCacheDir() {
-        return file('.gradle/configuration-cache')
-    }
-
     private static List<TestFile> subDirsOf(TestFile dir) {
         dir.listFiles().findAll { it.directory }
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCorruptEntryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCorruptEntryIntegrationTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.test.fixtures.file.TestFile
+
+/**
+ * Captures how a build behaves when the state files of an otherwise valid cache entry are damaged.
+ */
+class ConfigurationCacheCorruptEntryIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    private static final byte[] CORRUPT_MARKER = "corrupt".bytes
+    private static final String TRUNCATED_STREAM = "reached end of stream after reading 7 bytes; 16 bytes expected"
+
+    def "fails without running tasks when the work state is corrupted"() {
+        given:
+        withHelloTask()
+        def configurationCache = newConfigurationCacheFixture()
+
+        when:
+        configurationCacheRun("hello")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("Hello")
+
+        when:
+        corruptWorkState()
+        executer.withStackTraceChecksDisabled()
+        configurationCacheFails("hello")
+
+        then:
+        outputContains("Reusing configuration cache.")
+        // TODO This failure should name the configuration cache as the cause, not just the read error.
+        failure.assertHasDescription(TRUNCATED_STREAM)
+
+        and:
+        outputDoesNotContain("Hello")
+        hasCorruptedState()
+    }
+
+    def "fails without running tasks when #what is corrupted"() {
+        given:
+        withHelloTask()
+        def configurationCache = newConfigurationCacheFixture()
+
+        when:
+        configurationCacheRun("hello")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("Hello")
+
+        when:
+        corrupt(this)
+        executer.withStackTraceChecksDisabled()
+        configurationCacheFails("hello")
+
+        then:
+        // TODO This failure should name the configuration cache as the cause, not just the read error.
+        failure.assertHasDescription(expectedMessage)
+
+        and:
+        outputDoesNotContain("Hello")
+        hasCorruptedState()
+
+        where:
+        what          | corrupt                     | expectedMessage
+        "metadata"    | { it.corruptMetadata() }    | "Index 99 out of bounds for length 0"
+        "fingerprint" | { it.corruptFingerprint() } | TRUNCATED_STREAM
+    }
+
+    private void withHelloTask() {
+        buildFile """
+            tasks.register("hello") {
+                doLast { println "Hello" }
+            }
+        """
+    }
+
+    /**
+     * Damages every file the entry is loaded from, leaving the files the fingerprint check
+     * reads (the metadata, the classloader scopes and the fingerprints) intact, so that the
+     * entry is still considered reusable.
+     */
+    private void corruptWorkState() {
+        def readByCheck = ["entry.bin", "buildfingerprint.bin", "projectfingerprint.bin", "classloaderscopes.bin"]
+        def stateFiles = cacheEntryDir().listFiles().findAll {
+            it.name.endsWith(".bin") && !(it.name in readByCheck)
+        }
+        assert !stateFiles.empty
+        stateFiles.each { overwriteWithGarbage(it) }
+    }
+
+    protected void corruptMetadata() {
+        overwriteWithGarbage(cacheEntryDir().file("entry.bin"))
+    }
+
+    protected void corruptFingerprint() {
+        overwriteWithGarbage(cacheEntryDir().file("projectfingerprint.bin"))
+    }
+
+    private TestFile cacheEntryDir() {
+        configurationCacheDir.listFiles().findAll { it.directory && it.file("entry.bin").exists() }.with {
+            assert size() == 1
+            first()
+        }
+    }
+
+    private static void overwriteWithGarbage(TestFile file) {
+        assert file.exists()
+        file.bytes = CORRUPT_MARKER
+    }
+
+    private boolean hasCorruptedState() {
+        def corrupted = []
+        configurationCacheDir.eachFileRecurse { file ->
+            if (file.file && Arrays.equals(file.bytes, CORRUPT_MARKER)) {
+                corrupted << file
+            }
+        }
+        return !corrupted.empty
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
@@ -227,10 +227,6 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         }
     }
 
-    private TestFile getConfigurationCacheDir() {
-        file('.gradle/configuration-cache')
-    }
-
     private static List<TestFile> subDirsOf(TestFile dir) {
         dir.listFiles().findAll { it.directory }
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/AbstractConfigurationCacheOptInFeatureIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/AbstractConfigurationCacheOptInFeatureIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.fixtures
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheProblemsExecutionResultFixture
+import org.gradle.test.fixtures.file.TestFile
 
 abstract class AbstractConfigurationCacheOptInFeatureIntegrationTest extends AbstractIntegrationSpec {
     static final String WARN_PROBLEMS_CLI_OPT = "--${StartParameterBuildOptions.ConfigurationCacheProblemsOption.LONG_OPTION}=warn"
@@ -36,5 +37,9 @@ abstract class AbstractConfigurationCacheOptInFeatureIntegrationTest extends Abs
         // Verify that the test (or fixtures) has cleaned up state correctly
         assert System.getProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME) == null
         assert System.getProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME) == null
+    }
+
+    protected TestFile getConfigurationCacheDir() {
+        file(".gradle/configuration-cache")
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeConfigurationCache.kt
@@ -36,10 +36,15 @@ interface BuildTreeConfigurationCache {
     fun initializeCacheEntry()
 
     /**
-     * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
-     * writes the result to the cache.
+     * Loads the scheduled tasks from the cache entry, when there is one to reuse.
      */
-    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): WorkGraphResult
+    fun maybeLoadRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): LoadOutcome
+
+    /**
+     * Schedules the requested tasks by running the given function, and writes the result to the cache unless the
+     * entry is being skipped or discarded.
+     */
+    fun scheduleRequestedTasks(graph: BuildTreeWorkGraph, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): ScheduleOutcome
 
     /**
      * Loads the scheduled tasks from cache.
@@ -85,7 +90,19 @@ interface BuildTreeConfigurationCache {
     // This is a temporary property to allow migration from a root build scoped cache to a build tree scoped cache
     val isLoaded: Boolean
 
-    class WorkGraphResult(val graph: BuildTreeWorkGraph.FinalizedGraph, val wasLoadedFromCache: Boolean, val entryDiscarded: Boolean)
+    sealed interface LoadOutcome {
+        data class Reused(val graph: BuildTreeWorkGraph.FinalizedGraph) : LoadOutcome
+
+        object Missed : LoadOutcome
+    }
+
+    sealed interface ScheduleOutcome {
+        val graph: BuildTreeWorkGraph.FinalizedGraph
+
+        data class Stored(override val graph: BuildTreeWorkGraph.FinalizedGraph) : ScheduleOutcome
+
+        data class NotStored(override val graph: BuildTreeWorkGraph.FinalizedGraph) : ScheduleOutcome
+    }
 
     data class LoadRequestedTasksResult(val graph: BuildTreeWorkGraph.FinalizedGraph, val workGraphRestorationFailed: Boolean)
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -52,43 +52,55 @@ class ConfigurationCacheAwareBuildTreeWorkController(
                 addFinalization(rootBuildState, selector::postProcessExecutionPlan)
             }
         }
+        val cachedExecutionResult = loadAndRun(scheduleTaskSelectorPostProcessing)
+        if (cachedExecutionResult != null) {
+            return cachedExecutionResult
+        }
+        return Try.ofFailable {
+            scheduleStoreAndRun(scheduleTaskSelectorPostProcessing, taskSelector)
+        }.getOrMapFailure { ExecutionResult.failed(it) }
+    }
+
+    private fun loadAndRun(
+        scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder?
+    ): ExecutionResult<Void>? =
+        workGraph.withNewWorkGraph { graph ->
+            when (val outcome = cache.maybeLoadRequestedTasks(graph, scheduleTaskSelectorPostProcessing)) {
+                is BuildTreeConfigurationCache.LoadOutcome.Reused -> {
+                    maybeDumpHeap("cc-hit")
+                    workExecutor.execute(outcome.graph)
+                }
+
+                BuildTreeConfigurationCache.LoadOutcome.Missed -> null
+            }
+        }
+
+    private fun scheduleStoreAndRun(
+        scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder?,
+        taskSelector: EntryTaskSelector?
+    ): ExecutionResult<Void> {
         val executionResult: ExecutionResult<Void>? = workGraph.withNewWorkGraph { graph ->
-            val result = Try.ofFailable {
-                cache.loadOrScheduleRequestedTasks(
-                    graph = graph,
-                    graphBuilder = scheduleTaskSelectorPostProcessing
-                ) { workPreparer.scheduleRequestedTasks(graph, taskSelector) }
-            }
-
-            if (!result.isSuccessful) {
-                return@withNewWorkGraph ExecutionResult.failed(result.failure.get())
-            }
-
-            // There are four outcomes:
-            // 1. CC miss, graph has been successfully stored. We don't try to execute the graph directly but store it first, discard, and then reload.
-            // 2. Same as (1) but we also need tooling models. The model builders can be executed after the tasks (if any) in a build action,
-            //    and these builders may access project state as well as the task state. Because of that we execute the prepared graph directly.
-            // 3. CC miss, graph has been configured but the cached state discarded without failing the build (e.g. task.notCompatibleWithCC is used).
-            //    We execute the build immediately using the prepared graph.
-            // 4. CC hit: we've loaded the cached graph. We execute the build immediately using the loaded graph.
-            val workGraph = result.get()
-            if (!workGraph.wasLoadedFromCache && !workGraph.entryDiscarded && !buildModelParameters.isModelBuilding) {
-                // This is the first outcome of the list above.
+            val outcome = cache.scheduleRequestedTasks(graph) { workPreparer.scheduleRequestedTasks(graph, taskSelector) }
+            // The model builders can be executed after the tasks (if any) in a build action,
+            // and these builders may access project state as well as the task state. Because of that we execute the prepared graph directly.
+            if (outcome is BuildTreeConfigurationCache.ScheduleOutcome.Stored && !buildModelParameters.isModelBuilding) {
+                // CC miss, graph has been successfully stored. We don't try to execute the graph directly but store it first, discard, and then reload.
                 // We don't want to fold the code below here so the "live" graph can be garbage collected before execution.
                 null
             } else {
                 maybeDumpHeap("cc-hit")
-                workExecutor.execute(workGraph.graph)
+                workExecutor.execute(outcome.graph)
             }
         }
         if (executionResult != null) {
-            // Load/schedule operation failed or we have executed the work graph already.
             return executionResult
         }
 
         maybeDumpHeap("cc-miss-store")
+        return storeAndReload(scheduleTaskSelectorPostProcessing)
+    }
 
-        // Store and reload the graph for the execution.
+    private fun storeAndReload(scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder?): ExecutionResult<Void> {
         cache.finalizeCacheEntry()
         buildRegistry.resetModels()
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -257,20 +257,23 @@ class DefaultConfigurationCache internal constructor(
             cacheIO.readCacheEntryDetailsFrom(it)!!
         }.value
 
-    override fun loadOrScheduleRequestedTasks(
+    override fun maybeLoadRequestedTasks(
         graph: BuildTreeWorkGraph,
-        graphBuilder: BuildTreeWorkGraphBuilder?,
+        graphBuilder: BuildTreeWorkGraphBuilder?
+    ): BuildTreeConfigurationCache.LoadOutcome {
+        if (cacheAction !is Load) {
+            return BuildTreeConfigurationCache.LoadOutcome.Missed
+        }
+        val finalizedGraph = loadWorkGraph(graph, graphBuilder, false).graph
+        return BuildTreeConfigurationCache.LoadOutcome.Reused(finalizedGraph)
+    }
+
+    override fun scheduleRequestedTasks(
+        graph: BuildTreeWorkGraph,
         scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph
-    ): BuildTreeConfigurationCache.WorkGraphResult {
+    ): BuildTreeConfigurationCache.ScheduleOutcome {
         return when (cacheAction) {
-            is Load -> {
-                val finalizedGraph = loadWorkGraph(graph, graphBuilder, false).graph
-                BuildTreeConfigurationCache.WorkGraphResult(
-                    finalizedGraph,
-                    wasLoadedFromCache = true,
-                    entryDiscarded = false
-                )
-            }
+            is Load -> error("Cannot schedule the requested tasks while reusing a configuration cache entry.")
 
             SkipStore -> {
                 // build work graph without contributing to a cache entry
@@ -280,11 +283,7 @@ class DefaultConfigurationCache internal constructor(
                     problems.shouldDegradeGracefully()
                     result
                 }
-                BuildTreeConfigurationCache.WorkGraphResult(
-                    finalizedGraph,
-                    wasLoadedFromCache = false,
-                    entryDiscarded = true
-                )
+                BuildTreeConfigurationCache.ScheduleOutcome.NotStored(finalizedGraph)
             }
 
             Store, is Update -> {
@@ -293,11 +292,11 @@ class DefaultConfigurationCache internal constructor(
                     val rootBuild = buildStateRegistry.rootBuild
                     degradeGracefullyOr { saveWorkGraph(rootBuild) }
                     crossConfigurationTimeBarrier()
-                    BuildTreeConfigurationCache.WorkGraphResult(
-                        finalizedGraph,
-                        wasLoadedFromCache = false,
-                        entryDiscarded = problems.shouldDiscardEntry
-                    )
+                    if (problems.shouldDiscardEntry) {
+                        BuildTreeConfigurationCache.ScheduleOutcome.NotStored(finalizedGraph)
+                    } else {
+                        BuildTreeConfigurationCache.ScheduleOutcome.Stored(finalizedGraph)
+                    }
                 }
             }
         }


### PR DESCRIPTION
One commit split out of the refactor in #38811, stacked on #39017 — review that one first.

It is separated because it restructures the control flow around cache loading, which had no test coverage of its own.

### Why

`loadOrScheduleRequestedTasks` returned a graph plus two booleans encoding three valid outcomes, with a fourth combination unrepresentable. Callers had to reconstruct which case they were in, which is why the old implementation carried a four-outcome comment block explaining what the booleans meant. Sealed outcome types state it in the type system instead.

Loading and scheduling are also two different operations sharing one entry point: one reuses an entry, the other builds a graph and stores it. Splitting them lets each name its own outcomes.

### What

- a test covering what a build reports when it finds a corrupted cache entry, which nothing pinned before
- `loadOrScheduleRequestedTasks` → `maybeLoadRequestedTasks` + `scheduleRequestedTasks`
- `WorkGraphResult(graph, wasLoadedFromCache, entryDiscarded)` → sealed `LoadOutcome` (`Reused`/`Missed`) and `ScheduleOutcome` (`Stored`/`NotStored`)
- the work controller splits into `loadAndRun`, `scheduleStoreAndRun` and `storeAndReload`

### Verification

- The new test is the first commit, so it runs against the old control flow and the new one. It passes unchanged on both, which is the evidence that the restructure preserves behaviour on this path.
- Corrupting the work state exercises the load path specifically: the entry passes the fingerprint check, the build logs that it is reusing the entry, and only then fails. Corrupting the metadata or a fingerprint fails earlier, in the check.
- The branch conditions were checked against the old implementation for every reachable combination of `wasLoadedFromCache`, `entryDiscarded` and `isModelBuilding`; they agree in all cases, and the three `maybeDumpHeap` tags fire in the same scenarios.
- Both commits compile standalone.

### Details

- **The `Try.ofFailable` boundary moves, and the load path ends up outside it.** It now wraps `scheduleStoreAndRun`, covering `workExecutor.execute`, `finalizeCacheEntry()`, `resetModels()` and `loadRequestedTasks`, while `loadAndRun` sits outside. That looks like it would change how a load failure is reported, but it does not: `DefaultBuildTreeLifecycleController.runBuild` already wraps every entry into `scheduleAndRunRequestedTasks` in `catch (Throwable t) { result = ExecutionResult.failed(t) }`, so a throw and an `ExecutionResult.failed` converge on the same result with the same throwable before any reporting happens. Running the corrupted-entry test on both sides of the refactor produces byte-identical output. The inner `Try` was redundant with that outer catch for the load path.

- **That identity depends on a catch in another class.** If `runBuild`'s catch is ever narrowed, the load path loses its protection with nothing local to signal it. The corrupted-entry test is what would catch that.

- **Recovering from a failed load will need its own handling, not this `Try`.** Discarding a corrupted entry and continuing means rolling cache state back to `Store` and rescheduling, which needs private state the controller cannot reach — so it belongs inside `maybeLoadRequestedTasks`. Worth noting this makes the two operations asymmetric: loading would report its failure as an outcome, scheduling would still throw. If both reported outcomes instead, the controller's `Try` could go entirely and the controller would only dispatch. That may be the shape this change was reaching for.

- **`error(...)` on `Load` in `scheduleRequestedTasks` is now inside the `Try`.** The state is unreachable today — the controller only reaches the schedule path after `maybeLoadRequestedTasks` returned `Missed`, on the same thread with no intervening mutation — but were it reached, the assertion would surface as a build failure rather than a crash.

- **An extra `withNewWorkGraph` scope opens on every cache miss**, since `loadAndRun` opens and closes one before `scheduleStoreAndRun` opens another. It sets and restores a thread-local and closes an empty controller map, so this is harmless, but it is extra work on the miss path.

- **The test asserts exact serialization messages.** They come from observed runs, but they are incidental to the 7-byte corruption marker and would shift if the marker or the format changed. That is deliberate: it documents that a corrupted entry currently surfaces as a raw deserialization error with no configuration-cache-specific reporting.
