### PR TITLE
Preserve current-build lock resolutions when regenerating a deleted lockfile

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/dependency_locking.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/dependency_locking.adoc
@@ -113,6 +113,10 @@ $ ./gradlew dependencies --write-locks
 This will create or update the lock state for each resolved configuration during that build execution.
 If a lock state already exists, it will be overwritten.
 
+Lock state for configurations that are not resolved is retained if the lock file still exists when Gradle writes the updated state.
+To remove obsolete configurations, delete the lock file and resolve all configurations that should remain locked with `--write-locks`.
+The file can also be deleted during the build: if it remains absent until Gradle writes the lock state, only configurations resolved with locking enabled in that build are included, even if they were resolved before the deletion.
+
 [source,text]
 .gradle.lockfile
 ----

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/dependency_locking.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/dependency-management/dependency_locking.adoc
@@ -113,9 +113,9 @@ $ ./gradlew dependencies --write-locks
 This will create or update the lock state for each resolved configuration during that build execution.
 If a lock state already exists, it will be overwritten.
 
-Lock state for configurations that are not resolved is retained if the lock file still exists when Gradle writes the updated state.
+Unresolved configurations retain their lock state as long as the lock file exists when Gradle writes the updated state.
 To remove obsolete configurations, delete the lock file and resolve all configurations that should remain locked with `--write-locks`.
-The file can also be deleted during the build: if it remains absent until Gradle writes the lock state, only configurations resolved with locking enabled in that build are included, even if they were resolved before the deletion.
+The lock file can also be deleted during the build: if it remains absent until Gradle writes the lock state, only configurations resolved with locking enabled in that build appear in the lock state, including those resolved before the deletion.
 
 [source,text]
 .gradle.lockfile

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -17,12 +17,76 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.api.artifacts.dsl.LockMode
+import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
+import spock.lang.Issue
 
 class DependencyLockingIntegrationTest extends AbstractValidatingLockingIntegrationTest {
 
     @Override
     LockMode lockMode() {
         LockMode.DEFAULT
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/39081')
+    @UnsupportedWithConfigurationCache(because = 'resolves configurations in a task action')
+    def 'regenerates lock state after task deletes lock file (early: #earlyResolution, delete: #deleteLockFile)'() {
+        given:
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '2.0').publish()
+        file('gradle.lockfile').text = '''org:foo:1.0=early,obsolete
+empty=earlyEmpty,obsoleteEmpty
+'''
+        buildFile << """
+            repositories {
+                maven { url = '${mavenRepo.uri}' }
+            }
+            configurations {
+                early { resolutionStrategy.activateDependencyLocking() }
+                earlyEmpty { resolutionStrategy.activateDependencyLocking() }
+                lockedConf { resolutionStrategy.activateDependencyLocking() }
+                renamedEmpty { resolutionStrategy.activateDependencyLocking() }
+                unlocked
+            }
+            dependencies {
+                early 'org:foo:2.0'
+                lockedConf 'org:foo:1.0'
+                unlocked 'org:foo:1.0'
+            }
+            ${earlyResolution == 'locked' ? 'configurations.early.files; configurations.earlyEmpty.files' : ''}
+            ${earlyResolution == 'unlocked' ? 'configurations.unlocked.files' : ''}
+            def lockFile = file('gradle.lockfile')
+            def configurationsToResolve = [configurations.early, configurations.earlyEmpty, configurations.lockedConf, configurations.renamedEmpty]
+            tasks.register('resetAndLock') {
+                doLast {
+                    if ($deleteLockFile) {
+                        println 'Deleted lock file: ' + lockFile.delete()
+                    }
+                    configurationsToResolve.each { println it.files }
+                }
+            }
+        """
+
+        when:
+        succeeds 'resetAndLock', '--write-locks'
+
+        then:
+        if (deleteLockFile) {
+            outputContains('Deleted lock file: true')
+        }
+        def expected = [early: ['org:foo:2.0'], earlyEmpty: [], lockedConf: ['org:foo:1.0'], renamedEmpty: []]
+        if (!deleteLockFile) {
+            expected.putAll(obsolete: ['org:foo:1.0'], obsoleteEmpty: [])
+        }
+        lockfileFixture.verifyLockfile(expected)
+
+        where:
+        earlyResolution | deleteLockFile
+        'locked'        | true
+        'unlocked'      | true
+        'none'          | true
+        'locked'        | false
+        'unlocked'      | false
+        'none'          | false
     }
 
     def 'succeeds without lock file present and does not create one'() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -55,6 +55,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +77,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private final ListProperty<String> ignoredDependencies;
     private boolean uniqueLockStateLoaded;
     private Map<String, List<String>> allLockState;
+    private final Set<String> resolvedLockIds = new HashSet<>();
     private LockEntryFilter compoundLockEntryFilter;
     private LockEntryFilter ignoredEntryFilter;
 
@@ -215,12 +217,18 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                     lockOwner, changingModulesOrdered, DOC_REG.getDocumentationRecommendationFor("details", "dependency_locking"));
             }
             allLockState.put(lockId, modulesOrdered);
