### PR TITLE
Stabilize flaky HTTPS client-auth resolve test

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
@@ -103,8 +103,17 @@ abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDepen
 
         then:
         failure.assertHasCause("Could not GET '${server.uri}/repo1/my-group/my-module/1.0/")
-        // exact error might vary depending on JVM version and OS
-        failure.assertThatCause(matchesRegexp("Got (socket|SSL handshake) exception during request. It might be caused by SSL misconfiguration"))
+        // The server rejects the client certificate by hanging up. How far the TLS 1.3 handshake
+        // got before that decides which exception the JDK raises - a SocketException, an
+        // SSLException mentioning readHandshakeRecord, or an SSLHandshakeException reading
+        // "Remote host terminated the handshake" - and those map onto three different
+        // explanations. The last one is indistinguishable from a server that only speaks
+        // deprecated TLS versions (see DeprecatedTLSVersionTest), so it cannot be narrowed down
+        // here. Assert that the failure surfaces as an SSL/TLS problem, not which explanation won.
+        failure.assertThatCause(matchesRegexp(
+            /Got (socket|SSL handshake) exception during request\. It might be caused by SSL misconfiguration/ +
+                /|The server (may|does) not support the client's requested TLS protocol versions.*/
+        ))
     }
 
     def "build fails when client has invalid ssl configuration and has underlying cause in output"() {


### PR DESCRIPTION
`AbstractHttpsRepoResolveIntegrationTest."build fails when server can't
authenticate client"` is flaky on both `release` and `master`, taking
`MavenHttpsRepoResolveIntegrationTest` and
`IvyHttpsRepoResolveIntegrationTest` down together.

The test asserts the resolve failure is reported as either a socket
exception or an SSL handshake exception. The server rejects the client
certificate by hanging up, and how far the TLS 1.3 handshake got before
that decides which exception the JDK raises. When it raises
`SSLHandshakeException: Remote host terminated the handshake`,
`ApacheCommonsHttpClient` explains it as a TLS protocol version
mismatch, and the assertion fails.

### Why the production message is not the bug

A standalone JDK 17 probe of the three relevant scenarios:

| Scenario | JDK exception message |
| --- | --- |
| Peer closes mid-handshake (rejected client cert) | `Remote host terminated the handshake` |
| Server supports only TLSv1/TLSv1.1 (genuine deprecated-TLS case) | `Remote host terminated the handshake` |
| Server sends a version alert | `Received fatal alert: protocol_version` |

The first two are indistinguishable from the exception alone, which is
why `getConfidenceNote` already hedges the wording with "may".
Rerouting that message would strip a correct diagnostic from the real
deprecated-TLS case and break `DeprecatedTLSVersionTest`. The
production code is fine; the test was demanding a guarantee production
does not make.

### The change

Accept the TLS protocol version wording alongside the existing two, so
the test asserts the failure surfaces as an SSL/TLS problem rather than
which of three interchangeable explanations was chosen. The
`Could not GET '<url>'` cause assertion is unchanged.

The same assertion was widened once before for the same reason in
0fecbed2edb ("Fix flaky ssl test", 2023); this adds the third and last
branch `wrapWithExplanation` can produce for this scenario.
