### PR TITLE
Support Windows JDKs when running from WSL

### DIFF
--- a/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -17,11 +17,15 @@ package org.gradle.api.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.PluginTestPreconditions
 import org.gradle.test.preconditions.OsTestPreconditions
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
+import spock.lang.Issue
+
+import java.util.jar.JarOutputStream
 
 
 class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec {
@@ -45,6 +49,76 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
 
         then:
         outputContains('Hello World!')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/25721")
+    @Requires([OsTestPreconditions.Unix, PluginTestPreconditions.BashAvailable])
+    def "can execute generated Unix start script with a Java executable extension"() {
+        given:
+        def javaHome = file("windows-java-home")
+        javaHome.file("bin/java.exe").createLink(Jvm.current().javaExecutable)
+        succeeds('installDist')
+
+        when:
+        runViaUnixStartScriptWithJavaHome("bash", javaHome.absolutePath)
+
+        then:
+        outputContains('Hello World!')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/25721")
+    @Requires([OsTestPreconditions.Unix, PluginTestPreconditions.BashAvailable])
+    def "converts #pathOption path list when running Windows Java from WSL"() {
+        given:
+        def javaArgs = file("java-args.txt")
+        def wslpathCalls = file("wslpath-calls.txt")
+        def javaHome = file("windows-java-home")
+        def javaExecutable = javaHome.file("bin/java.exe") << """#!/bin/sh
+printf '%s\\n' "\$@" > '${javaArgs.absolutePath}'
+"""
+        javaExecutable.setExecutable(true)
+
+        def windowsInteropBin = file("windows-interop-bin")
+        def wslpath = windowsInteropBin.file("wslpath") << """#!/bin/sh
+[ "\$1" = "-m" ] || exit 1
+printf '%s\\n' "\$2" >> '${wslpathCalls.absolutePath}'
+printf 'windows/%s\\n' "\$2"
+"""
+        wslpath.setExecutable(true)
+
+        file("libs").createDir()
+        new JarOutputStream(file("libs/dependency.jar").newOutputStream()).close()
+        buildFile << """
+dependencies {
+    runtimeOnly files('libs/dependency.jar')
+}
+"""
+        if (modular) {
+            turnSampleProjectIntoModule()
+        }
+        succeeds('installDist')
+
+        when:
+        runViaUnixStartScriptWithJavaHome("bash", javaHome.absolutePath, [
+            PATH: "${windowsInteropBin.absolutePath}:${System.getenv('PATH')}",
+            WSL_DISTRO_NAME: "test-distro"
+        ])
+
+        then:
+        wslpathCalls.readLines().first() == file('build/install/sample').absolutePath
+        def args = javaArgs.readLines()
+        def pathOptionIndex = args.indexOf(pathOption)
+        pathOptionIndex >= 0
+        def convertedPaths = args[pathOptionIndex + 1].split(';')
+        convertedPaths.size() == expectedPathCount
+        convertedPaths.every { it.startsWith('windows/') }
+        convertedPaths.any { it.endsWith('/sample.jar') }
+        convertedPaths.any { it.endsWith('/dependency.jar') } == !modular
+
+        where:
+        modular | pathOption      | expectedPathCount
+        false   | '-classpath'    | 2
+        true    | '--module-path' | 1
     }
 
     @Requires([OsTestPreconditions.Unix, PluginTestPreconditions.DashAvailable])
@@ -219,6 +293,24 @@ task execStartScript(type: Exec) {
                 execStartScript.args "${args.join('", "')}"
             """
         }
+        return succeeds('execStartScript')
+    }
+
+    ExecutionResult runViaUnixStartScriptWithJavaHome(String shCommand, String javaHome, Map<String, String> additionalEnvironment = [:]) {
+        TestFile startScriptDir = file('build/install/sample/bin')
+        String additionalEnvironmentSetup = additionalEnvironment.collect { name, value ->
+            "    environment('${name}', '${value}')"
+        }.join('\n')
+        buildFile << """
+task execStartScript(type: Exec) {
+    workingDir '$startScriptDir.canonicalPath'
+    commandLine '${PluginTestPreconditions.locate(shCommand).absolutePath}'
+    args "./sample"
+    environment JAVA_HOME: "$javaHome"
+    environment.keySet().removeIf { it.equalsIgnoreCase('WSL_DISTRO_NAME') }
+$additionalEnvironmentSetup
+}
+"""
         return succeeds('execStartScript')
     }
 

--- a/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -161,6 +161,9 @@ if [ -n "\$JAVA_HOME" ] ; then
         JAVACMD=\$JAVA_HOME/jre/sh/java
     else
         JAVACMD=\$JAVA_HOME/bin/java
+        if [ ! -x "\$JAVACMD" ] ; then
+            JAVACMD=\$JAVACMD.exe
+        fi
     fi
     if [ ! -x "\$JAVACMD" ] ; then
         die "ERROR: JAVA_HOME is set to an invalid directory: \$JAVA_HOME
@@ -206,7 +209,7 @@ fi
 #   * --module-path (only if needed)
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, and ${optsEnvironmentVar} environment variables.
 
-# For Cygwin or MSYS, switch paths to Windows format before running java
+# For Cygwin or MSYS, switch paths to Windows format before running java.
 if "\$cygwin" || "\$msys" ; then
     APP_HOME=\$( cygpath --path --mixed "\$APP_HOME" )
 <% if ( classpath ) {%>\
@@ -237,10 +240,38 @@ if "\$cygwin" || "\$msys" ; then
         shift                   # remove old arg
         set -- "\$@" "\$arg"      # push replacement arg
     done
+elif [ -n "\${WSL_DISTRO_NAME:-}" ] &&
+     [ "\${JAVACMD%.exe}" != "\$JAVACMD" ] &&
+     command -v wslpath >/dev/null 2>&1
+then
+    # When running a Windows JDK from WSL, switch paths to Windows format.
+    APP_HOME=\$( wslpath -m "\$APP_HOME" )
+
+    wslpath_path_list () (
+        path_list=\$1
+        converted_path_list=
+        while [ -n "\$path_list" ] ; do
+            case \$path_list in #(
+              *:*) path=\${path_list%%:*}; path_list=\${path_list#*:} ;; #(
+              *)   path=\$path_list; path_list= ;;
+            esac
+            converted_path=\$( wslpath -m "\$path" )
+            if [ -z "\$converted_path_list" ] ; then
+                converted_path_list=\$converted_path
+            else
+                converted_path_list="\$converted_path_list;\$converted_path"
+            fi
+        done
+        printf '%s\\n' "\$converted_path_list"
+    )
+<% if ( classpath ) {%>\
+    CLASSPATH=\$( wslpath_path_list "\$CLASSPATH" )
+<% } %>\
+<% if ( mainClassName.startsWith('--module ') ) { %>    MODULE_PATH=\$( wslpath_path_list "\$MODULE_PATH" )<% } %>
 fi
 
 <% /*
-# The DEFAULT_JVM_OPTS variable is intentionally defined here to allow using cygwin-processed APP_HOME.
+# The DEFAULT_JVM_OPTS variable is intentionally defined here to allow using the Windows-formatted APP_HOME.
 # So far the only way to inject APP_HOME reference into DEFAULT_JVM_OPTS is to post-process the start script; the declaration is a good anchor to do that.
 */ %>
 # Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.


### PR DESCRIPTION
## Summary

- fall back to `$JAVA_HOME/bin/java.exe` when the extensionless Java executable is unavailable
- convert `APP_HOME`, `CLASSPATH`, and `MODULE_PATH` with `wslpath` only when a Windows Java executable is selected from WSL
- add integration coverage for the executable fallback and both classpath and module-path conversion

The path conversion is intentionally limited to WSL with an available `wslpath`. It does not convert application arguments, expand PATH probing, or change the existing Cygwin/MSYS behavior.

Fixes #25721

## Testing

- `./gradlew :plugins-application:integTest --tests org.gradle.api.plugins.ApplicationPluginUnixShellsIntegrationTest`
- `./gradlew :plugins-application:test --tests org.gradle.api.internal.plugins.UnixStartScriptGeneratorTest`
- `./gradlew :plugins-application:quickTest`
- `./gradlew :plugins-application:codeQuality`
- `./gradlew sanityCheck -x :performance:writeTmpPerformanceScenarioDefinitions -x :performance:verifyPerformanceScenarioDefinitions --max-workers=1 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=1024m"`
- manual WSL run of a generated `gradlew --version` using a Windows Microsoft JDK 21

The unfiltered root `sanityCheck` could not initialize 13 Android and 4 Swift performance scenarios because the corresponding JDKs and Swift 6 toolchain are not installed in this environment. Excluding the paired performance scenario definition tasks allowed the rest of the root `sanityCheck` to complete successfully (8,990 tasks).

## AI-assisted contribution disclosure

I used OpenAI Codex extensively to investigate the issue, help draft the implementation and tests, and run the validation. I reviewed the final diff, understand the submitted changes, and take responsibility for the contribution.