### PR TITLE
Prepare to provide CC/IP problem locations past full trace cap

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -1238,4 +1238,32 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
             totalProblemsCount = 6
         }
     }
+
+    def "location detail decreases as the stack capturing budgets are spent"() {
+        given:
+        // The problem is reported before the process is spawned, so an empty command reports it without
+        // starting anything. The failed start has to be caught, or evaluation stops at the first line.
+        6.times {
+            buildFile "try { new ProcessBuilder([]).start() } catch (Exception e) {}\n"
+        }
+
+        when:
+        // Three full captures for six problems, so the full budget is spent partway through.
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.stacktrace-count.max=3")
+        // TODO The bounded budget buys nothing here: a problem that carries an exception has no bounded
+        //      fallback, so the last three problems lose their line instead of keeping it more cheaply.
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.bounded-captures.max=2")
+        configurationCacheFails "help"
+
+        then:
+        outputContains("Configuration cache entry discarded with 6 problems.")
+        problems.assertFailureHasProblems(failure) {
+            withProblem("Build file 'build.gradle': external process started")
+            (1..3).each {
+                withProblem("Build file 'build.gradle': line $it: external process started")
+            }
+            totalProblemsCount = 6
+            problemsWithStackTraceCount = 3
+        }
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsProblemReportingIntegrationTest.groovy
@@ -106,4 +106,32 @@ class IsolatedProjectsProblemReportingIntegrationTest extends AbstractIsolatedPr
         }
         resolveConfigurationCacheReportDirectory(testDirectory.file(customBuildDir), failure.error)?.isDirectory()
     }
+
+    def "location detail decreases as the stack capturing budgets are spent"() {
+        given:
+        settingsFile "include(':a')"
+        createDir("a")
+        6.times {
+            buildFile "project(':a').version\n"
+        }
+
+        when:
+        // Three full captures for six accesses, so the full budget is spent partway through.
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.stacktrace-count.max=3")
+        // TODO The bounded budget buys nothing here: a problem that carries an exception has no bounded
+        //      fallback, so the last three accesses lose their line instead of keeping it more cheaply.
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.bounded-captures.max=2")
+        isolatedProjectsDiagnosticsFails "help"
+
+        then:
+        outputContains("Configuration cache entry discarded with 6 problems.")
+        problems.assertFailureHasProblems(failure) {
+            withProblem("Build file 'build.gradle': Project ':' cannot access 'Project.version' functionality on another project ':a'")
+            (1..3).each {
+                withProblem("Build file 'build.gradle': line $it: Project ':' cannot access 'Project.version' functionality on another project ':a'")
+            }
+            totalProblemsCount = 6
+            problemsWithStackTraceCount = 3
+        }
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -46,7 +46,6 @@ import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.composite.IncludedBuildInternal
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
-import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.Path
 import java.io.File
@@ -69,7 +68,7 @@ class CrossBuildConfigurationReportingGradle(
                 text(" on build ")
                 reference(identityPath.asString())
             }
-                .exception { message -> message.capitalized() }
+                .exception()
                 .build()
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -67,9 +67,7 @@ class CrossBuildConfigurationReportingGradle(
                 reference("Gradle.$what")
                 text(" on build ")
                 reference(identityPath.asString())
-            }
-                .exception()
-                .build()
+            }.build()
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -84,9 +84,7 @@ class CrossProjectConfigurationReportingGradle(
                 reference(referrerProject.buildTreePath)
                 text(" cannot access ")
                 reference("Gradle.$what")
-            }
-                .exception()
-                .build()
+            }.build()
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -50,7 +50,6 @@ import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.composite.IncludedBuildInternal
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.extensions.core.serviceOf
-import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.Path
 import java.io.File
@@ -86,7 +85,7 @@ class CrossProjectConfigurationReportingGradle(
                 text(" cannot access ")
                 reference("Gradle.$what")
             }
-                .exception { message -> message.capitalized() }
+                .exception()
                 .build()
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradleExtensionsContainer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradleExtensionsContainer.kt
@@ -39,9 +39,7 @@ internal class CrossProjectConfigurationReportingGradleExtensionsContainer(
                 reference(referrer.buildTreePath)
                 text(" cannot access ")
                 reference("Gradle.extensions")
-            }
-                .exception()
-                .build()
+            }.build()
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradleExtensionsContainer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradleExtensionsContainer.kt
@@ -25,7 +25,6 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
 import org.gradle.internal.extensibility.DefaultExtensionsSchema
