### PR TITLE
Make the Eclipse tooling models work with Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiEclipseModelIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiEclipseModelIntegrationTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+/**
+ * Covers the Eclipse tooling models that Buildship requests during project synchronization.
+ */
+class IsolatedProjectsToolingApiEclipseModelIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+
+    def "can fetch the Eclipse model"() {
+        given:
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile "a/build.gradle", """
+            plugins { id("java-library") }
+        """
+        buildFile "b/build.gradle", """
+            plugins { id("java-library") }
+        """
+
+        when:
+        withIsolatedProjects()
+        def model = fetchModel(EclipseProject)
+
+        then:
+        model != null
+        fixture.assertModelStored {
+            projectsConfigured(":", ":a", ":b")
+            // EclipseProject on the root, plus IsolatedGradleProjectInternal and
+            // IsolatedEclipseProjectInternal per project
+            modelsCreated(":", 3)
+            modelsCreated(":a", 2)
+            modelsCreated(":b", 2)
+        }
+    }
+
+    def "can fetch the Eclipse model for a build with project dependencies"() {
+        given:
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile "a/build.gradle", """
+            plugins { id("java-library") }
+            dependencies { implementation(project(":b")) }
+        """
+        buildFile "b/build.gradle", """
+            plugins { id("java-library") }
+        """
+
+        when:
+        withIsolatedProjects()
+        def model = fetchModel(EclipseProject)
+
+        then:
+        model != null
+        fixture.assertModelStored {
+            projectsConfigured(":", ":a", ":b")
+            // EclipseProject on the root, plus IsolatedGradleProjectInternal and
+            // IsolatedEclipseProjectInternal per project
+            modelsCreated(":", 3)
+            modelsCreated(":a", 2)
+            modelsCreated(":b", 2)
+        }
+    }
+
+    def "can run the Eclipse auto build tasks"() {
+        given:
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile """
+            plugins { id("eclipse") }
+            tasks.register("build1")
+            eclipse { autoBuildTasks("build1") }
+        """
+        buildFile "a/build.gradle", """
+            plugins { id("eclipse") }
+            tasks.register("build2")
+            eclipse { autoBuildTasks("build2") }
+        """
+        buildFile "b/build.gradle", """
+            plugins { id("eclipse") }
+        """
+
+        when:
+        withIsolatedProjects()
+        runBuildAction(new RunEclipseAutoBuildTasksAction())
+
+        then:
+        outputDoesNotContain("cannot access")
+    }
+
+    def "can run the Eclipse synchronization tasks"() {
+        given:
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile """
+            plugins { id("eclipse") }
+            tasks.register("sync1")
+            eclipse { synchronizationTasks("sync1") }
+        """
+        buildFile "a/build.gradle", """
+            plugins { id("eclipse") }
+            tasks.register("sync2")
+            eclipse { synchronizationTasks("sync2") }
+        """
+        buildFile "b/build.gradle", """
+            plugins { id("eclipse") }
+        """
+
+        when:
+        withIsolatedProjects()
+        runBuildAction(new RunEclipseSynchronizationTasksAction())
+
+        then:
+        // The model only adds the registered tasks to the start parameter; a plain build action does
+        // not execute them. Task execution is covered by RunEclipseSynchronizationTasksCrossVersionSpec.
+        // What matters here is that collecting them from every project no longer violates isolation.
+        outputDoesNotContain("cannot access")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest.groovy
@@ -43,7 +43,7 @@ class IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest extends Abst
         then:
         fixture.assertModelStored {
             projectConfigured(":")
-            modelsCreated(":", 3)
+            modelsCreated(":", 4)
         }
 
         and:
@@ -87,7 +87,7 @@ class IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest extends Abst
         then:
         fixture.assertModelStored {
             projectConfigured(":")
-            modelsCreated(":", 3)
+            modelsCreated(":", 4)
         }
 
         and:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/RunEclipseAutoBuildTasksAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/RunEclipseAutoBuildTasksAction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.cc.impl.isolated;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.RunEclipseAutoBuildTasks;
+
+import java.io.Serializable;
+
+/**
+ * Requests the model that makes Gradle run the tasks registered via {@code eclipse.autoBuildTasks}.
+ *
+ * <p>This mirrors what Buildship does when the Eclipse workspace triggers an auto build. It goes
+ * through the same builder as {@link RunEclipseSynchronizationTasksAction}, but reads a different
+ * property of the Eclipse extension of every project.
+ */
+public class RunEclipseAutoBuildTasksAction implements BuildAction<Void>, Serializable {
+
+    @Override
+    public Void execute(BuildController controller) {
+        controller.getModel(RunEclipseAutoBuildTasks.class);
+        return null;
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/RunEclipseSynchronizationTasksAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/RunEclipseSynchronizationTasksAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.cc.impl.isolated;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.RunEclipseSynchronizationTasks;
+
+import java.io.Serializable;
+
+/**
+ * Requests the model that makes Gradle run the tasks registered via {@code eclipse.synchronizationTasks}.
+ *
+ * <p>This mirrors what Buildship does in the {@code projectsLoaded} phase of its synchronization action.
+ */
+public class RunEclipseSynchronizationTasksAction implements BuildAction<Void>, Serializable {
+
+    @Override
+    public Void execute(BuildController controller) {
+        controller.getModel(RunEclipseSynchronizationTasks.class);
+        return null;
+    }
+}

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.internal.tasks.TaskDependencyUtil;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.composite.IncludedBuildInternal;
@@ -51,6 +52,9 @@ import org.gradle.plugins.ide.eclipse.model.Output;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
 import org.gradle.plugins.ide.eclipse.model.UnresolvedLibrary;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultProjectModulePathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseClasspathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.ProjectModulePathResolver;
 import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider;
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultAccessRule;
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultClasspathAttribute;
@@ -76,6 +80,8 @@ import org.gradle.tooling.model.eclipse.EclipseWorkspace;
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 import org.gradle.tooling.model.eclipse.HierarchicalEclipseProject;
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
+import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider;
+import org.jspecify.annotations.Nullable;
 import org.gradle.util.Path;
 import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.GUtil;
@@ -100,6 +106,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private final GradleProjectBuilderInternal gradleProjectBuilder;
     private final EclipseModelAwareUniqueProjectNameProvider uniqueProjectNameProvider;
+    private final @Nullable IntermediateToolingModelProvider intermediateToolingModelProvider;
 
     private boolean projectDependenciesOnly;
     private DefaultEclipseProject result;
@@ -109,15 +116,34 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
     private ProjectIdentity currentProjectId;
     private EclipseRuntime eclipseRuntime;
     private Map<String, Boolean> projectOpenStatus = new HashMap<>();
+    private ProjectModulePathResolver modulePathResolver = new DefaultProjectModulePathResolver();
 
     @VisibleForTesting
     public EclipseModelBuilder(GradleProjectBuilderInternal gradleProjectBuilder, EclipseModelAwareUniqueProjectNameProvider uniqueProjectNameProvider) {
-        this.gradleProjectBuilder = gradleProjectBuilder;
-        this.uniqueProjectNameProvider = uniqueProjectNameProvider;
+        this(gradleProjectBuilder, uniqueProjectNameProvider, null);
     }
 
-    public EclipseModelBuilder(GradleProjectBuilderInternal gradleProjectBuilder, ProjectStateLookup projectStateLookup) {
-        this(gradleProjectBuilder, new EclipseModelAwareUniqueProjectNameProvider(projectStateLookup));
+    public EclipseModelBuilder(
+        GradleProjectBuilderInternal gradleProjectBuilder,
+        EclipseModelAwareUniqueProjectNameProvider uniqueProjectNameProvider,
+        @Nullable IntermediateToolingModelProvider intermediateToolingModelProvider
+    ) {
+        this.gradleProjectBuilder = gradleProjectBuilder;
+        this.uniqueProjectNameProvider = uniqueProjectNameProvider;
+        this.intermediateToolingModelProvider = intermediateToolingModelProvider;
+    }
+
+    /**
+     * @param intermediateToolingModelProvider used to gather per-project data without reaching across
+     * project boundaries. Pass {@code null} when Isolated Projects is disabled, so that the data is
+     * read directly, as it always has been, and no intermediate models are built.
+     */
+    public EclipseModelBuilder(
+        GradleProjectBuilderInternal gradleProjectBuilder,
+        ProjectStateLookup projectStateLookup,
+        @Nullable IntermediateToolingModelProvider intermediateToolingModelProvider
+    ) {
+        this(gradleProjectBuilder, new EclipseModelAwareUniqueProjectNameProvider(projectStateLookup), intermediateToolingModelProvider);
     }
 
     @Override
@@ -163,6 +189,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         rootGradleProject = gradleProjectBuilder.buildForRoot(project);
         tasksFactory.collectTasks(root);
         applyEclipsePlugin(rootProjectState, new HashSet<>());
+        modulePathResolver = EclipseModulePathGatherer.resolverFor(rootProjectState, intermediateToolingModelProvider);
         deduplicateProjectNames(root);
         buildHierarchy(rootProjectState);
         populate(rootProjectState);
@@ -171,19 +198,30 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private void deduplicateProjectNames(ProjectInternal root) {
         uniqueProjectNameProvider.setReservedProjectNames(calculateReservedProjectNames(root, eclipseRuntime));
-        for (Project project : root.getAllprojects()) {
-            EclipseModel eclipseModel = project.getExtensions().findByType(EclipseModel.class);
-            if (eclipseModel != null) {
-                eclipseModel.getProject().setName(uniqueProjectNameProvider.getUniqueName(((ProjectInternal) project).getProjectIdentity()));
+        // Every project's Eclipse extension has to be renamed. Iterating Project.getAllprojects()
+        // would be reported as a cross-project access with Isolated Projects enabled, so the state
+        // of each project is taken under the lock that covers all of them instead.
+        BuildProjectRegistry projects = root.getOwner().getOwner().getProjects();
+        projects.applyToMutableStateOfAllProjects(access -> {
+            for (ProjectState projectState : projects.getAllProjects()) {
+                ProjectInternal project = access.getMutableModel(projectState);
+                EclipseModel eclipseModel = project.getExtensions().findByType(EclipseModel.class);
+                if (eclipseModel != null) {
+                    eclipseModel.getProject().setName(uniqueProjectNameProvider.getUniqueName(project.getProjectIdentity()));
+                }
             }
-        }
+        });
     }
 
     private static void applyEclipsePlugin(ProjectState rootState, Set<Path> alreadyProcessed) {
         BuildState build = rootState.getOwner();
-        build.getProjects().applyToMutableStateOfAllProjects(access -> {
-            for (Project p : access.getMutableModel(rootState).getAllprojects()) {
-                p.getPluginManager().apply(EclipsePlugin.class);
+        BuildProjectRegistry projects = build.getProjects();
+        // Resolving the projects through the root project would hand out decorated instances, so
+        // applying the plugin to them is reported as a cross-project access with Isolated Projects
+        // enabled. Take the state of each project through the all-projects lock instead.
+        projects.applyToMutableStateOfAllProjects(access -> {
+            for (ProjectState projectState : projects.getAllProjects()) {
+                access.getMutableModel(projectState).getPluginManager().apply(EclipsePlugin.class);
             }
         });
         for (IncludedBuildInternal reference : build.getMutableModel().includedBuilds()) {
@@ -237,7 +275,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
             boolean projectDependenciesOnly = this.projectDependenciesOnly;
 
-            ClasspathElements classpathElements = gatherClasspathElements(projectOpenStatus, eclipseModel.getClasspath(), projectDependenciesOnly);
+            ClasspathElements classpathElements = gatherClasspathElements(projectOpenStatus, eclipseModel.getClasspath(), projectDependenciesOnly, modulePathResolver);
 
             DefaultEclipseProject eclipseProject = findEclipseProject(project);
 
@@ -267,16 +305,16 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         }
     }
 
-    public static ClasspathElements gatherClasspathElements(Map<String, Boolean> projectOpenStatus, EclipseClasspath eclipseClasspath, boolean projectDependenciesOnly) {
+    public static ClasspathElements gatherClasspathElements(Map<String, Boolean> projectOpenStatus, EclipseClasspath eclipseClasspath, boolean projectDependenciesOnly, ProjectModulePathResolver modulePathResolver) {
         ClasspathElements classpathElements = new ClasspathElements();
         eclipseClasspath.setProjectDependenciesOnly(projectDependenciesOnly);
 
         List<ClasspathEntry> classpathEntries;
         if (eclipseClasspath.getFile() == null) {
-            classpathEntries = eclipseClasspath.resolveDependencies();
+            classpathEntries = EclipseClasspathResolver.resolveEntries(eclipseClasspath, modulePathResolver);
         } else {
             Classpath classpath = new Classpath(eclipseClasspath.getFileReferenceFactory());
-            eclipseClasspath.mergeXmlClasspath(classpath);
+            EclipseClasspathResolver.mergeXmlClasspath(eclipseClasspath, classpath, modulePathResolver);
             classpathEntries = classpath.getEntries();
         }
 

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModulePathGatherer.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModulePathGatherer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.internal.tooling;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.IncludedBuildState;
+import org.gradle.internal.composite.IncludedBuildInternal;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultProjectModulePathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.PrecomputedProjectModulePathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.ProjectModulePathResolver;
+import org.gradle.plugins.ide.internal.tooling.eclipse.IsolatedEclipseProjectInternal;
+import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Gathers the module path flag of every project in the build tree, so that resolving the Eclipse
+ * classpath of a project dependency does not have to read it from the depended-upon project.
+ *
+ * <p>The values are collected as {@link IsolatedEclipseProjectInternal} intermediate models, one per
+ * project, which is what makes the whole model safe to build with Isolated Projects enabled. A project
+ * dependency may be substituted from an included build, so the whole build tree is covered, not just
+ * the build being built.
+ */
+@NullMarked
+final class EclipseModulePathGatherer {
+
+    private EclipseModulePathGatherer() {
+    }
+
+    /**
+     * Returns a resolver backed by values gathered for the whole build tree, or one that reads them
+     * live when no {@link IntermediateToolingModelProvider} is available. The latter happens in unit
+     * tests that drive the builder directly; Isolated Projects is never enabled there.
+     */
+    static ProjectModulePathResolver resolverFor(ProjectState rootProjectState, @Nullable IntermediateToolingModelProvider modelProvider) {
+        if (modelProvider == null) {
+            return new DefaultProjectModulePathResolver();
+        }
+
+        Map<Path, Boolean> inferModulePathByBuildTreePath = new HashMap<>();
+        for (BuildState build : buildsInTree(rootProjectState.getOwner())) {
+            collectFromBuild(build, modelProvider, inferModulePathByBuildTreePath);
+        }
+        return new PrecomputedProjectModulePathResolver(inferModulePathByBuildTreePath);
+    }
+
+    private static void collectFromBuild(BuildState build, IntermediateToolingModelProvider modelProvider, Map<Path, Boolean> result) {
+        List<ProjectState> projects = ImmutableList.copyOf(build.getProjects().getAllProjects());
+        if (projects.isEmpty()) {
+            return;
+        }
+
+        List<IsolatedEclipseProjectInternal> models = modelProvider.getModels(
+            build.getProjects().getRootProject(), projects, IsolatedEclipseProjectInternal.class, null);
+
+        // getModels returns one model per requested project, in the order they were requested.
+        for (int i = 0; i < projects.size(); i++) {
+            result.put(projects.get(i).getIdentity().getBuildTreePath(), models.get(i).isInferModulePath());
+        }
+    }
+
+    private static Set<BuildState> buildsInTree(BuildState root) {
+        Set<BuildState> builds = new LinkedHashSet<>();
+        collectBuilds(root, builds);
+        return builds;
+    }
+
+    private static void collectBuilds(BuildState build, Set<BuildState> builds) {
+        if (!builds.add(build)) {
+            return; // included builds can form a cycle
+        }
+        for (IncludedBuildInternal reference : build.getMutableModel().includedBuilds()) {
+            BuildState target = reference.getTarget();
+            if (target instanceof IncludedBuildState) {
+                target.ensureProjectsConfigured();
+                collectBuilds(target, builds);
+            }
+        }
+    }
+}

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedEclipseProjectBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedEclipseProjectBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.internal.tooling;
+
+import org.gradle.api.Project;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseClassPathUtil;
+import org.gradle.plugins.ide.internal.tooling.eclipse.IsolatedEclipseProjectInternal;
+import org.gradle.tooling.provider.model.ToolingModelBuilder;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Builds {@link IsolatedEclipseProjectInternal} for a single project.
+ *
+ * <p>Everything this reads belongs to the project it is given, so it is safe to run under that
+ * project's own lock. The builder of the whole {@code EclipseProject} model requests this model for
+ * every project instead of reaching into them itself.
+ */
+@NullMarked
+public class IsolatedEclipseProjectBuilder implements ToolingModelBuilder {
+
+    @Override
+    public boolean canBuild(String modelName) {
+        return modelName.equals(IsolatedEclipseProjectInternal.class.getName());
+    }
+
+    @Override
+    public IsolatedEclipseProjectInternal buildAll(String modelName, Project project) {
+        // The classpath data below is only populated once the plugin has contributed its conventions.
+        project.getPluginManager().apply(EclipsePlugin.class);
+        return new IsolatedEclipseProjectInternal(EclipseClassPathUtil.isInferModulePath(project));
+    }
+}

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -29,8 +29,12 @@ import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultRunClosedProjectBu
 import org.gradle.tooling.model.eclipse.EclipseRuntime;
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultProjectModulePathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.ProjectModulePathResolver;
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
+import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +46,14 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
 
     private static final String MODEL_NAME = RunClosedProjectBuildDependencies.class.getName();
 
+    private final @Nullable IntermediateToolingModelProvider intermediateToolingModelProvider;
+
     private Map<String, Boolean> projectOpenStatus;
+    private ProjectModulePathResolver modulePathResolver = new DefaultProjectModulePathResolver();
+
+    public RunBuildDependenciesTaskBuilder(@Nullable IntermediateToolingModelProvider intermediateToolingModelProvider) {
+        this.intermediateToolingModelProvider = intermediateToolingModelProvider;
+    }
 
     @Override
     public Class<EclipseRuntime> getParameterType() {
@@ -55,6 +66,7 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
             .collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseModelBuilder::isProjectOpen, (a, b) -> a || b));
 
         ProjectState rootProjectState = ((ProjectInternal) project.getRootProject()).getOwner();
+        this.modulePathResolver = EclipseModulePathGatherer.resolverFor(rootProjectState, intermediateToolingModelProvider);
         List<TaskDependency> buildDependencies = populate(rootProjectState);
         if (!buildDependencies.isEmpty()) {
             GradleInternal rootGradle = ((ProjectInternal) project).getGradle().getRoot();
@@ -76,7 +88,7 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
             EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
             EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
 
-            EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
+            EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false, modulePathResolver);
             return elements.getBuildDependencies();
         });
 

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -67,9 +67,10 @@ public class ToolingModelServices extends AbstractGradleModuleServices {
                     boolean isolatedProjects = buildModelParameters.isIsolatedProjects();
                     GradleProjectBuilderInternal gradleProjectBuilder = createGradleProjectBuilder(isolatedProjects);
                     IdeaModelBuilderInternal ideaModelBuilder = createIdeaModelBuilder(isolatedProjects, gradleProjectBuilder);
-                    registry.register(new RunBuildDependenciesTaskBuilder());
+                    IntermediateToolingModelProvider modelProvider = isolatedProjects ? intermediateToolingModelProvider : null;
+                    registry.register(new RunBuildDependenciesTaskBuilder(modelProvider));
                     registry.register(new RunEclipseTasksBuilder());
-                    registry.register(new EclipseModelBuilder(gradleProjectBuilder, projectStateLookup));
+                    registry.register(new EclipseModelBuilder(gradleProjectBuilder, projectStateLookup, modelProvider));
                     registry.register(ideaModelBuilder);
                     registry.register(gradleProjectBuilder);
                     registry.register(new GradleBuildBuilder(buildStateRegistry, failedIncludedBuildsRegistry, failureFactory));
@@ -80,6 +81,7 @@ public class ToolingModelServices extends AbstractGradleModuleServices {
                     registry.register(new HelpBuilder());
                     registry.register(new IsolatedGradleProjectInternalBuilder());
                     registry.register(new IsolatedIdeaModuleInternalBuilder());
+                    registry.register(new IsolatedEclipseProjectBuilder());
                     registry.register(new PluginApplyingBuilder());
                     registry.register(new GradleDslBaseScriptModelBuilder());
                 }

--- a/platforms/ide/ide-plugins/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
+++ b/platforms/ide/ide-plugins/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
@@ -36,7 +36,8 @@ class EclipseDependenciesCreatorTest extends AbstractProjectBuilderSpec {
             eclipseClasspath,
             project.services.get(IdeArtifactRegistry),
             NullGradleApiSourcesResolver.INSTANCE,
-            false
+            false,
+            new DefaultProjectModulePathResolver()
         )
     }
 

--- a/platforms/ide/ide-plugins/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/platforms/ide/ide-plugins/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.plugins.ear.EarPlugin
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.EclipseWtpPlugin
 import org.gradle.plugins.ide.eclipse.model.BuildCommand
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultProjectModulePathResolver
 import org.gradle.plugins.ide.eclipse.model.EclipseModel
 import org.gradle.plugins.ide.eclipse.model.Link
 import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider
@@ -308,7 +309,7 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class)
 
         when:
-        def elements = EclipseModelBuilder.gatherClasspathElements([:], eclipseModel.getClasspath(), true)
+        def elements = EclipseModelBuilder.gatherClasspathElements([:], eclipseModel.getClasspath(), true, new DefaultProjectModulePathResolver())
 
         then:
         elements.getProjectDependencies().get(0).path == 'child1'

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -23,17 +23,14 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
-import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
-import org.gradle.plugins.ide.eclipse.model.internal.EclipseClassPathUtil;
+import org.gradle.plugins.ide.eclipse.model.internal.DefaultProjectModulePathResolver;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseClasspathResolver;
 import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory;
-import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
-import org.gradle.plugins.ide.internal.resolver.DefaultGradleApiSourcesResolver;
 import org.gradle.util.internal.ConfigureUtil;
 
 import javax.inject.Inject;
@@ -437,10 +434,7 @@ public abstract class EclipseClasspath {
      * @since 1.0
      */
     public List<ClasspathEntry> resolveDependencies() {
-        ProjectInternal projectInternal = (ProjectInternal) this.project;
-        IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), EclipseClassPathUtil.isInferModulePath(this.project));
-        return classpathFactory.createEntries();
+        return EclipseClasspathResolver.resolveEntries(this, new DefaultProjectModulePathResolver());
     }
 
 
@@ -449,12 +443,8 @@ public abstract class EclipseClasspath {
      *
      * @since 1.0
      */
-    @SuppressWarnings("unchecked")
     public void mergeXmlClasspath(Classpath xmlClasspath) {
-        file.getBeforeMerged().execute(xmlClasspath);
-        List<ClasspathEntry> entries = resolveDependencies();
-        xmlClasspath.configure(entries);
-        file.getWhenMerged().execute(xmlClasspath);
+        EclipseClasspathResolver.mergeXmlClasspath(this, xmlClasspath, new DefaultProjectModulePathResolver());
     }
 
     /**

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
@@ -36,9 +36,9 @@ public class ClasspathFactory {
     private final EclipseClasspath classpath;
     private final EclipseDependenciesCreator dependenciesCreator;
 
-    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, GradleApiSourcesResolver gradleApiSourcesResolver, boolean inferModulePath) {
+    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, GradleApiSourcesResolver gradleApiSourcesResolver, boolean inferModulePath, ProjectModulePathResolver modulePathResolver) {
         this.classpath = classpath;
-        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry, gradleApiSourcesResolver, inferModulePath);
+        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry, gradleApiSourcesResolver, inferModulePath, modulePathResolver);
     }
 
     public List<ClasspathEntry> createEntries() {

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultProjectModulePathResolver.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultProjectModulePathResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.Project;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Reads the flag straight off the given project.
+ *
+ * <p>This is the behaviour the {@code eclipse} tasks have always had. It reads the task container of
+ * the project it is given, so it reports a cross-project access when that is a project other than
+ * the one being configured and Isolated Projects is enabled. Model builders that have to be
+ * Isolated Projects safe use {@link PrecomputedProjectModulePathResolver} instead.
+ */
+@NullMarked
+public class DefaultProjectModulePathResolver implements ProjectModulePathResolver {
+
+    @Override
+    public boolean isInferModulePath(Project project) {
+        return EclipseClassPathUtil.isInferModulePath(project);
+    }
+}

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClasspathResolver.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClasspathResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.plugins.ide.api.XmlFileContentMerger;
+import org.gradle.plugins.ide.eclipse.model.Classpath;
+import org.gradle.plugins.ide.eclipse.model.ClasspathEntry;
+import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
+import org.gradle.plugins.ide.internal.resolver.DefaultGradleApiSourcesResolver;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+/**
+ * Resolves the classpath of an {@link EclipseClasspath} with an explicit
+ * {@link ProjectModulePathResolver}.
+ *
+ * <p>The resolver has to be passed in here rather than held on {@link EclipseClasspath}, because
+ * that class is public API and must not expose an internal type. Both operations that resolve a
+ * classpath live here so that the {@code eclipse} tasks and the tooling model builders share one
+ * implementation and differ only in the resolver they supply.
+ */
+@NullMarked
+public class EclipseClasspathResolver {
+
+    private EclipseClasspathResolver() {
+    }
+
+    /**
+     * Calculates the classpath entries of the given classpath.
+     */
+    public static List<ClasspathEntry> resolveEntries(EclipseClasspath classpath, ProjectModulePathResolver modulePathResolver) {
+        ProjectInternal project = (ProjectInternal) classpath.getProject();
+        ClasspathFactory classpathFactory = new ClasspathFactory(
+            classpath,
+            project.getServices().get(IdeArtifactRegistry.class),
+            new DefaultGradleApiSourcesResolver(project.newDetachedResolver()),
+            EclipseClassPathUtil.isInferModulePath(project),
+            modulePathResolver);
+        return classpathFactory.createEntries();
+    }
+
+    /**
+     * Merges the calculated entries of the given classpath into the given XML model, running the
+     * {@code beforeMerged} and {@code whenMerged} hooks around it.
+     */
+    @SuppressWarnings("unchecked")
+    public static void mergeXmlClasspath(EclipseClasspath classpath, Classpath xmlClasspath, ProjectModulePathResolver modulePathResolver) {
+        XmlFileContentMerger file = classpath.getFile();
+        file.getBeforeMerged().execute(xmlClasspath);
+        xmlClasspath.configure(resolveEntries(classpath, modulePathResolver));
+        file.getWhenMerged().execute(xmlClasspath);
+    }
+}

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -65,13 +65,15 @@ public class EclipseDependenciesCreator {
     private final ProjectComponentIdentifier currentProjectId;
     private final GradleApiSourcesResolver gradleApiSourcesResolver;
     private final boolean inferModulePath;
+    private final ProjectModulePathResolver modulePathResolver;
 
-    public EclipseDependenciesCreator(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, GradleApiSourcesResolver gradleApiSourcesResolver, boolean inferModulePath) {
+    public EclipseDependenciesCreator(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, GradleApiSourcesResolver gradleApiSourcesResolver, boolean inferModulePath, ProjectModulePathResolver modulePathResolver) {
         this.classpath = classpath;
         this.projectDependencyBuilder = new ProjectDependencyBuilder(ideArtifactRegistry);
         this.currentProjectId = ((ProjectInternal) classpath.getProject()).getOwner().getComponentIdentifier();
         this.gradleApiSourcesResolver = gradleApiSourcesResolver;
         this.inferModulePath = inferModulePath;
+        this.modulePathResolver = modulePathResolver;
     }
 
     public List<AbstractClasspathEntry> createDependencyEntries() {
@@ -126,7 +128,7 @@ public class EclipseDependenciesCreator {
             if (!asJavaModule) {
                 Project artifactProject = project.findProject(componentIdentifier.getProjectPath());
                 if (artifactProject != null) {
-                    asJavaModule = EclipseClassPathUtil.isInferModulePath(artifactProject);
+                    asJavaModule = modulePathResolver.isInferModulePath(artifactProject);
                 }
             }
             projects.add(projectDependencyBuilder.build(componentIdentifier, classpath.getFileReferenceFactory().fromFile(artifact.getFile()), buildDependencies, testDependency, asJavaModule));

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/PrecomputedProjectModulePathResolver.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/PrecomputedProjectModulePathResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+
+/**
+ * Answers from values gathered per project before classpath resolution started.
+ *
+ * <p>Projects are keyed by build tree path, which is unique across the whole build tree, so this also
+ * covers project dependencies substituted from included builds. Only the project identity is read
+ * from the given project, which is metadata rather than mutable state and therefore does not report a
+ * cross-project access.
+ *
+ * <p>A project that is missing from the map is treated as not being a Java module. That is the same
+ * answer {@link EclipseClassPathUtil} gives for a project without a {@code compileJava} task, and it
+ * keeps a gap in the gathered values from failing the build.
+ */
+@NullMarked
+public class PrecomputedProjectModulePathResolver implements ProjectModulePathResolver {
+
+    private final Map<Path, Boolean> inferModulePathByBuildTreePath;
+
+    public PrecomputedProjectModulePathResolver(Map<Path, Boolean> inferModulePathByBuildTreePath) {
+        this.inferModulePathByBuildTreePath = inferModulePathByBuildTreePath;
+    }
+
+    @Override
+    public boolean isInferModulePath(Project project) {
+        Path buildTreePath = ((ProjectInternal) project).getProjectIdentity().getBuildTreePath();
+        return inferModulePathByBuildTreePath.getOrDefault(buildTreePath, false);
+    }
+}

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectModulePathResolver.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectModulePathResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.Project;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Tells whether the sources of a project form a Java module, which decides if a project dependency
+ * on it goes on the module path.
+ *
+ * <p>Resolving the Eclipse classpath of a project dependency needs this answer about the
+ * <em>depended-upon</em> project. Reading it directly from that project is a cross-project access
+ * and is not allowed with Isolated Projects enabled, so the model builders supply an implementation
+ * backed by values gathered per project up front.
+ */
+@NullMarked
+public interface ProjectModulePathResolver {
+
+    /**
+     * Resolves the flag for the given project, which may be a project other than the one whose
+     * classpath is being built.
+     */
+    boolean isInferModulePath(Project project);
+}

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunEclipseTasksBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunEclipseTasksBuilder.java
@@ -19,9 +19,12 @@ package org.gradle.plugins.ide.internal.tooling;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyUtil;
+import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 
@@ -45,21 +48,30 @@ public class RunEclipseTasksBuilder implements ToolingModelBuilder {
         boolean isAutoBuildModel = isAutoBuildModel(modelName);
 
         CachingTaskDependencyResolveContext<Task> taskResolver = TaskDependencyUtil.newTaskResolver();
-        for (Project p : project.getAllprojects()) {
-            EclipseModel model = p.getExtensions().findByType(EclipseModel.class);
-            if (model != null) {
-                if (isSyncModel) {
-                    for (Task t : taskResolver.getDependencies(null, (TaskDependencyContainer) model.getSynchronizationTasks())) {
-                        taskPaths.add(t.getPath());
+        // The Eclipse extension of every project has to be read to collect the registered tasks.
+        // Going through Project.getAllprojects() would be reported as a cross-project access with
+        // Isolated Projects enabled, so the state of each project is taken under the lock that
+        // covers all of them instead. The build is reached through the target project's own state
+        // rather than through getRootProject(), which hands out a project that reports every
+        // mutable state access made on it.
+        BuildProjectRegistry projects = ((ProjectInternal) project).getOwner().getOwner().getProjects();
+        projects.applyToMutableStateOfAllProjects(access -> {
+            for (ProjectState projectState : projects.getAllProjects()) {
+                EclipseModel model = access.getMutableModel(projectState).getExtensions().findByType(EclipseModel.class);
+                if (model != null) {
+                    if (isSyncModel) {
+                        for (Task t : taskResolver.getDependencies(null, (TaskDependencyContainer) model.getSynchronizationTasks())) {
+                            taskPaths.add(t.getPath());
+                        }
                     }
-                }
-                if (isAutoBuildModel) {
-                    for (Task t : taskResolver.getDependencies(null, (TaskDependencyContainer) model.getAutoBuildTasks())) {
-                        taskPaths.add(t.getPath());
+                    if (isAutoBuildModel) {
+                        for (Task t : taskResolver.getDependencies(null, (TaskDependencyContainer) model.getAutoBuildTasks())) {
+                            taskPaths.add(t.getPath());
+                        }
                     }
                 }
             }
-        }
+        });
 
         if (taskPaths.isEmpty()) {
             // If no tasks is specified then the default tasks will be executed.

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/TasksFactory.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/TasksFactory.java
@@ -17,9 +17,14 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.build.BuildProjectRegistry;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import static java.util.Collections.emptySet;
 
@@ -32,7 +37,21 @@ public class TasksFactory {
     }
 
     public void collectTasks(Project root) {
-        allTasks = root.getAllTasks(true);
+        // Project.getAllTasks(true) reads the task container of every subproject, which is reported
+        // as a cross-project access with Isolated Projects enabled. Collect the tasks of each
+        // project under the lock that covers all of them instead.
+        BuildProjectRegistry projects = ((ProjectInternal) root).getOwner().getOwner().getProjects();
+        allTasks = projects.fromMutableStateOfAllProjects(access -> {
+            // Same shape as DefaultProject.getAllTasks(true): tasks are discovered per project and
+            // collected into a sorted set.
+            Map<Project, Set<Task>> result = new TreeMap<>();
+            for (ProjectState projectState : projects.getAllProjects()) {
+                projectState.ensureTasksDiscovered();
+                ProjectInternal project = access.getMutableModel(projectState);
+                result.put(project, new TreeSet<>(project.getTasks()));
+            }
+            return result;
+        });
     }
 
     public Set<Task> getTasks(Project project) {

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/IsolatedEclipseProjectInternal.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/IsolatedEclipseProjectInternal.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.internal.tooling.eclipse;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.io.Serializable;
+
+/**
+ * The part of a project's Eclipse model that other projects need in order to build theirs.
+ *
+ * <p>This is an intermediate model: it is built for each project separately, under that project's own
+ * lock, and the results are then combined by the builder of the whole {@code EclipseProject} model.
+ * That is what makes the combined model safe to build with Isolated Projects enabled, where reaching
+ * into another project directly is not allowed.
+ *
+ * <p>Only the module path flag lives here so far. More of the per-project data that
+ * {@code EclipseModelBuilder} currently reads across project boundaries can move here as it is made
+ * Isolated Projects safe.
+ */
+@NullMarked
+public class IsolatedEclipseProjectInternal implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean inferModulePath;
+
+    public IsolatedEclipseProjectInternal(boolean inferModulePath) {
+        this.inferModulePath = inferModulePath;
+    }
+
+    /**
+     * Whether the sources of this project form a Java module, so that a project dependency on it
+     * belongs on the module path rather than the classpath.
+     */
+    public boolean isInferModulePath() {
+        return inferModulePath;
+    }
+
+    @Override
+    public String toString() {
+        return "IsolatedEclipseProjectInternal{inferModulePath=" + inferModulePath + '}';
+    }
+}


### PR DESCRIPTION
Buildship cannot synchronize a build that has Isolated Projects enabled. Every Eclipse model builder walks the project tree through the decorated Project API, and each of those walks is reported as a cross-project access.

Four of them had the same shape and are fixed the same way, by taking the state of each project under the lock that covers all of them and reading the undecorated project out of it: `RunEclipseTasksBuilder`, which collects the tasks registered via `eclipse.synchronizationTasks` and `eclipse.autoBuildTasks`, `TasksFactory`, which called `Project.getAllTasks(true)`, and the two loops in `EclipseModelBuilder` that apply the `eclipse` plugin and deduplicate project names. Undecorating only the root project is not enough there, because `getAllprojects()` on an undecorated root still hands back decorated children.

The fifth case could not be rerouted that way. `EclipseDependenciesCreator` reads the `inferModulePath` flag of the project it depends on, so the value genuinely belongs to another project. That one now goes through Gradle's intended mechanism for whole-build model builders: a per-project `IsolatedEclipseProjectInternal` model, gathered once per build through `IntermediateToolingModelProvider` and handed to the classpath code as a `ProjectModulePathResolver`. When Isolated Projects is disabled the resolver reads the flag directly, exactly as before, and no intermediate models are built. Gathering them unconditionally would make the tooling action runner fire the `org.gradle.tooling.parallel` deprecation an extra time.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
