### PR TITLE
Give ParallelDownloads tests worker lease headroom

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
@@ -33,6 +33,16 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
     String getAuthConfig() { '' }
 
+    /**
+     * Artifact downloads run on the MAX_WORKERS build operation executor, whose queue is backed by
+     * {@code maxWorkerCount - 1} threads plus the submitting thread. A test that blocks until N downloads
+     * are simultaneously in flight therefore needs max workers > N: at exactly N it is sitting on the
+     * theoretical ceiling, so any other worker lease holder in the build leaves only N-1 downloads in
+     * flight, {@link BlockingHttpServer#expectConcurrent} never releases them, and the build wedges until
+     * the client's 60s HTTP socket timeout frees a lease and lets the last request through far too late.
+     */
+    private static final String MAX_WORKERS = '8'
+
     def "downloads artifacts in parallel from a Maven repo - #expression"() {
         def m1 = mavenRepo.module('test', 'test1', '1.0').publish()
         def m2 = mavenRepo.module('test', 'test2', '1.0').publish()
@@ -75,7 +85,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.artifact.path).sendFile(m4.artifact.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
 
         where:
@@ -130,7 +140,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.jar.path).sendFile(m4.jar.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
     }
 
@@ -272,7 +282,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.jar.path).sendFile(m4.jar.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
     }
 


### PR DESCRIPTION
## Problem

`ParallelDownloadsIntegrationTest` and its subclass `ParallelDownloadsOnAuthenticatedRepoIntegrationTest` fail intermittently across all seven integ-test buckets — **104/789 (13.2%)** and **90/791 (11.4%)** flaky between 2026-08-25 and 2026-09-06, and rising.

Artifact downloads run on the MAX_WORKERS build operation executor, whose queue is backed by `maxWorkerCount - 1` threads plus the submitting thread (`DefaultBuildOperationExecutor.java:63`; the `-1` dates to #3273). Three of these tests block until **four** downloads are simultaneously in flight while running with `--max-workers 4` — exactly the theoretical ceiling. If anything else in the build holds one of the four leases, only three downloads start, `expectConcurrent(4)` never releases them, and the build wedges until the client's `socketTimeout=60000` frees a lease.

Metadata is unaffected (unconstrained executor, 20/route), which gives the failure a clean fingerprint: every failing execution lasts 62–65s, all POMs arrive within milliseconds, and the last jar arrives at exactly +60.0s. `BlockingHttpServer`'s own timeout is 120s, so the client always dies first and the harness never prints its "did not receive expected concurrent requests" message — every failure surfaces as an opaque `Read timed out`.

Two natural controls confirm the mechanism, both **0 flaky** over the same sample: `should not deadlock when downloading parent pom…` (needs only 2 of 4 leases) and `configurations.compile.files` (resolves eagerly at configuration time, before the task graph competes for leases).

## Fix

Raise the three 4-of-4 sites to `--max-workers 8` so the demanded concurrency sits below the ceiling instead of on it. The parent-pom test already has headroom and is left alone.

## Verification

**Local, deterministic.** Setting max workers *below* the demanded concurrency reproduces the CI failure every time:

| `--max-workers` | Result |
|---|---|
| **3** (below the 4 demanded) | **FAILED, 65.09s** — jars 1/2/3 at `20:28:16.854`, jar 4 at `20:29:16.891` (**+60.04s**), 12× `Read timed out` |
| 4 (master, at the ceiling) | PASS, 17s |
| 8 (this change) | PASS, 18s |

That is the exact CI signature. Note `4` and `8` both pass locally — a quiet machine never produces the competing lease holder, so **local cannot discriminate the fix**; it can only prove the mechanism.

**CI red-before control.** `Gradle_Master_Util_RerunFlakyTestLinuxAmd64` on `master`, 3 builds × 10 executions of `:dependency-management:configCacheIntegTest`: builds `117044337` (10 pass), `117044339` (**1 fail**, 9 pass), `117044341` (10 pass). The failure was `…Maven repo - configurations.compile.incoming.artifacts.artifactFiles`, duration **61,754 ms**.

That reproduced at 3.3% versus the ~13% seen in real buckets, because `RerunFlakyTest` runs the task in isolation with less competing work. Good enough as a positive control, **too weak to prove the fix** — 30 green runs against a 3.3% base rate is not significant. The green-after run should target the real integ-test buckets.

## Not covered

- `downloads more dependencies in parallel than the number of max workers` sets `expectedArtifactParallelism = maxWorkers` by construction, so it is knife-edge by design and headroom cannot fix it.
- The production issue remains: `ParallelResolveArtifactSet.java:67` carries a TODO to move downloads to `BuildOperationQueue#addUnconstrained`, blocked on classifying the CPU-bound transform work submitted by `Artifact#startFinalization`. This PR buys headroom; it does not stop a lease being taken.

Same lease-ceiling pattern as #39012 (`ScalaConcurrencyIntegrationTest`).