### PR TITLE
TeamCity: drop the shared-host agent requirement

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -98,15 +98,6 @@ fun Requirements.requiresNotEc2Agent() {
 }
 
 /**
- * We have some "shared" host where a Linux build agent and a Windows build agent
- * both run on the same bare metal. Some builds require exclusive access to the
- * hardware resources (e.g. performance test).
- */
-fun Requirements.requiresNotSharedHost() {
-    doesNotContain("agent.host.type", "shared")
-}
-
-/**
  * This is an undocumented location that forbids anonymous access.
  * We put artifacts here to avoid accidentally exposing sensitive information publicly.
  */

--- a/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
@@ -37,7 +37,6 @@ fun BuildType.applyPerformanceTestSettings(
     detectHangingBuilds = false
     requirements {
         requiresNotEc2Agent()
-        requiresNotSharedHost()
     }
     params {
         param("env.JPROFILER_HOME", os.jprofilerHome)

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -10,7 +10,6 @@ import common.customGradle
 import common.functionalTestParameters
 import common.getBuildScanCustomValueParam
 import common.gradleWrapper
-import common.requiresNotSharedHost
 import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
@@ -61,10 +60,6 @@ class Gradleception(
             }
         description =
             "Builds Gradle with the version of Gradle which is currently under development (twice)$descriptionSuffix"
-
-        requirements {
-            requiresNotSharedHost()
-        }
 
     /*
      To avoid unnecessary rerun, what we do here is a bit complicated:


### PR DESCRIPTION
## Summary
- Remove `requiresNotSharedHost()` and its two call sites (performance tests, Gradleception).
- Nothing has set `agent.host.type=shared` since the last mixed Linux/Windows Hetzner boxes were converted in 2023; [gradle/dev-infrastructure#3339](https://github.com/gradle/dev-infrastructure/pull/3339) deletes the last setter.

Follow-up from [cobexer's comment](https://github.com/gradle/dev-infrastructure/pull/3339#issuecomment-5567298567) on that PR.

## Test plan
- [ ] Confirm `rg requiresNotSharedHost .teamcity` is empty
- [ ] TeamCity config check on this branch still compiles (Check CI / TeamCity DSL)