### PR TITLE
Allow linear fetch failure analysis by client

### DIFF
--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/internal/build/event/types/DefaultFailure.java
@@ -107,8 +107,20 @@ public class DefaultFailure implements Serializable, InternalFailure {
     }
 
     public static InternalFailure fromThrowable(Throwable t, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {
+        return fromThrowable(t, mapper, FailureCache.NONE);
+    }
+
+    public static InternalFailure fromThrowable(
+        Throwable t,
+        Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper,
+        FailureCache cache
+    ) {
+        InternalFailure cached = cache.get(t);
+        if (cached != null) {
+            return cached;
+        }
         Failure failure = DefaultFailureFactory.withDefaultClassifier().create(t);
-        return fromFailure(failure, mapper);
+        return fromFailure(failure, mapper, cache);
     }
 
     public static InternalFailure fromFailure(Failure buildFailure, Function<ProblemInternal, InternalBasicProblemDetailsVersion3> mapper) {

--- a/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/integration/tooling_api.adoc
@@ -163,6 +163,37 @@ Resilient sync requires Tooling API 9.3.0 or later and a target Gradle version t
 * Gradle 9.3.0: The `fetch(...)` methods and `FetchModelResult` are available.
 * Gradle 9.4.0: Partial build models, returned when a settings script or a settings plugin fails.
 * Gradle 9.7.0: Reporting a resilient sync that partially failed as a failed operation. In earlier versions, such an operation could complete successfully, with the failures reported only through `FetchModelResult.getFailures()`.
+* Gradle 9.8.0: link:{javadocPath}/org/gradle/tooling/Failure.html#getOwnDescription()[`Failure.getOwnDescription()`] is available on failures returned by `FetchModelResult.getFailures()`, providing the per-node description without the cause subtree. Returns `null` when the target Gradle version is earlier than 9.7.0.
+
+[[sec:embedding_failure_traversal]]
+==== Traversing failure trees efficiently
+
+When a build failure is shared across multiple fetch results, for example, a single configuration error that affects several projects, Gradle reuses the same link:{javadocPath}/org/gradle/tooling/Failure.html[`Failure`] instance for each occurrence.
+Clients can exploit this with an `IdentityHashMap` to visit each unique failure node exactly once:
+
+[source,java]
+----
+IdentityHashMap<Failure, Void> visited = new IdentityHashMap<>();
+
+void visit(Failure failure) {
+    if (visited.putIfAbsent(failure, null) != null) {
+        return; // already processed this node
+    }
+    String ownText = failure.getOwnDescription(); // null for daemons older than 9.7
+    if (ownText != null) {
+        process(ownText);
+    } else {
+        process(failure.getDescription());
+        return; // causes already included in the full description
+    }
+    for (Failure cause : failure.getCauses()) {
+        visit(cause);
+    }
+}
+----
+
+link:{javadocPath}/org/gradle/tooling/Failure.html#getOwnDescription()[`Failure.getOwnDescription()`] is available when the Tooling API and target Gradle version are both 9.8.0 or later.
+When the target Gradle version is earlier than 9.7.0, it returns `null`, and you should fall back to link:{javadocPath}/org/gradle/tooling/Failure.html#getDescription()[`Failure.getDescription()`] on the root node.
 
 [[sec:embedding_phased_action_example]]
 === Reading intermediate models with a phased build action

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.build.event.types.DefaultFailure;
 import org.gradle.internal.buildtree.BuildTreeModelController;
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor;
 import org.gradle.internal.buildtree.BuildTreeModelTarget;
@@ -179,7 +178,7 @@ class DefaultBuildController implements
             List<InternalFailure> failures = toInternalFailures(resultInternal.getFailures());
             return new DefaultInternalFetchModelResult<>(uncheckedNonnullCast(resultInternal.getModel()), failures);
         } catch (Exception e) {
-            List<InternalFailure> failures = ImmutableList.of(DefaultFailure.fromThrowable(e));
+            List<InternalFailure> failures = ImmutableList.of(failureConverter.convert(e));
             return new DefaultInternalFetchModelResult<>(null, failures);
         }
     }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FetchFailureConverter.java
