### PR TITLE
Revert "Update tested AGP versions"

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,6 +1,6 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-aapt2Versions=9.0.1-14304508,9.1.1-14792394,9.2.1-15009934,9.3.2-15703166,9.4.0-15978811,9.5.0-alpha04-15978811
+aapt2Versions=9.0.1-14304508,9.1.1-14792394,9.2.1-15009934,9.3.2-15703166,9.4.0-rc02-15978811,9.5.0-alpha03-15978811
 buildToolsVersion=36.0.0
-latests=9.0.1,9.1.1,9.2.1,9.3.2,9.4.0,9.5.0-alpha04
-nightlyBuildId=16272297
+latests=9.0.1,9.1.1,9.2.1,9.3.2,9.4.0-rc02,9.5.0-alpha03
+nightlyBuildId=16211158
 nightlyVersion=9.5.0-dev

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -123,7 +123,7 @@ Gradle plugins written in Groovy must use Groovy 4.x for compatibility with Grad
 [[android_compatibility]]
 == Android
 
-Gradle is tested with Android Gradle Plugin 9.0 through 9.5.0-alpha04.
+Gradle is tested with Android Gradle Plugin 9.0 through 9.5.0-alpha03.
 Alpha and beta versions may or may not work.
 
 [[target_platforms]]


### PR DESCRIPTION
### Context

Reverts #39060, which promoted the tested AGP version from `9.4.0-rc02` to the `9.4.0` release (and `9.5.0-alpha03` → `9.5.0-alpha04`).

That bump moves `AndroidGradlePluginVersions.latestStable` from `9.3.2` to `9.4.0`. `RealLifeAndroidStudioPerformanceTest` uses `latestStable` for its Studio sync scenario, but the smoke-tested Android Studio is pinned at `2026.1.3.8`, which supports at most AGP 9.3.0. The sync therefore fails deterministically:

```
java.lang.IllegalStateException: Gradle sync has failed with error message:
'The project is using an incompatible version (AGP 9.4.0) of the Android Gradle plugin.
 Latest supported version is AGP 9.3.0'
  at org.gradle.profiler.ide.IdeGradleClient.maybeThrownExceptionOnSyncFailure
```

The test's `-Dcom.android.build.gradle.overrideVersionCheck=true` only relaxes Gradle's own AGP check, not Studio's compatibility gate.

`Gradle_Master_Check_PerformanceTestTestLinuxbucket21` has failed on every real execution since the bump landed — builds 23594, 23598, 23600, 23601, 23603, 23604. The interleaved green builds (23597, 23602, 23605) are build-cache hits that ran zero tests, which is also how #39060 itself got through the merge queue.

This revert restores the last known-green combination (AGP 9.3.2 + Studio 2026.1.3.8) to unblock master. The follow-up is to bump `android.studio` in `gradle/dependency-management/smoke-tested-ides.properties` to a release that supports AGP 9.4, then re-apply the AGP bump — the same sequence as 294ea8d9bd2 ("Fix smoke and perf test failures for AGP 9.3.0").

Note that `agp-versions.properties` is bot-generated, so the weekly `updateAgpVersions` run will re-propose 9.4.0 until the Studio pin is updated.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
