### PR TITLE
Stop resolving CC entry-selection services through the root build host

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheCandidateEntries.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheCandidateEntries.kt
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.internal.cc.base.serialize.HostServiceProvider
-import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.cc.operations.EntrySearchResult
 
 
@@ -25,7 +23,7 @@ internal class ConfigurationCacheCandidateEntries(
     private val store: ConfigurationCacheStateStore,
     private val cacheIO: ConfigurationCacheBuildTreeIO,
     private val entriesPerKey: Int,
-    private val host: HostServiceProvider
+    private val entryCollector: ConfigurationCacheEntryCollector
 ) {
 
     fun searchForValidEntry(checkCandidate: (CandidateEntry) -> EntrySearchResult): EntrySearchResult {
@@ -101,12 +99,8 @@ internal class ConfigurationCacheCandidateEntries(
 
     private
     fun scheduleForCollection(evictedEntries: List<CandidateEntry>) {
-        if (evictedEntries.isNotEmpty()) {
-            host.service<ConfigurationCacheEntryCollector>().let { collector ->
-                evictedEntries.forEach { entry ->
-                    collector.scheduleForCollection(entry.id)
-                }
-            }
+        evictedEntries.forEach { entry ->
+            entryCollector.scheduleForCollection(entry.id)
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.internal.cc.base.logger
 import org.gradle.internal.cc.base.serialize.HostServiceProvider
@@ -85,8 +84,7 @@ internal class ConfigurationCacheEntrySelector(
     private
     fun ConfigurationCacheRepository.Layout.checkFingerprint(candidateEntry: CandidateEntry, rootDirs: List<File>): CheckedFingerprint {
         if (rootDirs.isNotEmpty() && startParameter.buildTreeRootDirectory !in rootDirs) {
-            return CheckedFingerprint.Invalid(
-                buildPath(),
+            return invalidBuildTreeFingerprint(
                 StructuredMessage.build {
                     text("the location of the build has changed from ")
                     reference(rootDirs.first().path)
@@ -103,7 +101,7 @@ internal class ConfigurationCacheEntrySelector(
 
         val classLoaderScopesInvalidationReason = checkClassLoaderScopes()
         if (classLoaderScopesInvalidationReason != null) {
-            return CheckedFingerprint.Invalid(buildPath(), classLoaderScopesInvalidationReason)
+            return invalidBuildTreeFingerprint(classLoaderScopesInvalidationReason)
         }
 
         val systemPropertiesSnapshot = System.getProperties().clone()
@@ -139,11 +137,11 @@ internal class ConfigurationCacheEntrySelector(
                     )
                 }
 
-                else -> CheckedFingerprint.Invalid(buildPath(), invalidationReason)
+                else -> invalidBuildTreeFingerprint(invalidationReason)
             }
         } catch (e: FingerprintDeserializationException) {
             logger.info("Configuration cache entry discarded because a fingerprint value could not be loaded", e)
-            CheckedFingerprint.Invalid(buildPath(), e.reason)
+            invalidBuildTreeFingerprint(e.reason)
         }
 
     private
@@ -170,8 +168,8 @@ internal class ConfigurationCacheEntrySelector(
         cacheIO.readFingerprintFrom(fingerprintFile, host, action)
 
     private
-    fun buildPath(): Path =
-        host.service<GradleInternal>().identityPath
+    fun invalidBuildTreeFingerprint(invalidationReason: StructuredMessage) =
+        CheckedFingerprint.Invalid(Path.ROOT, invalidationReason)
 
     private
     fun registerWatchableBuildDirectories(buildDirs: Iterable<File>) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
@@ -19,7 +19,6 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.internal.cc.base.logger
 import org.gradle.internal.cc.base.serialize.HostServiceProvider
-import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.cc.impl.fingerprint.ClassLoaderScopesFingerprintController
 import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.internal.cc.impl.fingerprint.InvalidationReason
@@ -50,6 +49,7 @@ internal class ConfigurationCacheEntrySelector(
     private val classLoaderScopes: ClassLoaderScopesFingerprintController,
     private val virtualFileSystem: BuildLifecycleAwareVirtualFileSystem,
     private val buildOperationRunner: BuildOperationRunner,
+    private val gradlePropertiesController: GradlePropertiesController,
     private val host: HostServiceProvider
 ) {
     fun selectEntry(): CheckedFingerprint = buildOperationRunner.withFingerprintCheckOperations {
@@ -175,10 +175,6 @@ internal class ConfigurationCacheEntrySelector(
     fun registerWatchableBuildDirectories(buildDirs: Iterable<File>) {
         buildDirs.forEach(virtualFileSystem::registerWatchableHierarchy)
     }
-
-    private
-    val gradlePropertiesController: GradlePropertiesController
-        get() = host.service()
 
     private
     fun rollbackProperties(systemPropertiesSnapshot: Properties) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheEntrySelector.kt
@@ -18,7 +18,6 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.internal.cc.base.logger
-import org.gradle.internal.cc.base.serialize.HostServiceProvider
 import org.gradle.internal.cc.impl.fingerprint.ClassLoaderScopesFingerprintController
 import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.internal.cc.impl.fingerprint.InvalidationReason
@@ -30,6 +29,7 @@ import org.gradle.internal.cc.operations.withFingerprintCheckOperations
 import org.gradle.internal.configuration.problems.StructuredMessage
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.internal.serialize.graph.IsolateOwner
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.util.Path
@@ -50,7 +50,7 @@ internal class ConfigurationCacheEntrySelector(
     private val virtualFileSystem: BuildLifecycleAwareVirtualFileSystem,
     private val buildOperationRunner: BuildOperationRunner,
     private val gradlePropertiesController: GradlePropertiesController,
-    private val host: HostServiceProvider
+    private val isolateOwner: IsolateOwner
 ) {
     fun selectEntry(): CheckedFingerprint = buildOperationRunner.withFingerprintCheckOperations {
         val searchResult = candidateEntries.searchForValidEntry(::checkCandidate)
@@ -165,7 +165,7 @@ internal class ConfigurationCacheEntrySelector(
         fingerprintFile: ConfigurationCacheStateFile,
         action: suspend ReadContext.(ConfigurationCacheFingerprintController.Host) -> T
     ): T =
-        cacheIO.readFingerprintFrom(fingerprintFile, host, action)
+        cacheIO.readFingerprintFrom(fingerprintFile, isolateOwner, action)
 
     private
     fun invalidBuildTreeFingerprint(invalidationReason: StructuredMessage) =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -161,7 +161,7 @@ class DefaultConfigurationCache internal constructor(
             virtualFileSystem,
             buildOperationRunner,
             gradlePropertiesController,
-            host
+            isolateOwnerHost
         )
     }
 
@@ -717,7 +717,7 @@ class DefaultConfigurationCache internal constructor(
     fun ConfigurationCacheRepository.Layout.writeConfigurationCacheFingerprint(reusedProjects: Set<Path>) {
         // Collect fingerprint entries for any projects whose state was reused from cache
         if (reusedProjects.isNotEmpty()) {
-            cacheIO.readFingerprintFrom(fileForRead(StateType.ProjectFingerprint), host) { fingerprintHost ->
+            cacheIO.readFingerprintFrom(fileForRead(StateType.ProjectFingerprint), isolateOwnerHost) { fingerprintHost ->
                 cacheFingerprintController.run {
                     collectFingerprintForReusedProjects(fingerprintHost, reusedProjects)
                 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.properties.GradlePropertiesController
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
 import org.gradle.api.logging.LogLevel
@@ -100,7 +101,8 @@ class DefaultConfigurationCache internal constructor(
     private val fileSystemAccess: FileSystemAccess,
     private val calculatedValueContainerFactory: CalculatedValueContainerFactory,
     private val modelSideEffectExecutor: ConfigurationCacheBuildTreeModelSideEffectExecutor,
-    private val deferredRootBuildGradle: DeferredRootBuildGradle
+    private val deferredRootBuildGradle: DeferredRootBuildGradle,
+    private val gradlePropertiesController: GradlePropertiesController
 ) : BuildTreeConfigurationCache, Stoppable {
 
     private
@@ -157,6 +159,7 @@ class DefaultConfigurationCache internal constructor(
             classLoaderScopes,
             virtualFileSystem,
             buildOperationRunner,
+            gradlePropertiesController,
             host
         )
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -102,7 +102,8 @@ class DefaultConfigurationCache internal constructor(
     private val calculatedValueContainerFactory: CalculatedValueContainerFactory,
     private val modelSideEffectExecutor: ConfigurationCacheBuildTreeModelSideEffectExecutor,
     private val deferredRootBuildGradle: DeferredRootBuildGradle,
-    private val gradlePropertiesController: GradlePropertiesController
+    private val gradlePropertiesController: GradlePropertiesController,
+    private val entryCollector: ConfigurationCacheEntryCollector
 ) : BuildTreeConfigurationCache, Stoppable {
 
     private
@@ -145,7 +146,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     val candidateEntries by lazy {
-        ConfigurationCacheCandidateEntries(store, cacheIO, startParameter.entriesPerKey, host)
+        ConfigurationCacheCandidateEntries(store, cacheIO, startParameter.entriesPerKey, entryCollector)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/FingerprintRead.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/FingerprintRead.kt
@@ -17,12 +17,11 @@
 package org.gradle.internal.cc.impl.fingerprint
 
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
-import org.gradle.internal.cc.base.serialize.HostServiceProvider
-import org.gradle.internal.cc.base.serialize.IsolateOwners
-import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.cc.impl.ConfigurationCacheBuildTreeIO
 import org.gradle.internal.cc.impl.ConfigurationCacheStateFile
+import org.gradle.internal.serialize.graph.IsolateOwner
 import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.serviceOf
 import org.gradle.internal.serialize.graph.withIsolate
 
 
@@ -32,13 +31,13 @@ import org.gradle.internal.serialize.graph.withIsolate
 internal
 fun <T> ConfigurationCacheBuildTreeIO.readFingerprintFrom(
     stateFile: ConfigurationCacheStateFile,
-    host: HostServiceProvider,
+    isolateOwner: IsolateOwner,
     action: suspend ReadContext.(ConfigurationCacheFingerprintController.Host) -> T
 ): T {
     val decoder = decoderFor(stateFile.stateType, stateFile::inputStream)
     return runReadOperation(stateFile.stateFile.name, decoder) { codecs ->
-        withIsolate(IsolateOwners.OwnerHost(host), codecs.fingerprintTypesCodec()) {
-            action(FingerprintControllerHost(host))
+        withIsolate(isolateOwner, codecs.fingerprintTypesCodec()) {
+            action(FingerprintControllerHost(isolateOwner))
         }
     }
 }
@@ -46,8 +45,8 @@ fun <T> ConfigurationCacheBuildTreeIO.readFingerprintFrom(
 
 private
 class FingerprintControllerHost(
-    private val host: HostServiceProvider
+    private val isolateOwner: IsolateOwner
 ) : ConfigurationCacheFingerprintController.Host {
     override val valueSourceProviderFactory: ValueSourceProviderFactory
-        get() = host.service()
+        get() = isolateOwner.serviceOf()
 }


### PR DESCRIPTION
Removes four places where configuration cache entry selection resolved services through the root build's host although they were reachable directly.

### Why

The cache is a build-tree service. Its entry selection code still reached the properties controller, the entry collector, the root build's identity path and the value source factory through the root build's `ConfigurationCacheHost`. For the first three the detour was unnecessary. The services live in the build-tree or build-session scope, and the host's child registry returns the same singleton that constructor injection returns. Each detour hid an ordering dependency on the root build being attached before use. This is groundwork for a fingerprint check that does not depend on the root build. It does not change when or where the check runs.

### What

- The properties controller and the entry collector are constructor-injected.
- An invalid build-tree fingerprint reports the root path directly.
- Fingerprint reading takes an isolate owner instead of a host service provider.
  - The entry selector and the candidate entries no longer hold a host.

### Verification

- Service identity checked against `DefaultServiceRegistry`: a lookup through a child registry for a type registered only in an ancestor returns the ancestor's singleton. Neither injected type is re-registered in build scope.
- No new tests. The change replaces lookups with injection of the same instances; existing entry selection coverage applies.

### Details

**Same instances, different route.** Build logic and the cache entry format see no difference.

**The root path is hard-coded for the build-tree fingerprint.** The identity path came from the root build's `GradleInternal`. For the build-tree fingerprint that path is always the root, so the lookup added a dependency without adding information.

**One root-build lookup remains on this path.** The value source factory is still resolved through the isolate owner, which is the root build's host. Removing it needs a build-tree scoped instantiator, which is follow-up work; revisit when that lands.
