### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,9 +23,9 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default ReadyForNightly performance baseline
-defaultRfnPerformanceBaselines=9.8.0-commit-242eb931e5f
+defaultRfnPerformanceBaselines=9.9.0-commit-6e1d3eb66bc
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.7.1-commit-ff0c023bffc
+defaultRfrPerformanceBaselines=9.9.0-commit-6e1d3eb66bc
 systemProp.dependency.analysis.test.analysis=false
 
 # Informs BuildCommitDistribution task that the current commit can be built with CC enabled


### PR DESCRIPTION
We observed some perf tests failures with non-prod changes. Also, ReadyForRelease also fails with ~1% regression.