### PR TITLE
Stop injecting GradleProperties into value sources

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.GradleException;
 import org.gradle.api.NonExtensible;
-import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.internal.provider.ValueSupplier.ExecutionTimeValue;
 import org.gradle.api.internal.provider.ValueSupplier.Value;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -53,7 +52,6 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
 
     private final InstantiatorFactory instantiatorFactory;
     private final IsolatableFactory isolatableFactory;
-    private final GradleProperties gradleProperties;
     private final CalculatedValueFactory calculatedValueFactory;
     private final ExecOperations execOperations;
     private final ValueListener valueListener;
@@ -67,7 +65,6 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         ComputationListener computationListener,
         InstantiatorFactory instantiatorFactory,
         IsolatableFactory isolatableFactory,
-        GradleProperties gradleProperties,
         CalculatedValueFactory calculatedValueFactory,
         ExecOperations execOperations,
         ServiceLookup services
@@ -76,7 +73,6 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         this.computationListener = computationListener;
         this.instantiatorFactory = instantiatorFactory;
         this.isolatableFactory = isolatableFactory;
-        this.gradleProperties = gradleProperties;
         this.calculatedValueFactory = calculatedValueFactory;
         this.execOperations = execOperations;
         // TODO - dedupe logic copied from DefaultBuildServicesRegistry
@@ -137,7 +133,6 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         ServiceRegistry services = ServiceRegistryBuilder.builder()
             .displayName("value source services")
             .provider(registration -> {
-                registration.add(GradleProperties.class, gradleProperties);
                 registration.add(ExecOperations.class, execOperations);
                 registration.add(parametersType, isolatedParameters);
             })

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.Action
-import org.gradle.api.internal.properties.GradleProperties
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -46,7 +45,6 @@ abstract class ValueSourceBasedSpec extends Specification {
         computationListener,
         TestUtil.instantiatorFactory(),
         isolatableFactory,
-        Mock(GradleProperties),
         TestUtil.calculatedValueContainerFactory(),
         execOperations,
         TestUtil.services()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -61,7 +61,6 @@ class LibrariesSourceGeneratorTest extends AbstractVersionCatalogTest {
             Stub(ValueSourceProviderFactory.ComputationListener),
             TestUtil.instantiatorFactory(),
             new TestIsolatableFactory(),
-            Stub(GradleProperties),
             TestUtil.calculatedValueContainerFactory(),
             Stub(ExecOperations),
             TestUtil.services()

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -428,7 +428,6 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         InstantiatorFactory instantiatorFactory,
         IsolatableFactory isolatableFactory,
         ServiceRegistry services,
-        GradleProperties gradleProperties,
         ExecFactory execFactory,
         CalculatedValueFactory calculatedValueFactory
     ) {
@@ -437,7 +436,6 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
             computationListener,
             instantiatorFactory,
             isolatableFactory,
-            gradleProperties,
             calculatedValueFactory,
             new DefaultExecOperations(execFactory.forContext().withoutExternalProcessStartedListener().build()),
             services


### PR DESCRIPTION
Removes the internal `GradleProperties` service from the set of services that can be injected into a `ValueSource` implementation. Only `ExecOperations` and the parameters object remain.

### Why

The injection was added in January 2020 to support `GradlePropertyValueSource`, which was then the implementation behind `providers.gradleProperty`. That value source was removed in August 2025, when `providers.gradleProperty` became a plain provider over the build's properties. The registration stayed behind.

The result was an internal service that user code could reach, but only by accident. It is absent from the `ValueSource` javadoc and from the user guide, both of which list `ExecOperations` as the one supported service.

The injection was also unsound for composite builds. During a fingerprint check, a value source is re-instantiated through the root build's provider factory, so it receives the root build's properties. A value source declared in an included build or in `buildSrc` was therefore checked against the wrong build, which invalidates the entry on every run, or hides a real change when the root value happens to match.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
