### PR TITLE
Publish to Artifactory with a Bearer token

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -45,7 +45,7 @@ class PromotionProject(
         params {
             password("env.ORG_GRADLE_PROJECT_gradleS3AccessKey", "%gradleS3AccessKey%")
             password("env.ORG_GRADLE_PROJECT_gradleS3SecretKey", "%gradleS3SecretKey%")
-            password("env.ORG_GRADLE_PROJECT_artifactoryUserPassword", "%gradle.internal.repository.build-tool.publish.password%")
+            password("env.ORG_GRADLE_PROJECT_artifactoryToken", "%gradle.internal.repository.build-tool.publish.token%")
             password("env.DOTCOM_DEV_DOCS_AWS_ACCESS_KEY", "%dotcomDevDocsAwsAccessKey%")
             password("env.DOTCOM_DEV_DOCS_AWS_SECRET_KEY", "%dotcomDevDocsAwsSecretKey%")
             password("env.ORG_GRADLE_PROJECT_sdkmanToken", "%sdkmanToken%")
@@ -57,7 +57,6 @@ class PromotionProject(
             // Keep 21 and 25 for tests requiring it specifically: https://github.com/gradle/gradle/pull/35410#discussion_r2460835304
             param("env.JDK21", javaHome(OpenJdk21, Os.LINUX))
             param("env.JDK25", javaHome(OpenJdk25, Os.LINUX))
-            param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
             password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
             param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
             param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -16,6 +16,8 @@
 
 import gradlebuild.basics.gradleProperty
 import gradlebuild.identity.extension.GradleModuleExtension
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
 
 plugins {
     id("publishing")
@@ -24,11 +26,8 @@ plugins {
 val artifactoryUrl
     get() = System.getenv("GRADLE_INTERNAL_REPO_URL") ?: ""
 
-val artifactoryUserName
-    get() = project.providers.gradleProperty("artifactoryUserName").orNull
-
-val artifactoryUserPassword
-    get() = project.providers.gradleProperty("artifactoryUserPassword").orNull
+val artifactoryToken
+    get() = project.providers.gradleProperty("artifactoryToken").orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")
@@ -40,18 +39,14 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
     }
 }
 
-@Suppress("ThrowsCount")
 fun Project.failEarlyIfUrlOrCredentialsAreNotSet(publish: Task) {
     gradle.taskGraph.whenReady {
         if (hasTask(publish)) {
             if (artifactoryUrl.isEmpty()) {
                 throw GradleException("artifactoryUrl is not set!")
             }
-            if (artifactoryUserName.isNullOrEmpty()) {
-                throw GradleException("artifactoryUserName is not set!")
-            }
-            if (artifactoryUserPassword.isNullOrEmpty()) {
-                throw GradleException("artifactoryUserPassword is not set!")
+            if (artifactoryToken.isNullOrEmpty()) {
+                throw GradleException("artifactoryToken is not set!")
             }
         }
     }
@@ -63,9 +58,12 @@ publishing {
             name = "remote"
             val libsType = the<GradleModuleExtension>().identity.snapshot.map { if (it) "snapshots" else "releases" }
             url = uri("$artifactoryUrl/libs-${libsType.get()}-local")
-            credentials {
-                username = artifactoryUserName
-                password = artifactoryUserPassword
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                value = "Bearer $artifactoryToken"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
@@ -59,8 +59,7 @@ class GradleBuildIsolatedProjectsSmokeTest extends AbstractGradleBuildIsolatedPr
         // sets properties that are required by tasks being realized
         def requiredGradleProperties = [
             "-Pgradle_installPath=/dev/null",
-            "-PartifactoryUserName=foo",
-            "-PartifactoryUserPassword=bar",
+            "-PartifactoryToken=foo",
             "-PtoolingApiShadedJarInstallPath=/tmp",
             "-PpromotionCommitId=1234567"
         ]


### PR DESCRIPTION
## Summary
- Stop publishing to `repo.grdev.net` with `artifactoryUserName` / `artifactoryUserPassword`.
- Authenticate with `Authorization: Bearer` from `artifactoryToken` (`%gradle.internal.repository.build-tool.publish.token%`).

Retargeted from `master` to `release` and rebased onto it.

Prerequisites, both now in place:
- https://github.com/gradle/develocity-artifactory/pull/344 (token applied)
- TeamCity `Gradle` project parameter `gradle.internal.repository.build-tool.publish.token`

## Verification

Promotion with the Bearer token succeeded on `xperimental`, promoting `9.9.0-branch-xperimental-20260904053952+0000` to `libs-snapshots-local`:

https://builds.gradle.org/buildConfiguration/Gradle_Xperimental_Promotion_PublishBranchSnapshotFromQuickFeedback/116977154?buildTab=overview&focusLine=NaN&hideTestsFromDependencies=true
