### PR TITLE
Reject stale execution history writes after failed output cleanup

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryCacheAccess.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryCacheAccess.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.internal.execution.history;
 
+import org.gradle.cache.IndexedCache;
+import org.gradle.cache.IndexedCacheParameters;
+import org.gradle.cache.MultiProcessSafeIndexedCache;
 import org.gradle.cache.PersistentCache;
+import org.gradle.internal.Cast;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -26,4 +30,14 @@ import java.util.function.Supplier;
  */
 @ServiceScope(Scope.Build.class)
 public interface ExecutionHistoryCacheAccess extends Supplier<PersistentCache> {
+    /**
+     * Creates an execution-history cache with the cross-process locking semantics required by the execution engine.
+     */
+    default <K, V> MultiProcessSafeIndexedCache<K, V> createIndexedCache(IndexedCacheParameters<K, V> parameters) {
+        IndexedCache<K, V> indexedCache = get().createIndexedCache(parameters);
+        if (!(indexedCache instanceof MultiProcessSafeIndexedCache<?, ?>)) {
+            throw new IllegalStateException("Execution history requires a multi-process-safe indexed cache");
+        }
+        return Cast.uncheckedCast(indexedCache);
+    }
 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryStore.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryStore.java
@@ -27,5 +27,13 @@ public interface ExecutionHistoryStore {
 
     void store(String key, AfterExecutionState executionState);
 
+    /**
+     * Stores the execution state only if the history entry has not changed since it was loaded.
+     *
+     * @return {@code true} when the state was stored, {@code false} when another execution changed
+     * the history entry first
+     */
+    boolean storeIfUnchanged(String key, Optional<PreviousExecutionState> expectedState, AfterExecutionState executionState);
+
     void remove(String key);
 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
@@ -19,11 +19,11 @@ package org.gradle.internal.execution.history.impl;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Interner;
 import org.gradle.cache.CacheDecorator;
-import org.gradle.cache.IndexedCache;
 import org.gradle.cache.IndexedCacheParameters;
-import org.gradle.cache.PersistentCache;
+import org.gradle.cache.MultiProcessSafeIndexedCache;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.internal.execution.history.AfterExecutionState;
+import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.PreviousExecutionState;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
@@ -32,17 +32,17 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.serialize.HashCodeSerializer;
 
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.UUID;
 
 import static com.google.common.collect.ImmutableSortedMap.copyOfSorted;
 import static com.google.common.collect.Maps.transformValues;
 
 public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
 
-    private final IndexedCache<String, PreviousExecutionState> store;
+    private final MultiProcessSafeIndexedCache<String, PreviousExecutionState> store;
 
     public DefaultExecutionHistoryStore(
-        Supplier<PersistentCache> cache,
+        ExecutionHistoryCacheAccess cache,
         InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory,
         Interner<String> stringInterner,
         ClassLoaderHierarchyHasher classLoaderHasher
@@ -55,7 +55,7 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
         );
 
         CacheDecorator inMemoryCacheDecorator = inMemoryCacheDecoratorFactory.decorator(10000, false);
-        this.store = cache.get().createIndexedCache(
+        this.store = cache.createIndexedCache(
             IndexedCacheParameters.of("executionHistory", String.class, serializer)
             .withCacheDecorator(inMemoryCacheDecorator)
         );
@@ -68,7 +68,40 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
 
     @Override
     public void store(String key, AfterExecutionState executionState) {
-        store.put(key, new DefaultPreviousExecutionState(
+        store.put(key, toPreviousExecutionState(executionState));
+    }
+
+    @Override
+    public boolean storeIfUnchanged(String key, Optional<PreviousExecutionState> expectedState, AfterExecutionState executionState) {
+        PreviousExecutionState newState = toPreviousExecutionState(executionState);
+        return store.putIf(
+            key,
+            newState,
+            currentState -> sameHistoryEntry(Optional.ofNullable(currentState), expectedState)
+        );
+    }
+
+    @Override
+    public void remove(String key) {
+        store.remove(key);
+    }
+
+    private static boolean sameHistoryEntry(Optional<PreviousExecutionState> currentState, Optional<PreviousExecutionState> expectedState) {
+        if (!currentState.isPresent() || !expectedState.isPresent()) {
+            return !currentState.isPresent() && !expectedState.isPresent();
+        }
+        PreviousExecutionState current = currentState.get();
+        PreviousExecutionState expected = expectedState.get();
+        if (!(current instanceof DefaultPreviousExecutionState) || !(expected instanceof DefaultPreviousExecutionState)) {
+            return false;
+        }
+        return ((DefaultPreviousExecutionState) current).getExecutionHistoryEntryId()
+            .equals(((DefaultPreviousExecutionState) expected).getExecutionHistoryEntryId());
+    }
+
+    private static PreviousExecutionState toPreviousExecutionState(AfterExecutionState executionState) {
+        return new DefaultPreviousExecutionState(
+            UUID.randomUUID().toString(),
             executionState.getOriginMetadata(),
             executionState.getCacheKey(),
             executionState.getImplementation(),
@@ -77,12 +110,7 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
             prepareForSerialization(executionState.getInputFileProperties()),
             executionState.getOutputFilesProducedByWork(),
             executionState.isSuccessful()
-        ));
-    }
-
-    @Override
-    public void remove(String key) {
-        store.remove(key);
+        );
     }
 
     private static ImmutableSortedMap<String, FileCollectionFingerprint> prepareForSerialization(ImmutableSortedMap<String, CurrentFileCollectionFingerprint> fingerprints) {

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionState.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionState.java
@@ -27,12 +27,14 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 
 public class DefaultPreviousExecutionState extends AbstractInputExecutionState<FileCollectionFingerprint> implements PreviousExecutionState {
+    private final String executionHistoryEntryId;
     private final ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork;
     private final OriginMetadata originMetadata;
     private final boolean successful;
     private final HashCode cacheKey;
 
     public DefaultPreviousExecutionState(
+        String executionHistoryEntryId,
         OriginMetadata originMetadata,
         HashCode cacheKey,
         ImplementationSnapshot implementation,
@@ -43,10 +45,15 @@ public class DefaultPreviousExecutionState extends AbstractInputExecutionState<F
         boolean successful
     ) {
         super(implementation, additionalImplementations, inputProperties, inputFileProperties);
+        this.executionHistoryEntryId = executionHistoryEntryId;
         this.outputFilesProducedByWork = outputFilesProducedByWork;
         this.originMetadata = originMetadata;
         this.successful = successful;
         this.cacheKey = cacheKey;
+    }
+
+    public String getExecutionHistoryEntryId() {
+        return executionHistoryEntryId;
     }
 
     @Override

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
@@ -61,6 +61,7 @@ public class DefaultPreviousExecutionStateSerializer extends AbstractSerializer<
 
     @Override
     public PreviousExecutionState read(Decoder decoder) throws Exception {
+        String executionHistoryEntryId = decoder.readString();
         OriginMetadata originMetadata = originMetadataSerializer.read(decoder);
 
         HashCode cacheKey = hashCodeSerializer.read(decoder);
@@ -83,6 +84,7 @@ public class DefaultPreviousExecutionStateSerializer extends AbstractSerializer<
         boolean successful = decoder.readBoolean();
 
         return new DefaultPreviousExecutionState(
+            executionHistoryEntryId,
             originMetadata,
             cacheKey,
             taskImplementation,
@@ -96,6 +98,11 @@ public class DefaultPreviousExecutionStateSerializer extends AbstractSerializer<
 
     @Override
     public void write(Encoder encoder, PreviousExecutionState execution) throws Exception {
+        if (!(execution instanceof DefaultPreviousExecutionState)) {
+            throw new IllegalArgumentException("Execution history serializer requires DefaultPreviousExecutionState");
+        }
+        DefaultPreviousExecutionState persistedState = (DefaultPreviousExecutionState) execution;
+        encoder.writeString(persistedState.getExecutionHistoryEntryId());
         originMetadataSerializer.write(encoder, execution.getOriginMetadata());
 
         hashCodeSerializer.write(encoder, execution.getCacheKey());

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -106,7 +106,7 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
         });
     }
 
-    private void cleanupExclusivelyOwnedOutputs(MutableBeforeExecutionContext context, UnitOfWork work) {
+    private void cleanupExclusivelyOwnedOutputs(MutableBeforeExecutionContext context, MutableUnitOfWork work) {
         work.visitOutputs(context.getWorkspace(), new OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, OutputFileValueSupplier value) {
@@ -124,6 +124,8 @@ public class RemovePreviousOutputsStep<C extends InputChangesContext, R extends 
                                 throw new AssertionError();
                         }
                     } catch (IOException ex) {
+                        // Cleanup may have already mutated the output tree, so the previous execution state is no longer trustworthy.
+                        work.getHistory().ifPresent(history -> history.remove(context.getIdentity().getUniqueId()));
                         throw UncheckedException.throwAsUncheckedException(ex);
                     }
                 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
@@ -53,8 +53,9 @@ public class StoreExecutionStateStep<C extends PreviousExecutionContext & Cachin
                         cacheKeyCalculatedState.getBeforeExecutionState(),
                         executionOutputState
                     )))
-                .ifPresent(afterExecutionState -> history.store(
+                .ifPresent(afterExecutionState -> history.storeIfUnchanged(
                     context.getIdentity().getUniqueId(),
+                    context.getPreviousExecutionState(),
                     // TODO: Encode the "no cache key available" case in the context type hierarchy
                     afterExecutionState)));
         return result;

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/ExecutionHistoryCacheAccessTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/ExecutionHistoryCacheAccessTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.execution.history
+
+import org.gradle.cache.IndexedCache
+import org.gradle.cache.IndexedCacheParameters
+import org.gradle.cache.MultiProcessSafeIndexedCache
+import org.gradle.cache.PersistentCache
+import spock.lang.Specification
+
+class ExecutionHistoryCacheAccessTest extends Specification {
+    def persistentCache = Stub(PersistentCache)
+    def cacheAccess = new ExecutionHistoryCacheAccess() {
+        @Override
+        PersistentCache get() {
+            return persistentCache
+        }
+    }
+
+    def "exposes multi-process-safe indexed cache"() {
+        def indexedCache = Stub(MultiProcessSafeIndexedCache)
+        def parameters = IndexedCacheParameters.of("history", String, String)
+        persistentCache.createIndexedCache(parameters) >> indexedCache
+
+        expect:
+        cacheAccess.createIndexedCache(parameters).is(indexedCache)
+    }
+
+    def "rejects indexed cache without multi-process safety"() {
+        def indexedCache = Stub(IndexedCache)
+        def parameters = IndexedCacheParameters.of("history", String, String)
+        persistentCache.createIndexedCache(parameters) >> indexedCache
+
+        when:
+        cacheAccess.createIndexedCache(parameters)
+
+        then:
+        def failure = thrown(IllegalStateException)
+        failure.message == "Execution history requires a multi-process-safe indexed cache"
+    }
+}

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStoreTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStoreTest.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.execution.history.impl
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSortedMap
+import com.google.common.collect.Interners
+import org.gradle.cache.CacheDecorator
+import org.gradle.cache.MultiProcessSafeIndexedCache
+import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.caching.internal.origin.OriginMetadata
+import org.gradle.internal.execution.history.AfterExecutionState
+import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess
+import org.gradle.internal.execution.history.PreviousExecutionState
+import org.gradle.internal.hash.ClassLoaderHierarchyHasher
+import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.snapshot.impl.ImplementationSnapshot
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.function.Predicate
+
+class DefaultExecutionHistoryStoreTest extends Specification {
+    def indexedCache = Mock(MultiProcessSafeIndexedCache<String, PreviousExecutionState>)
+    def cacheAccess = Stub(ExecutionHistoryCacheAccess)
+    def decoratorFactory = Stub(InMemoryCacheDecoratorFactory)
+    def decorator = Stub(CacheDecorator)
+    def classLoaderHasher = Stub(ClassLoaderHierarchyHasher)
+
+    def store
+
+    def setup() {
+        decoratorFactory.decorator(10000, false) >> decorator
+        cacheAccess.createIndexedCache(_) >> indexedCache
+
+        store = new DefaultExecutionHistoryStore(
+            cacheAccess,
+            decoratorFactory,
+            Interners.newStrongInterner(),
+            classLoaderHasher
+        )
+    }
+
+    def "does not store when expected history was removed"() {
+        def expected = previousState("entry-1", "previous")
+
+        when:
+        def stored = store.storeIfUnchanged("work", Optional.of(expected), afterState("current"))
+
+        then:
+        1 * indexedCache.putIf("work", _ as PreviousExecutionState, _ as Predicate) >> { String key, PreviousExecutionState value, Predicate condition ->
+            assert !condition.test(null)
+            false
+        }
+        !stored
+    }
+
+    def "does not store after ABA replacement with equivalent history"() {
+        def expected = previousState("entry-1", "same-origin")
+        def replacement = previousState("entry-2", "same-origin")
+
+        when:
+        def stored = store.storeIfUnchanged("work", Optional.of(expected), afterState("current"))
+
+        then:
+        1 * indexedCache.putIf("work", _ as PreviousExecutionState, _ as Predicate) >> { String key, PreviousExecutionState value, Predicate condition ->
+            assert !condition.test(replacement)
+            false
+        }
+        !stored
+    }
+
+    def "stores when exact expected history entry is still current"() {
+        def expected = previousState("entry-1", "previous")
+        def current = previousState("entry-1", "previous")
+
+        when:
+        def stored = store.storeIfUnchanged("work", Optional.of(expected), afterState("current"))
+
+        then:
+        1 * indexedCache.putIf("work", _ as PreviousExecutionState, _ as Predicate) >> { String key, PreviousExecutionState value, Predicate condition ->
+            assert condition.test(current)
+            true
+        }
+        stored
+    }
+
+    def "stores when history was absent and remains absent"() {
+        when:
+        def stored = store.storeIfUnchanged("work", Optional.empty(), afterState("current"))
+
+        then:
+        1 * indexedCache.putIf("work", _ as PreviousExecutionState, _ as Predicate) >> { String key, PreviousExecutionState value, Predicate condition ->
+            assert condition.test(null)
+            true
+        }
+        stored
+    }
+
+    def "does not overwrite a concurrent store after loading absent history"() {
+        def concurrentState = previousState("entry-2", "concurrent")
+
+        when:
+        def stored = store.storeIfUnchanged("work", Optional.empty(), afterState("current"))
+
+        then:
+        1 * indexedCache.putIf("work", _ as PreviousExecutionState, _ as Predicate) >> { String key, PreviousExecutionState value, Predicate condition ->
+            assert !condition.test(concurrentState)
+            false
+        }
+        !stored
+    }
+
+    private DefaultPreviousExecutionState previousState(String entryId, String buildId) {
+        def cacheKey = TestHashCodes.hashCodeFrom(1234)
+        def originMetadata = new OriginMetadata(buildId, cacheKey, Duration.ofMillis(10))
+        return Mock(DefaultPreviousExecutionState) {
+            getExecutionHistoryEntryId() >> entryId
+            getCacheKey() >> cacheKey
+            getOriginMetadata() >> originMetadata
+            isSuccessful() >> true
+        }
+    }
+
+    private AfterExecutionState afterState(String buildId) {
+        def cacheKey = TestHashCodes.hashCodeFrom(5678)
+        def originMetadata = new OriginMetadata(buildId, cacheKey, Duration.ofMillis(20))
+        return Stub(AfterExecutionState) {
+            getOriginMetadata() >> originMetadata
+            getCacheKey() >> cacheKey
+            getImplementation() >> ImplementationSnapshot.of("Test", TestHashCodes.hashCodeFrom(42))
+            getAdditionalImplementations() >> ImmutableList.of()
+            getInputProperties() >> ImmutableSortedMap.of()
+            getInputFileProperties() >> ImmutableSortedMap.of()
+            getOutputFilesProducedByWork() >> ImmutableSortedMap.of()
+            isSuccessful() >> true
+        }
+    }
+}

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializerTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializerTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.execution.history.impl
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSortedMap
+import com.google.common.collect.Interners
+import org.gradle.caching.internal.origin.OriginMetadata
+import org.gradle.internal.hash.ClassLoaderHierarchyHasher
+import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.serialize.HashCodeSerializer
+import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.internal.snapshot.impl.ImplementationSnapshot
+
+import java.time.Duration
+
+class DefaultPreviousExecutionStateSerializerTest extends SerializerSpec {
+    def stringInterner = Interners.newStrongInterner()
+    def serializer = new DefaultPreviousExecutionStateSerializer(
+        new FileCollectionFingerprintSerializer(stringInterner),
+        new FileSystemSnapshotSerializer(stringInterner),
+        Stub(ClassLoaderHierarchyHasher),
+        new HashCodeSerializer()
+    )
+
+    def "preserves execution history entry id across serialization"() {
+        def originMetadata = new OriginMetadata("build-invocation", TestHashCodes.hashCodeFrom(1234), Duration.ofMillis(25))
+        def state = new DefaultPreviousExecutionState(
+            "history-entry-123",
+            originMetadata,
+            TestHashCodes.hashCodeFrom(5678),
+            ImplementationSnapshot.of("TestImplementation", TestHashCodes.hashCodeFrom(42)),
+            ImmutableList.of(),
+            ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
+            true
+        )
+
+        when:
+        def restored = serialize(state, serializer)
+
+        then:
+        restored instanceof DefaultPreviousExecutionState
+        restored.executionHistoryEntryId == "history-entry-123"
+        restored.originMetadata == originMetadata
+        restored.cacheKey == state.cacheKey
+        restored.successful
+    }
+}

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -22,8 +22,10 @@ import org.gradle.internal.execution.MutableUnitOfWork
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.OutputVisitor
 import org.gradle.internal.execution.history.BeforeExecutionState
+import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OverlappingOutputs
 import org.gradle.internal.execution.history.PreviousExecutionState
+import org.gradle.internal.file.Deleter
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -139,6 +141,28 @@ class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implem
 
         !outputs.file.exists()
         !outputs.dir.exists()
+    }
+
+    def "invalidates execution history when exclusive output cleanup fails"() {
+        def outputs = new WorkOutputs()
+        outputs.createContents()
+        def history = Mock(ExecutionHistoryStore)
+        def failingDeleter = Mock(Deleter)
+        def failingStep = new RemovePreviousOutputsStep<>(failingDeleter, outputChangeListener, delegate)
+        work.history >> Optional.of(history)
+
+        when:
+        failingStep.execute(work, context)
+
+        then:
+        def failure = thrown(UncheckedIOException)
+        failure.cause.message == "output is still being written"
+        interaction {
+            cleanupExclusiveOutputs(outputs)
+        }
+        1 * failingDeleter.ensureEmptyDirectory(outputs.dir) >> { throw new IOException("output is still being written") }
+        1 * history.remove(workId)
+        0 * delegate.execute(_, _)
     }
 
     def "does not cleanup outputs when build is incremental"() {

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -71,10 +71,11 @@ class StoreExecutionStateStepTest extends StepSpec<MutableCachingContext> implem
         })
 
         _ * context.cachingState >> CachingState.enabled(new SimpleBuildCacheKey(cacheKey), beforeExecutionState)
+        _ * context.previousExecutionState >> Optional.empty()
         _ * delegateResult.execution >> Try.successful(Mock(Execution))
 
         then:
-        interaction { expectStore(true, outputFilesProducedByWork) }
+        interaction { expectStore(true, outputFilesProducedByWork, Optional.empty()) }
         0 * _
     }
 
@@ -96,12 +97,13 @@ class StoreExecutionStateStepTest extends StepSpec<MutableCachingContext> implem
         _ * context.previousExecutionState >> Optional.empty()
 
         then:
-        interaction { expectStore(false, outputFilesProducedByWork) }
+        interaction { expectStore(false, outputFilesProducedByWork, Optional.empty()) }
         0 * _
     }
 
     def "output snapshots are stored after failed execution with changed outputs"() {
         def previousExecutionState = Mock(PreviousExecutionState)
+        def expectedState = Optional.of(previousExecutionState)
 
         when:
         def result = step.execute(work, context)
@@ -117,11 +119,11 @@ class StoreExecutionStateStepTest extends StepSpec<MutableCachingContext> implem
         })
         _ * context.cachingState >> CachingState.enabled(new SimpleBuildCacheKey(cacheKey), beforeExecutionState)
         _ * delegateResult.execution >> Try.failure(new RuntimeException("execution error"))
