### PR TITLE
Document the Gradle Plugin Portal mirrorOf id

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
@@ -92,7 +92,7 @@ This is an incubating feature and is disabled by default.
 Organizations that already build with Maven often use an internal
 repository manager by declaring a `<mirror>` in `~/.m2/settings.xml`. Gradle can read those same mirrors instead of requiring the configuration to be duplicated in your build. This is meant for teams with a working Maven mirror setup to reuse those mirrors in Gradle. This is not a general-purpose way to redirect repositories.
 
-Gradle will only replace HTTP/HTTPS Maven repositories that match mirror declarations in Maven settings. Local file, S3, GCS and Ivy repositories are unaffected. Maven repositories can be used for build script dependencies as well as project dependencies, so the Gradle Plugin Portal is also affected by Maven mirrors.
+Gradle will only replace HTTP/HTTPS Maven repositories that match mirror declarations in Maven settings. Local file, S3, GCS and Ivy repositories are unaffected. Maven repositories can be used for build script dependencies as well as project dependencies, so the Gradle Plugin Portal is also affected by Maven mirrors; see <<sec:maven-mirror-ids,which id a repository is matched by>> to mirror it or leave it alone.
 
 If you are not already using mirrors defined in
 Maven's `settings.xml`, prefer configuring repositories directly in your build or setting up a mirror init script, as described in
@@ -131,6 +131,54 @@ include::sample[dir="snippets/reference/dependency-management/declaring-reposito
 See link:https://maven.apache.org/guides/mini/guide-encryption.html[Maven's Password Encryption
 guide] for how to set up the Maven master password and produce encrypted server passwords, and
 link:https://maven.apache.org/settings.html[the Settings Reference] for the file as a whole.
+
+[[sec:maven-mirror-ids]]
+=== Which id a repository is matched by
+
+A `mirrorOf` pattern matches repository *ids*, never URLs. Gradle repositories do not have Maven
+ids, so Gradle matches each repository by:
+
+* `central`, if the repository URL is Maven Central's. This is the id Maven's Super POM gives that
+  URL, so an existing `<mirrorOf>central</mirrorOf>` keeps working for `mavenCentral()`.
+* the repository's Gradle name, for every other repository. This is the name set with
+  `name =` in the repository block, or the default name Gradle assigns.
+
+The Gradle Plugin Portal is matched by the name `gradlePluginPortal()` gives it, `Gradle Central
+Plugin Repository`. Spaces are part of the id, and the match is exact:
+
+.Mirroring only the Gradle Plugin Portal
+[source,xml]
+----
+<mirror>
+    <id>portal-mirror</id>
+    <mirrorOf>Gradle Central Plugin Repository</mirrorOf>
+    <url>https://repo.example.com/gradle-plugins</url>
+</mirror>
+----
+
+.Mirroring everything except the Gradle Plugin Portal
+[source,xml]
+----
+<mirror>
+    <id>corp-mirror</id>
+    <mirrorOf>*,!Gradle Central Plugin Repository</mirrorOf>
+    <url>https://repo.example.com/maven</url>
+</mirror>
+----
+
+A `!` token excludes a repository whatever its position in the pattern, so
+`!Gradle Central Plugin Repository,*` behaves the same way.
+
+[NOTE]
+====
+`external:*` matches the Gradle Plugin Portal, because the portal is neither `localhost` nor a
+`file` URL. An `external:*` mirror needs the same `!` exclusion as `*` if the portal should not be
+mirrored.
+====
+
+Maven's `mirrorOf` grammar has no partial globs, so a repository cannot be matched by part of its
+name or by its host: `*Plugin*` and `plugins.gradle.org` match nothing. A pattern is split on
+commas and each token is trimmed, so a name containing a comma cannot be matched at all.
 
 [[sec:maven-mirrors-and-publishing]]
 === Publishing is not affected

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
@@ -135,16 +135,12 @@ link:https://maven.apache.org/settings.html[the Settings Reference] for the file
 [[sec:maven-mirror-ids]]
 === Which id a repository is matched by
 