-import org.gradle.internal.extensions.stdlib.capitalized
 
 internal class CrossProjectConfigurationReportingGradleExtensionsContainer(
     private val delegate: ExtensionContainerInternal,
@@ -41,7 +40,7 @@ internal class CrossProjectConfigurationReportingGradleExtensionsContainer(
                 text(" cannot access ")
                 reference("Gradle.extensions")
             }
-                .exception { message -> message.capitalized() }
+                .exception()
                 .build()
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -148,8 +148,8 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
                 text("Project ")
                 reference(referrerProject.buildTreePath)
                 text(" cannot access the tasks in the task graph that were created by other projects")
-            }.exception { message ->
-                // As the exception message is not used for grouping, we can safely add the exact task name to it:
+            }.exceptionMessage { message ->
+                // The exception message is not used for grouping, so it can name the exact task:
                 message + if (requestPath != null) "; tried to access '$requestPath'" else ""
             }.build()
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -30,7 +30,6 @@ import org.gradle.execution.plan.FinalizedExecutionPlan
 import org.gradle.execution.taskgraph.TaskExecutionGraphExecutionListener
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsReporter
-import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.util.Path
 import java.util.Objects
 
@@ -151,7 +150,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
                 text(" cannot access the tasks in the task graph that were created by other projects")
             }.exception { message ->
                 // As the exception message is not used for grouping, we can safely add the exact task name to it:
-                message.capitalized() + if (requestPath != null) "; tried to access '$requestPath'" else ""
+                message + if (requestPath != null) "; tried to access '$requestPath'" else ""
             }.build()
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -581,9 +581,7 @@ class ProblemReportingCrossProjectModelAccess(
                     text(" $accessRefKind on ")
                     describeCrossProjectAccess()
                     buildAdditionalMessage()
-                }
-                    .exception()
-                    .build()
+                }.build()
             }
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
@@ -43,9 +43,7 @@ class ReportingTaskDependencyUsageTracker(
                 text("Project ")
                 reference(referrer.buildTreePath)
                 text(" cannot access task dependencies directly")
-            }
-                .exception()
-                .build()
+            }.build()
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -66,7 +66,6 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
             text(" caused by invocation ")
             reference(getterName)
         }
-            .exception("Accessing non-serializable type '$injectedServiceType' during execution time is unsupported.")
             .documentationSection(DocumentationSection.RequirementsDisallowedTypes)
             .build()
         problems.onExecutionTimeProblem(problem)
@@ -95,7 +94,6 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
             text("external process started ")
             reference(command)
         }
-            .exception("Starting an external process '$command' during configuration time is unsupported.")
             .documentationSection(RequirementsExternalProcess)
             .build()
         problems.onProblem(problem)
@@ -134,13 +132,14 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
                     text(" at execution time is unsupported with the configuration cache.")
                 }
             }
-                .exception(
+                .exceptionMessage {
+                    // The exception message is not used for grouping, so it can name the accessing task:
                     if (isExecutingOtherTask) {
                         "Execution of $runningTask caused invocation of '$invocationDescription' by $task at execution time which is unsupported with the configuration cache."
                     } else {
                         "Invocation of '$invocationDescription' by $task at execution time is unsupported with the configuration cache."
                     }
-                )
+                }
                 .documentationSection(RequirementsUseProjectDuringExecution)
                 .mapLocation { locationForTask(it, contextTask) }
                 .build()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -278,6 +278,7 @@ class ConfigurationCacheProblems(
             .mapLocation {
                 trace
             }
+            .informational()
             .documentationSection(DocumentationSection.TaskOptOut).build()
         report.onIncompatibleTask(problem)
         summarizer.onIncompatibleTask()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl.problems
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.collect.Sets.newConcurrentHashSet
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Task
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
@@ -308,7 +309,9 @@ class ConfigurationCacheProblems(
         }
 
         if (severity == ProblemSeverity.Interrupting) {
-            val exception = problem.exception ?: error("Interrupting problems must have an associated exception. Got: $problem")
+            // The exception is missing once the full stack-capture budget is spent, which is unlikely
+            // for an interrupting problem, since the build stops at the first one.
+            val exception = problem.exception ?: InvalidUserCodeException(problem.message.renderCapitalized())
             throw exception
         }
     }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
