### PR TITLE
Revert maven-surefire-plugin to 3.5.6 in .teamcity

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>com.github.gantsign.maven</groupId>


### PR DESCRIPTION
Reverts b625323aa278b7188968750c945ce1369c7cb07b (dependabot bump of
`maven-surefire-plugin` 3.5.6 -> 3.6.0, 2026-09-07).

## Symptom

`Gradle_Master_Check_LightweightChecks` fails on a subset of agents
(dev325, dev360, dev366, dev382) while passing on the rest. All nine
mockk-based tests error, and the build log surfaces a misleading
top-level failure:

```
NoClassDefFoundError: Could not initialize class
org.apache.maven.surefire.api.report.StackWalkerStrategy
```

## Correlation

| build | surefire | self-attach failures |
|---|---|---|
| 117263905 (dev360) | 3.6.0 | 9 |
| 117258003 (dev366) | 3.6.0 | 9 |
| 117166836 (dev382) | 3.6.0 | 9 |
| 117163222 (dev382) | 3.6.0 | 9 |
| 117188507 (master) | 3.6.0 | 9 |
| 117038938 (dev325, last green) | 3.5.6 | 0 |
| 117031628 (green) | 3.5.6 | 0 |

Nothing has ever failed on 3.5.6. Every failure is on 3.6.0.

## Root cause

Reproduced on dev325. mockk loads its byte-buddy agent dynamically. On
JDK 21 the JVM prints the "agent has been loaded dynamically" warning
from inside the `sun.instrument.InstrumentationImpl` constructor. Under
the 3.6.0 fork that print fails, so the constructor throws:

```
*** java.lang.instrument ASSERTION FAILED ***: "!errorOutstanding" with message
call constructor on InstrumentationImpl failed at JPLISAgent.c line: 526
*** java.lang.instrument ASSERTION FAILED ***: "success" with message
createInstrumentationImpl failed at InvocationAdapter.c line: 425
Agent failed to start!
```

byte-buddy only sees the flattened `AgentInitializationException`, so
mockk's `JvmMockKGateway` fails to initialise. Surefire 3.6.0 then dies
in its own `StackWalkerStrategy` while reporting those errors, which is
what reaches the build log.

Confirmed on dev325 with the same checkout and deps:

- `-XX:+EnableDynamicAgentLoading` (skips the warning print): 9/9 pass
- `-javaagent:byte-buddy-agent.jar` (no dynamic attach): 9/9 pass
- fresh dependency repo: still fails, so not a dependency change
- JDK binaries byte-identical to a healthy agent (dev348)

## Why revert rather than add a flag

The mockk usage dates to Feb 2021 and 3.5.6 tolerated it on every agent
for years. Reverting restores known-good behaviour fleet-wide and
unblocks the merge queue. The 3.6.0 regression, and whatever makes it
host-sensitive, can be investigated separately before re-attempting the
bump.

Adding `-XX:+EnableDynamicAgentLoading` to the surefire `argLine` is
worth doing on its own merits, since dynamic agent loading is disallowed
by default in a future JDK, but it should not be what unblocks this.
