### PR TITLE
Re-quarantine flaky kotlin-dsl-tooling-builders cross-version specs

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.test.fixtures.Flaky
 import org.gradle.util.GradleVersion
 import org.hamcrest.Matcher
 
@@ -33,6 +34,7 @@ import static org.junit.Assert.assertTrue
 import static org.junit.Assume.assumeFalse
 
 @TargetGradleVersion(">=5.4")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     def "can fetch buildSrc classpath in face of compilation errors"() {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinInitScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinInitScriptModelCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.test.fixtures.Flaky
 
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
@@ -25,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 @TargetGradleVersion(">=5.4")
 class KotlinInitScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3708')
     def "initscript classpath does not include buildSrc"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
 
@@ -99,6 +100,7 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
 
     @TargetGradleVersion(">=5.4 <7.5")
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath includes buildSrc source roots"() {
 
         given:
@@ -115,6 +117,7 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
 
     @TargetGradleVersion(">=5.4 <7.5")
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath includes buildSrc project dependencies source roots"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
@@ -20,12 +20,14 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.Flaky
 
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.MatcherAssert.assertThat
 
 @TargetGradleVersion(">=5.4")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     @LeaksFileHandles("Kotlin Compiler Daemon working directory")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.gradle.util.GradleVersion
@@ -25,6 +26,7 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.gradle.util.GradleVersion
@@ -25,6 +26,7 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "can fetch model for a given set of scripts"() {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
@@ -29,6 +30,7 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "single request models equal multi requests models"() {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,12 +17,14 @@
 package org.gradle.kotlin.dsl.tooling.builders.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.8")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.tooling.builders.r71
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
@@ -25,6 +26,7 @@ import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 @TargetGradleVersion(">=7.1")
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "kotlin-dsl project with pre-compiled script plugins should import without errors"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r75/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r75/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.tooling.builders.r75
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import static org.hamcrest.MatcherAssert.assertThat
@@ -44,6 +45,7 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
     }
 
     @LeaksFileHandles("Kotlin compiler daemon on buildSrc jar")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3708")
     def "sourcePath does not include buildSrc project dependencies source roots"() {
 
         given:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -18,8 +18,10 @@ package org.gradle.kotlin.dsl.tooling.builders.r88
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
+import org.gradle.test.fixtures.Flaky
 
 @TargetGradleVersion(">=8.8")
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/3714")
 class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     def "settings script has type-safe accessors on the classpath"() {


### PR DESCRIPTION
### Context

Commit f48219ee05e ("Re-enable cross-version flaky quarantine and un-flag stable kotlin-dsl cross-version tests") removed `@Flaky` from 11 `kotlin-dsl-tooling-builders` cross-version spec classes. Its stated reasoning was:

> They haven't run for a long time so now we can check if they're still flaky - if they're, we can do further actions - they're anyway in ReadyForRelease stage and won't blocker user feedback.

That was a reasonable experiment. It has now returned its answer, and both halves of the premise turned out to be wrong.

**1. They are still flaky.** Since 2026-09-03 there has been a recurring cluster of *exactly 24 failed test occurrences* (8 features × 3 TAPI/target combos) across:

- `r54.KotlinBuildScriptModelCrossVersionSpec`
- `r54.PrecompiledScriptPluginModelCrossVersionSpec`
- `r60.KotlinDslScriptsModelCrossVersionSpec`
- `r88.KotlinSettingsScriptModelCrossVersionSpec`

It has ejected PRs from the merge queue:

- **#38762** — ejected three times in a row on 2026-09-03: TC builds 116965871, 116966368, 116967289 (`Gradle_Master_Check_Quick_1_bucket13`), with the paired `Platform_3_bucket18` builds 116965942 / 116966439 / 116967360 canceled carrying the same 24 failures. It merged only on the 4th attempt.
- **#38993** — ejected on 2026-09-08: TC build 117129320 (`Gradle_Master_Check_Platform_3_bucket18`); scans [run 1](https://ge.gradle.org/s/243kfebqf7rou) and [retry](https://ge.gradle.org/s/acaosdhifefqm).
- Also hit `bz/flaky-crossversion-subprojects-json` (117129582), `devprod/upgrade-to-latest-wrapper` (116950498 / 116950756 / 116950724) and `pull/38918` (116951919 / 116951854, Windows).

A different CI agent was involved every time, so this is not agent-local state. The base rate is low — for the r88 case, roughly 970 passed / 3 failed / 10 flaky over 60 days — but each hit costs a full merge-queue cycle.

**2. They do block PR feedback, not just ReadyForRelease.** These build configs live under the TeamCity project `Gradle / Master / Check / Pull Request Feedback / …` and run with `-Dscan.tag.PullRequestFeedback` and `-DbuildScan.PartOf=…,PullRequestFeedback,ReadyforNightly,ReadyforRelease`.

There is also a compounding factor worth recording. `Test.determineMaxFailures()` in `build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts` returns `10` outside the quarantine pipeline, so a 24-failure round exceeds the cap and the Develocity test-retry plugin disables retrying entirely. This is visible in build 117129320: run 1 (7 failures) retried each case 3× and mostly recovered as flaky, while the retry run (24 failures) shows `ordinal: 1` only on all 24 — `flaky: 0, failed: 24`. **That is a separate problem and is deliberately not addressed here**; `maxFailures` is left alone. It does mean these specs turn a single bad round into a hard queue ejection rather than a recovered flake.

Finally, the same commit f48219ee05e also restored `FlakyTestQuarantine` for cross-version coverage. That pipeline runs with `-PflakyTests=ONLY`, which selects *only* `@Flaky`-annotated tests. With the annotations gone, these specs lost the net on both sides at once: blocking PR feedback while being invisible to the quarantine meant to watch them. Re-adding `@Flaky` puts them back under quarantine.

### What

Restores exactly the `@Flaky` annotations (12 annotations across 11 files) and the `import org.gradle.test.fixtures.Flaky` lines that f48219ee05e removed, at their original positions with their original issue URLs.

Two things from f48219ee05e are **deliberately kept** and not reverted:

- `.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt` — the `.filter { it.os == os }` change stays, so cross-version coverage remains quarantined. The file is untouched by this PR.
- The `assumeFalse("Gradle distribution sources are not published for snapshot builds", targetDist.version.snapshot)` guard in `r54/KotlinBuildScriptModelCrossVersionSpec.groovy`. That fixed a genuinely *deterministic* failure and is unrelated to flakiness, so that file now carries both the restored `@Flaky` and the retained `assumeFalse`.

Verified: `./gradlew :kotlin-dsl-tooling-builders:compileCrossVersionTestGroovy` passes. The cross-version suites were not run locally — the failure is intermittent, so a local run proves nothing either way.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/). — n/a, sign-off is waived for Gradle org members per `.github/dco.yml` (`require.members: false`).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. — n/a, this only re-adds quarantine annotations to existing tests.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. — n/a, no logic change.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. — n/a, no user-facing change.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`. — will be covered by CI; the change is test-annotation-only.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`. — n/a, deliberately not run: the failure being quarantined is intermittent, so a local pass or fail is not evidence either way. Compilation was verified with `:kotlin-dsl-tooling-builders:compileCrossVersionTestGroovy`.
