### PR TITLE
Make IGNORE_MIRROR a complete mirror kill switch

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -158,7 +158,18 @@ as much as the mirror list — it is what TeamCity injects as
 **Run it both ways.** Without `env.IGNORE_REPO_MIRROR` the build must FAIL on a
 `repo-mirror-outage-test.invalid` URL — that is what proves the simulation is faithful.
 
-Verified locally on 2026-09-08 with a cold `GRADLE_USER_HOME`:
+**Verified on CI, 2026-09-08** — controlled A/B on `Gradle_Master_Check_CompileAllBuild`, same branch and
+agent pool, `env.IGNORE_REPO_MIRROR` the only variable:
+
+| Build | `env.IGNORE_REPO_MIRROR` | Result |
+|---|---|---|
+| https://builds.gradle.org/build/117128279 | unset | **FAILURE** — `Gradle Central Plugin Repository(https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/)` |
+| https://builds.gradle.org/build/117128278 | `true` | **SUCCESS** · https://ge.gradle.org/s/y5vw4guq54rsu |
+
+The control failing is what makes the pass meaningful: it rules out the success coming from warm agent
+caches, because the same resolution demonstrably needed the network on the same pool.
+
+Also verified locally with a cold `GRADLE_USER_HOME`:
 
 | Scenario | Result |
 |---|---|

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -165,10 +165,26 @@ nothing shared is touched and no other branch is affected:
 
 ```bash
 teamcity run start <buildTypeId> --branch <branch> \
-  -P env.REPO_MIRROR_URLS="<real value, repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
-  -P gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
-  -P env.IGNORE_REPO_MIRROR=true
+  -P reverse.dep.'*'.env.REPO_MIRROR_URLS="<real value, repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
+  -P reverse.dep.'*'.gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
+  -P reverse.dep.'*'.env.IGNORE_REPO_MIRROR=true
 ```
+
+**The `reverse.dep.*.` prefix is not optional on a composite/trigger build.** TeamCity does not propagate
+plain `-P` parameters to snapshot dependencies. Without the prefix the overrides sit on the trigger build
+while every build that actually resolves anything runs against the real mirror — and the run comes back
+green having tested nothing. This bit me on build 117128838: 77,000 tests passed and the run was worthless
+as bypass verification. On a *leaf* build (e.g. `..._Check_CompileAllBuild`) plain `-P` is fine, since there
+are no dependencies to propagate to.
+
+Always confirm before trusting a green result:
+
+```bash
+teamcity api "/app/rest/builds/id:<a dependency build id>/resulting-properties" \
+  | grep -E 'IGNORE_REPO_MIRROR|REPO_MIRROR_URLS|plugins.portal.url'
+```
+
+It must show `env.IGNORE_REPO_MIRROR` present and the `.invalid` URLs — not `repo.grdev.net`.
 
 `.invalid` is reserved by RFC 6761 and never resolves, so anything still pointed at the "mirror" fails
 fast instead of silently succeeding against the real one. Overriding `gradle.plugins.portal.url` matters

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -129,19 +129,38 @@ explained by that bug and should not be read as either a master problem or a def
 switch's own correctness evidence — 0 grdev references — is unaffected. **A full PR-feedback chain has
 not been re-run since the fix; that is the outstanding verification.**
 
-### Known limitation — upstream load
+### Known limitation — upstream capacity is the real ceiling
 
