### PR TITLE
Document Develocity plugin version option and env vars in Build Scan basics

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/fundamentals/running-builds/build_scans.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/fundamentals/running-builds/build_scans.adoc
@@ -59,6 +59,29 @@ You enable this with the `--develocity-url` command line option:
  ./gradlew build --develocity-url=https://develocity.example.com
 ----
 
+This triggers auto-application of the Develocity Gradle plugin if it is not already applied.
+Gradle auto-applies a default version of the plugin.
+To use a different version, add the `--develocity-plugin-version` command line option:
+
+[source,text]
+----
+ ./gradlew build --develocity-url=https://develocity.example.com --develocity-plugin-version=4.5.0
+----
+
+The plugin version must be `4.4.0` or higher when a Develocity URL is specified.
+This option is only used when `--develocity-url` or `--scan` triggers auto-application of the plugin.
+
+Both options can also be set with environment variables, which is convenient on CI where you do not control the command line:
+
+[source,bash]
+----
+$ export COM_GRADLE_DEVELOCITY_URL=https://develocity.example.com
+$ export COM_GRADLE_DEVELOCITY_PLUGIN_VERSION=4.5.0
+$ ./gradlew build --scan
+----
+
+The equivalent Gradle properties are `com.gradle.develocity.url` and `com.gradle.develocity.plugin.version`.
+
 Check the https://docs.gradle.com/develocity/gradle/current/gradle-plugin/#publish_no_modify[Develocity Gradle plugin documentation] for more details.
 
 [[sec:captured-information]]


### PR DESCRIPTION
### Context

The "Publishing to a specific Develocity server" section of the Build Scan basics page only documented `--develocity-url`. The companion option that controls which Develocity plugin version gets auto-applied was undocumented in the user guide, as were the environment variable forms of both — which are what most people actually need on CI, where the Gradle command line is often not under their control.

This adds to that section:

- The `--develocity-plugin-version` command-line option, with an example, the "must be 4.4.0 or higher when a Develocity URL is specified" constraint, and the note that it only takes effect when `--develocity-url` or `--scan` triggers auto-application.
- The `COM_GRADLE_DEVELOCITY_URL` and `COM_GRADLE_DEVELOCITY_PLUGIN_VERSION` environment variables.
- A pointer to the equivalent Gradle properties `com.gradle.develocity.url` and `com.gradle.develocity.plugin.version`.

The stated behavior comes from `StartParameterBuildOptions.DevelocityPluginVersionOption`; the version used in the examples matches the current `AutoAppliedDevelocityPlugin.VERSION` (4.5.0).

Documentation-only change — no production code touched.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — n/a, docs only
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. — n/a, docs only
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`. — not run locally
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`. — not run locally

https://claude.ai/code/session_01KnNGf4GvHeJ6CpYXW1MrZ3