-        _ * context.previousExecutionState >> Optional.of(previousExecutionState)
+        _ * context.previousExecutionState >> expectedState
         1 * previousExecutionState.outputFilesProducedByWork >> snapshotsOf([:])
 
         then:
-        interaction { expectStore(false, outputFilesProducedByWork) }
+        interaction { expectStore(false, outputFilesProducedByWork, expectedState) }
         0 * _
     }
 
@@ -158,9 +160,10 @@ class StoreExecutionStateStepTest extends StepSpec<MutableCachingContext> implem
         0 * _
     }
 
-    void expectStore(boolean successful, ImmutableSortedMap<String, FileSystemSnapshot> finalOutputs) {
-        1 * executionHistoryStore.store(
+    void expectStore(boolean successful, ImmutableSortedMap<String, FileSystemSnapshot> finalOutputs, Optional<PreviousExecutionState> expectedState) {
+        1 * executionHistoryStore.storeIfUnchanged(
             identity.uniqueId,
+            expectedState,
             { AfterExecutionState executionState ->
                 executionState.outputFilesProducedByWork == finalOutputs
                 executionState.originMetadata == originMetadata

--- a/platforms/core-execution/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionHistoryStore.java
+++ b/platforms/core-execution/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionHistoryStore.java
@@ -28,6 +28,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.collect.ImmutableSortedMap.copyOfSorted;
 import static com.google.common.collect.Maps.transformValues;
@@ -43,7 +44,40 @@ public class TestExecutionHistoryStore implements ExecutionHistoryStore {
 
     @Override
     public void store(String key, AfterExecutionState executionState) {
-        executionHistory.put(key, new DefaultPreviousExecutionState(
+        executionHistory.put(key, toPreviousExecutionState(executionState));
+    }
+
+    @Override
+    public boolean storeIfUnchanged(String key, Optional<PreviousExecutionState> expectedState, AfterExecutionState executionState) {
+        Optional<PreviousExecutionState> currentState = load(key);
+        if (!sameHistoryEntry(currentState, expectedState)) {
+            return false;
+        }
+        executionHistory.put(key, toPreviousExecutionState(executionState));
+        return true;
+    }
+
+    @Override
+    public void remove(String key) {
+        executionHistory.remove(key);
+    }
+
+    private static boolean sameHistoryEntry(Optional<PreviousExecutionState> currentState, Optional<PreviousExecutionState> expectedState) {
+        if (!currentState.isPresent() || !expectedState.isPresent()) {
+            return !currentState.isPresent() && !expectedState.isPresent();
+        }
+        PreviousExecutionState current = currentState.get();
+        PreviousExecutionState expected = expectedState.get();
+        if (!(current instanceof DefaultPreviousExecutionState) || !(expected instanceof DefaultPreviousExecutionState)) {
+            return false;
+        }
+        return ((DefaultPreviousExecutionState) current).getExecutionHistoryEntryId()
+            .equals(((DefaultPreviousExecutionState) expected).getExecutionHistoryEntryId());
+    }
+
+    private static PreviousExecutionState toPreviousExecutionState(AfterExecutionState executionState) {
+        return new DefaultPreviousExecutionState(
+            UUID.randomUUID().toString(),
             executionState.getOriginMetadata(),
             executionState.getCacheKey(),
             executionState.getImplementation(),
@@ -52,12 +86,7 @@ public class TestExecutionHistoryStore implements ExecutionHistoryStore {
             prepareForSerialization(executionState.getInputFileProperties()),
             executionState.getOutputFilesProducedByWork(),
             executionState.isSuccessful()
-        ));
-    }
-
-    @Override
-    public void remove(String key) {
-        executionHistory.remove(key);
+        );
     }
 
     private static ImmutableSortedMap<String, FileCollectionFingerprint> prepareForSerialization(ImmutableSortedMap<String, CurrentFileCollectionFingerprint> fingerprints) {

--- a/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/MultiProcessSafeIndexedCacheIntegrationTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/MultiProcessSafeIndexedCacheIntegrationTest.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.TestExecutionPreconditions
+import org.junit.Rule
+
+@Requires(value = TestExecutionPreconditions.NotEmbeddedExecutor, reason = "requires two independent Gradle processes")
+class MultiProcessSafeIndexedCacheIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.start()
+        executer.requireOwnGradleUserHomeDir().withDaemonBaseDir(file("daemon")).requireDaemon()
+    }
+
+    def "stale conditional writer cannot overwrite an invalidation from another process"() {
+        given:
+        def cacheFile = file("shared-cache/entries.bin")
+        buildFile << """
+            import org.gradle.cache.FileLockManager
+            import org.gradle.cache.IndexedCacheParameters
+            import org.gradle.cache.internal.DefaultMultiProcessSafeIndexedCache
+            import org.gradle.cache.internal.OnDemandFileAccess
+            import org.gradle.cache.internal.btree.BTreePersistentIndexedCache
+
+            abstract class CacheOperation extends DefaultTask {
+                @Inject
+                abstract FileLockManager getFileLockManager()
+
+                @Input
+                abstract Property<String> getOperation()
+
+                @Input
+                abstract Property<String> getCacheFilePath()
+
+                private def withCache(Closure action) {
+                    def target = new File(cacheFilePath.get())
+                    target.parentFile.mkdirs()
+                    def parameters = IndexedCacheParameters.of("entries", String.class, String.class)
+                    def fileAccess = new OnDemandFileAccess(target, "conditional update integration test cache", fileLockManager)
+                    def indexedCache = new DefaultMultiProcessSafeIndexedCache<String, String>(
+                        { new BTreePersistentIndexedCache<String, String>(
+                            target,
+                            parameters.getKeySerializer(),
+                            parameters.getValueSerializer()
+                        ) } as java.util.function.Supplier,
+                        fileAccess
+                    )
+                    try {
+                        return action(indexedCache)
+                    } finally {
+                        indexedCache.finishWork()
+                    }
+                }
+
+                @TaskAction
+                void runOperation() {
+                    def projectDir = new File(cacheFilePath.get()).parentFile.parentFile
+                    switch (operation.get()) {
+                        case "seed":
+                            withCache { cache ->
+                                cache.put("key", "initial")
+                            }
+                            break
+                        case "staleWriter":
+                            def expected = withCache { cache ->
+                                cache.getIfPresent("key")
+                            }
+                            assert expected == "initial"
+                            new File(projectDir, "writer.pid").text = ProcessHandle.current().pid().toString()
+                            ${server.callFromBuild("writerLoaded")}
+                            def stored = withCache { cache ->
+                                cache.putIf(
+                                    "key",
+                                    "stale",
+                                    { current -> current == expected } as java.util.function.Predicate<String>
+                                )
+                            }
+                            println "STALE_STORE_RESULT=" + stored
+                            break
+                        case "invalidate":
+                            new File(projectDir, "invalidator.pid").text = ProcessHandle.current().pid().toString()
+                            withCache { cache ->
+                                cache.remove("key")
+                            }
+                            break
+                        case "assertAbsent":
+                            withCache { cache ->
+                                assert cache.getIfPresent("key") == null
+                            }
+                            break
+                        default:
+                            throw new GradleException("Unknown operation: " + operation.get())
+                    }
+                }
+            }
+
+            tasks.register("seed", CacheOperation) {
+                operation.set("seed")
+                cacheFilePath.set("${cacheFile.absolutePath}")
+            }
+            tasks.register("staleWriter", CacheOperation) {
+                operation.set("staleWriter")
+                cacheFilePath.set("${cacheFile.absolutePath}")
+            }
+            tasks.register("invalidate", CacheOperation) {
+                operation.set("invalidate")
+                cacheFilePath.set("${cacheFile.absolutePath}")
+            }
+            tasks.register("assertAbsent", CacheOperation) {
+                operation.set("assertAbsent")
+                cacheFilePath.set("${cacheFile.absolutePath}")
+            }
+        """
+
+        and:
+        succeeds("seed")
+        def writerLoaded = server.expectAndBlock("writerLoaded")
+
+        when:
+        def staleWriter = executer.withTasks("staleWriter").start()
+        writerLoaded.waitForAllPendingCalls()
+        succeeds("invalidate")
+        writerLoaded.releaseAll()
+        staleWriter.waitForFinish()
+
+        then:
+        staleWriter.standardOutput.contains("STALE_STORE_RESULT=false")
+        file("writer.pid").text != file("invalidator.pid").text
+
+        and:
+        succeeds("assertAbsent")
+    }
+}

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/MultiProcessSafeIndexedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/MultiProcessSafeIndexedCache.java
@@ -15,8 +15,19 @@
  */
 package org.gradle.cache;
 
+import java.util.function.Predicate;
+
 /**
  * A {@link IndexedCache} implementation that is aware of file locking.
  */
 public interface MultiProcessSafeIndexedCache<K, V> extends IndexedCache<K, V>, UnitOfWorkParticipant {
+    /**
+     * Replaces the value for {@code key} when the current value matches the supplied condition.
+     *
+     * The comparison and update are performed synchronously while holding the cache's cross-process lock.
+     * The condition receives {@code null} when the key is not currently present.
+     *
+     * @return {@code true} when the value was stored, {@code false} when the condition did not match.
+     */
+    boolean putIf(K key, V value, Predicate<? super V> condition);
 }

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
@@ -22,6 +22,7 @@ import org.gradle.cache.MultiProcessSafeIndexedCache;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentIndexedCache<K, V> {
     private final AsyncCacheAccess asyncCacheAccess;
@@ -46,6 +47,11 @@ public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsy
     @Override
     public V get(K key, Function<? super K, ? extends V> producer, Runnable completion) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean putIf(K key, V value, Predicate<? super V> condition) {
+        return asyncCacheAccess.read(() -> indexedCache.putIf(key, value, condition));
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossProcessSynchronizingIndexedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossProcessSynchronizingIndexedCache.java
@@ -22,6 +22,7 @@ import org.gradle.cache.MultiProcessSafeIndexedCache;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Applies cross-process file locking to a backing cache, to ensure that any in-memory and on file state is kept in sync while this process is read from or writing to the cache.
@@ -56,6 +57,11 @@ public class CrossProcessSynchronizingIndexedCache<K, V> implements MultiProcess
     public void put(K key, V value) {
         Runnable runnable = cacheAccess.acquireFileLock();
         target.putLater(key, value, runnable);
+    }
+
+    @Override
+    public boolean putIf(K key, V value, Predicate<? super V> condition) {
+        return cacheAccess.withFileLock(() -> target.putIf(key, value, condition));
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultMultiProcessSafeIndexedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultMultiProcessSafeIndexedCache.java
@@ -22,6 +22,7 @@ import org.gradle.cache.MultiProcessSafeIndexedCache;
 import org.gradle.cache.internal.btree.BTreePersistentIndexedCache;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class DefaultMultiProcessSafeIndexedCache<K, V> implements MultiProcessSafeIndexedCache<K, V> {
@@ -65,6 +66,20 @@ public class DefaultMultiProcessSafeIndexedCache<K, V> implements MultiProcessSa
         // Use writeFile because the cache can internally recover from datafile
         // corruption, so we don't care at this level if it's corrupt
         fileAccess.writeFile(() -> cache.put(key, value));
+    }
+
+    @Override
+    public boolean putIf(K key, V value, Predicate<? super V> condition) {
+        final BTreePersistentIndexedCache<K, V> cache = getCache();
+        final boolean[] stored = {false};
+        fileAccess.writeFile(() -> {
+            V current = cache.get(key);
+            if (condition.test(current)) {
+                cache.put(key, value);
+                stored[0] = true;
+            }
+        });
+        return stored[0];
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryDecoratedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/InMemoryDecoratedCache.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 class InMemoryDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentIndexedCache<K, V>, InMemoryCacheController {
     private final static Logger LOG = LoggerFactory.getLogger(InMemoryDecoratedCache.class);
@@ -101,6 +102,17 @@ class InMemoryDecoratedCache<K, V> implements MultiProcessSafeAsyncPersistentInd
         } else {
             return Cast.uncheckedCast(value);
         }
+    }
+
+    @Override
+    public boolean putIf(K key, V value, Predicate<? super V> condition) {
+        boolean stored = delegate.putIf(key, value, condition);
+        if (stored) {
+            inMemoryCache.put(key, value);
+        } else {
+            inMemoryCache.invalidate(key);
+        }
+        return stored;
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/MultiProcessSafeAsyncPersistentIndexedCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/MultiProcessSafeAsyncPersistentIndexedCache.java
@@ -19,6 +19,7 @@ import org.gradle.cache.UnitOfWorkParticipant;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * An indexed cache that may perform updates asynchronously.
@@ -34,6 +35,11 @@ public interface MultiProcessSafeAsyncPersistentIndexedCache<K, V> extends UnitO
      * Fetches the given entry, producing if necessary, blocking until the result is available. This method may or may not block until any updates have completed and will invoke the given completion action when the operation is complete.
      */
     V get(K key, Function<? super K, ? extends V> producer, Runnable completion);
+
+    /**
+     * Replaces the current value synchronously when the supplied condition matches.
+     */
+    boolean putIf(K key, V value, Predicate<? super V> condition);
 
     /**
      * Submits an update to be applied later. This method may or may not block, and will invoke the given completion action when the operation is complete.

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AsyncCacheAccessDecoratedCacheTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AsyncCacheAccessDecoratedCacheTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.cache.AsyncCacheAccess
+import org.gradle.cache.MultiProcessSafeIndexedCache
+import spock.lang.Specification
+
+import java.util.function.Predicate
+import java.util.function.Supplier
+
+class AsyncCacheAccessDecoratedCacheTest extends Specification {
+    def asyncCacheAccess = Mock(AsyncCacheAccess)
+    def indexedCache = Mock(MultiProcessSafeIndexedCache<String, String>)
+    def cache = new AsyncCacheAccessDecoratedCache<String, String>(asyncCacheAccess, indexedCache)
+
+    def "conditional update runs synchronously behind async read barrier"() {
+        def condition = Mock(Predicate<String>)
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * asyncCacheAccess.read(_ as Supplier) >> { Supplier action -> action.get() }
+        1 * indexedCache.putIf("key", "new", condition) >> true
+        stored
+        0 * _
+    }
+
+    def "conditional update reports rejection through async read barrier"() {
+        def condition = Mock(Predicate<String>)
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * asyncCacheAccess.read(_ as Supplier) >> { Supplier action -> action.get() }
+        1 * indexedCache.putIf("key", "new", condition) >> false
+        !stored
+        0 * _
+    }
+}

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/CrossProcessSynchronizingIndexedCacheTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/CrossProcessSynchronizingIndexedCacheTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.cache.CrossProcessCacheAccess
+import spock.lang.Specification
+
+import java.util.function.Predicate
+import java.util.function.Supplier
+
+class CrossProcessSynchronizingIndexedCacheTest extends Specification {
+    def cacheAccess = Mock(CrossProcessCacheAccess)
+    def target = Mock(MultiProcessSafeAsyncPersistentIndexedCache<String, String>)
+    def cache = new CrossProcessSynchronizingIndexedCache<String, String>(target, cacheAccess)
+
+    def "conditional update holds cross-process file lock for whole operation"() {
+        def condition = Mock(Predicate<String>)
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * cacheAccess.withFileLock(_ as Supplier) >> { Supplier action -> action.get() }
+        1 * target.putIf("key", "new", condition) >> true
+        stored
+        0 * cacheAccess.acquireFileLock()
+        0 * _
+    }
+
+    def "conditional update releases result only after target rejects under lock"() {
+        def condition = Mock(Predicate<String>)
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * cacheAccess.withFileLock(_ as Supplier) >> { Supplier action -> action.get() }
+        1 * target.putIf("key", "new", condition) >> false
+        !stored
+        0 * cacheAccess.acquireFileLock()
+        0 * _
+    }
+}

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/InMemoryDecoratedCacheTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/InMemoryDecoratedCacheTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Function
+import java.util.function.Predicate
 
 class InMemoryDecoratedCacheTest extends ConcurrentSpec {
     def target = Mock(MultiProcessSafeAsyncPersistentIndexedCache)
@@ -109,6 +110,49 @@ class InMemoryDecoratedCacheTest extends ConcurrentSpec {
         then:
         cached == "value"
         0 * _
+    }
+
+    def "conditional update refreshes in-memory value when stored"() {
+        def condition = Stub(Predicate)
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * target.putIf("key", "new", condition) >> true
+        stored
+
+        when:
+        def cached = cache.get("key")
+
+        then:
+        cached == "new"
+        0 * target.get(_)
+    }
+
+    def "rejected conditional update invalidates stale in-memory value"() {
+        def condition = Stub(Predicate)
+
+        when:
+        def initial = cache.get("key")
+
+        then:
+        1 * target.get("key") >> "stale"
+        initial == "stale"
+
+        when:
+        def stored = cache.putIf("key", "new", condition)
+
+        then:
+        1 * target.putIf("key", "new", condition) >> false
+        !stored
+
+        when:
+        def refreshed = cache.get("key")
+
+        then:
+        1 * target.get("key") >> "fresh"
+        refreshed == "fresh"
     }
 
     def "propagates failure to produce value and marks completed"() {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/MultiProcessSafeIndexedCacheTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/MultiProcessSafeIndexedCacheTest.groovy
@@ -65,6 +65,36 @@ class MultiProcessSafeIndexedCacheTest extends Specification {
         0 * _._
     }
 
+    def "conditionally updates entry under one write lock"() {
+        given:
+        cacheOpened()
+
+        when:
+        def stored = cache.putIf("key", "new", { it == "old" })
+
+        then:
+        stored
+        1 * fileAccess.writeFile(!null) >> { Runnable action -> action.run() }
+        1 * backingCache.get("key") >> "old"
+        1 * backingCache.put("key", "new")
+        0 * _._
+    }
+
+    def "does not update entry when condition does not match"() {
+        given:
+        cacheOpened()
+
+        when:
+        def stored = cache.putIf("key", "new", { it == "expected" })
+
+        then:
+        !stored
+        1 * fileAccess.writeFile(!null) >> { Runnable action -> action.run() }
+        1 * backingCache.get("key") >> "different"
+        0 * backingCache.put(_, _)
+        0 * _._
+    }
+
     def "holds write lock while removing entry from cache"() {
         given:
         cacheOpened()


### PR DESCRIPTION
## Summary

Fixes #38985.

A cancelled in-process compile can keep writing to its output directory after the client exits. A competing build may then partially clean that directory and fail, while the older build later republishes execution history describing outputs that are no longer valid. A subsequent build can trust that stale history and report the task `UP-TO-DATE` over a partial class directory.

This change closes that stale-writer race by making execution-history publication conditional on the history entry that was loaded by the execution still being current.

## Design

The fix has three parts:

1. Add an atomic `putIf()` operation to `MultiProcessSafeIndexedCache`. The compare and update happen synchronously while holding the same cross-process cache lock. The async and in-memory decorators preserve the required barrier and coherence semantics.
2. Publish execution history with compare-and-set semantics. Each persisted history entry carries a unique ID, and `StoreExecutionStateStep` stores only if the entry loaded before execution is still the same entry. The unique ID prevents remove-and-recreate ABA cycles from making an obsolete writer appear current.
3. If exclusive output cleanup throws after it may already have mutated the output tree, remove that work's execution-history entry before propagating the failure.

The resulting invariant is:

- if cleanup invalidates first, an older writer cannot publish over that invalidation;
- if the older writer publishes first, the later cleanup invalidation removes it.

Concurrent writers that both initially observe no history are handled conservatively: after one publishes, the other publication is rejected. That can force a later rebuild, but it cannot make stale state appear current.

## Tests

Added/extended coverage for:

- atomic conditional updates in the raw multi-process cache;
- async barrier behavior;
- cross-process locking behavior;
- in-memory cache coherence on accepted/rejected conditional stores;
- a real two-process `MultiProcessSafeIndexedCacheIntegrationTest`;
- execution-history conditional publication;
- ABA-safe history-entry IDs and serializer round-trip;
- concurrent publication after an initially absent history load;
- history invalidation when output cleanup fails;
- `StoreExecutionStateStep` using the previously loaded state as its CAS expectation.

## Validation

Final clean branch: `ba69c49896a29060807771be32dafaf44ce0a1d1`, rebased on current `master`.

Local validation on that exact SHA:

- `:persistent-cache:quickTest` + `:execution:quickTest` — PASS
- real two-process `MultiProcessSafeIndexedCacheIntegrationTest` — PASS
- `ProcessCrashHandlingIntegrationTest` — PASS
- applicable `sanityCheck` — PASS
- clean Gradle distribution built from the final SHA — PASS
- final tuned #38985 end-to-end race: **0/10 bad iterations**, all runs ending with `1801/1801` class files

Additional adversarial validation performed during development:

- focused A/B race: baseline **36/100** bad vs candidate **0/100** bad
- JDK 21 / JDK 25 × build cache on/off matrix: **80/80** candidate runs green
- tuned ABA-hardened stress: **0/30** bad
- no execution-history lock timeouts after the final synchronous conditional-update design

The literal full local `sanityCheck` cannot complete on this machine because Swift 6 is not installed and `:performance:writeTmpPerformanceScenarioDefinitions` requires it. Running `sanityCheck` with only `:performance:verifyPerformanceScenarioDefinitions` excluded passes. All patch-relevant checks above pass on the final clean SHA.

## AI-assisted contribution disclosure

AI tools were used extensively during this contribution for source tracing, experiment design, test generation, implementation assistance, and adversarial review. I reviewed and understand the resulting code and validation evidence, made the engineering decisions about the final design, and will actively respond to maintainer review and revise the patch as needed.