@@ -40,10 +40,14 @@ import java.util.concurrent.ConcurrentMap;
 @NullMarked
 public class FetchFailureConverter implements FailureCache {
 
-    private final ConcurrentMap<Throwable, InternalFailure> cache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<IdentityKey, InternalFailure> cache = new ConcurrentHashMap<>();
 
     InternalFailure convert(Failure failure) {
         return DefaultFailure.fromFailure(failure, FetchFailureConverter::noProblemDetails, this);
+    }
+
+    InternalFailure convert(Throwable failure) {
+        return DefaultFailure.fromThrowable(failure, FetchFailureConverter::noProblemDetails, this);
     }
 
     @Nullable
@@ -54,12 +58,32 @@ public class FetchFailureConverter implements FailureCache {
     @Override
     @Nullable
     public InternalFailure get(Throwable original) {
-        return cache.get(original);
+        return cache.get(new IdentityKey(original));
     }
 
     @Override
     public InternalFailure intern(Throwable original, InternalFailure converted) {
-        InternalFailure previous = cache.putIfAbsent(original, converted);
+        InternalFailure previous = cache.putIfAbsent(new IdentityKey(original), converted);
         return previous != null ? previous : converted;
+    }
+
+    private static final class IdentityKey {
+        private final Throwable throwable;
+        private final int hashCode;
+
+        private IdentityKey(Throwable throwable) {
+            this.throwable = throwable;
+            this.hashCode = System.identityHashCode(throwable);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof IdentityKey && throwable == ((IdentityKey) other).throwable;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
     }
 }

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -186,6 +186,21 @@ class DefaultBuildControllerTest extends Specification {
         result.getModel() == model.model
     }
 
+    def "reuses a thrown failure across resilient fetches"() {
+        def failure = new RuntimeException("broken model")
+
+        given:
+        _ * workerThreadRegistry.workerThread >> true
+        2 * modelController.getModel(_, _) >> { throw failure }
+
+        when:
+        def first = controller.fetch(null, modelId, null)
+        def second = controller.fetch(null, modelId, null)
+
+        then:
+        first.failures.first().is(second.failures.first())
+    }
+
     def "runs supplied actions"() {
         def action1 = Mock(Supplier)
         def action2 = Mock(Supplier)

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/FetchFailureConverterTest.groovy
@@ -41,8 +41,8 @@ class FetchFailureConverterTest extends Specification {
 
     def "converts failures with distinct originals into distinct instances"() {
         when:
-        def first = converter.convert(failureOf(new RuntimeException("one")))
-        def second = converter.convert(failureOf(new RuntimeException("two")))
+        def first = converter.convert(failureOf(new EqualThrowable("one")))
+        def second = converter.convert(failureOf(new EqualThrowable("two")))
 
         then:
         !first.is(second)
@@ -70,6 +70,20 @@ class FetchFailureConverterTest extends Specification {
         def b = converter.convert(failureOf(topB))
 
         then: "the per-project wrappers differ but the shared deep cause is converted once"
+        !a.is(b)
+        a.causes[0].is(b.causes[0])
+    }
+
+    def "reuses a shared deep cause when converting thrown failures"() {
+        def sharedCause = new RuntimeException("shared included build failure")
+        def topA = new RuntimeException("project :a failed", sharedCause)
+        def topB = new RuntimeException("project :b failed", sharedCause)
+
+        when:
+        def a = converter.convert(topA)
+        def b = converter.convert(topB)
+
+        then:
         !a.is(b)
         a.causes[0].is(b.causes[0])
     }
@@ -105,5 +119,21 @@ class FetchFailureConverterTest extends Specification {
         Throwable t = new RuntimeException("leaf")
         (1..(depth - 1)).each { t = new RuntimeException("level-$it", t) }
         t
+    }
+
+    private static class EqualThrowable extends RuntimeException {
+        EqualThrowable(String message) {
+            super(message)
+        }
+
+        @Override
+        boolean equals(Object other) {
+            return other instanceof EqualThrowable
+        }
+
+        @Override
+        int hashCode() {
+            return 1
+        }
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r16.CustomModel
+import org.gradle.integtests.tooling.r980.FetchFailureDescriptionsAction
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.util.GradleVersion
 
@@ -121,6 +122,28 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         then:
         result.modelValue == null
         result.failureMessages == ["broken builder"]
+    }
+
+    @ToolingApiVersion(">=9.8.0")
+    @TargetGradleVersion(">=9.3.0 <9.7.0")
+    def "reports node-only failure descriptions as unavailable from an older provider"() {
+        given:
+        setupInitScriptWithCustomModelBuilder("throw new RuntimeException('broken builder', new IllegalStateException('root cause'))")
+
+        when:
+        def failures = succeeds {
+            action(new FetchFailureDescriptionsAction())
+                .withArguments("--init-script=${file('init.gradle').absolutePath}")
+                .run()
+        }
+
+        then:
+        failures.size() == 1
+        def failure = failures.first()
+        failure.message == "broken builder"
+        failure.description.contains("Caused by: java.lang.IllegalStateException: root cause")
+        failure.ownDescription == null
+        failure.causes.first().ownDescription == null
     }
 
     @TargetGradleVersion(">=7.6.6 <9.7.0")

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -168,7 +168,7 @@ class CustomPlugin implements Plugin<Project> {
         result.rootDescriptionByProject['c'].contains("Caused by:")
     }
 
-    @ToolingApiVersion('>=9.9.0')
+    @ToolingApiVersion('>=9.8.0')
     @TargetGradleVersion('>=9.7.0')
     def "configure-on-demand wrappers preserve the identity of their shared included build cause"() {
         when:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r970/ResilientFetchFailureCrossVersionSpec.groovy
@@ -168,6 +168,20 @@ class CustomPlugin implements Plugin<Project> {
         result.rootDescriptionByProject['c'].contains("Caused by:")
     }
 
+    @ToolingApiVersion('>=9.9.0')
+    @TargetGradleVersion('>=9.7.0')
+    def "configure-on-demand wrappers preserve the identity of their shared included build cause"() {
+        when:
+        fetchFailures(CONFIGURE_ON_DEMAND_ON)
+
+        then:
+        thrown(BuildException)
+        def b = fetchResult.failureTreeByProject['b']
+        def c = fetchResult.failureTreeByProject['c']
+        !b.is(c)
+        b.deepest().is(c.deepest())
+    }
+
     def "a configuration failure attached to every fetched project fails the build only once"() {
         given: "a project failing eager configuration, with no other failure source"
         settingsKotlinFile.text = """

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r970/FetchFailureTreeAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r970/FetchFailureTreeAction.java
@@ -25,6 +25,7 @@ import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,14 +49,15 @@ public class FetchFailureTreeAction implements BuildAction<FetchFailureTreeActio
         GradleBuild gradleBuild = controller.fetch(GradleBuild.class).getModel();
         assert gradleBuild != null;
         Result result = new Result();
-        collect(controller, gradleBuild, result);
+        IdentityHashMap<Failure, FailureNode> snapshots = new IdentityHashMap<Failure, FailureNode>();
+        collect(controller, gradleBuild, result, snapshots);
         for (GradleBuild includedBuild : gradleBuild.getEditableBuilds()) {
-            collect(controller, includedBuild, result);
+            collect(controller, includedBuild, result, snapshots);
         }
         return result;
     }
 
-    private void collect(BuildController controller, GradleBuild gradleBuild, Result result) {
+    private void collect(BuildController controller, GradleBuild gradleBuild, Result result, IdentityHashMap<Failure, FailureNode> snapshots) {
         for (BasicGradleProject project : gradleBuild.getProjects()) {
             FetchModelResult<?> fetched = controller.fetch(project, modelType);
             if (fetched.getFailures().isEmpty() && fetched.getModel() != null) {
@@ -64,17 +66,22 @@ public class FetchFailureTreeAction implements BuildAction<FetchFailureTreeActio
                 result.failedToQueryProjects.add(project.getName());
                 Failure failure = fetched.getFailures().iterator().next();
                 result.rootDescriptionByProject.put(project.getName(), failure.getDescription());
-                result.failureTreeByProject.put(project.getName(), snapshot(failure));
+                result.failureTreeByProject.put(project.getName(), snapshot(failure, snapshots));
             }
         }
     }
 
-    private static FailureNode snapshot(Failure failure) {
-        List<FailureNode> causes = new ArrayList<FailureNode>();
-        for (Failure cause : failure.getCauses()) {
-            causes.add(snapshot(cause));
+    private static FailureNode snapshot(Failure failure, IdentityHashMap<Failure, FailureNode> snapshots) {
+        FailureNode existing = snapshots.get(failure);
+        if (existing != null) {
+            return existing;
         }
-        return new FailureNode(failure.getMessage(), causes);
+        FailureNode node = new FailureNode(failure.getMessage(), new ArrayList<FailureNode>());
+        snapshots.put(failure, node);
+        for (Failure cause : failure.getCauses()) {
+            node.causes.add(snapshot(cause, snapshots));
+        }
+        return node;
     }
 
     public static class Result implements Serializable {

--- a/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r980/FetchFailureDescriptionsAction.java
+++ b/platforms/ide/tooling-api/src/crossVersionTestModels/java/org/gradle/integtests/tooling/r980/FetchFailureDescriptionsAction.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r980;
+
+import org.gradle.integtests.tooling.r16.CustomModel;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.Failure;
+import org.gradle.tooling.FetchModelResult;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchFailureDescriptionsAction implements BuildAction<List<FetchFailureDescriptionsAction.FailureNode>> {
+
+    @Override
+    public List<FailureNode> execute(BuildController controller) {
+        FetchModelResult<CustomModel> result = controller.fetch(CustomModel.class);
+        List<FailureNode> failures = new ArrayList<FailureNode>();
+        for (Failure failure : result.getFailures()) {
+            failures.add(snapshot(failure));
+        }
+        return failures;
+    }
+
+    private static FailureNode snapshot(Failure failure) {
+        List<FailureNode> causes = new ArrayList<FailureNode>();
+        for (Failure cause : failure.getCauses()) {
+            causes.add(snapshot(cause));
+        }
+        return new FailureNode(failure.getMessage(), failure.getDescription(), failure.getOwnDescription(), causes);
+    }
+
+    public static class FailureNode implements Serializable {
+        public final String message;
+        public final String description;
+        public final String ownDescription;
+        public final List<FailureNode> causes;
+
+        public FailureNode(String message, String description, String ownDescription, List<FailureNode> causes) {
+            this.message = message;
+            this.description = description;
+            this.ownDescription = ownDescription;
+            this.causes = causes;
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
@@ -48,6 +48,23 @@ public interface Failure {
     String getDescription();
 
     /**
+     * Returns a long description of this failure node alone. For example, the failure header, its stack frames, and
+     * any suppressed exceptions, but not the descriptions of the failures returned by {@link #getCauses()}.
+     * <p>
+     * Unlike {@link #getDescription()}, which may contain the text of the whole cause subtree, this method can be used
+     * to inspect the description of every node in a failure tree without processing cause descriptions repeatedly.
+     * <p>
+     * This information is not available from Gradle providers earlier than 9.7, in which case this method returns
+     * {@code null}.
+     *
+     * @return a long description of this failure node, or {@code null} if it is not available
+     * @since 9.8.0
+     */
+    @Nullable
+    @Incubating
+    String getOwnDescription();
+
+    /**
      * Returns the underlying causes for this failure, if any.
      *
      * @return the causes for this failure. Returns an empty list if this failure has no causes.

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
@@ -39,7 +39,10 @@ public interface Failure {
     String getMessage();
 
     /**
-     * Returns a long description of the failure. For example, a stack trace.
+     * Returns a long description of the failure. For example, a stack trace. This method is intended to be called on
+     * the root failure, as the description may include the descriptions of the failures returned by {@link #getCauses()}.
+     * When inspecting every node in a failure tree, use {@link #getOwnDescription()} to avoid processing cause
+     * descriptions repeatedly.
      *
      * @return a long description of the failure
      * @since 2.4
@@ -54,8 +57,7 @@ public interface Failure {
      * Unlike {@link #getDescription()}, which may contain the text of the whole cause subtree, this method can be used
      * to inspect the description of every node in a failure tree without processing cause descriptions repeatedly.
      * <p>
-     * This information is not available from Gradle providers earlier than 9.7, in which case this method returns
-     * {@code null}.
+     * When using a target Gradle version earlier than 9.7.0, this method returns {@code null}.
      *
      * @return a long description of this failure node, or {@code null} if it is not available
      * @since 9.8.0

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/Failure.java
@@ -39,8 +39,8 @@ public interface Failure {
     String getMessage();
 
     /**
-     * Returns a long description of the failure. For example, a stack trace. This method is intended to be called on
-     * the root failure, as the description may include the descriptions of the failures returned by {@link #getCauses()}.
+     * Returns a long description of the failure. For example, a stack trace. Call this method on the root failure
+     * only: the description may include the full text of the failures returned by {@link #getCauses()}.
      * When inspecting every node in a failure tree, use {@link #getOwnDescription()} to avoid processing cause
      * descriptions repeatedly.
      *
@@ -51,7 +51,7 @@ public interface Failure {
     String getDescription();
 
     /**
-     * Returns a long description of this failure node alone. For example, the failure header, its stack frames, and
+     * Returns a long description of this failure node, excluding the descriptions of its causes. For example, the failure header, its stack frames, and
      * any suppressed exceptions, but not the descriptions of the failures returned by {@link #getCauses()}.
      * <p>
      * Unlike {@link #getDescription()}, which may contain the text of the whole cause subtree, this method can be used

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/FetchModelResult.java
@@ -44,6 +44,9 @@ public interface FetchModelResult<M> {
 
     /**
      * Returns the failures that occurred during the fetch operation.
+     * <p>
+     * Gradle attempts to reuse the same {@link Failure} instance when the same underlying failure is reported by multiple
+     * fetches in one build action. Clients can use reference identity to avoid processing such shared failures repeatedly.
      *
      * @return a collection of failures, empty if the fetch operation was successful
      * @since 9.3.0

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ClientFailureCache.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ClientFailureCache.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer;
+
+import org.gradle.tooling.Failure;
+import org.gradle.tooling.internal.protocol.InternalFailure;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Retains consumer failures by the identity of the protocol failures from which they were converted.
+ *
+ * <p>The cache is safe to use when model queries run in parallel. Its owner determines the scope in which failure
+ * identity is preserved.</p>
+ */
+@NullMarked
+public final class ClientFailureCache {
+    private final ConcurrentMap<IdentityKey, Failure> failures = new ConcurrentHashMap<>();
+
+    @Nullable
+    public Failure get(InternalFailure original) {
+        return failures.get(new IdentityKey(original));
+    }
+
+    public Failure intern(InternalFailure original, Failure converted) {
+        Failure previous = failures.putIfAbsent(new IdentityKey(original), converted);
+        return previous != null ? previous : converted;
+    }
+
+    private static final class IdentityKey {
+        private final InternalFailure failure;
+        private final int hashCode;
+
+        private IdentityKey(InternalFailure failure) {
+            this.failure = failure;
+            this.hashCode = System.identityHashCode(failure);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof IdentityKey && failure == ((IdentityKey) other).failure;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFailure.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFailure.java
@@ -41,7 +41,7 @@ public class DefaultFailure implements Failure {
     }
 
     public DefaultFailure(String message, String description, List<? extends Failure> causes, List<Problem> problems) {
-        this(message, description, description, causes, problems);
+        this(message, description, null, causes, problems);
     }
 
     private DefaultFailure(String message, @Nullable String fullDescription, @Nullable String ownDescription, List<? extends Failure> causes, List<Problem> problems) {
@@ -68,15 +68,14 @@ public class DefaultFailure implements Failure {
         }
         String reconstructed = reconstructedDescription;
         if (reconstructed == null) {
-            // Walk the concrete node type rather than the Failure interface: own text is an internal detail used only
-            // to reassemble the full description, and is not part of the public Failure API.
             reconstructed = FailureDescriptionReconstructor.reconstruct(this, DefaultFailure::getOwnDescription, DefaultFailure::ownCauses);
             reconstructedDescription = reconstructed;
         }
         return reconstructed;
     }
 
-    private @Nullable String getOwnDescription() {
+    @Override
+    public @Nullable String getOwnDescription() {
         return ownDescription;
     }
 

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFetchModelResult.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultFetchModelResult.java
@@ -49,8 +49,12 @@ public class DefaultFetchModelResult<M> implements FetchModelResult<M> {
         return failures.get();
     }
 
-    public static <M> DefaultFetchModelResult<M> of(@Nullable M model, Collection<? extends InternalFailure> failures) {
-        return new DefaultFetchModelResult<>(model, () -> BuildProgressListenerAdapter.toFailures(failures));
+    public static <M> DefaultFetchModelResult<M> of(
+        @Nullable M model,
+        Collection<? extends InternalFailure> failures,
+        ClientFailureCache failureCache
+    ) {
+        return new DefaultFetchModelResult<>(model, () -> BuildProgressListenerAdapter.toFailures(failures, failureCache));
     }
 
     public static <M> DefaultFetchModelResult<M> success(M model) {

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapter.java
@@ -19,6 +19,7 @@ package org.gradle.tooling.internal.consumer.connection;
 import org.gradle.api.Action;
 import org.gradle.tooling.FetchModelResult;
 import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
+import org.gradle.tooling.internal.consumer.ClientFailureCache;
 import org.gradle.tooling.internal.consumer.DefaultFetchModelResult;
 import org.gradle.tooling.internal.consumer.versioning.ModelMapping;
 import org.gradle.tooling.internal.consumer.versioning.VersionDetails;
@@ -35,6 +36,7 @@ import java.io.File;
 @NullMarked
 class FetchAwareBuildControllerAdapter extends StreamingAwareBuildControllerAdapter {
     private final InternalFetchAwareBuildController fetch;
+    private final ClientFailureCache failureCache = new ClientFailureCache();
 
     public FetchAwareBuildControllerAdapter(InternalBuildControllerVersion2 buildController, ProtocolToModelAdapter adapter, ModelMapping modelMapping, VersionDetails gradleVersion, File rootDir) {
         super(buildController, adapter, modelMapping, gradleVersion, rootDir);
@@ -58,6 +60,6 @@ class FetchAwareBuildControllerAdapter extends StreamingAwareBuildControllerAdap
     private <T extends Model, M> FetchModelResult<M> adaptResult(@Nullable T target, Class<M> modelType, InternalFetchModelResult<Object> result) {
         Object model = result.getModel();
         M adaptedModel = model != null ? adaptModel(target, modelType, model) : null;
-        return DefaultFetchModelResult.of(adaptedModel, result.getFailures());
+        return DefaultFetchModelResult.of(adaptedModel, result.getFailures(), failureCache);
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -167,6 +167,7 @@ import org.gradle.tooling.events.work.internal.DefaultWorkItemFinishEvent;
 import org.gradle.tooling.events.work.internal.DefaultWorkItemOperationDescriptor;
 import org.gradle.tooling.events.work.internal.DefaultWorkItemStartEvent;
 import org.gradle.tooling.events.work.internal.DefaultWorkItemSuccessResult;
+import org.gradle.tooling.internal.consumer.ClientFailureCache;
 import org.gradle.tooling.internal.consumer.DefaultFailure;
 import org.gradle.tooling.internal.consumer.DefaultFileComparisonTestAssertionFailure;
 import org.gradle.tooling.internal.consumer.DefaultTestAssertionFailure;
@@ -1320,19 +1321,27 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
     }
 
     public static List<Failure> toFailures(@Nullable Collection<? extends InternalFailure> causes) {
+        return toFailures(causes, new ClientFailureCache());
+    }
+
+    public static List<Failure> toFailures(@Nullable Collection<? extends InternalFailure> causes, ClientFailureCache failureCache) {
         if (causes == null) {
             return null;
         }
         List<Failure> failures = new ArrayList<>(causes.size());
         for (InternalFailure cause : causes) {
-            Failure f = toFailure(cause);
-            if (f != null) {
-                failures.add(f);
+            Failure failure = toFailure(cause, failureCache);
+            if (failure != null) {
+                failures.add(failure);
             }
         }
         return failures;
     }
 
+    /*
+     * Kept as a separate conversion for failures nested in problem details. Progress event conversion does not retain
+     * a cache across events, while the fetch path supplies its build action scoped cache.
+     */
     @Nullable
     private static Failure toFailure(InternalBasicProblemDetails problemDetails) {
         if (!(problemDetails instanceof InternalBasicProblemDetailsVersion2)) {
@@ -1343,9 +1352,25 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
 
     @Nullable
     private static Failure toFailure(@Nullable InternalFailure origFailure) {
+        return toFailure(origFailure, new ClientFailureCache());
+    }
+
+    @Nullable
+    private static Failure toFailure(@Nullable InternalFailure origFailure, ClientFailureCache failureCache) {
         if (origFailure == null) {
             return null;
         }
+
+        Failure cached = failureCache.get(origFailure);
+        if (cached != null) {
+            return cached;
+        }
+
+        Failure converted = convertFailure(origFailure, failureCache);
+        return failureCache.intern(origFailure, converted);
+    }
+
+    private static Failure convertFailure(InternalFailure origFailure, ClientFailureCache failureCache) {
         List<InternalBasicProblemDetailsVersion3> problemDetails = new ArrayList<>();
         try {
             problemDetails.addAll(origFailure.getProblems());
@@ -1366,9 +1391,9 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
                     assertionFailure.getDescription(),
                     assertionFailure.getExpected(),
                     assertionFailure.getActual(),
-                    toFailures(origFailure.getCauses()),
-                    ((InternalTestAssertionFailure) origFailure).getClassName(),
-                    ((InternalTestAssertionFailure) origFailure).getStacktrace(),
+                    toFailures(origFailure.getCauses(), failureCache),
+                    assertionFailure.getClassName(),
+                    assertionFailure.getStacktrace(),
                     ((InternalFileComparisonTestAssertionFailure) origFailure).getExpectedContent(),
                     ((InternalFileComparisonTestAssertionFailure) origFailure).getActualContent()
                 );
@@ -1379,21 +1404,21 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
                 assertionFailure.getDescription(),
                 assertionFailure.getExpected(),
                 assertionFailure.getActual(),
-                toFailures(origFailure.getCauses()),
-                ((InternalTestAssertionFailure) origFailure).getClassName(),
-                ((InternalTestAssertionFailure) origFailure).getStacktrace()
+                toFailures(origFailure.getCauses(), failureCache),
+                assertionFailure.getClassName(),
+                assertionFailure.getStacktrace()
             );
         } else if (origFailure instanceof InternalTestFrameworkFailure) {
             InternalTestFrameworkFailure frameworkFailure = (InternalTestFrameworkFailure) origFailure;
             return new DefaultTestFrameworkFailure(
                 frameworkFailure.getMessage(),
                 frameworkFailure.getDescription(),
-                toFailures(origFailure.getCauses()),
-                ((InternalTestFrameworkFailure) origFailure).getClassName(),
-                ((InternalTestFrameworkFailure) origFailure).getStacktrace()
+                toFailures(origFailure.getCauses(), failureCache),
+                frameworkFailure.getClassName(),
+                frameworkFailure.getStacktrace()
             );
         }
-        List<Failure> causes = toFailures(origFailure.getCauses());
+        List<Failure> causes = toFailures(origFailure.getCauses(), failureCache);
         try {
             return DefaultFailure.fromOwnDescription(origFailure.getMessage(), origFailure.getOwnDescription(), causes, clientProblems);
         } catch (NoSuchMethodError | AbstractMethodError ignore) {
@@ -1426,4 +1451,5 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
         }
         return AnnotationProcessorResult.Type.UNKNOWN;
     }
+
 }

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ClientFailureCacheTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ClientFailureCacheTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer
+
+import org.gradle.tooling.internal.consumer.parameters.BuildProgressListenerAdapter
+import org.gradle.tooling.internal.protocol.InternalFailure
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class ClientFailureCacheTest extends Specification {
+
+    def "concurrent conversions of a shared protocol failure return the same consumer failure"() {
+        def root = internalFailure("java.lang.RuntimeException: boom\n", [])
+        def failureCache = new ClientFailureCache()
+        def threadCount = 20
+        def executor = Executors.newFixedThreadPool(threadCount)
+        def start = new CountDownLatch(1)
+
+        when:
+        def futures = (1..threadCount).collect {
+            executor.submit({
+                start.await()
+                BuildProgressListenerAdapter.toFailures([root], failureCache).first()
+            } as Callable)
+        }
+        start.countDown()
+        def failures = futures.collect { it.get() }
+
+        then:
+        failures.every { it.is(failures.first()) }
+
+        cleanup:
+        executor.shutdownNow()
+    }
+
+    private InternalFailure internalFailure(String own, List<InternalFailure> causes) {
+        Stub(InternalFailure) {
+            getMessage() >> "msg"
+            getOwnDescription() >> own
+            getDescription() >> "FULL-NOT-USED"
+            getCauses() >> causes
+            getProblems() >> []
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapterTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapterTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.connection
+
+import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter
+import org.gradle.tooling.internal.consumer.versioning.ModelMapping
+import org.gradle.tooling.internal.consumer.versioning.VersionDetails
+import org.gradle.tooling.internal.protocol.InternalActionAwareBuildController
+import org.gradle.tooling.internal.protocol.InternalBuildControllerVersion2
+import org.gradle.tooling.internal.protocol.InternalFailure
+import org.gradle.tooling.internal.protocol.InternalFetchAwareBuildController
+import org.gradle.tooling.internal.protocol.InternalFetchModelResult
+import org.gradle.tooling.internal.protocol.InternalStreamedValueRelay
+import org.gradle.util.GradleVersion
+import spock.lang.Specification
+
+class FetchAwareBuildControllerAdapterTest extends Specification {
+
+    def delegate = Mock(FetchingBuildController)
+    def controller = new FetchAwareBuildControllerAdapter(
+        delegate,
+        new ProtocolToModelAdapter(),
+        new ModelMapping(),
+        VersionDetails.from(GradleVersion.current()),
+        new File("root")
+    )
+
+    def "preserves a shared failure's identity across fetch results"() {
+        def shared = failure("shared", [])
+        def rootA = failure("project :a failed", [shared])
+        def rootB = failure("project :b failed", [shared])
+
+        given:
+        2 * delegate.fetch(null, _, null) >>> [result(rootA), result(rootB)]
+
+        when:
+        def failureA = controller.fetch(Object).failures.first()
+        def failureB = controller.fetch(Object).failures.first()
+
+        then:
+        !failureA.is(failureB)
+        failureA.causes.first().is(failureB.causes.first())
+    }
+
+    private InternalFailure failure(String message, List<InternalFailure> causes) {
+        Stub(InternalFailure) {
+            getMessage() >> message
+            getOwnDescription() >> "java.lang.RuntimeException: $message\n"
+            getDescription() >> "java.lang.RuntimeException: $message\n"
+            getCauses() >> causes
+            getProblems() >> []
+        }
+    }
+
+    private InternalFetchModelResult<Object> result(InternalFailure failure) {
+        Stub(InternalFetchModelResult) {
+            getModel() >> null
+            getFailures() >> [failure]
+        }
+    }
+
+    private interface FetchingBuildController extends InternalBuildControllerVersion2, InternalActionAwareBuildController, InternalStreamedValueRelay, InternalFetchAwareBuildController {}
+}

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/FailureReconstructionTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/FailureReconstructionTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.consumer.parameters
 
+import org.gradle.tooling.internal.consumer.DefaultFailure
 import org.gradle.tooling.internal.protocol.FailureDescriptionReconstructor
 import org.gradle.tooling.internal.protocol.InternalFailure
 import spock.lang.Specification
@@ -79,14 +80,26 @@ class FailureReconstructionTest extends Specification {
         rebuiltRoot.description.contains("java.lang.RuntimeException: boom")
         rebuiltRoot.description.contains("Caused by: java.lang.IllegalStateException: inner")
         !rebuiltRoot.description.contains("FULL-NOT-USED")
+
+        and: "the node-only descriptions are exposed without duplicating the cause text"
+        rebuiltRoot.ownDescription == "java.lang.RuntimeException: boom\n\tat Root.run(Root.java:9)"
+        rebuiltRoot.causes[0].ownDescription == "java.lang.IllegalStateException: inner\n\tat Inner.run(Inner.java:5)"
     }
 
-    def "falls back to the full description when the daemon has no own description (#error.class.simpleName)"() {
+    def "falls back to full descriptions without deriving node-only descriptions (#error.class.simpleName)"() {
+        def nl = System.lineSeparator()
+        def leaf = Stub(InternalFailure) {
+            getMessage() >> "inner"
+            getOwnDescription() >> { throw error }
+            getDescription() >> "java.lang.IllegalStateException: inner${nl}\tat Inner.run(Inner.java:5)${nl}"
+            getCauses() >> []
+            getProblems() >> []
+        }
         def origFailure = Stub(InternalFailure) {
             getMessage() >> "boom"
             getOwnDescription() >> { throw error }
-            getDescription() >> "FULL TEXT FROM OLD DAEMON"
-            getCauses() >> []
+            getDescription() >> "java.lang.RuntimeException: boom${nl}\tat Root.run(Root.java:9)${nl}Caused by: java.lang.IllegalStateException: inner${nl}\t... 1 more${nl}"
+            getCauses() >> [leaf]
             getProblems() >> []
         }
 
@@ -94,12 +107,26 @@ class FailureReconstructionTest extends Specification {
         def failures = BuildProgressListenerAdapter.toFailures([origFailure])
 
         then:
-        failures[0].description == "FULL TEXT FROM OLD DAEMON"
+        failures[0].description == "java.lang.RuntimeException: boom${nl}\tat Root.run(Root.java:9)${nl}Caused by: java.lang.IllegalStateException: inner${nl}\t... 1 more${nl}"
+        failures[0].ownDescription == null
+        failures[0].causes.first().ownDescription == null
 
         where:
         // An old daemon's InternalFailure implements the interface without the method (AbstractMethodError) or
         // predates it entirely (NoSuchMethodError); the consumer must fall back in both cases.
         error << [new AbstractMethodError("old daemon"), new NoSuchMethodError("old daemon")]
+    }
+
+    def "fromThrowable does not derive node-only descriptions"() {
+        def throwable = new RuntimeException("outer", new IllegalStateException("inner"))
+
+        when:
+        def failure = DefaultFailure.fromThrowable(throwable)
+
+        then:
+        failure.description.contains("Caused by: java.lang.IllegalStateException: inner")
+        failure.ownDescription == null
+        failure.causes.first().ownDescription == null
     }
 
     def "does not read the full per-node description when own descriptions are available"() {

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -388,7 +388,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 603 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 610 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Kotlin DSL
         assertIsGradleJar(contentsDir.file("lib/gradle-kotlin-dsl-${baseVersion}.jar"))


### PR DESCRIPTION
A failure reported by multiple resilient model fetches can contain the same underlying cause:


```
  project :a failure 
    ─ shared configuration failure
  project :b failure
    ─ shared configuration failure
  ```


  Although the provider can preserve this sharing, the Tooling API consumer previously converted the protocol failure
  separately for every `FetchModelResult`. Clients therefore received different `Failure` instances and could not use
  reference identity to avoid processing the shared cause repeatedly.

  Additionally, `Failure.getDescription()` contains the description of the complete cause subtree. Calling it for every node can therefore process the same text repeatedly and result in quadratic work.

  ### Changes

  - Preserve `Failure` reference identity across fetches within one build action.
    - Add a build-action-scoped, thread-safe consumer failure cache.
    - Cache by protocol object identity rather than `equals()`.
    - Route thrown fetch failures through the provider's existing scoped failure converter.
    - Document that Gradle attempts to reuse `Failure` instances across fetch results.

  - Add the incubating `Failure.getOwnDescription()` API.
    - Returns the description of the current node without its causes.
    - Allows clients to analyze each unique failure node without repeatedly processing its cause subtree.
    - Returns `null` when used with providers earlier than Gradle 9.7, where this information is unavailable.

  Clients can combine these features by traversing failures using an `IdentityHashMap<Failure, ...>` and analyzing
  `getOwnDescription()` once per unique node.

  ### Compatibility

`getOwnDescription()` works for 9.7+ daemon while `Preserve Failure reference identity across fetches within one build action` works for most cases with 9.7+ daemon. Some exceptional cases were additionally handled and will work only with 9.9.0+ daemon.