+            resolvedLockIds.add(lockId);
         }
     }
 
     @Override
     public void buildFinished() {
         if (uniqueLockStateLoaded && lockFileReaderWriter.canWrite()) {
+            if (!lockFile.get().getAsFile().exists()) {
+                // Deleting the lock file discards the imported state, but resolutions from this build
+                // must survive, including those performed before deletion whose graphs are cached.
+                allLockState.keySet().retainAll(resolvedLockIds);
+            }
             lockFileReaderWriter.writeUniqueLockfile(allLockState);
             LOGGER.lifecycle("Persisted dependency lock state for {}", instanceIdentity.getDisplayName());
         }
@@ -257,6 +265,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         if (writeLocks) {
             loadLockState();
             allLockState.remove(lockId);
+            resolvedLockIds.remove(lockId);
         }
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -43,6 +43,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
 import org.gradle.util.Path
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -280,6 +281,61 @@ empty=
 org:foo:1.0=otherConf
 empty=
 """
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/39081')
+    def 'retains current build resolutions when lock file is deleted (delete: #deleteLockFile, custom: #customLocation)'() {
+        given:
+        startParameter.isWriteDependencyLocks() >> true
+        provider = newProvider()
+        def target = customLocation ? tmpDir.file('custom/gradle.lockfile') : uniqueLockFile
+        provider.lockFile.set(target)
+        target.parentFile.mkdirs()
+        target.text = '''org:foo:1.0=early,obsolete
+empty=earlyEmpty,obsoleteEmpty
+'''
+        provider.loadLockState('early', owner)
+        provider.persistResolvedDependencies('early', owner, [module('org', 'foo', '2.0')] as Set, emptySet())
+        provider.loadLockState('earlyEmpty', owner)
+        provider.persistResolvedDependencies('earlyEmpty', owner, emptySet(), emptySet())
+
+        when:
+        if (deleteLockFile) {
+            target.delete()
+        }
+        provider.loadLockState('late', owner)
+        provider.persistResolvedDependencies('late', owner, [module('org', 'bar', '1.0')] as Set, emptySet())
+        provider.buildFinished()
+
+        then:
+        target.text == """${expectedHeader()}
+org:bar:1.0=late
+${deleteLockFile ? '' : 'org:foo:1.0=obsolete\n'}org:foo:2.0=early
+empty=earlyEmpty${deleteLockFile ? '' : ',obsoleteEmpty'}
+"""
+
+        where:
+        deleteLockFile | customLocation
+        true           | false
+        true           | true
+        false          | false
+        false          | true
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/39081')
+    def 'does not restore deleted lock file when only unlocked configurations resolve'() {
+        given:
+        uniqueLockFile.text = 'org:foo:1.0=obsolete\nempty=obsoleteEmpty\n'
+        startParameter.isWriteDependencyLocks() >> true
+        provider = newProvider()
+        provider.confirmNotLocked('unlocked')
+
+        when:
+        uniqueLockFile.delete()
+        provider.buildFinished()
+
+        then:
+        !uniqueLockFile.exists()
     }
 
     private String expectedHeader() {


### PR DESCRIPTION
Fixes #39081.

## Problem

Dependency lock state is cached on first resolution. Deleting the lock file later in a task can therefore restore obsolete configuration entries when Gradle writes the cached state at build completion.

## Change

Track lock IDs resolved with locking enabled during the current build. If the lock file is absent at persistence, retain only those IDs. This preserves results resolved before deletion, including empty configurations whose resolution results are cached.

When the file remains present, unresolved imported entries retain their existing behavior. The patch includes unit tests, integration tests, and user-guide documentation.

## Local validation

Candidate: `91a4e68ca793083d75291240bf425880beca9da5`.

Recorded test commands completed successfully, and saved XML reports were checked during review:

- `DefaultDependencyLockingProviderTest`: 25 passed.
- `LockFileReaderWriterTest`: 17 passed.
- Issue-linked `DependencyLockingIntegrationTest` regression via `embeddedIntegTest`: 6 passed.
- Total: 48 tests; zero failures, errors, or skips.
- `checkstyleMain`, `checkstyleTestGroovy`, `checkstyleIntegTestGroovy`, `codenarcTest`, and `codenarcIntegTest`: passed.
- `git diff --check`: passed.

Ten supplemental offline runtime scenarios passed on JDK 25 using the compiled candidate provider in a private copy of Gradle 9.8.0-milestone-2. The regression expectations failed against the unmodified distribution because obsolete entries were restored. These supplemental experiments are separate from the committed regression tests.

The local test launcher used JAVA_HOME pointing to JDK 17; the repository specifies a JDK 25 daemon toolchain. These results do not establish a JDK compatibility matrix.

## Limitations

- Full `:dependency-management:quickTest` was not run.
- A full `sanityCheck` pass is not established by the collected evidence.
- Cross-platform validation remains unverified.
- Deletion followed by recreation before persistence does not trigger reset; this is documented.
- Local results do not establish an upstream CI pass.

## AI assistance

AI tools were used extensively for investigation, implementation, test development, and review. The validation summary above is based on recorded command results and saved test reports.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
