### PR TITLE
Set up JDK 25 in update-kotlin-versions workflow

### DIFF
--- a/.github/workflows/update-kotlin-versions.yml
+++ b/.github/workflows/update-kotlin-versions.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v6.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
       - name: Update Kotlin versions
         run: ./gradlew updateKotlinVersions
       - name: Open bot PR


### PR DESCRIPTION
`.github/workflows/update-kotlin-versions.yml` was missed when Gradle's own build moved from JDK 17 to JDK 25 in #37896 — every sibling workflow was updated, this one was not.

The job did not break: `gradle/gradle-daemon-jvm.properties` declares daemon JVM criteria with `toolchainUrl.*` entries, so Gradle auto-provisioned a JDK 25 on each weekly run. This makes it use the pre-installed JDK instead, and restores consistency with the other workflows.

The one remaining non-25 setup is intentional and left alone: `contributor-pr.yml`'s `windows-11-arm` job (JDK-8371740 workaround).

Tracking issues:
- gradle/gradle-private#5243
- #35819