-A `mirrorOf` pattern matches repository *ids*, never URLs. Gradle repositories do not have Maven
-ids, so Gradle matches each repository by:
+A `mirrorOf` pattern matches repository *ids*. Gradle repositories do not have Maven ids, so Gradle matches each repository by name. This is the name set with `name =` in the repository block or the default name Gradle assigns.
 
-* `central`, if the repository URL is Maven Central's. This is the id Maven's Super POM gives that
-  URL, so an existing `<mirrorOf>central</mirrorOf>` keeps working for `mavenCentral()`.
-* the repository's Gradle name, for every other repository. This is the name set with
-  `name =` in the repository block, or the default name Gradle assigns.
+Maven Central is treated special. Maven uses the id `central` for Maven Central, so Gradle will match a repository with Maven Central's URL as if its name is `central`.
 
-The Gradle Plugin Portal is matched by the name `gradlePluginPortal()` gives it, `Gradle Central
-Plugin Repository`. Spaces are part of the id, and the match is exact:
+The Gradle Plugin Portal is matched by the name `Gradle Central
+Plugin Repository`. Spaces are part of the name, and the match must be exact:
 
 .Mirroring only the Gradle Plugin Portal
 [source,xml]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSettingsMirrorIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSettingsMirrorIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.resolve.maven
 
+import org.gradle.api.internal.artifacts.BaseRepositoryFactory
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.server.http.AuthScheme
@@ -194,6 +195,104 @@ class MavenSettingsMirrorIntegrationTest extends AbstractHttpDependencyResolutio
         run 'retrieve'
 
         then:
+        file('libs').assertHasDescendants('projectA-1.0.jar')
+    }
+
+    def "mirrorOf matches the gradle plugin portal by its repository name"() {
+        given: "the portal is redirected at a local repository that is never served"
+        def portalRepo = mavenHttpRepo("portal")
+        def mirrorRepo = mavenHttpRepo("mirror")
+        def module = mirrorRepo.module("org.test", "projectA", "1.0").publish()
+        writeMirrorSettings(mirrorRepo.uri.toString(), "Gradle Central Plugin Repository", "portal-mirror")
+
+        buildFile << """
+            repositories {
+                gradlePluginPortal()
+            }
+        """
+
+        and:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+
+        when:
+        using m2
+        executer.withArguments(
+            "-D${BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${portalRepo.uri}",
+            "-Dorg.gradle.mirror.maven.settings=true")
+        run 'retrieve'
+
+        then: "the portal is matched by the name gradlePluginPortal() gives it"
+        file('libs').assertHasDescendants('projectA-1.0.jar')
+    }
+
+    def "a negated mirrorOf token excludes the gradle plugin portal from a wildcard mirror"() {
+        given:
+        def portalRepo = mavenHttpRepo("portal")
+        def mirrorRepo = mavenHttpRepo("mirror")
+        def module = portalRepo.module("org.test", "projectA", "1.0").publish()
+        // The mirror is never served, so the build fails if the portal is mirrored after all
+        mirrorRepo.module("org.test", "projectA", "1.0").publish()
+        writeMirrorSettings(mirrorRepo.uri.toString(), "*,!Gradle Central Plugin Repository", "portal-mirror")
+
+        buildFile << """
+            repositories {
+                gradlePluginPortal()
+            }
+        """
+
+        and:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+
+        when:
+        using m2
+        executer.withArguments(
+            "-D${BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${portalRepo.uri}",
+            "-Dorg.gradle.mirror.maven.settings=true")
+        run 'retrieve'
+
+        then: "the negated token wins over the wildcard, so the portal url is used"
+        file('libs').assertHasDescendants('projectA-1.0.jar')
+    }
+
+    def "mirrorOf tolerates surrounding whitespace around an id containing spaces"() {
+        given:
+        def portalRepo = mavenHttpRepo("portal")
+        def mirrorRepo = mavenHttpRepo("mirror")
+        def module = mirrorRepo.module("org.test", "projectA", "1.0").publish()
+        m2.userSettingsFile.text = """
+            <settings>
+                <mirrors>
+                    <mirror>
+                        <id>portal-mirror</id>
+                        <mirrorOf>
+                            Gradle Central Plugin Repository
+                        </mirrorOf>
+                        <url>${mirrorRepo.uri}</url>
+                    </mirror>
+                </mirrors>
+            </settings>
+        """
+
+        buildFile << """
+            repositories {
+                gradlePluginPortal()
+            }
+        """
+
+        and:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+
+        when:
+        using m2
+        executer.withArguments(
+            "-D${BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${portalRepo.uri}",
+            "-Dorg.gradle.mirror.maven.settings=true")
+        run 'retrieve'
+
+        then: "the settings reader trims the element, internal spaces are kept"
         file('libs').assertHasDescendants('projectA-1.0.jar')
     }
 