-The single non-test build failure (`Quick_2_bucket3_virtual_Batch_4_1`, scan
-https://ge.gradle.org/s/gs6zvv2w5phkq):
+This is the most important operational finding, and it is a capacity limit, not a correctness one.
+
+With the bypass on there is no caching proxy in front of anything: every agent fetches straight from
+`repo.maven.apache.org`, `plugins.gradle.org` and `repo.gradle.org`. At full-stage scale that gets the
+fleet throttled.
+
+Measured on build 117129908 (Quick Feedback - Linux Only, Xperimental, ~166 agents, simulated outage with
+overrides correctly propagated):
 
 ```
-> Could not GET 'https://repo.gradle.org/gradle/public/org/gradle/fileevents/gradle-fileevents/0.2.8/gradle-fileevents-0.2.8.pom'
-    > Read timed out
+CompileAllBuild (117129884):
+  HttpErrorStatusCodeException: Received status code 429 from server: Too Many Requests
+  repo-mirror-outage-test.invalid refs: 0    grdev refs: 0
 ```
 
-Note the URL is **upstream** — the reverse map worked; the GET timed out. With the bypass on, ~166
-agents fetch from upstream directly with no caching proxy. **Sporadic `Read timed out` resolution
-failures are expected and do not mean the switch is broken.** Documented in the runbook comment.
+That single failure cascaded into **24 failed builds** (the rest all `Snapshot dependency failed`). A
+lone artifact fetch can also simply time out — `Could not GET ... > Read timed out`, seen on build
+116950940 against `repo.gradle.org/gradle/public`.
+
+**In both cases the URLs had already been correctly rewritten to upstream, with zero grdev requests.** The
+switch worked; upstream could not absorb what the mirror normally absorbs.
+
+Plan for this during a real outage:
+
+- **Do not expect a full `check` to pass.** Run reduced scope. Retry before concluding there is a regression.
+- **Builds that never touched the mirror can fail too.** `.teamcity`'s `./mvnw clean verify` resolves
+  directly from Maven Central at all times (hardcoded in `.teamcity/pom.xml` and the Maven wrapper — no
+  mirror reference anywhere). It passed with the mirror healthy (117129934) and failed inside the bypass
+  run (117129887), purely as collateral damage from the same throttling. This is *not* a gap in the
+  switch's coverage; that build never used the mirror to begin with.
 
 ### Local runs (cold isolated `GRADLE_USER_HOME`, grdev returning HTTP 522)
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,252 @@
+# Handoff — `IGNORE_REPO_MIRROR` kill switch + 2026-09-02 Artifactory incident
+
+> Renamed 2026-09-08: the env var was `IGNORE_MIRROR` up to and including build 116950940.
+> Anything below quoting that older name refers to the same switch.
+
+Branch `feat/ignore-mirror-switch` · Draft PR https://github.com/gradle/gradle/pull/39042
+Written 2026-09-03.
+
+---
+
+## 1. What this branch does
+
+Makes `env.IGNORE_REPO_MIRROR=true` a **single, complete kill switch** that makes a CI build resolve
+everything from upstream repositories instead of `repo.grdev.net`, so `check` still works during an
+Artifactory outage.
+
+**Hard requirement from Bo: one lever, nothing else.** No second TeamCity parameter. Not
+`gradle.plugins.portal.url`, not `env.REPO_MIRROR_URLS`. A runbook that says "also flip these two
+others" gets half-applied at 3am. The code absorbs the difficulty.
+
+### How to use it
+
+Set TeamCity parameter **`env.IGNORE_REPO_MIRROR` = `true` on the root `Gradle` project**. Effective next
+build. No code change, no config regeneration. Remove it when the mirror is healthy.
+
+- `env.IGNORE_REPO_MIRROR` is deliberately **not** declared in the `.teamcity` Kotlin DSL. A
+  build-configuration-level parameter would outrank the project-level one and block the flip.
+- **`env.REPO_MIRROR_URLS` must stay set** while the bypass is on — the reverse mapping reads it to
+  recognise which URLs are mirror URLs.
+
+### Out of scope (still grdev-pinned, flippable as their own TC params)
+
+- `env.YARNPKG_MIRROR_URL` — JS/docs builds
+- `gradle.internal.repository.url` → `env.GRADLE_INTERNAL_REPO_URL` — publishing only, irrelevant to `check`
+
+---
+
+## 2. The three commits
+
+```
+53badd27cd7  Make IGNORE_REPO_MIRROR a complete repo.grdev.net kill switch
+45f00f5d5ca  Undo the plugin portal override early enough for settings plugin resolution
+79321eaec5c  Document the upstream-load caveat for the mirror bypass
+```
+
+8 files, +124/−11.
+
+| File | Change |
+|---|---|
+| `gradle/shared-with-buildSrc/mirrors.settings.gradle.kts` | `ignoreMirrors` hoisted to a `val` (CC-compatible: `providers.environmentVariable`, no `System.getenv`/`setProperty`). Reverse map mirror-URL → upstream-URL. Bypass extended to `dependencyResolutionManagement` repositories. Runbook comment at top. |
+| `settings.gradle.kts`, `build-logic/`, `build-logic-commons/`, `build-logic-settings/` settings | Undo the injected portal override inside `pluginManagement { repositories { … } }`. `build-logic-commons` gains an explicit `repositories { gradlePluginPortal() }` — already the implicit default, made explicit so there is something to rewrite. |
+| `build-logic/jvm/.../CiEnvironmentProvider.kt` | `collectMirrorUrls()` returns `emptyMap()`. Choke point for the whole test-fixture layer. |
+| `build-logic/performance-testing/.../mirroring-init-script.gradle` | Skip building the mirror map; `mirror()` becomes a no-op. |
+| `testing/internal-distribution-testing/.../RepoScriptBlockUtil.groovy` | Use the original URL in the `MirroredRepository` constructor when `isMirrorEnabled()` is false. |
+
+### The non-obvious part — read this before touching it
+
+`ignoreMirrors()` had existed in `mirrors.settings.gradle.kts` for years as **dead code**. Its only
+call site was deleted by PR #17794 / `271636d99e8` (2021-07-21), which moved the plugin-portal
+override into TeamCity.
+
+Two things make a naive "skip mirroring" insufficient:
+
+1. **`.teamcity/src/main/kotlin/common/CommonExtensions.kt:45`** adds
+   `-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%` to essentially
+   every build step, and `DefaultBaseRepositoryFactory.java:148` reads it **eagerly** into the
+   `gradlePluginPortal()` URL. So the portal repository *is* a grdev URL before any script sees it.
+   Hence the **reverse map**, not a skip.
+
+2. **The mirrors script cannot be applied early enough.** The root `settings.gradle.kts`
+   `plugins {}` block — and the equivalents in `build-logic`, `build-logic-commons`,
+   `build-logic-settings` — resolve *before* `apply(from = mirrors.settings.gradle.kts)` runs, and
+   the Kotlin DSL forbids placing that apply above a `plugins {}` block. The only hook that runs
+   early enough is inside `pluginManagement { repositories { … } }` itself. **Do not try to "clean
+   this up" by consolidating it back into the mirrors script — it will silently stop working.**
+
+`RepoScriptBlockUtil.getName()`'s `_MIRROR` suffix logic is deliberately **unchanged** — those names
+appear in test expectations and in `RepositoryMirrorOutputNormalizer`.
+
+---
+
+## 3. Verification status
+
+### CI — the real test
+
+https://builds.gradle.org/build/116950940 — revision `45f00f5d5caaab64242e9413b45aa234408ef5b4`,
+run with `env.IGNORE_REPO_MIRROR=true`, TeamCity's grdev portal override injected, and Artifactory dead.
+
+Final: **459 tests failed, 81,763 passed, 1,016 ignored**. Build chain finished: **151 succeeded, 93 failed** (244 builds).
+
+Sampling 400 failures:
+
+| Signal | Count |
+|---|---|
+| `grdev` anywhere in a failure | **0** |
+| `Could not resolve` | 2 |
+| `Cannot create a NativeToolChain named 'gcc'` | 266 |
+| Non-test build failures | 1 |
+
+**Zero grdev references against a dead Artifactory with 81k tests passing — the switch works.**
+
+### The 459 failures are not from this branch
+
+- **266/400 are `Cannot create a NativeToolChain named 'gcc'`** — pre-existing on master. Every
+  commit touching `CommonToolchainCustomizationIntegTest` is already on `origin/master` (newest
+  `4b3213e43bb`, 2026-08-12). This branch does not touch `platforms/native`. **Someone should look at
+  this separately — it is failing a lot of tests on master.**
+- Others sampled: local `127.0.0.1` Ivy fixtures, progress-logger assertions, `FinalizeBuildCache…`
+  expecting `"after 5 days"` vs actual `"after 7 days"`, a changed exception message in
+  `MultiProducerSingleConsumerProcessorTest`. All assertion/default drift, unrelated to mirrors.
+
+### Known limitation — upstream load
+
+The single non-test build failure (`Quick_2_bucket3_virtual_Batch_4_1`, scan
+https://ge.gradle.org/s/gs6zvv2w5phkq):
+
+```
+> Could not GET 'https://repo.gradle.org/gradle/public/org/gradle/fileevents/gradle-fileevents/0.2.8/gradle-fileevents-0.2.8.pom'
+    > Read timed out
+```
+
+Note the URL is **upstream** — the reverse map worked; the GET timed out. With the bypass on, ~166
+agents fetch from upstream directly with no caching proxy. **Sporadic `Read timed out` resolution
+failures are expected and do not mean the switch is broken.** Documented in the runbook comment.
+
+### Local runs (cold isolated `GRADLE_USER_HOME`, grdev returning HTTP 522)
+
+| Scenario | Result |
+|---|---|
+| Baseline, no fix | FAILED on `repo.grdev.net/.../gradle-plugin-portal-prod/...` 522 · https://ge.gradle.org/s/vbgc5xoechzoc |
+| `IGNORE_REPO_MIRROR=true` | `BUILD SUCCESSFUL in 6m 36s`, `grep -c grdev` = **0** · https://ge.gradle.org/s/thhpdmddhhkki |
+| No env vars (non-CI path) | `BUILD SUCCESSFUL` · https://ge.gradle.org/s/ncb2vq5inbu5c |
+
+A **positive** end-to-end run through the mirrors was not possible while grdev was down. The
+mirror-enabled path is verified only indirectly, by the baseline run rewriting
+`https://plugins.gradle.org/m2` → grdev and failing against it. **Re-check this once grdev is back.**
+
+---
+
+## 3b. Testing the bypass while the mirror is healthy
+
+grdev came back up on 2026-09-08, so the bypass can no longer be tested by simply flipping it — with a
+healthy mirror, a build passes either way and proves nothing. Simulate an outage instead, per-run, so
+nothing shared is touched and no other branch is affected:
+
+```bash
+teamcity run start <buildTypeId> --branch <branch> \
+  -P env.REPO_MIRROR_URLS="<real value, repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
+  -P gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
+  -P env.IGNORE_REPO_MIRROR=true
+```
+
+`.invalid` is reserved by RFC 6761 and never resolves, so anything still pointed at the "mirror" fails
+fast instead of silently succeeding against the real one. Overriding `gradle.plugins.portal.url` matters
+as much as the mirror list — it is what TeamCity injects as
+`-Dorg.gradle.internal.plugins.portal.url.override`.
+
+**Run it both ways.** Without `env.IGNORE_REPO_MIRROR` the build must FAIL on a
+`repo-mirror-outage-test.invalid` URL — that is what proves the simulation is faithful.
+
+Verified locally on 2026-09-08 with a cold `GRADLE_USER_HOME`:
+
+| Scenario | Result |
+|---|---|
+| Simulated outage, **no** switch | FAILED — `Gradle Central Plugin Repository(https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/)` |
+| Simulated outage, **with** switch | `BUILD SUCCESSFUL` — 0 `repo-mirror-outage-test.invalid` refs, **0 grdev refs** (did not fall back to the now-online real mirror) · https://ge.gradle.org/s/gdactj372f7a4 |
+
+---
+
+## 4. The incident, and what was actually wrong
+
+Two separate problems got tangled together. Both are resolved.
+
+### 4a. repo.grdev.net down
+
+JFrog Artifactory, compromised/rebuilt 2026-09-02. It is **both** the caching proxy for every
+upstream repository **and** TeamCity's internal artifact storage, so an outage stops all development.
+`env.IGNORE_REPO_MIRROR=true` was set on the root `Gradle` project during the incident.
+
+### 4b. All Gradle VCS roots dead — `HTTP 400` on `git fetch`
+
+Every `Gradle_*` build failed at change collection:
+
+```
+Failed to collect changes ... expected flush after ref listing
+error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400
+freeze.settings.error: Failed to load build settings from VCS
+```
+
+**Root cause: one corrupt/bloated server-side git mirror.** TeamCity keys mirrors by repository URL
+**including the username**, so `gradle/gradle` had four:
+
+```
+https://github.com/gradle/gradle.git              = git-1BEEE9E9.git
+https://bot-gradle@github.com/gradle/gradle.git   = git-DE5DA23E.git
+https://blindpirate@github.com/gradle/gradle.git  = git-AE01687B.git
+https://bot-teamcity@github.com/gradle/gradle.git = git-8D669E1D.git   ← the broken one
+```
+
+Ten VCS roots point at `github.com/gradle/gradle` (`Gradle`, `GradleMaster`, `GradleRelease`,
+`GradleRelease6x/7x/8x/9x`, `GradleXperimental`, `DistributedTest_DistributedTest`,
+`Parallelquarantine`). All the `bot-teamcity` ones share `git-8D669E1D.git`, so they broke together
+— while Enterprise roots (different repos → different mirrors) kept working. That shared-mirror fact
+is the whole explanation.
+
+**Fix applied:**
+
+```bash
+mv /data/.BuildServer/system/caches/git/git-8D669E1D.git /var/tmp/git-8D669E1D.git.bak
+```
+
+The `.bak` is still on the server. **Delete it once CI has been healthy for a while**, not before.
+
+**Dead ends, so nobody repeats them:** it was not the `bot-teamcity` token (verified `HTTP/2 200`,
+40 chars, no stray bytes, full authenticated fetch succeeded); not server egress (Enterprise roots
+fine, 50/50); not repo visibility (anonymous `ls-remote` works); not `JDK_JAVA_OPTIONS` polluting the
+credential helper (the helper script has no `2>&1`, and the banner goes to stderr, which git never
+parses); not ref count on `GradleMaster` alone (narrowing its branch spec changed nothing, because
+nine other roots keep refilling the same mirror).
+
+**Do not use anonymous auth as a workaround.** GitHub rate-limits unauthenticated traffic to 60/hr
+per IP, and versioned settings + commit status publishing + the merge-queue integration all need
+auth regardless of fetching.
+
+---
+
+## 5. State right now
+
+- Branch pushed, 3 commits. Draft PR #39042 open with full verification in the body.
+- `GradleMaster` branch spec **restored** to `+:refs/heads/*` / `-:refs/heads/release`. ✅
+- Build queue recovering (657 and draining; it had been paused with 19,967 queued, most of which
+  were cancelled during the incident).
+- `env.IGNORE_REPO_MIRROR=true` still set on root `Gradle`. **Remove it once grdev is healthy.**
+- Merge queue verification build https://builds.gradle.org/build/116951307 was still starved behind
+  the PR chain at time of writing — worth re-checking.
+
+## 6. Next steps
+
+1. Re-check the merge-queue build `116951307` on master.
+2. Once grdev is back: unset `env.IGNORE_REPO_MIRROR`, and verify the **mirror-enabled** path still
+   rewrites correctly (the one path that could not be positively verified during the outage).
+3. Investigate `Cannot create a NativeToolChain named 'gcc'` on master — unrelated to this branch but
+   failing hundreds of tests.
+4. Delete `/var/tmp/git-8D669E1D.git.bak` once CI is confirmed stable.
+5. Mark PR #39042 ready for review.
+
+## 7. Security note
+
+`/app/rest/projects/id:Gradle/parameters` returns **`plugin.portal.publish.secret` in plaintext** —
+it is not password-typed, so anyone with project read access can read it. Separately: the
+`bot-teamcity` GitHub token was restored, **not rotated**, during an incident whose trigger was a
+host compromise. "The token is correct" and "the token is safe" are different claims. Worth a look.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -99,15 +99,35 @@ Sampling 400 failures:
 
 **Zero grdev references against a dead Artifactory with 81k tests passing — the switch works.**
 
-### The 459 failures are not from this branch
+### The 459 failures WERE from this branch — corrected 2026-09-03
 
-- **266/400 are `Cannot create a NativeToolChain named 'gcc'`** — pre-existing on master. Every
-  commit touching `CommonToolchainCustomizationIntegTest` is already on `origin/master` (newest
-  `4b3213e43bb`, 2026-08-12). This branch does not touch `platforms/native`. **Someone should look at
-  this separately — it is failing a lot of tests on master.**
-- Others sampled: local `127.0.0.1` Ivy fixtures, progress-logger assertions, `FinalizeBuildCache…`
-  expecting `"after 5 days"` vs actual `"after 7 days"`, a changed exception message in
-  `MultiProducerSingleConsumerProcessorTest`. All assertion/default drift, unrelated to mirrors.
+**This section originally claimed the failures were pre-existing on master. That was wrong.** The real
+cause was found by Bo in commit `58895e7809a`:
+
+`AbstractGradleExecuter.usingInitScript()` was gated on `RepoScriptBlockUtil.isMirrorEnabled()`, so with
+the switch on it silently dropped **every** fixture init script — not just the repository-mirror one.
+Toolchain, lifecycle and progress-logging fixtures all vanished. That is why the failures clustered
+where they did:
+
+- `Cannot create a NativeToolChain named 'gcc'` — the toolchain init script was never applied
+- `progressLogger.downloadProgressLogged(...)` assertions in the Ivy HTTP tests — progress-logging init
+  script never applied
+- `BinaryNativePlatformIntegrationTest` toolchain assertions — same cause
+
+The fix moves the guard to `withRepositoryMirrors()`, where it belongs, and leaves `usingInitScript()`
+unconditional.
+
+**Why the original conclusion was wrong, so the mistake is not repeated:** the reasoning was "every
+commit touching `CommonToolchainCustomizationIntegTest` is already on master, and this branch does not
+touch `platforms/native`". Both facts were true and the conclusion still did not follow — the *test* was
+unchanged while its *environment* changed, because the init scripts it depended on were being discarded.
+When failures cluster in unrelated-looking areas (toolchains, progress logging) right after a change to
+test-fixture plumbing, suspect the plumbing, not the tests.
+
+**Consequence for the evidence below:** build 116950940 predates `58895e7809a`. Its 459 failures are
+explained by that bug and should not be read as either a master problem or a defect in the switch. The
+switch's own correctness evidence — 0 grdev references — is unaffected. **A full PR-feedback chain has
+not been re-run since the fix; that is the outstanding verification.**
 
 ### Known limitation — upstream load
 

--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -16,6 +16,20 @@
 
 pluginManagement {
     includeBuild("../build-logic-settings")
+    repositories {
+        // The implicit default for pluginManagement, made explicit so the emergency mirror bypass
+        // (IGNORE_MIRROR) can undo the plugin portal URL override TeamCity injects. This block is
+        // resolved before gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can be applied.
+        // See that script for the full runbook.
+        gradlePluginPortal()
+        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+            all {
+                if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
+                    setUrl("https://plugins.gradle.org/m2")
+                }
+            }
+        }
+    }
 }
 
 dependencyResolutionManagement {
@@ -53,3 +67,5 @@ include("gradle-plugin")
 include("publishing")
 
 rootProject.name = "build-logic-commons"
+
+apply(from = "../gradle/shared-with-buildSrc/mirrors.settings.gradle.kts")

--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -18,11 +18,11 @@ pluginManagement {
     includeBuild("../build-logic-settings")
     repositories {
         // The implicit default for pluginManagement, made explicit so the emergency mirror bypass
-        // (IGNORE_MIRROR) can undo the plugin portal URL override TeamCity injects. This block is
+        // (IGNORE_REPO_MIRROR) can undo the plugin portal URL override TeamCity injects. This block is
         // resolved before gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can be applied.
         // See that script for the full runbook.
         gradlePluginPortal()
-        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+        if (System.getenv("IGNORE_REPO_MIRROR")?.toBoolean() == true) {
             all {
                 if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
                     setUrl("https://plugins.gradle.org/m2")

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -41,6 +41,17 @@ pluginManagement {
         }
 
         gradlePluginPortal()
+        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
+        // plugin portal URL override that TeamCity injects has to be undone here as well.
+        // See that script for the full runbook.
+        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+            all {
+                if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
+                    setUrl("https://plugins.gradle.org/m2")
+                }
+            }
+        }
     }
 }
 
@@ -51,3 +62,5 @@ include("default-settings-plugins")
 include("version-catalogs")
 
 rootProject.name = "build-logic-settings"
+
+apply(from = "../gradle/shared-with-buildSrc/mirrors.settings.gradle.kts")

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -41,11 +41,11 @@ pluginManagement {
         }
 
         gradlePluginPortal()
-        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // Emergency mirror bypass (IGNORE_REPO_MIRROR): the plugins {} block below is resolved before
         // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
         // plugin portal URL override that TeamCity injects has to be undone here as well.
         // See that script for the full runbook.
-        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+        if (System.getenv("IGNORE_REPO_MIRROR")?.toBoolean() == true) {
             all {
                 if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
                     setUrl("https://plugins.gradle.org/m2")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
@@ -59,9 +59,17 @@ class CiEnvironmentProvider(private val test: Test) : CommandLineArgumentProvide
 
     private
     fun collectMirrorUrls(): Map<String, String> =
-        // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
-        System.getenv("REPO_MIRROR_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
-            val (name, url) = nameToUrl.split(':', limit = 2)
-            name to url
-        } ?: emptyMap()
+        // The emergency mirror bypass, see gradle/shared-with-buildSrc/mirrors.settings.gradle.kts.
+        // Publishing no -Dorg.gradle.integtest.mirrors.* properties makes the whole test fixture layer
+        // (RepoScriptBlockUtil, the mirror init script, the plugin portal override AbstractGradleExecuter
+        // passes to nested builds) fall back to the upstream URLs.
+        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+            emptyMap()
+        } else {
+            // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
+            System.getenv("REPO_MIRROR_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
+                val (name, url) = nameToUrl.split(':', limit = 2)
+                name to url
+            } ?: emptyMap()
+        }
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
@@ -63,7 +63,7 @@ class CiEnvironmentProvider(private val test: Test) : CommandLineArgumentProvide
         // Publishing no -Dorg.gradle.integtest.mirrors.* properties makes the whole test fixture layer
         // (RepoScriptBlockUtil, the mirror init script, the plugin portal override AbstractGradleExecuter
         // passes to nested builds) fall back to the upstream URLs.
-        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+        if (System.getenv("IGNORE_REPO_MIRROR")?.toBoolean() == true) {
             emptyMap()
         } else {
             // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -70,7 +70,7 @@ val propagatedEnvironmentVariables = listOf(
     "JPROFILER_HOME",
 
     // Used by mirror init script, see RepoScriptBlockUtil
-    "IGNORE_MIRROR",
+    "IGNORE_REPO_MIRROR",
 
     "LANG",
     "LANGUAGE",

--- a/build-logic/performance-testing/src/main/resources/mirroring-init-script.gradle
+++ b/build-logic/performance-testing/src/main/resources/mirroring-init-script.gradle
@@ -24,8 +24,11 @@ apply plugin: MirrorPlugin
 class MirrorPlugin implements Plugin<Gradle> {
     Map<String, String> mirrors = [:]
     MirrorPlugin() {
+        // The emergency mirror bypass leaves `mirrors` empty, which makes mirror() a no-op.
+        // See gradle/shared-with-buildSrc/mirrors.settings.gradle.kts.
+        def ignoreMirror = Boolean.parseBoolean(System.getenv("IGNORE_MIRROR"))
         def repoMirrorUrls = System.getenv("REPO_MIRROR_URLS")?.split(',')?.collectEntries { mirrorEntry -> mirrorEntry.split(":", 2) } as Map<String, String>
-        if (repoMirrorUrls) {
+        if (repoMirrorUrls && !ignoreMirror) {
             repoMirrorUrls.get('jcenter')?.with { mirrors.put(normalizeUrl('https://jcenter.bintray.com/'), it) }
             repoMirrorUrls.get('mavencentral')?.with { mirrors.put(normalizeUrl('https://repo.maven.apache.org/maven2/'), it) }
             repoMirrorUrls.get('google')?.with { mirrors.put(normalizeUrl('https://dl.google.com/dl/android/maven2/'), it) }

--- a/build-logic/performance-testing/src/main/resources/mirroring-init-script.gradle
+++ b/build-logic/performance-testing/src/main/resources/mirroring-init-script.gradle
@@ -26,7 +26,7 @@ class MirrorPlugin implements Plugin<Gradle> {
     MirrorPlugin() {
         // The emergency mirror bypass leaves `mirrors` empty, which makes mirror() a no-op.
         // See gradle/shared-with-buildSrc/mirrors.settings.gradle.kts.
-        def ignoreMirror = Boolean.parseBoolean(System.getenv("IGNORE_MIRROR"))
+        def ignoreMirror = Boolean.parseBoolean(System.getenv("IGNORE_REPO_MIRROR"))
         def repoMirrorUrls = System.getenv("REPO_MIRROR_URLS")?.split(',')?.collectEntries { mirrorEntry -> mirrorEntry.split(":", 2) } as Map<String, String>
         if (repoMirrorUrls && !ignoreMirror) {
             repoMirrorUrls.get('jcenter')?.with { mirrors.put(normalizeUrl('https://jcenter.bintray.com/'), it) }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -19,6 +19,17 @@ pluginManagement {
     includeBuild("../build-logic-settings")
     repositories {
         gradlePluginPortal()
+        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
+        // plugin portal URL override that TeamCity injects has to be undone here as well.
+        // See that script for the full runbook.
+        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+            all {
+                if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
+                    setUrl("https://plugins.gradle.org/m2")
+                }
+            }
+        }
     }
 }
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -19,11 +19,11 @@ pluginManagement {
     includeBuild("../build-logic-settings")
     repositories {
         gradlePluginPortal()
-        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // Emergency mirror bypass (IGNORE_REPO_MIRROR): the plugins {} block below is resolved before
         // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
         // plugin portal URL override that TeamCity injects has to be undone here as well.
         // See that script for the full runbook.
-        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+        if (System.getenv("IGNORE_REPO_MIRROR")?.toBoolean() == true) {
             all {
                 if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
                     setUrl("https://plugins.gradle.org/m2")

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -34,6 +34,12 @@
  * Still pinned to repo.grdev.net and needing their own TeamCity parameter edits if those builds matter:
  *   - `env.YARNPKG_MIRROR_URL`       - JS/docs builds
  *   - `gradle.internal.repository.url` - publishing only, irrelevant to `check`
+ *
+ * Expect some flakiness while the bypass is on. Every agent then fetches from the upstream
+ * repositories directly, with no caching proxy in front of them, so sporadic
+ * "Could not GET ... > Read timed out" resolution failures are normal under full CI load and do
+ * not mean the switch is broken. Retry; if a whole stage is failing this way, the upstream
+ * repository is the bottleneck, not this script.
  */
 
 class Helper(private val providers: ProviderFactory) {

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -14,6 +14,27 @@
  * limitations under the License.
  */
 
+/*
+ * Redirects the repositories declared by this build to the caching mirrors on repo.grdev.net when running on CI.
+ *
+ * EMERGENCY BYPASS (repo.grdev.net / Artifactory outage)
+ * -----------------------------------------------------
+ * Set the TeamCity parameter `env.IGNORE_MIRROR` = `true` on the root `Gradle` project. It takes effect on the
+ * next build; no code change and no `.teamcity` configuration regeneration is needed. Remove the parameter once
+ * the mirror is healthy again.
+ *
+ * `env.IGNORE_MIRROR` is deliberately NOT declared in the `.teamcity` Kotlin DSL: a build-configuration-level
+ * parameter would take precedence over the project-level one and would therefore block the emergency flip.
+ *
+ * `env.REPO_MIRROR_URLS` must stay set while the bypass is on. The bypass works by mapping mirror URLs back to
+ * their upstream URLs, so it needs that variable to recognise which URLs are mirror URLs. That reverse mapping
+ * is also what undoes `-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%`, which
+ * TeamCity bakes into the Gradle command line of essentially every build step.
+ *
+ * Still pinned to repo.grdev.net and needing their own TeamCity parameter edits if those builds matter:
+ *   - `env.YARNPKG_MIRROR_URL`       - JS/docs builds
+ *   - `gradle.internal.repository.url` - publishing only, irrelevant to `check`
+ */
 
 class Helper(private val providers: ProviderFactory) {
     val originalUrls: Map<String, String> = mapOf(
@@ -38,7 +59,18 @@ class Helper(private val providers: ProviderFactory) {
             }
             ?: emptyMap()
 
-    fun ignoreMirrors() = providers.environmentVariable("IGNORE_MIRROR").orNull?.toBoolean() == true
+    val ignoreMirrors: Boolean = providers.environmentVariable("IGNORE_MIRROR").orNull?.toBoolean() == true
+
+    /**
+     * Normalized mirror URL -> upstream URL, for the mirrors this build actually declares repositories for.
+     * Used by the emergency bypass to map a repository that already points at a mirror back to upstream,
+     * regardless of whether it was rewritten by this script or handed to us already mirrored (as the
+     * `gradlePluginPortal()` URL is, via the `org.gradle.internal.plugins.portal.url.override` system property).
+     */
+    val upstreamUrlsByMirrorUrl: Map<String, String> =
+        originalUrls.mapNotNull { (name, originalUrl) ->
+            mirrorUrls[name]?.let { mirrorUrl -> normalizeUrl(mirrorUrl) to originalUrl }
+        }.toMap()
 
     fun isCI() = providers.environmentVariable("CI").isPresent()
 
@@ -51,9 +83,13 @@ class Helper(private val providers: ProviderFactory) {
                 // see https://github.com/gradle/gradle/issues/37612
                 @Suppress("USELESS_ELVIS")
                 val currentUrl = this.url?.toString() ?: return@all
-                originalUrls.forEach { name, originalUrl ->
-                    if (normalizeUrl(originalUrl) == normalizeUrl(currentUrl) && mirrorUrls.containsKey(name)) {
-                        mirrorUrls.get(name)?.let { this.setUrl(it) }
+                if (ignoreMirrors) {
+                    upstreamUrlsByMirrorUrl[normalizeUrl(currentUrl)]?.let { this.setUrl(it) }
+                } else {
+                    originalUrls.forEach { name, originalUrl ->
+                        if (normalizeUrl(originalUrl) == normalizeUrl(currentUrl) && mirrorUrls.containsKey(name)) {
+                            mirrorUrls.get(name)?.let { this.setUrl(it) }
+                        }
                     }
                 }
             }

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -114,5 +114,11 @@ with(Helper(providers)) {
 
     gradle.settingsEvaluated {
         withMirrors(settings.pluginManagement.repositories)
+        if (ignoreMirrors) {
+            // The mirroring path deliberately leaves dependencyResolutionManagement repositories alone,
+            // but the bypass has to reach them: their `gradlePluginPortal()` carries the TeamCity
+            // `org.gradle.internal.plugins.portal.url.override` value, which points at repo.grdev.net.
+            withMirrors(settings.dependencyResolutionManagement.repositories)
+        }
     }
 }

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -19,11 +19,11 @@
  *
  * EMERGENCY BYPASS (repo.grdev.net / Artifactory outage)
  * -----------------------------------------------------
- * Set the TeamCity parameter `env.IGNORE_MIRROR` = `true` on the root `Gradle` project. It takes effect on the
+ * Set the TeamCity parameter `env.IGNORE_REPO_MIRROR` = `true` on the root `Gradle` project. It takes effect on the
  * next build; no code change and no `.teamcity` configuration regeneration is needed. Remove the parameter once
  * the mirror is healthy again.
  *
- * `env.IGNORE_MIRROR` is deliberately NOT declared in the `.teamcity` Kotlin DSL: a build-configuration-level
+ * `env.IGNORE_REPO_MIRROR` is deliberately NOT declared in the `.teamcity` Kotlin DSL: a build-configuration-level
  * parameter would take precedence over the project-level one and would therefore block the emergency flip.
  *
  * `env.REPO_MIRROR_URLS` must stay set while the bypass is on. The bypass works by mapping mirror URLs back to
@@ -34,6 +34,26 @@
  * Still pinned to repo.grdev.net and needing their own TeamCity parameter edits if those builds matter:
  *   - `env.YARNPKG_MIRROR_URL`       - JS/docs builds
  *   - `gradle.internal.repository.url` - publishing only, irrelevant to `check`
+ *
+ * TESTING THE BYPASS WHILE THE MIRROR IS HEALTHY
+ * ----------------------------------------------
+ * Do not wait for the next outage to find out whether this still works. Simulate one on a single build by
+ * pointing the mirror at a host that cannot resolve, using per-run TeamCity parameter overrides so nothing
+ * shared is touched and no other branch is affected:
+ *
+ *   teamcity run start <buildTypeId> --branch <branch> \
+ *     -P env.REPO_MIRROR_URLS="<the real value, with repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
+ *     -P gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
+ *     -P env.IGNORE_REPO_MIRROR=true
+ *
+ * `.invalid` is reserved by RFC 6761 and never resolves, so any request that still goes to the "mirror" fails
+ * fast and loudly instead of silently succeeding against the real one. Overriding `gradle.plugins.portal.url`
+ * matters as much as the mirror list: it is what TeamCity injects as
+ * `-Dorg.gradle.internal.plugins.portal.url.override`, and it is the case this whole script exists to undo.
+ *
+ * Run it BOTH ways. Without `env.IGNORE_REPO_MIRROR` the build must FAIL on a
+ * `repo-mirror-outage-test.invalid` URL - that is what proves the simulation is faithful. With it, the build
+ * must pass and no `repo-mirror-outage-test.invalid` URL may appear anywhere in the log.
  *
  * Expect some flakiness while the bypass is on. Every agent then fetches from the upstream
  * repositories directly, with no caching proxy in front of them, so sporadic
@@ -65,7 +85,7 @@ class Helper(private val providers: ProviderFactory) {
             }
             ?: emptyMap()
 
-    val ignoreMirrors: Boolean = providers.environmentVariable("IGNORE_MIRROR").orNull?.toBoolean() == true
+    val ignoreMirrors: Boolean = providers.environmentVariable("IGNORE_REPO_MIRROR").orNull?.toBoolean() == true
 
     /**
      * Normalized mirror URL -> upstream URL, for the mirrors this build actually declares repositories for.

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -63,11 +63,25 @@
  * `repo-mirror-outage-test.invalid` URL - that is what proves the simulation is faithful. With it, the build
  * must pass and no `repo-mirror-outage-test.invalid` URL may appear anywhere in the log.
  *
- * Expect some flakiness while the bypass is on. Every agent then fetches from the upstream
- * repositories directly, with no caching proxy in front of them, so sporadic
- * "Could not GET ... > Read timed out" resolution failures are normal under full CI load and do
- * not mean the switch is broken. Retry; if a whole stage is failing this way, the upstream
- * repository is the bottleneck, not this script.
+ * THE REAL LIMIT IS UPSTREAM CAPACITY, NOT CORRECTNESS
+ * ----------------------------------------------------
+ * With the bypass on there is no caching proxy in front of anything: every agent fetches straight from
+ * repo.maven.apache.org, plugins.gradle.org and repo.gradle.org. At full-stage scale that is enough to get
+ * the whole fleet throttled. Measured on build 117129908 (Quick Feedback - Linux Only, ~166 agents):
+ *
+ *   CompileAllBuild: HttpErrorStatusCodeException: Received status code 429 from server: Too Many Requests
+ *
+ * which cascaded into 24 failed builds. A single artifact fetch can also just time out
+ * ("Could not GET ... > Read timed out", seen on build 116950940).
+ *
+ * Neither means the switch is broken - in both cases the URLs were already correctly rewritten to upstream,
+ * with zero repo.grdev.net requests. It means upstream cannot absorb what the mirror normally absorbs.
+ *
+ * Consequences to plan for during a real outage:
+ *   - Do not expect a full `check` to pass. Run reduced scope, and retry rather than assuming a regression.
+ *   - Builds that never used the mirror can fail too. `.teamcity`'s `./mvnw clean verify` resolves directly
+ *     from Maven Central at all times; it passed with the mirror healthy (117129934) and failed inside the
+ *     bypass run (117129887), purely as collateral damage from the same throttling.
  */
 
 class Helper(private val providers: ProviderFactory) {

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -42,9 +42,17 @@
  * shared is touched and no other branch is affected:
  *
  *   teamcity run start <buildTypeId> --branch <branch> \
- *     -P env.REPO_MIRROR_URLS="<the real value, with repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
- *     -P gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
- *     -P env.IGNORE_REPO_MIRROR=true
+ *     -P reverse.dep.*.env.REPO_MIRROR_URLS="<real value, repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
+ *     -P reverse.dep.*.gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
+ *     -P reverse.dep.*.env.IGNORE_REPO_MIRROR=true
+ *
+ * The `reverse.dep.*.` prefix is NOT optional on a composite/trigger build. TeamCity does not propagate plain
+ * `-P` parameters to snapshot dependencies, so without it the overrides land only on the trigger build while
+ * every build that actually resolves anything runs against the real mirror - and the run comes back green
+ * having tested nothing. On a leaf build (e.g. `..._Check_CompileAllBuild`) plain `-P` is fine, because there
+ * are no dependencies to propagate to. Verify before trusting a green result:
+ *   teamcity api "/app/rest/builds/id:<a dependency build id>/resulting-properties"
+ * must show env.IGNORE_REPO_MIRROR and the .invalid URLs.
  *
  * `.invalid` is reserved by RFC 6761 and never resolves, so any request that still goes to the "mirror" fails
  * fast and loudly instead of silently succeeding against the real one. Overriding `gradle.plugins.portal.url`

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,17 @@ import org.gradle.api.internal.FeaturePreviews
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
+        // plugin portal URL override that TeamCity injects has to be undone here as well.
+        // See that script for the full runbook.
+        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+            all {
+                if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
+                    setUrl("https://plugins.gradle.org/m2")
+                }
+            }
+        }
     }
     includeBuild("build-logic-settings")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,11 +8,11 @@ import org.gradle.api.internal.FeaturePreviews
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        // Emergency mirror bypass (IGNORE_MIRROR): the plugins {} block below is resolved before
+        // Emergency mirror bypass (IGNORE_REPO_MIRROR): the plugins {} block below is resolved before
         // gradle/shared-with-buildSrc/mirrors.settings.gradle.kts can possibly be applied, so the
         // plugin portal URL override that TeamCity injects has to be undone here as well.
         // See that script for the full runbook.
-        if (System.getenv("IGNORE_MIRROR")?.toBoolean() == true) {
+        if (System.getenv("IGNORE_REPO_MIRROR")?.toBoolean() == true) {
             all {
                 if (name == "Gradle Central Plugin Repository" && this is MavenArtifactRepository) {
                     setUrl("https://plugins.gradle.org/m2")

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -69,7 +69,10 @@ class RepoScriptBlockUtil {
 
         private MirroredRepository(String originalUrl, String mirrorUrl, String type) {
             this.originalUrl = originalUrl
-            this.mirrorUrl = mirrorUrl ?: originalUrl
+            // Belt and braces for the emergency mirror bypass: a stale system property leaking in via
+            // Test Distribution or a cached executer must not be able to defeat IGNORE_MIRROR.
+            // See gradle/shared-with-buildSrc/mirrors.settings.gradle.kts.
+            this.mirrorUrl = isMirrorEnabled() ? (mirrorUrl ?: originalUrl) : originalUrl
             this.type = type
         }
 

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -27,7 +27,7 @@ import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 @CompileStatic
 class RepoScriptBlockUtil {
     static boolean isMirrorEnabled() {
-        return !Boolean.parseBoolean(System.getenv("IGNORE_MIRROR"))
+        return !Boolean.parseBoolean(System.getenv("IGNORE_REPO_MIRROR"))
     }
 
     static String repositoryDefinition(GradleDsl dsl = GROOVY, String type, String name, String url) {
@@ -70,7 +70,7 @@ class RepoScriptBlockUtil {
         private MirroredRepository(String originalUrl, String mirrorUrl, String type) {
             this.originalUrl = originalUrl
             // Belt and braces for the emergency mirror bypass: a stale system property leaking in via
-            // Test Distribution or a cached executer must not be able to defeat IGNORE_MIRROR.
+            // Test Distribution or a cached executer must not be able to defeat IGNORE_REPO_MIRROR.
             // See gradle/shared-with-buildSrc/mirrors.settings.gradle.kts.
             this.mirrorUrl = isMirrorEnabled() ? (mirrorUrl ?: originalUrl) : originalUrl
             this.type = type

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -492,9 +492,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     @Override
     public GradleExecuter usingInitScript(File initScript) {
-        if (RepoScriptBlockUtil.isMirrorEnabled()) {
-            initScripts.add(initScript);
-        }
+        // Must not be gated on IGNORE_MIRROR: this is the public API for every fixture
+        // init script, not just the repository-mirror one. Skip mirrors in withRepositoryMirrors().
+        initScripts.add(initScript);
         return this;
     }
 
@@ -952,12 +952,17 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     @Override
     public GradleExecuter withRepositoryMirrors() {
-        beforeExecute(gradleExecuter -> usingInitScript(RepoScriptBlockUtil.createMirrorInitScript()));
+        if (RepoScriptBlockUtil.isMirrorEnabled()) {
+            beforeExecute(gradleExecuter -> usingInitScript(RepoScriptBlockUtil.createMirrorInitScript()));
+        }
         return this;
     }
 
     @Override
     public GradleExecuter withGlobalRepositoryMirrors() {
+        if (!RepoScriptBlockUtil.isMirrorEnabled()) {
+            return this;
+        }
         beforeExecute(gradleExecuter -> {
             TestFile userHome = testDirectoryProvider.getTestDirectory().file("user-home");
             withGradleUserHomeDir(userHome);

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -492,7 +492,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     @Override
     public GradleExecuter usingInitScript(File initScript) {
-        // Must not be gated on IGNORE_MIRROR: this is the public API for every fixture
+        // Must not be gated on IGNORE_REPO_MIRROR: this is the public API for every fixture
         // init script, not just the repository-mirror one. Skip mirrors in withRepositoryMirrors().
         initScripts.add(initScript);
         return this;


### PR DESCRIPTION
## Problem

`repo.grdev.net` (JFrog Artifactory) is **both** the caching proxy in front of every upstream repository the build declares **and** TeamCity's internal artifact storage. When it goes down, all development stops. During the **2026-09-02 incident** the host was rebuilt and `https://repo.grdev.net/artifactory/` returned HTTP 522 for hours; every CI build failed at dependency resolution.

## Goal: one lever, nothing else

Flipping the single TeamCity parameter **`env.IGNORE_REPO_MIRROR = true`** on the root `Gradle` project must be enough to make a build resolve everything from upstream. No second parameter, no code change, no configuration regeneration. A runbook that says "also flip these other two parameters" is a runbook that gets half-applied at 3am, so the code absorbs the difficulty.

`env.IGNORE_REPO_MIRROR` is deliberately **not** declared in the `.teamcity` Kotlin DSL: a build-configuration-level parameter would outrank the project-level one and block the flip.

`env.REPO_MIRROR_URLS` must stay set while the bypass is on — the reverse mapping reads it to recognise which URLs are mirror URLs.

## Key finding: the switch was already there, and dead

`gradle/shared-with-buildSrc/mirrors.settings.gradle.kts` has declared

```kotlin
fun ignoreMirrors() = providers.environmentVariable("IGNORE_MIRROR").orNull?.toBoolean() == true
```

for years, and **nothing called it**. Its only call site was deleted by PR #17794 / commit `271636d99e8` ("Refine mirror settings", 2021-07-21), which moved the plugin-portal override out of this script and into TeamCity. `IGNORE_MIRROR` kept working for the *test-fixture* layer but has had no effect on the build's own resolution since.

The variable is renamed to `IGNORE_REPO_MIRROR` here: the old name did not say *what* was being ignored, and this switch only ever concerned the repository mirror.

## The hard part: the plugin portal override

`.teamcity/src/main/kotlin/common/CommonExtensions.kt:45` adds

```
-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%
```

to the Gradle command line of essentially every build step, and that parameter is `https://repo.grdev.net/artifactory/gradle-plugin-portal-prod/`. `DefaultBaseRepositoryFactory.java:148` reads it **eagerly** when creating `gradlePluginPortal()`, so the portal repository's URL *is* a grdev URL before any build script sees it.

Two consequences:

1. **Skipping mirroring does not fix it.** So when the switch is on, `withMirrors` does the **inverse** mapping: a repository whose normalized URL equals a known mirror URL from `REPO_MIRROR_URLS` is set back to its upstream URL. One mechanism undoes both this script's own mirroring and the baked-in override, because `gradle-prod-plugins` maps `https://plugins.gradle.org/m2` ↔ the grdev portal URL.

2. **The script cannot be applied early enough.** The root `settings.gradle.kts` `plugins {}` block — and the equivalents in `build-logic`, `build-logic-commons` and `build-logic-settings` — resolve *before* `apply(from = mirrors.settings.gradle.kts)` runs, and the Kotlin DSL forbids placing that apply above a `plugins {}` block. The only hook that runs early enough is inside `pluginManagement { repositories { … } }` itself, so the override is undone there too. **Please don't consolidate that back into the mirrors script — it will silently stop working.**

`build-logic-commons` and `build-logic-settings` never applied the mirrors script at all; they do now.

## Changes

| File | Change |
|---|---|
| `gradle/shared-with-buildSrc/mirrors.settings.gradle.kts` | `ignoreMirrors` as a hoisted `val` (configuration-cache compatible — `providers.environmentVariable`, no `System.getenv`/`setProperty`). Reverse map. Bypass extended to `dependencyResolutionManagement` repositories. Runbook comment covering both the emergency procedure and how to test it. |
| `settings.gradle.kts`, `build-logic/`, `build-logic-commons/`, `build-logic-settings/` settings | Undo the injected portal override inside `pluginManagement { repositories { … } }`. `build-logic-commons` gains an explicit `repositories { gradlePluginPortal() }` — already the implicit default, made explicit so the bypass has something to rewrite. |
| `build-logic/jvm/.../CiEnvironmentProvider.kt` | `collectMirrorUrls()` returns `emptyMap()`. Choke point for the whole test-fixture layer: with no `-Dorg.gradle.integtest.mirrors.*` properties, `RepoScriptBlockUtil.MirroredRepository.mirrorUrl` falls back to `originalUrl`, `mirrorInitScript()` becomes an identity mapping, and `AbstractGradleExecuter` points the nested build's portal override at the real `https://plugins.gradle.org/m2`. |
| `build-logic/performance-testing/.../mirroring-init-script.gradle` | Skip building the mirror map, leaving `mirror()` a no-op. |
| `testing/internal-distribution-testing/.../RepoScriptBlockUtil.groovy` | Belt and braces: use the original URL in the `MirroredRepository` constructor when `isMirrorEnabled()` is false, so a stale system property leaking in via Test Distribution or a cached executer cannot defeat the switch. `getName()`'s `_MIRROR` suffix logic is deliberately **unchanged** — those names appear in test expectations and in `RepositoryMirrorOutputNormalizer`. |
| `testing/internal-integ-testing/.../AbstractGradleExecuter.java` | `usingInitScript()` was gated on `isMirrorEnabled()`, so the switch silently dropped **every** fixture init script rather than just the mirror one. The guard moves to `withRepositoryMirrors()` where it belongs. |

Out of scope, still grdev-pinned and flippable as their own TeamCity parameters if those builds matter: `env.YARNPKG_MIRROR_URL` (JS/docs) and `gradle.internal.repository.url` (publishing only, irrelevant to `check`).

## Testing the bypass while the mirror is healthy

grdev recovered on 2026-09-08, so the switch can no longer be tested by simply flipping it — with a healthy mirror a build passes either way and proves nothing. Simulate an outage per-run instead, so nothing shared is touched and no other branch is affected:

```bash
teamcity run start <buildTypeId> --branch <branch> \
  -P reverse.dep.'*'.env.REPO_MIRROR_URLS="<real value, repo.grdev.net replaced by repo-mirror-outage-test.invalid>" \
  -P reverse.dep.'*'.gradle.plugins.portal.url="https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/" \
  -P reverse.dep.'*'.env.IGNORE_REPO_MIRROR=true
```

**The `reverse.dep.*.` prefix is not optional on a composite/trigger build.** TeamCity does not propagate plain `-P` parameters to snapshot dependencies, so without it the overrides sit on the trigger while every build that actually resolves anything runs against the real mirror — and the run comes back green having tested nothing. That happened on build 117128838: 77,000 tests passed and it was worthless as bypass verification. Plain `-P` is fine on a *leaf* build (e.g. `..._Check_CompileAllBuild`), which have no dependencies to propagate to. Always confirm before trusting a green result:

```bash
teamcity api "/app/rest/builds/id:<a dependency build id>/resulting-properties" \
  | grep -E 'IGNORE_REPO_MIRROR|REPO_MIRROR_URLS|plugins.portal.url'
```

`.invalid` is reserved by RFC 6761 and never resolves, so anything still aimed at the "mirror" fails fast instead of silently succeeding against the real one. Overriding `gradle.plugins.portal.url` matters as much as the mirror list — it is what TeamCity injects as the portal override, and it is the case this PR exists for.

**Run it both ways.** Without the switch the build must FAIL on a `repo-mirror-outage-test.invalid` URL; that is what proves the simulation is faithful.

## Verification

### CI A/B, simulated outage — the primary evidence

Same build config (`Gradle_Master_Check_CompileAllBuild`), same branch, same agent pool, `env.IGNORE_REPO_MIRROR` the only variable:

| Build | `env.IGNORE_REPO_MIRROR` | Result |
|---|---|---|
| [117128279](https://builds.gradle.org/build/117128279) | unset | **FAILURE** |
| [117128278](https://builds.gradle.org/build/117128278) | `true` | **SUCCESS** · https://ge.gradle.org/s/y5vw4guq54rsu |

The control's failure names the black-holed portal explicitly:

```
Plugin [id: 'org.gradle.kotlin.kotlin-dsl', version: '6.7.6'] was not found in any of the following sources:
  Searched in the following repositories:
    maven(https://repo-mirror-outage-test.invalid/artifactory/enterprise-libs-release-candidates-local/)
    Gradle Central Plugin Repository(https://repo-mirror-outage-test.invalid/artifactory/gradle-plugin-portal-prod/)
```

The control failing is what makes the pass meaningful — it rules out the success coming from warm agent caches, since the same resolution demonstrably needed the network on the same pool.

### CI during the real outage

[116950940](https://builds.gradle.org/build/116950940) ran against the genuinely dead Artifactory with the switch on: **81,763 tests passed**, and across 400 sampled failures **zero** mentions of `grdev` and 2 `Could not resolve`.

### Local, cold isolated `GRADLE_USER_HOME`

| Scenario | Result |
|---|---|
| Real outage, before the fix | FAILED on `repo.grdev.net/.../gradle-plugin-portal-prod/...` 522 · https://ge.gradle.org/s/vbgc5xoechzoc |
| Real outage, with the switch | `BUILD SUCCESSFUL`, `grep -c grdev` = **0** · https://ge.gradle.org/s/thhpdmddhhkki |
| Simulated outage, no switch | FAILED on the `.invalid` portal URL |
| Simulated outage, with switch | `BUILD SUCCESSFUL`, 0 `.invalid` refs, **0 grdev refs** · https://ge.gradle.org/s/gdactj372f7a4 |
| No env vars (non-CI path) | `BUILD SUCCESSFUL` · https://ge.gradle.org/s/ncb2vq5inbu5c |

The zero-grdev count in the fourth row matters: with the real mirror back online, a broken switch could have passed by quietly falling back to it. It did not.

### In progress

A full `Gradle_Xperimental_Check_Stage_PullRequestFeedback_Trigger` run under simulated outage — [117128838](https://builds.gradle.org/build/117128838) — is measuring the whole test suite with the init-script fix in place. Result to follow as a comment.

### Not verified

A **positive** end-to-end run through the mirrors was never captured, because grdev was down for the whole development window. The mirror-enabled path is verified only indirectly, by the baseline run rewriting `https://plugins.gradle.org/m2` → grdev and failing against it. Now that grdev is healthy, an ordinary green build on this branch with no overrides covers it.

## Known limitation: upstream capacity is the real ceiling

This is the most important operational finding, and it is a capacity limit rather than a correctness one.

With the bypass on there is no caching proxy in front of anything — every agent fetches straight from `repo.maven.apache.org`, `plugins.gradle.org` and `repo.gradle.org`. At full-stage scale that gets the fleet throttled. Measured on [117129908](https://builds.gradle.org/build/117129908) (Quick Feedback - Linux Only, ~166 agents, simulated outage with overrides correctly propagated):

```
CompileAllBuild (117129884):
  HttpErrorStatusCodeException: Received status code 429 from server: Too Many Requests
  repo-mirror-outage-test.invalid refs: 0    grdev refs: 0
```

That one failure cascaded into **24 failed builds**. A lone artifact fetch can also just time out — `Could not GET ... > Read timed out` against `repo.gradle.org/gradle/public` on [116950940](https://ge.gradle.org/s/gs6zvv2w5phkq).

**In both cases the URLs had already been rewritten correctly to upstream, with zero grdev requests.** The switch worked; upstream cannot absorb what the mirror normally absorbs.

What to plan for during a real outage:

- **Do not expect a full `check` to pass.** Run reduced scope, and retry before concluding there is a regression.
- **Builds that never touched the mirror can fail too.** `.teamcity`'s `./mvnw clean verify` resolves directly from Maven Central at all times (hardcoded in `.teamcity/pom.xml` and the Maven wrapper; no mirror reference anywhere). It passed with the mirror healthy ([117129934](https://builds.gradle.org/build/117129934)) and failed inside the bypass run ([117129887](https://builds.gradle.org/build/117129887)) purely as collateral damage from the same throttling. This is *not* a coverage gap — that build never used the mirror.

## Corrections to earlier revisions of this description

- An earlier version attributed build 116950940's 459 test failures to a pre-existing master problem (`Cannot create a NativeToolChain named 'gcc'`). **That was wrong.** The cause was `usingInitScript()` being gated on `isMirrorEnabled()`, so the switch dropped every fixture init script — which is why the failures clustered in toolchain and progress-logging tests. Fixed in `58895e7809a`. The reasoning behind the wrong call ("the test file is unchanged and this branch does not touch `platforms/native`") was factually true but did not support the conclusion: the test was unchanged while its environment changed.
- The switch's own correctness evidence — zero grdev references — is unaffected by that error.
- An earlier revision presented build 117128838 as closing the verification gap. It did not: the `-P` overrides were not prefixed `reverse.dep.*`, so they never reached the work builds and the entire run executed against the real, healthy mirror. Caught only because a `repo.grdev.net` URL appeared in a nested build's command line where `.invalid` was expected. The recipe above is corrected, and the earlier leaf-build A/B (117128278 / 117128279) is unaffected because leaf builds have no dependencies to propagate to.
- An earlier revision described the `.teamcity` Maven failure as a gap in the switch's coverage. It is not — that build resolves directly from Maven Central at all times and never used the mirror. It was collateral damage from bypass-induced throttling.
