### PR TITLE
Fail javadoc on unresolvable doc references

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -71,8 +71,12 @@ tasks.withType<Javadoc>().configureEach {
 
         // Enable all javadoc warnings, except for:
         // - missing: Classes and methods are not required to have javadoc
-        // - reference: We allow references to classes that are not part of the compilation
-        addBooleanOption("Xdoclint:all,-missing,-reference", true)
+        addBooleanOption("Xdoclint:all,-missing", true)
+
+        // Fail the build on any javadoc warning. Cross-module `{@link}` targets are made
+        // resolvable via the `javadocReferences` configuration above, so an unresolvable
+        // reference now means the doc is wrong, not that the classpath is incomplete.
+        addBooleanOption("Werror", true)
 
         // Add support for custom tags
         tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:")

--- a/platforms/core-execution/worker-shared/build.gradle.kts
+++ b/platforms/core-execution/worker-shared/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation(libs.jsr305)
 
     testImplementation(testFixtures(projects.core))
+
+    // Javadoc-only: downstream modules whose types are referenced by {@link ...} in this module's docs.
+    javadocReferences(projects.core) // for GlobalScopeServices
 }
 
 gradleModule {

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     javadocReferences(projects.testingJvm)
     javadocReferences(projects.kotlinDsl)
     javadocReferences(projects.coreFlowServicesApi)
+    javadocReferences(projects.workerShared) // for DefaultLegacyTypesSupport
     javadocReferences(libs.groovyTemplates) // for groovy.text.SimpleTemplateEngine references in ContentFilterable / ExpandDetails
 }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/internal/DelegatingConvention.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/internal/DelegatingConvention.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Implementation of the custom {@code org.gradle.api.pliugns.Convention} interface that delegates all {@code ExtensionContainer} methods
+ * Implementation of the custom {@code org.gradle.api.plugins.Convention} interface that delegates all {@code ExtensionContainer} methods
  * to another {@code ExtensionContainer} implementation.
  *
  * This class is used in {@link org.gradle.initialization.DefaultLegacyTypesSupport} to create an instance of the runtime only convention interface.


### PR DESCRIPTION
The per-module javadoc tasks disabled the doclint `reference` group, so a `{@link}` naming a type outside the module's javadoc classpath only produced a warning nobody acted on. Two such references had already rotted into the codebase.

These two existing offenders are fixed by declaring the modules that own the referenced types.

This change enables the `reference` group and adds `-Werror`, turning both classes of problem into build failures. The `javadocReferences` configuration already exists to put cross-module `{@link}` targets on the javadoc classpath, so an unresolvable reference now means the doc is wrong rather than the classpath being incomplete. The `missing` group stays suppressed: members are still not required to have javadoc.