### PR DESCRIPTION
### Context

The Maven mirror settings reuse feature matches each repository against `mirrorOf` patterns by **id**, never by URL. Gradle repositories have no Maven id, so `DefaultMavenMirrorResolver.effectiveIdOf` matches them by their Gradle *name* — except Maven Central, which is matched as `central` because that is the id the Super POM gives that URL.

The userguide already warns that the Gradle Plugin Portal is affected by Maven mirrors, but never says what id targets it. Without that, there is no way to write a `mirrorOf` that mirrors only the portal, or that excludes the portal from a wildcard mirror — a real need, since an internal repository manager often proxies Maven Central but not the plugin portal.

The id is the display name `gradlePluginPortal()` assigns: `Gradle Central Plugin Repository`, spaces included.

```xml
<!-- only the portal -->
<mirrorOf>Gradle Central Plugin Repository</mirrorOf>

<!-- everything but the portal -->
<mirrorOf>*,!Gradle Central Plugin Repository</mirrorOf>
```

### What this changes

Documentation and tests only — no behavior change.

- A new `[[sec:maven-mirror-ids]]` section, "Which id a repository is matched by", in `centralizing_repositories.adoc`, covering the `central` special case, the name-based match for everything else, the portal id, and both XML examples above. The existing sentence about the portal being affected now cross-references it.
- A note that `external:*` also matches the portal — it is neither `localhost` nor a `file` URL — so it needs the same `!` exclusion as `*`.
- A note that the grammar has no partial globs, so `*Plugin*` and `plugins.gradle.org` match nothing, and that a name containing a comma cannot be matched.
- Three integration tests in `MavenSettingsMirrorIntegrationTest`, each redirecting the portal with `org.gradle.internal.plugins.portal.url.override` at a local HTTP repo and leaving the repository that should *not* be used unserved, so a mis-match fails the build:
  - `mirrorOf matches the gradle plugin portal by its repository name`
  - `a negated mirrorOf token excludes the gradle plugin portal from a wildcard mirror`
  - `mirrorOf tolerates surrounding whitespace around an id containing spaces` — pins that Maven's `SettingsXpp3Reader` reads `<mirrorOf>` through `interpolatedTrimmed`, so the element is trimmed but spaces inside the id are kept

### Follow-up worth discussing

Depending on a display name is fragile: renaming `GRADLE_PLUGIN_PORTAL_REPO_NAME` would silently break every settings file matching it, and a repository whose name contains a comma is unmatchable because `mirrorOf` splits on commas with no escaping. A stable alias for the portal in `effectiveIdOf` (e.g. `gradle-plugin-portal`, alongside the existing `central` case) would fix both. Left out of this PR since the feature is incubating and that is a behavior change rather than documentation.

### Verification

- `./gradlew :dependency-management:embeddedIntegTest --tests "org.gradle.integtests.resolve.maven.MavenSettingsMirrorIntegrationTest"` → 29 tests, 0 failures
- `./gradlew :docs:userguide` renders the new section and the cross-reference resolves to a real anchor
- `./gradlew :docs:checkDeadInternalLinks` → BUILD SUCCESSFUL

https://claude.ai/code/session_01KnNGf4GvHeJ6CpYXW1MrZ3
