### PR TITLE
Don't require a Swift 6 toolchain for sanityCheck

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/RunFor.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/RunFor.groovy
@@ -94,6 +94,18 @@ class RunForExtension implements IAnnotationDrivenExtension<RunFor> {
         } as Runnable))
     }
 
+    /**
+     * Whether this test run only collects the scenario definitions instead of executing the scenarios.
+     *
+     * This is the case for {@code writeTmpPerformanceScenarioDefinitions} and
+     * {@code writePerformanceScenarioDefinitions}, which use the {@code Test} task infrastructure to
+     * visit all performance tests without running any build. Fixture methods still run in that mode,
+     * so they must not require anything from the environment that only a performance test agent has.
+     */
+    static boolean isCollectingScenarioDefinitionsOnly() {
+        return SCENARIO_DEFINITION_FILE != null
+    }
+
     @Override
     void visitSpecAnnotation(RunFor runFor, SpecInfo spec) {
         assert runFor.value().every { it.iterationMatcher().isEmpty() }: "No iterationMatchers allowed in class-level @Scenario!"

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/SwiftToolchainFixture.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/SwiftToolchainFixture.groovy
@@ -20,11 +20,18 @@ import org.gradle.language.swift.plugins.SwiftBasePlugin
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.toolchain.Swiftc
+import org.gradle.performance.annotations.RunForExtension
 import org.gradle.test.fixtures.file.TestFile
 
 class SwiftToolchainFixture {
 
     static void configureSwift6Toolchain(CrossVersionPerformanceTestRunner runner, TestFile workDir) {
+        if (RunForExtension.isCollectingScenarioDefinitionsOnly()) {
+            // No build is executed, so no Swift compiler is needed. Requiring one here would break
+            // :performance:verifyPerformanceScenarioDefinitions, and with it ./gradlew sanityCheck,
+            // on every machine without a Swift 6 toolchain.
+            return
+        }
         def swiftc = AvailableToolChains.getToolChain(ToolChainRequirement.SWIFTC_6)
         if (swiftc == null || !swiftc.available) {
             throw new IllegalStateException("Swift 6 toolchain is required for this performance test but was not found on the agent.")


### PR DESCRIPTION
- `sanityCheck` depends on `:performance:verifyPerformanceScenarioDefinitions`, which visits every performance test via the `Test` task infrastructure without running a build. Spock still executes `setup()` in that mode, so the Swift 6 toolchain lookup added in gradle/gradle#38052 failed the task on any machine without a Swift 6 compiler.
- Skip the toolchain requirement while only scenario definitions are collected; it still applies when the scenarios actually execute on a performance test agent.
- Reported in [Slack](https://gradle.slack.com/archives/CBSJ2GUTV/p1788789124662019) by Anze Sodja (failing on Linux without Swift 6).
- Targets `release` because the offending commit predates the release cut, so 9.8 is affected too; it merges forward to master.