@@ -52,22 +52,18 @@ class DefaultProblemFactory(
     override fun problem(consumer: String?, message: Action<StructuredMessage.Builder>): ProblemFactory.Builder {
         val builtMessage = StructuredMessage.build { message.execute(this) }
         return object : ProblemFactory.Builder {
-            var exceptionMessage: String? = null
+            var failure = true
+            var exceptionMessageBuilder: ((String) -> String)? = null
             var documentationSection: DocumentationSection? = null
             var locationMapper: (PropertyTrace) -> PropertyTrace = { it }
 
-            override fun exception(message: String): ProblemFactory.Builder {
-                exceptionMessage = message
+            override fun informational(): ProblemFactory.Builder {
+                failure = false
                 return this
             }
 
-            override fun exception(): ProblemFactory.Builder {
-                exceptionMessage = builtMessage.renderCapitalized()
-                return this
-            }
-
-            override fun exception(builder: (String) -> String): ProblemFactory.Builder {
-                exceptionMessage = builder(builtMessage.renderCapitalized())
+            override fun exceptionMessage(message: (String) -> String): ProblemFactory.Builder {
+                exceptionMessageBuilder = message
                 return this
             }
 
@@ -82,14 +78,18 @@ class DefaultProblemFactory(
             }
 
             override fun build(): PropertyProblem {
-                val exceptionMessage = exceptionMessage
-                val diagnostics = if (exceptionMessage == null) {
-                    problemStream.forCurrentCaller()
+                val diagnostics = if (failure) {
+                    problemStream.forCurrentCaller(Supplier { InvalidUserCodeException(exceptionMessage()) })
                 } else {
-                    problemStream.forCurrentCaller(Supplier { InvalidUserCodeException(exceptionMessage) })
+                    problemStream.forCurrentCaller()
                 }
                 val location = locationMapper(locationForCaller(consumer, diagnostics))
                 return PropertyProblem(location, builtMessage, diagnostics.exception, diagnostics.failure, documentationSection)
+            }
+
+            private fun exceptionMessage(): String {
+                val message = builtMessage.renderCapitalized()
+                return exceptionMessageBuilder?.invoke(message) ?: message
             }
         }
     }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
@@ -21,7 +21,6 @@ import org.gradle.api.Action
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.internal.code.UserCodeApplicationContext
 import org.gradle.internal.code.UserCodeSource
-import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.problems.ProblemDiagnostics
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory
@@ -63,12 +62,12 @@ class DefaultProblemFactory(
             }
 
             override fun exception(): ProblemFactory.Builder {
-                exceptionMessage = builtMessage.toString().capitalized()
+                exceptionMessage = builtMessage.renderCapitalized()
                 return this
             }
 
             override fun exception(builder: (String) -> String): ProblemFactory.Builder {
-                exceptionMessage = builder(builtMessage.toString().capitalized())
+                exceptionMessage = builder(builtMessage.renderCapitalized())
                 return this
             }
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemFactory.kt
@@ -50,20 +50,22 @@ interface ProblemFactory {
     fun problem(message: Action<StructuredMessage.Builder>): Builder = problem(null, message)
 
     interface Builder {
-        /**
-         * Creates an InvalidUserCodeException for this problem, with the given message.
-         */
-        fun exception(message: String): Builder
 
         /**
-         * Creates an InvalidUserCodeException for this problem, with a message derived from the problem message.
+         * Marks this problem as reporting a state rather than blaming user code, so it carries no exception.
+         *
+         * Such a problem can still appear in the report and the summary, but it shouldn't fail the build.
          */
-        fun exception(builder: (String) -> String): Builder
+        fun informational(): Builder
 
         /**
-         * Creates an InvalidUserCodeException for this problem, using the problem message to create the exception message.
+         * Replaces the exception message, which by default repeats the problem message.
+         *
+         * Use it only for detail too specific to put in the problem message, which we keep generic because
+         * we group problems by it. Treat the exception as a deeper level of detail: expect to lose this
+         * detail once the stack-capture budget runs out.
          */
-        fun exception(): Builder
+        fun exceptionMessage(message: (String) -> String): Builder
 
         fun documentationSection(documentationSection: DocumentationSection): Builder
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -21,6 +21,7 @@ import org.gradle.internal.cc.impl.problems.JsonWriter
 import org.gradle.internal.code.UserCodeSource
 import org.gradle.internal.configuration.problems.StructuredMessage.Fragment.Reference
 import org.gradle.internal.configuration.problems.StructuredMessage.Fragment.Text
+import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.problems.failure.Failure
 import org.gradle.problems.Location
 import org.gradle.util.Path
@@ -89,6 +90,13 @@ data class StructuredMessage(val fragments: List<Fragment>) {
             is Reference -> "$quote${fragment.name}$quote"
         }
     }
+
+    /**
+     * Renders a message to stand on its own, such as in an exception message.
+     *
+     * Messages are typically not capitalized, so that they can be part of a longer sentence.
+     */
+    fun renderCapitalized() = render().capitalized()
 
     override fun toString(): String = render()
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/GroovyCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/GroovyCodecs.kt
@@ -161,15 +161,11 @@ object ClosureCodec : Codec<Closure<*>> {
 
         private
         fun scriptReferenced(invocationDescription: String): Nothing {
-            val exceptionMessage =
-                "Invocation of '$invocationDescription' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache."
-
             val problem = problemFactory.problem {
                 text("invocation of ")
                 reference(invocationDescription)
                 text(" references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration cache.")
             }
-                .exception(exceptionMessage)
                 .documentationSection(RequirementsGradleModelTypes)
                 .mapLocation { trace }
                 .build()
@@ -179,7 +175,7 @@ object ClosureCodec : Codec<Closure<*>> {
             // We normally fail immediately on execution-time problems, except when in the warning mode.
             // However, even in the warning mode, we don't have a reasonable way of proceeding in this situation
             // so we make sure to throw
-            throw problem.exception ?: InvalidUserCodeException(exceptionMessage)
+            throw problem.exception ?: InvalidUserCodeException(problem.message.renderCapitalized())
         }
     }
 }

--- a/platforms/ide/problems-api/build.gradle.kts
+++ b/platforms/ide/problems-api/build.gradle.kts
@@ -30,6 +30,7 @@ at https://github.com/melix/jdoctor/
 dependencies {
     api(projects.baseServices)
     api(projects.buildOperations)
+    api(projects.buildOption)
     api(projects.enterpriseOperations)
     api(projects.serialization)
     api(projects.snapshots)

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationDetailIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemLocationDetailIntegrationTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems
+
+import groovy.transform.TupleConstructor
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.api.problems.internal.DefaultProblemProgressDetails
+import org.gradle.api.problems.internal.StackTraceLocation
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.problems.ReceivedProblem
+
+class ProblemLocationDetailIntegrationTest extends AbstractIntegrationSpec {
+
+    def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)
+
+    def "location detail decreases as the stack capturing budgets are spent"() {
+        given:
+        settingsFile "rootProject.name = 'root'"
+        buildFile """
+            def reporter = services.get(${Problems.name}).getReporter()
+            def group = ${ProblemGroup.name}.create('demo', 'demo group')
+            def problemId = { String id -> ${ProblemId.name}.create(id, id, group) }
+        """
+        // A problem is located where `report` is called, so each call has to be on its own line.
+        6.times {
+            buildFile "\nreporter.report(problemId('issue-${it + 1}')) {}"
+        }
+
+        and:
+        def reportingLines = buildFileLinesStartingWith("reporter.report(")
+        assert reportingLines.size() == 6
+
+        when:
+        // The default warning mode lifts the bounded budget, which would hide the last level of detail.
+        executer.withWarningMode(WarningMode.Summary)
+        // Three full captures and two bounded ones for six problems, so every level is reached.
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.stacktrace-count.max=3")
+        executer.withArgument("-Dorg.gradle.internal.problem.diagnostics.bounded-captures.max=2")
+        succeeds 'help'
+
+        then:
+        def located = (1..6).collect { locationReportedFor("issue-$it") }
+        // The three full captures and the two bounded ones all say which line the problem came from.
+        located[0..4].every { it != null }
+        // Past both budgets a problem no longer says where it came from.
+        located[5..-1].every { it == null }
+
+        and:
+        // Every located problem points at the line of its own `report` call in the build file.
+        located[0..4].every { it.file == buildFile.absolutePath }
+        located[0..4].collect { it.line } == reportingLines[0..4]
+
+        and:
+        // A full capture descends into the Gradle runtime; a bounded one is cut at the calling script.
+        located[0..2].every { it.frames > 100 }
+        located[3..4].every { it.frames < 20 }
+    }
+
+    private List<Integer> buildFileLinesStartingWith(String prefix) {
+        def lines = buildFile.text.readLines()
+        return (1..lines.size()).findAll { lines[it - 1].startsWith(prefix) }
+    }
+
+    private ReportedLocation locationReportedFor(String problemId) {
+        def problem = buildOperations.progress(DefaultProblemProgressDetails).details
+            .collect { new ReceivedProblem(0, it['problem'] as Map<String, Object>) }
+            .find { it.definition.id.name == problemId }
+        def location = problem.allLocations(StackTraceLocation).find { it.fileLocation != null }
+        if (location == null) {
+            return null
+        }
+        def fileLocation = location.fileLocation as LineInFileLocation
+        return new ReportedLocation(fileLocation.path, fileLocation.line, location.stackTrace.size())
+    }
+
+    @TupleConstructor
+    private static class ReportedLocation {
+        final String file
+        final int line
+        final int frames
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/DefaultProblemDiagnosticsFactory.java
@@ -19,6 +19,7 @@ package org.gradle.internal.problems;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.code.UserCodeSource;
@@ -47,12 +48,23 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
 
     private static final ProblemStream.StackTraceTransformer NO_OP = new CopyStackTraceTransFormer();
 
-    private static final int MAX_STACKTRACE_COUNT = 50;
-    private static final int ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT = 5000;
+    /// Caps the full stack traces captured per stream, since capturing one is expensive.
+    ///
+    /// Isolated Projects only raises the default, since it reports far more problems. An
+    /// explicit value applies to either kind of build.
+    public static final String MAX_STACKTRACE_COUNT_PROPERTY = "org.gradle.internal.problem.diagnostics.stacktrace-count.max";
 
-    // Budget for bounded location captures past the cap: capping the count keeps the stack walk cost
-    // bounded and negligible at scale. Builds with more distinct call sites lose locations past it.
-    private static final int MAX_BOUNDED_CAPTURES = 2000;
+    private static final int DEFAULT_MAX_STACKTRACE_COUNT = 50;
+
+    private static final int DEFAULT_ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT = 5000;
+
+    /// Caps the cheap bounded captures past the full cap, keeping the stack walk cost negligible.
+    ///
+    /// Past this cap a problem is located by its user code source, such as the script that
+    /// reported it, rather than by a line within it.
+    public static final String MAX_BOUNDED_CAPTURES_PROPERTY = "org.gradle.internal.problem.diagnostics.bounded-captures.max";
+
+    private static final int DEFAULT_MAX_BOUNDED_CAPTURES = 2000;
 
     private final FailureFactory failureFactory;
     private final ProblemLocationAnalyzer locationAnalyzer;
@@ -67,13 +79,24 @@ public class DefaultProblemDiagnosticsFactory implements ProblemDiagnosticsFacto
         ProblemLocationAnalyzer locationAnalyzer,
         UserCodeApplicationContext userCodeContext,
         BuildModelParameters buildModelParameters,
+        InternalOptions internalOptions,
         BoundedCallerStackCapturer boundedCallerStackCapturer
     ) {
-        this(failureFactory, locationAnalyzer, userCodeContext, getMaxStackTraces(buildModelParameters), MAX_BOUNDED_CAPTURES, boundedCallerStackCapturer);
+        this(
+            failureFactory,
+            locationAnalyzer,
+            userCodeContext,
+            maxStackTraces(buildModelParameters, internalOptions),
+            internalOptions.getInt(MAX_BOUNDED_CAPTURES_PROPERTY, DEFAULT_MAX_BOUNDED_CAPTURES),
+            boundedCallerStackCapturer
+        );
     }
 
-    private static int getMaxStackTraces(BuildModelParameters buildModelParameters) {
-        return buildModelParameters.isIsolatedProjects() ? ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT : MAX_STACKTRACE_COUNT;
+    private static int maxStackTraces(BuildModelParameters buildModelParameters, InternalOptions internalOptions) {
+        int defaultValue = buildModelParameters.isIsolatedProjects()
+            ? DEFAULT_ISOLATED_PROJECTS_MAX_STACKTRACE_COUNT
+            : DEFAULT_MAX_STACKTRACE_COUNT;
+        return internalOptions.getInt(MAX_STACKTRACE_COUNT_PROPERTY, defaultValue);
     }
 
     @VisibleForTesting

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/DefaultProblemBuilderStackCapTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/internal/problems/DefaultProblemBuilderStackCapTest.groovy
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.problems
+
+import org.gradle.api.problems.ProblemGroup
+import org.gradle.api.problems.ProblemId
+import org.gradle.api.problems.Severity
+import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
+import org.gradle.api.problems.internal.DefaultProblemBuilder
+import org.gradle.api.problems.internal.IsolatableToBytesSerializer
+import org.gradle.api.problems.internal.ProblemInternal
+import org.gradle.api.problems.internal.ProblemsInfrastructure
+import org.gradle.api.problems.internal.StackTraceLocation
+import org.gradle.internal.code.UserCodeApplicationContext
+import org.gradle.internal.isolation.IsolatableFactory
+import org.gradle.internal.problems.failure.DefaultFailureFactory
+import org.gradle.internal.reflect.Instantiator
+import org.gradle.problems.buildtree.ProblemStream
+import org.gradle.tooling.internal.provider.serialization.PayloadSerializer
+import spock.lang.Specification
+
+/**
+ * Characterizes which problems still collect a stack once the capture cap is spent.
+ *
+ * <p>An ERROR-severity problem without its own exception gets a synthetic one, routing it through
+ * {@link ProblemStream#forThrownException} and so past the cap that stops every other problem.</p>
+ */
+class DefaultProblemBuilderStackCapTest extends Specification {
+
+    private static final int FULL_BUDGET = 2
+
+    def locationAnalyzer = Mock(ProblemLocationAnalyzer)
+    def userCodeContext = Mock(UserCodeApplicationContext)
+    def boundedCallerStackCapturer = Mock(BoundedCallerStackCapturer)
+
+    def problemGroup = ProblemGroup.create("group", "label")
+    def problemId = ProblemId.create("id", "Problem Id", problemGroup)
+
+    def problemStream = new DefaultProblemDiagnosticsFactory(
+        DefaultFailureFactory.withDefaultClassifier(),
+        locationAnalyzer,
+        userCodeContext,
+        FULL_BUDGET,
+        0,
+        boundedCallerStackCapturer
+    ).newStream()
+
+    def "error severity keeps collecting stacks past the cap"() {
+        given:
+        exhaustFullBudget()
+
+        when:
+        def problem = buildProblemWithSeverity(Severity.ERROR)
+
+        then:
+        !stackOf(problem).empty
+    }
+
+    def "warning severity stops collecting stacks past the cap"() {
+        given:
+        exhaustFullBudget()
+
+        when:
+        def problem = buildProblemWithSeverity(Severity.WARNING)
+
+        then:
+        stackOf(problem).empty
+    }
+
+    def "unset severity stops collecting stacks past the cap"() {
+        given:
+        exhaustFullBudget()
+
+        when:
+        def problem = createProblemBuilder().id(problemId).stackLocation().build()
+
+        then:
+        problem.definition.severity == Severity.WARNING
+        stackOf(problem).empty
+    }
+
+    def "#severity severity collects a stack while the cap allows it"() {
+        when:
+        def problem = buildProblemWithSeverity(severity)
+
+        then:
+        !stackOf(problem).empty
+
+        where:
+        severity << [Severity.ERROR, Severity.WARNING]
+    }
+
+    def "a caller-supplied exception is kept past the cap regardless of severity"() {
+        given:
+        exhaustFullBudget()
+        def failure = new RuntimeException("boom")
+
+        when:
+        def problem = createProblemBuilder()
+            .id(problemId)
+            .internalSeverity(Severity.WARNING)
+            .stackLocation()
+            .withException(failure)
+            .build()
+
+        then:
+        problem.exception.is(failure)
+        !stackOf(problem).empty
+    }
+
+    def "error severity does not surface its synthetic exception on the problem"() {
+        when:
+        def problem = buildProblemWithSeverity(Severity.ERROR)
+
+        then:
+        !stackOf(problem).empty
+        problem.exception == null
+    }
+
+    private void exhaustFullBudget() {
+        FULL_BUDGET.times { problemStream.forCurrentCaller() }
+    }
+
+    private ProblemInternal buildProblemWithSeverity(Severity severity) {
+        createProblemBuilder()
+            .id(problemId)
+            .internalSeverity(severity)
+            .stackLocation()
+            .build()
+    }
+
+    private static List<StackTraceElement> stackOf(ProblemInternal problem) {
+        def stackLocations = (problem.originLocations + problem.contextualLocations).findAll { it instanceof StackTraceLocation }
+        stackLocations.collectMany { (it as StackTraceLocation).stackTrace }
+    }
+
+    private DefaultProblemBuilder createProblemBuilder() {
+        new DefaultProblemBuilder(new ProblemsInfrastructure(
+            new AdditionalDataBuilderFactory(),
+            Mock(Instantiator),
+            Mock(PayloadSerializer),
+            Mock(IsolatableFactory),
+            Mock(IsolatableToBytesSerializer),
+            problemStream
+        ))
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1185,7 +1185,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             factory.problem(message -> message
                 .text("use of ").reference("Project.getProperties()")
                 .text(" is not allowed with Isolated Projects")
-            ).exception().build()
+            ).build()
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -467,7 +467,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
                         .text(" when Isolated Projects is enabled. Only ").reference("findByName(String)")
                         .text(" is permitted. Alternatively, use ").reference("BuildServicesRegistry.registerIfAbsent(String, Class)")
                         .text(" if possible.")
-                    ).exception().build()
+                    ).build()
                 );
             }
             super.onMethodCall(signature);

--- a/subprojects/core/src/main/java/org/gradle/initialization/internal/settings/StartParameterMutationReportingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/internal/settings/StartParameterMutationReportingSettingsProcessor.java
@@ -52,7 +52,7 @@ public class StartParameterMutationReportingSettingsProcessor implements Setting
                 factory.problem(message -> message
                     .text("The start parameter cannot be mutated after settings have been evaluated when Isolated Projects is enabled. ")
                     .text("The mutation occurred via ").reference(methodSignature).text(" call.")
-                ).exception().build()
+                ).build()
             )
         );
         return state;


### PR DESCRIPTION
Preparation for fixing #39117 and a step before #39107, which keeps problem locations past the stack-capture budget. No behavior change.

### Why

Problem diagnostics spend two budgets: full stack captures, and cheaper bounded captures past them. How much of each is left decides whether a problem reports an exact line, the same line from a shorter capture, or nothing at all. Reaching either budget takes thousands of problems, so no test could show the difference, and no committed test distinguished the three levels of detail.

`ProblemFactory.Builder.exception()` also made a caller decide three unrelated things at once: that they wanted a rethrowable exception, what its message said, and — without meaning to — that they gave up the bounded capture. Almost every caller wanted the exception, so almost every problem gave up the cheaper capture. Separating those decisions is what makes the fallback reachable in the follow-up.

Asking for an exception is the wrong default to state explicitly, too, because it describes the mechanism rather than the problem. A task that opts out with `notCompatibleWithConfigurationCache` reports a state the build declared about itself: there is no user code to blame and nothing to throw. That is what `informational()` now says.

### What

- Both stack-capture budgets are internal options, keeping their current values as defaults. Isolated Projects raises only the default rather than reading a separate property.
- `ProblemFactory.Builder.exception()` → `informational()` and `exceptionMessage()`. Retaining an exception is the default; a caller opts out where a problem reports a state rather than blames user code.
- `StructuredMessage.renderCapitalized()` replaces a pattern repeated at each use.

### Verification

- A characterization test per channel — Problems API, Configuration Cache, Isolated Projects — drives both budgets below the number of problems reported, so each level of detail is reached in one build instead of by exhausting a production-sized budget.
- The Problems API test pins all three levels: a full stack with an exact line, a short stack with the same line, and no location at all.
- The Configuration Cache and Isolated Projects tests carry a TODO where the bounded budget currently buys nothing, which #39107 resolves.
- A characterization test pins which severities still collect a stack past the cap, including the error-severity path that previously had no coverage.

### Details

**Read the commits in order.** The severity characterization comes first and passes throughout. The budgets become settable next, because the tests need them. The characterization tests follow, then the two refactors they protect.

**Why the budgets are settable rather than the tests being large.** Existing tests in this area fire 100–530 problems to cross one threshold; crossing the second was impractical, which is why the third level of detail was never covered end to end. An internal option per budget reaches each level in a six-problem build.

**Isolated Projects keeps its higher default.** It reports far more problems, so its 5000 full captures still buy locations that the bounded tier cannot yet provide. Removing that cap depends on the follow-up and is not part of this change.

**The `exceptionMessage()` overload survives for one caller.** Cross-project task-graph access appends the exact task path to its exception message, which is detail too specific for the grouped problem message. Every other caller took the default.

**A drive-by fix.** An interrupting problem past the full budget has no exception, so it failed with an internal `IllegalStateException` instead of reporting the user's problem. It now gets an exception built from its own message.
