### PR TITLE
Keep the version constraint of a plugin from a version catalog

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
@@ -103,6 +103,7 @@ class PluginsInterpretationSequenceStep(
                     if (it.versionIsSet) it.version else null,
                     null,
                     null,
+                    null,
                     null
                 )
             }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
@@ -87,7 +87,8 @@ public class GradleEnterpriseAutoAppliedPluginRegistry implements AutoAppliedPlu
             versionToApply,
             selector,
             null,
-            gradleEnterprisePluginCoordinates(versionToApply)
+            gradleEnterprisePluginCoordinates(versionToApply),
+            null
         );
     }
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
@@ -49,7 +49,8 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             targetPluginRequest.getVersion(),
             USE_MODULE_NOTATION_PARSER.parseNotation(notation),
             targetPluginRequest,
-            targetPluginRequest.getAlternativeCoordinates().orElse(null)
+            targetPluginRequest.getAlternativeCoordinates().orElse(null),
+            null
         );
     }
 
@@ -64,7 +65,8 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             version,
             targetPluginRequest.getSelector(),
             targetPluginRequest,
-            targetPluginRequest.getAlternativeCoordinates().orElse(null)
+            targetPluginRequest.getAlternativeCoordinates().orElse(null),
+            null
         );
     }
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -24,6 +24,8 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.dsl.DependencyFactory;
@@ -120,15 +122,21 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
         }
 
         private void visitDependency(PluginResolutionVisitor visitor, ModuleIdentifier module) {
-            ExternalModuleDependency dependency = dependencyFactory.create(module.getGroup(), module.getName(), null);
-            dependency.version(version -> {
-                if (useWeakVersion) {
-                    version.prefer(getPluginVersion());
-                } else {
-                    version.require(getPluginVersion());
-                }
-            });
+            ExternalModuleDependency dependency =
+                dependencyFactory.create(module.getGroup(), module.getName(), null);
+            dependency.version(this::applyRequestedVersion);
             visitor.visitDependency(dependency);
+        }
+
+        private void applyRequestedVersion(MutableVersionConstraint version) {
+            VersionConstraint requested = pluginRequest.getVersionConstraint();
+            if (useWeakVersion) {
+                version.prefer(getPluginVersion());
+            } else if (requested != null) {
+                copyInto(requested, version);
+            } else {
+                version.require(getPluginVersion());
+            }
         }
 
         private static void visitModuleReplacements(PluginResolutionVisitor visitor, PluginCoordinates altCoords, String id, ModuleIdentifier module) {
@@ -188,12 +196,34 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
 
     private ModuleDependency getMarkerDependency(PluginRequestInternal pluginRequest) {
         ComponentSelector selector = pluginRequest.getSelector();
-        if (!(selector instanceof ModuleComponentSelector)) {
-            String id = pluginRequest.getId().getId();
-            return getDependencyFactory().create(id, id + PLUGIN_MARKER_SUFFIX, pluginRequest.getVersion());
-        } else {
+        if (selector instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleSelector = (ModuleComponentSelector) selector;
             return getDependencyFactory().create(moduleSelector.getGroup(), moduleSelector.getModule(), moduleSelector.getVersion());
+        }
+        String id = pluginRequest.getId().getId();
+        VersionConstraint versionConstraint = pluginRequest.getVersionConstraint();
+        ExternalModuleDependency marker = getDependencyFactory().create(
+            id, id + PLUGIN_MARKER_SUFFIX, versionConstraint == null ? pluginRequest.getVersion() : null
+        );
+        if (versionConstraint != null) {
+            marker.version(version -> copyInto(versionConstraint, version));
+        }
+        return marker;
+    }
+
+    private static void copyInto(VersionConstraint source, MutableVersionConstraint target) {
+        if (!source.getStrictVersion().isEmpty()) {
+            target.strictly(source.getStrictVersion());
+        } else if (!source.getRequiredVersion().isEmpty()) {
+            target.require(source.getRequiredVersion());
+        }
+        if (!source.getPreferredVersion().isEmpty()) {
+            target.prefer(source.getPreferredVersion());
+        }
+        target.setBranch(source.getBranch());
+        // Every version setter clears the rejects, so this one has to come last.
+        if (!source.getRejectedVersions().isEmpty()) {
+            target.reject(source.getRejectedVersions().toArray(new String[0]));
         }
     }
 

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/management/internal/DefaultPluginResolutionStrategyTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/management/internal/DefaultPluginResolutionStrategyTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.plugin.management.internal
 
+import org.gradle.api.artifacts.MutableVersionConstraint
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.invocation.Gradle
 import org.gradle.internal.InternalBuildAdapter
 import org.gradle.internal.event.ListenerManager
@@ -41,7 +43,15 @@ class DefaultPluginResolutionStrategyTest extends Specification {
     }
 
     private PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(DefaultPluginId.of(id), true, PluginRequestInternal.Origin.OTHER, "test", 1, version, null, null, null)
+        new DefaultPluginRequest(DefaultPluginId.of(id), true, PluginRequestInternal.Origin.OTHER, "test", 1, version, null, null, null, null)
+    }
+
+    private PluginRequestInternal aliasRequest(String id, @DelegatesTo(MutableVersionConstraint) Closure<?> version = {}) {
+        def constraint = new DefaultMutableVersionConstraint("")
+        version.delegate = constraint
+        version.resolveStrategy = Closure.DELEGATE_FIRST
+        version.call()
+        new DefaultPluginRequest(DefaultPluginId.of(id), true, PluginRequestInternal.Origin.OTHER, "test", 1, null, null, null, null, constraint)
     }
 
     def "applies a default version set before projects are loaded"() {
@@ -77,5 +87,40 @@ class DefaultPluginResolutionStrategyTest extends Specification {
         then:
         def e = thrown(IllegalArgumentException)
         e.message == "Cannot provide multiple default versions for the same plugin."
+    }
+
+    def "useVersion drops the constraint that came from a catalog"() {
+        given:
+        strategy.eachPlugin { it.useVersion("1.0") }
+
+        when:
+        def target = strategy.applyTo(aliasRequest("org.example") {prefer "2.0"})
+
+        then:
+        target.version == "1.0"
+        target.versionConstraint == null
+    }
+
+    def "useModule drops the constraint that came from a catalog"() {
+        given:
+        strategy.eachPlugin { it.useModule("org.example:plugin:1.0") }
+
+        when:
+        def target = strategy.applyTo(aliasRequest("org.example") {prefer "2.0"})
+
+        then:
+        target.versionConstraint == null
+    }
+
+    def "a default version wins over a preferred version from a catalog"() {
+        given:
+        strategy.setDefaultPluginVersion(DefaultPluginId.of("org.example"), "1.0")
+
+        when:
+        def target = strategy.applyTo(aliasRequest("org.example") {prefer "2.0"})
+
+        then:
+        target.version == "1.0"
+        target.versionConstraint == null
     }
 }

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
@@ -45,7 +45,7 @@ class CorePluginResolverTest extends Specification {
     def resolver = new CorePluginResolver(docRegistry, pluginRegistry)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(DefaultPluginId.of(id), true, PluginRequestInternal.Origin.OTHER, "source display name", 1, version, null, null, null)
+        new DefaultPluginRequest(DefaultPluginId.of(id), true, PluginRequestInternal.Origin.OTHER, "source display name", 1, version, null, null, null, null)
     }
 
     def "non core plugins are ignored"() {
@@ -96,7 +96,7 @@ class CorePluginResolverTest extends Specification {
 
     def "cannot have custom artifact"() {
         when:
-        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), true, PluginRequestInternal.Origin.OTHER, "test", 1, null, Mock(ModuleComponentSelector), null, null))
+        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), true, PluginRequestInternal.Origin.OTHER, "test", 1, null, Mock(ModuleComponentSelector), null, null, null))
 
         then:
         1 * pluginRegistry.lookup(DefaultPluginId.of("foo")) >> impl

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsGroovyDSLIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsGroovyDSLIntegrationTest.groovy
@@ -21,9 +21,44 @@ import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
 import org.junit.Rule
 
 class CatalogPluginsGroovyDSLIntegrationTest extends AbstractVersionCatalogIntegrationTest {
+
+    private static final String PLUGIN_ID = 'com.acme.greeter'
+    private static final String PLUGIN_VERSION = '1.5'
+    private static final String TASK_NAME = 'greet'
+    private static final String MESSAGE = 'Hello from plugin!'
+
     @Rule
     final MavenHttpPluginRepository pluginPortal = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
 
+    private publishGreeter(String version = PLUGIN_VERSION, String message = MESSAGE) {
+        new PluginBuilder(file("greeter-$version"))
+            .addPluginWithPrintlnTask(TASK_NAME, message, PLUGIN_ID)
+            .publishAs("some", "artifact$version", version, pluginPortal, executer)
+    }
+
+    private void publishGreeterVersions(Map<String, String> messagesByVersion) {
+        messagesByVersion.each { version, message -> publishGreeter(version, message).allowAll() }
+        pluginPortal.getModuleMetaData(PLUGIN_ID, PLUGIN_ID + ".gradle.plugin").allowGetOrHead()
+    }
+
+    private void catalogWith(String declaration) {
+        file("settings.gradle") << """
+        dependencyResolutionManagement {
+            versionCatalogs {
+                libs {
+                    plugin('greeter', '$PLUGIN_ID').$declaration
+                }
+            }
+        }"""
+    }
+
+    private void applyGreeter(String path = "build.gradle") {
+        file(path) << """
+            plugins {
+                alias(libs.plugins.greeter)
+            }
+        """
+    }
 
     def "can apply a plugin declared in a catalog"() {
         String taskName = 'greet'
@@ -242,4 +277,88 @@ dependencyResolutionManagement {
         alias << ['greeter', 'some.greeter', 'some-greeter']
     }
 
+    def "resolves a plugin declared with a rich version [#declaration]"() {
+
+        given:
+        def plugin = publishGreeter()
+        catalogWith(declaration)
+        applyGreeter()
+
+        when:
+        plugin.allowAll()
+        succeeds(TASK_NAME)
+
+        then:
+        outputContains MESSAGE
+
+        where:
+        declaration << [
+            "version { prefer '$PLUGIN_VERSION' }",
+            "version { strictly '$PLUGIN_VERSION' }",
+            "version { require '$PLUGIN_VERSION'; prefer '$PLUGIN_VERSION' }",
+            "version { require '$PLUGIN_VERSION'; reject '1.4' }",
+            "version { require '$PLUGIN_VERSION'; branch = 'main' }",
+        ]
+    }
+
+    def "a preferred version does not clash with a plugin already on the classpath"() {
+        given:
+        def plugin = publishGreeter()
+        catalogWith("version { prefer '1.4' }")
+        file("settings.gradle") << "\ninclude 'sub'"
+        buildFile << """
+            plugins {
+                id '$PLUGIN_ID' version '$PLUGIN_VERSION' apply false
+            }
+        """
+        applyGreeter("sub/build.gradle")
+
+        when:
+        plugin.allowAll()
+        succeeds(":sub:$TASK_NAME")
+
+        then:
+        outputContains MESSAGE
+    }
+
+    def "a plugin alias without a version is not reported with an empty version"() {
+        given:
+        file("gradle/libs.versions.toml") << """
+            [plugins]
+            greeter = { id = "$PLUGIN_ID" }
+        """
+        applyGreeter()
+
+        when:
+        fails 'help'
+
+        then:
+        failure.assertHasDescription("Plugin [id: '$PLUGIN_ID'] was not found")
+    }
+
+    def "a preferred version is honoured inside the range the catalog requires"() {
+        given:
+        publishGreeterVersions(['1.4': 'Greetings from 1.4', '1.5': 'Greetings from 1.5', '1.6': 'Greetings from 1.6'])
+        catalogWith("version { require '[1.0,2.0)'; prefer '1.5' }")
+        applyGreeter()
+
+        when:
+        succeeds(TASK_NAME)
+
+        then:
+        outputContains 'Greetings from 1.5'
+    }
+
+    def "a rejected version is not selected from the range the catalog requires"() {
+        given:
+        publishGreeterVersions(['1.4': 'Greetings from 1.4', '1.5': 'Greetings from 1.5', '1.6': 'Greetings from 1.6'])
+        catalogWith("version { require '[1.0,2.0)'; reject '1.6' }")
+        applyGreeter()
+
+        when:
+        succeeds(TASK_NAME)
+
+        then:
+        outputContains 'Greetings from 1.5'
+    }
 }

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
@@ -146,7 +146,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
 
         return PluginRequests.of(
             requests.stream()
-                .map(original -> new DefaultPluginRequest(DefaultPluginId.of(original.getId()), true, PluginRequestInternal.Origin.AUTO_APPLIED, null, null, null, null, null, null))
+                .map(original -> new DefaultPluginRequest(DefaultPluginId.of(original.getId()), true, PluginRequestInternal.Origin.AUTO_APPLIED, null, null, null, null, null, null, null))
                 .collect(Collectors.toList())
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -17,6 +17,7 @@
 package org.gradle.plugin.management.internal;
 
 import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
@@ -37,6 +38,7 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final @Nullable PluginRequest originalRequest;
     private final Origin origin;
     private final @Nullable PluginCoordinates alternativeCoordinates;
+    private final @Nullable VersionConstraint versionConstraint;
 
     public DefaultPluginRequest(
         PluginId id,
@@ -47,7 +49,8 @@ public class DefaultPluginRequest implements PluginRequestInternal {
         @Nullable String version,
         @Nullable ComponentSelector selector,
         @Nullable PluginRequest originalRequest,
-        @Nullable PluginCoordinates alternativeCoordinates
+        @Nullable PluginCoordinates alternativeCoordinates,
+        @Nullable VersionConstraint versionConstraint
     ) {
         this.id = id;
         this.version = version;
@@ -58,6 +61,7 @@ public class DefaultPluginRequest implements PluginRequestInternal {
         this.originalRequest = originalRequest;
         this.origin = origin;
         this.alternativeCoordinates = alternativeCoordinates;
+        this.versionConstraint = versionConstraint;
     }
 
     @Override
@@ -111,8 +115,9 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     public String getDisplayName() {
         StringBuilder b = new StringBuilder();
         b.append("[id: '").append(id).append("'");
-        if (version != null) {
-            b.append(", version: '").append(version).append("'");
+        String requestedVersion = versionConstraint == null ? version : versionConstraint.getDisplayName();
+        if (requestedVersion != null && !requestedVersion.isEmpty()) {
+            b.append(", version: '").append(requestedVersion).append("'");
         }
         if (selector != null) {
             b.append(", artifact: '").append(selector).append("'");
@@ -139,5 +144,11 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     @Override
     public Optional<PluginCoordinates> getAlternativeCoordinates() {
         return Optional.ofNullable(alternativeCoordinates);
+    }
+
+    @Nullable
+    @Override
+    public VersionConstraint getVersionConstraint() {
+        return versionConstraint;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
@@ -16,6 +16,7 @@
 
 package org.gradle.plugin.management.internal;
 
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.plugin.management.PluginRequest;
 import org.jspecify.annotations.Nullable;
 
@@ -43,5 +44,15 @@ public interface PluginRequestInternal extends PluginRequest {
     enum Origin {
         AUTO_APPLIED,
         OTHER
+    }
+
+    /**
+     * The whole constraint when the request came from a version catalog, otherwise null.
+     * {@link #getVersion()} then carries only its required version, which a constraint
+     * built from {@code prefer} alone does not have.
+     */
+    @Nullable
+    default VersionConstraint getVersionConstraint() {
+        return null;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -18,6 +18,8 @@ package org.gradle.plugin.use.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.provider.Provider;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.plugin.internal.InvalidPluginIdException;
@@ -28,8 +30,10 @@ import org.gradle.plugin.management.internal.InvalidPluginRequestException;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 import org.gradle.plugin.use.PluginDependenciesSpec;
+import org.gradle.plugin.use.PluginDependency;
 import org.gradle.plugin.use.PluginDependencySpec;
 import org.gradle.plugin.use.PluginId;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -71,7 +75,11 @@ public class PluginRequestCollector {
     @VisibleForTesting
     List<PluginRequestInternal> listPluginRequests() {
         List<PluginRequestInternal> pluginRequests = collect(specs, original ->
-            new DefaultPluginRequest(original.id, original.apply, PluginRequestInternal.Origin.OTHER, scriptSource.getDisplayName(), original.lineNumber, original.version, null, null, null)
+            new DefaultPluginRequest(
+                original.id, original.apply, PluginRequestInternal.Origin.OTHER,
+                scriptSource.getDisplayName(), original.lineNumber, original.version,
+                null, null, null, original.versionConstraint
+            )
         );
 
         Map<PluginId, List<PluginRequestInternal>> groupedById = pluginRequests.stream().collect(groupingBy(PluginRequest::getId, Collectors.toList()));
@@ -99,14 +107,20 @@ public class PluginRequestCollector {
         }
 
         @Override
-        public PluginDependencySpec id(String id) {
+        public PluginDependencySpecImpl id(String id) {
             return id(id, blockLineNumber);
         }
 
-        public PluginDependencySpec id(String id, int requestLineNumber) {
+        public PluginDependencySpecImpl id(String id, int requestLineNumber) {
             PluginDependencySpecImpl spec = new PluginDependencySpecImpl(id, requestLineNumber);
             specs.add(spec);
             return spec;
+        }
+
+        @Override
+        public PluginDependencySpec alias(Provider<PluginDependency> notation) {
+            PluginDependency dependency = notation.get();
+            return id(dependency.getPluginId()).fromCatalog(dependency.getVersion());
         }
     }
 
@@ -115,6 +129,7 @@ public class PluginRequestCollector {
         private String version;
         private boolean apply;
         private final int lineNumber;
+        private @Nullable VersionConstraint versionConstraint;
 
         private PluginDependencySpecImpl(String id, int lineNumber) {
             if (Strings.isNullOrEmpty(id)) {
@@ -131,6 +146,7 @@ public class PluginRequestCollector {
                 throw new InvalidPluginVersionException(version, EMPTY_VALUE);
             }
             this.version = version;
+            this.versionConstraint = null;
             return this;
         }
 
@@ -139,6 +155,14 @@ public class PluginRequestCollector {
             this.apply = apply;
             return this;
         }
-    }
 
+        PluginDependencySpecImpl fromCatalog(VersionConstraint constraint) {
+            this.versionConstraint = constraint;
+            // A preferred version stays out of here: everything downstream reads this field as
+            // a version the user asked for, and a preference is not one.
+            String required = constraint.getRequiredVersion();
+            this.version = required.isEmpty() ? null : required;
+            return this;
+        }
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestCollectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/plugin/use/internal/PluginRequestCollectorTest.groovy
@@ -17,10 +17,15 @@
 package org.gradle.plugin.use.internal
 
 
+import org.gradle.api.artifacts.MutableVersionConstraint
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.dependencies.DefaultPluginDependency
+import org.gradle.api.internal.provider.Providers
 import org.gradle.groovy.scripts.TextResourceScriptSource
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.resource.StringTextResource
 import org.gradle.plugin.management.internal.InvalidPluginRequestException
+import org.gradle.plugin.management.internal.PluginRequestInternal
 import org.gradle.plugin.use.PluginDependenciesSpec
 import spock.lang.Specification
 
@@ -36,6 +41,21 @@ class PluginRequestCollectorTest extends Specification {
         }.collect {
             [id: it.id.id, version: it.version]
         }
+    }
+
+    List<PluginRequestInternal> requests(@DelegatesTo(PluginDependenciesSpec) Closure<?> closure) {
+        new PluginRequestCollector(scriptSource).with {
+            createSpec(LINE_NUMBER).with(closure)
+            listPluginRequests()
+        }
+    }
+
+    private static def catalogEntry(String id, @DelegatesTo(MutableVersionConstraint) Closure<?> version = {}) {
+        def constraint = new DefaultMutableVersionConstraint("")
+        version.delegate = constraint
+        version.resolveStrategy = Closure.DELEGATE_FIRST
+        version.call()
+        Providers.of(new DefaultPluginDependency(id, constraint))
     }
 
     def "can use spec dsl to build one request"() {
@@ -77,4 +97,44 @@ class PluginRequestCollectorTest extends Specification {
         e.cause instanceof InvalidPluginRequestException
     }
 
+    def "alias keeps the whole version constraint"() {
+        when:
+        def constraint = requests {
+            alias(catalogEntry("foo") {
+                require "[1.0,)"
+                prefer "1.5"
+                reject "1.2"
+            })
+        }.first().versionConstraint
+
+        then:
+        constraint.requiredVersion == "[1.0,)"
+        constraint.preferredVersion == "1.5"
+        constraint.rejectedVersions == ["1.2"]
+    }
+
+    def "a preferred version is not reported as the requested version"() {
+        when:
+        def request = requests { alias(catalogEntry("foo") { prefer "1.5" }) }.first()
+
+        then:
+        request.version == null
+        request.versionConstraint.preferredVersion == "1.5"
+    }
+
+    def "an explicit version replaces the constraint from the catalog"() {
+        when:
+        def request = requests {
+            alias(catalogEntry("foo") { require "[1.0,)"; prefer "1.5" }).version("2.0")
+        }.first()
+
+        then:
+        request.version == "2.0"
+        request.versionConstraint == null
+    }
+
+    def "a catalog entry without a version is not displayed as an empty version"() {
+        expect:
+        requests { alias(catalogEntry("foo")) }.first().displayName == "[id: 'foo']"
+    }
 }


### PR DESCRIPTION
Fixes #27208

### Context

A plugin taken from a version catalog keeps only its required version. `prefer`, `strictly`, `reject` and `branch` are dropped before the request is built, and nothing warns. The same constraint on a library works, so the two diverge inside one build.

`settings.gradle`

```groovy
plugin("spotless", "com.diffplug.spotless").version {
    require "[6.12.0,)"
    prefer "6.22.0"
}
```

`buildEnvironment` on Gradle 9.3.1, then on a distribution built from this branch.

require `[6.12.0,)` + prefer `6.22.0`

```
before  com.diffplug.spotless.gradle.plugin:[6.12.0,) -> 8.10.1
after   com.diffplug.spotless.gradle.plugin:{require [6.12.0,); prefer 6.22.0} -> 6.22.0
```

prefer `6.22.0` alone

```
before  Plugin [id: 'com.diffplug.spotless', apply: false] was not found
after   com.diffplug.spotless.gradle.plugin:{prefer 6.22.0} -> 6.22.0
```

require `[6.12.0,)` + reject `8.10.1`

```
before  com.diffplug.spotless.gradle.plugin:[6.12.0,) -> 8.10.1
after   com.diffplug.spotless.gradle.plugin:{require [6.12.0,); reject 8.10.1} -> 8.10.0
```

The `prefer`-alone failure is not in the issue: with no required version the request goes out with no version at all.

### Cause

`PluginDependenciesSpec.alias` reads one field of five, because `PluginDependencySpec.version` takes a `String` and a constraint cannot pass through it.

### Implementation

`PluginRequestCollector` overrides `alias` and keeps the whole `VersionConstraint` on the request. `ArtifactRepositoriesPluginResolver` copies it onto the marker dependency and onto the dependency that reaches the buildscript classpath. Nothing public changed: the specs are private nested classes, the request types are internal, and the resolver already takes the internal type. Both Kotlin DSL paths reuse the same collector.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :core:quickTest :plugin-use:quickTest :dependency-management:quickTest`.