### PR TITLE
release8x: Publish to the internal repo with a Bearer token

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -45,7 +45,7 @@ class PromotionProject(
         params {
             password("env.ORG_GRADLE_PROJECT_gradleS3AccessKey", "%gradleS3AccessKey%")
             password("env.ORG_GRADLE_PROJECT_gradleS3SecretKey", "%gradleS3SecretKey%")
-            password("env.ORG_GRADLE_PROJECT_artifactoryUserPassword", "%gradle.internal.repository.build-tool.publish.password%")
+            password("env.ORG_GRADLE_PROJECT_artifactoryToken", "%gradle.internal.repository.build-tool.publish.token%")
             password("env.DOTCOM_DEV_DOCS_AWS_ACCESS_KEY", "%dotcomDevDocsAwsAccessKey%")
             password("env.DOTCOM_DEV_DOCS_AWS_SECRET_KEY", "%dotcomDevDocsAwsSecretKey%")
             password("env.ORG_GRADLE_PROJECT_sdkmanToken", "%sdkmanToken%")
@@ -56,7 +56,6 @@ class PromotionProject(
             param("env.JDK17", javaHome(OpenJdk17, Os.LINUX))
             param("env.JDK21", javaHome(OpenJdk21, Os.LINUX))
             param("env.JDK25", javaHome(OpenJdk25, Os.LINUX))
-            param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
             password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
             param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")
             param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -16,7 +16,9 @@
 
 import gradlebuild.basics.gradleProperty
 import gradlebuild.identity.extension.ModuleIdentityExtension
+import org.gradle.api.credentials.HttpHeaderCredentials
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.authentication.http.HttpHeaderAuthentication
 
 plugins {
     id("publishing")
@@ -25,11 +27,8 @@ plugins {
 val artifactoryUrl
     get() = System.getenv("GRADLE_INTERNAL_REPO_URL") ?: ""
 
-val artifactoryUserName
-    get() = project.providers.gradleProperty("artifactoryUserName").orNull
-
-val artifactoryUserPassword
-    get() = project.providers.gradleProperty("artifactoryUserPassword").orNull
+val artifactoryToken
+    get() = project.providers.gradleProperty("artifactoryToken").orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")
@@ -39,18 +38,14 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
     }
 }
 
-@Suppress("ThrowsCount")
 fun Project.failEarlyIfUrlOrCredentialsAreNotSet(publish: Task) {
     gradle.taskGraph.whenReady {
         if (hasTask(publish)) {
             if (artifactoryUrl.isEmpty()) {
                 throw GradleException("artifactoryUrl is not set!")
             }
-            if (artifactoryUserName.isNullOrEmpty()) {
-                throw GradleException("artifactoryUserName is not set!")
-            }
-            if (artifactoryUserPassword.isNullOrEmpty()) {
-                throw GradleException("artifactoryUserPassword is not set!")
+            if (artifactoryToken.isNullOrEmpty()) {
+                throw GradleException("artifactoryToken is not set!")
             }
         }
     }
@@ -62,9 +57,12 @@ publishing {
             name = "remote"
             val libsType = the<ModuleIdentityExtension>().snapshot.map { if (it) "snapshots" else "releases" }
             url = uri("$artifactoryUrl/libs-${libsType.get()}-local")
-            credentials {
-                username = artifactoryUserName
-                password = artifactoryUserPassword
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                value = "Bearer $artifactoryToken"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }


### PR DESCRIPTION
Backport of gradle/gradle#39048 to the release8x line.

- Authenticate to the internal Artifactory repo with `Authorization: Bearer` from the `artifactoryToken` Gradle property instead of `artifactoryUserName` / `artifactoryUserPassword`.
- TeamCity promotion builds now pass `%gradle.internal.repository.build-tool.publish.token%` as `ORG_GRADLE_PROJECT_artifactoryToken`.
