### PR TITLE
Continue daemon expiration checks after strategy failures

### DIFF
--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -17,6 +17,7 @@ package org.gradle.launcher.daemon.context;
 
 import org.gradle.api.internal.specs.ExplainingSpec;
 import org.gradle.internal.jvm.JavaInfo;
+import org.gradle.internal.jvm.JavaHomeException;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.launcher.daemon.toolchain.DaemonJvmCriteria;
@@ -95,7 +96,7 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
                 File desiredJava = desiredJavaInfo.getJavaExecutable();
                 return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
             }
-        } catch (IOException e) {
+        } catch (IOException | JavaHomeException | IllegalArgumentException e) {
             // ignore
         }
         return false;

--- a/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
+++ b/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
@@ -82,6 +82,16 @@ class DaemonCompatibilitySpecSpec extends Specification {
         unsatisfiedReason.contains "JVM is incompatible"
     }
 
+    def "context with a missing java home is incompatible"() {
+        clientWants(new DaemonJvmCriteria.JavaHome(DaemonJvmCriteria.JavaHome.Source.ORG_GRADLE_JAVA_HOME, javaHome))
+        candidate.javaHome >> javaHome
+        javaHome.deleteDir()
+
+        expect:
+        !compatible
+        unsatisfiedReason.contains "JVM is incompatible"
+    }
+
     def "contexts with different jvm criteria are incompatible"() {
         clientWants(new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(11), JvmVendorSpec.ADOPTIUM, JvmImplementation.VENDOR_SPECIFIC, false))
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategy.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategy.java
@@ -17,6 +17,8 @@
 package org.gradle.launcher.daemon.server.expiry;
 
 import com.google.common.base.Joiner;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,7 @@ import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.hi
  * Expires the daemon if any of the children would expire the daemon.
  */
 public class AnyDaemonExpirationStrategy implements DaemonExpirationStrategy {
+    private static final Logger LOGGER = Logging.getLogger(AnyDaemonExpirationStrategy.class);
     private Iterable<DaemonExpirationStrategy> expirationStrategies;
 
     public AnyDaemonExpirationStrategy(List<DaemonExpirationStrategy> expirationStrategies) {
@@ -41,7 +44,12 @@ public class AnyDaemonExpirationStrategy implements DaemonExpirationStrategy {
         List<String> reasons = new ArrayList<>();
 
         for (DaemonExpirationStrategy expirationStrategy : expirationStrategies) {
-            expirationResult = expirationStrategy.checkExpiration();
+            try {
+                expirationResult = expirationStrategy.checkExpiration();
+            } catch (Exception e) {
+                LOGGER.error("Problem in daemon expiration strategy " + expirationStrategy.getClass().getName() + ". Continuing with other strategies.", e);
+                continue;
+            }
             if (expirationResult.getStatus() != DO_NOT_EXPIRE) {
                 reasons.add(expirationResult.getReason());
                 expirationStatus = highestPriorityOf(expirationResult.getStatus(), expirationStatus);

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategyTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/expiry/AnyDaemonExpirationStrategyTest.groovy
@@ -78,4 +78,18 @@ class AnyDaemonExpirationStrategyTest extends Specification {
         result.status == DO_NOT_EXPIRE
         result.reason == null
     }
+
+    def "continues checking strategies when one fails"() {
+        given:
+        AnyDaemonExpirationStrategy agg = new AnyDaemonExpirationStrategy([c1, c2])
+
+        when:
+        1 * c1.checkExpiration() >> { throw new IllegalStateException("broken strategy") }
+        1 * c2.checkExpiration() >> new DaemonExpirationResult(GRACEFUL_EXPIRE, "r2")
+
+        then:
+        DaemonExpirationResult result = agg.checkExpiration()
+        result.status == GRACEFUL_EXPIRE
+        result.reason == "r2"
+    }
 }


### PR DESCRIPTION
Fixes #39043

### Summary

- continue evaluating sibling daemon expiration strategies when one strategy fails
- treat invalid or missing Java homes as incompatible daemon contexts
- add regression coverage for both behaviors

### Tests

- `./gradlew :launcher:test --tests org.gradle.launcher.daemon.server.expiry.AnyDaemonExpirationStrategyTest --tests org.gradle.launcher.daemon.context.DaemonCompatibilitySpecSpec --no-daemon`
- `./gradlew :daemon-protocol:test --tests org.gradle.launcher.daemon.context.DaemonCompatibilitySpecSpec --no-daemon`
- `./gradlew :launcher:checkstyleMain :daemon-protocol:checkstyleMain --no-daemon`
- `./gradlew :launcher:quickTest :daemon-protocol:quickTest --no-daemon` (fails in existing continuous-build file-system integration tests on this machine; targeted tests and checkstyle pass.)