### PR TITLE
Give ParallelDownloads tests worker lease headroom

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
@@ -33,6 +33,16 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
 
     String getAuthConfig() { '' }
 
+    /**
+     * Artifact downloads run on the MAX_WORKERS build operation executor, whose queue is backed by
+     * {@code maxWorkerCount - 1} threads plus the submitting thread. A test that blocks until N downloads
+     * are simultaneously in flight therefore needs max workers > N: at exactly N it is sitting on the
+     * theoretical ceiling, so any other worker lease holder in the build leaves only N-1 downloads in
+     * flight, {@link BlockingHttpServer#expectConcurrent} never releases them, and the build wedges until
+     * the client's 60s HTTP socket timeout frees a lease and lets the last request through far too late.
+     */
+    private static final String MAX_WORKERS = '8'
+
     def "downloads artifacts in parallel from a Maven repo - #expression"() {
         def m1 = mavenRepo.module('test', 'test1', '1.0').publish()
         def m2 = mavenRepo.module('test', 'test2', '1.0').publish()
@@ -75,7 +85,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.artifact.path).sendFile(m4.artifact.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
 
         where:
@@ -130,7 +140,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.jar.path).sendFile(m4.jar.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
     }
 
@@ -272,7 +282,7 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.jar.path).sendFile(m4.jar.file))
 
         expect:
-        executer.withArguments('--max-workers', '4')
+        executer.withArguments('--max-workers', MAX_WORKERS)
         succeeds("resolve")
     }
 


### PR DESCRIPTION
### Context

`ParallelDownloadsIntegrationTest` and its subclass `ParallelDownloadsOnAuthenticatedRepoIntegrationTest` have been flaky across all seven integ-test buckets. Over 2026-09-01 → 09-06 they ran **12.8%** (50 flaky + 1 failed / 391) and **15.1%** (59 flaky / 392) — up from ~4.4–4.9% over the preceding six weeks, so this is getting worse rather than settling.

Authentication is not the differentiator: the non-auth base class is equally flaky (177/4014 vs 197/4030 in the earlier window).

#### Root cause

Artifact downloads run on the `MAX_WORKERS` build operation executor, whose queue is backed by `maxWorkerCount - 1` threads plus the submitting thread ([`DefaultBuildOperationExecutor.java:63`](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java#L63), the `-1` dating to #3273). Three of these tests block until four downloads are simultaneously in flight while running with `--max-workers 4` — the theoretical ceiling, with zero headroom. If anything else in the build holds one of the four worker leases, only three downloads start, `expectConcurrent(4)` never releases, and the build wedges until the client's 60s HTTP socket timeout frees a lease and lets the fourth request through far too late.

Metadata is unaffected because it uses the unconstrained executor at 20-per-route, which is why every failure shows all POMs arriving within milliseconds while the jars starve.

From a representative failure (build scan `nfesmudqlx5f6`):

```
21:19:35.576  handling GET /test/test2/1.0/test2-1.0.jar
21:19:35.578  handling GET /test/test1/1.0/test1-1.0.jar
21:19:35.579  handling GET /test/test3/1.0/test3-1.0.jar   <- 3 in flight, "waiting for 1 further requests"
21:20:35.640  handling GET /test/test4/1.0/test4-1.0.jar   <- exactly +60.06s
21:20:36.147  handling GET .../test2-1.0.jar failed with exception
              > Could not GET '.../test1-1.0.jar'. > Read timed out
```

The wedge is invisible while it lasts and then surfaces as an opaque `Read timed out`, because `BlockingHttpServer`'s own timeout is 120s and never gets to report the concurrent request it was still waiting for.

#### Evidence

Two natural control cases in the same class have **zero** flakiness in ~3900 runs each, both consistent with lease starvation and nothing else:

| Test case | Concurrency demanded | Flaky |
|---|---|---|
| 5 lazy Maven expressions, Ivy repo, metadata rules | 4 of max-workers 4 | 21–41 each |
| `downloads more dependencies…than max workers` | 2 of 2 | 28 |
| `should not deadlock…parent pom` | **2 of 4 (headroom)** | **0** |
| `configurations.compile.files` (resolves eagerly at configuration time) | 4 of 4 | **0** |

The mechanism reproduces deterministically — no need to chase a 13% flake. Setting max workers *below* the demanded concurrency (3 when 4 are expected) fails every time in ~65s with the identical server-log shape and `SocketTimeoutException at SessionInputBufferImpl.java:137`.

### Fix

Raise max workers to 8 for the three tests that block on four concurrent downloads, so the demanded concurrency sits below the ceiling rather than on it. Each still requires four genuinely concurrent downloads, and each phase issues only four requests in total, so the extra workers cannot mask a regression by permitting more parallelism than the test intends. For `component metadata rules are executed synchronously` it makes the assertion slightly stronger.

Two tests are deliberately left at four:

- `should not deadlock when downloading parent pom concurrently with a top-level dependency` already has headroom at two of four leases.
- `downloads more dependencies in parallel than the number of max workers` asserts that artifact parallelism *equals* max workers, so it is knife-edge by construction and headroom cannot fix it. It accounts for roughly 11% of the case-level flakiness and is left for separate consideration.

### Not addressed here

The underlying production limitation is already tracked by the TODO at [`ParallelResolveArtifactSet.java:67`](https://github.com/gradle/gradle/blob/master/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java#L67): downloads should use `BuildOperationQueue#addUnconstrained`, blocked on classifying the CPU-bound transform work submitted by `Artifact#startFinalization`. Commit 486244b7848 moved artifact resolution onto `MAX_WORKERS` and flagged the same thing. For real users this ceiling is a mild throughput limit, never a hang — the hang is an artifact of the blocking server, so the flakiness genuinely lives in the test's zero-headroom assumption.

gradle/gradle#39012 fixes `ScalaConcurrencyIntegrationTest`, which starves on the same worker leases (3 of 4 held by blocked `:test` tasks). These two are siblings and probably worth reviewing together.

### Verification

- Both classes: 20/20 green, 0 skipped, on current master.
- Mechanism confirmed by forcing the shortfall as described above.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic — n/a, test-only change.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes — n/a.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck` — not yet run locally; test-only change.
- [x] Ensure that tests pass locally: `./gradlew :dependency-management:embeddedIntegTest --tests '*ParallelDownloads*'`

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things