### PR TITLE
Narrow the Claude git push deny to protected branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,10 @@
       "Bash(.claude/skills/gradle-code-review/gradle-code-review.sh:*)"
     ],
     "deny": [
-      "Bash(git push *)"
+      "Bash(git push * master*)",
+      "Bash(git push * release*)",
+      "Bash(git push *:master*)",
+      "Bash(git push *:release*)"
     ]
   }
 }


### PR DESCRIPTION
## Problem

`.claude/settings.json` allows `Bash(git *)` then denies `Bash(git push *)`. As written it blocks **every** push, including to a personal feature branch — so agent-assisted workflows that end in a PR can't complete, including this repo's own `ci-check` skills.

Deny rules override allow rules and `bypassPermissions`, so there's no local opt-in. Editing this file is the only way out.

## Change

Restrict the deny to `master` and `release*`; leave feature branches pushable.

```json
"deny": [
  "Bash(git push * master*)",
  "Bash(git push * release*)",
  "Bash(git push *:master*)",
  "Bash(git push *:release*)"
]
```

Best-effort pattern matching, not a security control — a bare `git push` with `master` checked out matches none of these. GitHub branch protection remains the real guard.

## Context

Introduced by 96653801de5c in #38518, which imported the rule wholesale from `bt-agents`; I found no discussion of it for gradle/gradle specifically. The DV repo hit the same over-broad deny and narrowed rather than removed it ([gradle/dv#63082](https://github.com/gradle/dv/pull/63082)).

Open question: whether to also deny `--force`/`-f`. Left out to keep this to what it says on the tin.

cc @ghale