### PR TITLE
Make UpdateWrapper version-info artifact dependencies optional

### DIFF
--- a/.teamcity/scripts/update_wrapper_and_create_pr.sh
+++ b/.teamcity/scripts/update_wrapper_and_create_pr.sh
@@ -14,6 +14,10 @@ set -e
 #   GITHUB_TOKEN    - GitHub bot token
 #   TRIGGERED_BY    - Optional. If it's "Release - Final", version will be from version-info-final-release/version-info.properties
 #                     If it's "Release - Release Candidate", version will be from version-info-release-candidate/version-info.properties
+#
+# Both version-info.properties artifact dependencies are optional ("?:" rules), because the
+# artifacts of an older lastSuccessful() promotion build may already have been cleaned up.
+# Only the one belonging to the triggering build is actually needed, and it is always fresh.
 
 post() {
     local endpoint="$1"
@@ -39,6 +43,18 @@ post() {
     echo "$body"
 }
 
+source_promoted_version() {
+    local version_info="$1/promote-projects/gradle/build/version-info.properties"
+
+    if [[ ! -f "$version_info" ]]; then
+        printf "Error: %s was not downloaded from the triggering build. Was its artifact cleaned up?\n" "$version_info" >&2
+        exit 1
+    fi
+
+    source "$version_info"
+    export WRAPPER_VERSION="$promotedVersion"
+}
+
 main() {
     WRAPPER_VERSION="${1:-}"
 
@@ -46,11 +62,9 @@ main() {
     : "${GITHUB_TOKEN:?GITHUB_TOKEN environment variable is required}"
 
     if [[ "$TRIGGERED_BY" == *"Release - Final"* ]]; then
-        source version-info-final-release/promote-projects/gradle/build/version-info.properties
-        export WRAPPER_VERSION="$promotedVersion"
+        source_promoted_version version-info-final-release
     elif [[ "$TRIGGERED_BY" == *"Release - Release Candidate"* ]]; then
-        source version-info-release-candidate/promote-projects/gradle/build/version-info.properties
-        export WRAPPER_VERSION="$promotedVersion"
+        source_promoted_version version-info-release-candidate
     fi
 
     ./gradlew :wrapper --gradle-version=$WRAPPER_VERSION

--- a/.teamcity/src/main/kotlin/util/UpdateWrapper.kt
+++ b/.teamcity/src/main/kotlin/util/UpdateWrapper.kt
@@ -67,13 +67,13 @@ object UpdateWrapper : BuildType({
         dependency(AbsoluteId("Gradle_${vcsBranch.branchName.toCapitalized()}_$FINAL_RELEASE_BUILD_CONFIGURATION_ID")) {
             artifacts {
                 buildRule = lastSuccessful()
-                artifactRules = "version-info.properties => ./version-info-final-release"
+                artifactRules = "?:version-info.properties => ./version-info-final-release"
             }
         }
         dependency(AbsoluteId("Gradle_${vcsBranch.branchName.toCapitalized()}_$RELEASE_CANDIDATE_BUILD_CONFIGURATION_ID")) {
             artifacts {
                 buildRule = lastSuccessful()
-                artifactRules = "version-info.properties => ./version-info-release-candidate"
+                artifactRules = "?:version-info.properties => ./version-info-release-candidate"
             }
         }
     }


### PR DESCRIPTION
`UpdateWrapper` requires artifacts from `lastSuccessful()` of both `Release - Final` and `Release - Release Candidate`, but reads only the `version-info.properties` of the build that triggered it. Once the other one's artifacts are cleaned up, the build fails with `Failed to resolve artifact dependency` before the first step — which is what currently breaks `Gradle_Release_UpdateWrapper` on `release`.

Prefixing both rules with `?:` downgrades a missing artifact to a build-log warning. The script now also reports a clear error if the file it does need is absent.