### PR TITLE
Use compileOnly deps on xdcl-gradle-api in the builtins

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild.xdcl-ecosystem-library.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.xdcl-ecosystem-library.gradle.kts
@@ -17,9 +17,9 @@
 /**
  * Shared contract for a published built-in XDCL ecosystem schema library (the `:xdcl-*` lib half
  * of each ecosystem). The generated facades extend `org.gradle.api.xdcl.*`, so every such library
- * needs the external `xdclGradleApi` facade base types as `api` (exposed transitively to
- * consumers) — declared here once instead of in every lib build script. Every such library is also
- * served by the distribution's embedded Maven repository (that is what makes it a BUILT-IN
+ * compiles against the `xdclGradleApi` facade base types — declared here once instead of in every
+ * lib build script, and `compileOnly` on purpose (see the dependencies block). Every such library is
+ * also served by the distribution's embedded Maven repository (that is what makes it a BUILT-IN
  * ecosystem library), so `gradlebuild.distribution-repository` — and through it
  * `gradlebuild.publish-public-libraries` — is applied here rather than by each module.
  */
@@ -36,10 +36,17 @@ plugins {
 excludeGeneratedXdclSourcesFromChecks()
 publishGeneratedXdclSources()
 
-// External (org.xdcl) facade base types the generated facades extend; `api` so consumers of the
-// published library get them transitively.
+// The facade base types the generated facades extend (org.gradle.api.xdcl.*). `compileOnly`, so the
+// dependency appears in NO published metadata — not in the module metadata, in any variant, not in
+// the POM, at any scope: the API is part of the Gradle distribution (lib/, on gradleApi()), which is
+// where every consumer of a published ecosystem library gets it. A plugin author's build compiles
+// against it through gradleApi() — the plugin-development ecosystem's reactions apply
+// `java-gradle-plugin`, which adds gradleApi() as `api`, and `xdcl-gradle-plugin`, which adds it
+// `compileOnly` — and a build applying such a plugin runs on a Gradle that already has the classes.
+// Nothing under org.xdcl is published, so a dependency on it would be unresolvable for anyone
+// outside this build.
 dependencies {
-    "api"(project.versionCatalogs.named("libs").findLibrary("xdclGradleApi").get())
+    "compileOnly"(project.versionCatalogs.named("libs").findLibrary("xdclGradleApi").get())
 }
 
 // Opt this library's jar out of the generated Gradle API Kotlin DSL extensions: the generated

--- a/packaging/distributions-full/build.gradle.kts
+++ b/packaging/distributions-full/build.gradle.kts
@@ -46,12 +46,12 @@ dependencies {
     pluginsRuntimeOnly(projects.xdclPluginDevelopmentPlugin)
 
     // The embedded Maven repository (repo/ in the image): the published ecosystem libraries at the
-    // distribution version, plus the org.xdcl API module their published metadata strictly
-    // requires — the full offline-resolution closure a consumer build's settings classpath needs
-    // when the XDCL provider injects built-in ecosystems into dependency resolution.
+    // distribution version — the full offline-resolution closure a consumer build's settings
+    // classpath needs when the XDCL provider injects built-in ecosystems into dependency resolution.
+    // (The org.xdcl API the libraries' facades extend is a compileOnly dependency of theirs, named
+    // by no published metadata, and present in lib/ — so the repository has nothing to serve for it.)
     distributionRepositoryOnly(projects.xdclCommonEcosystem)
     distributionRepositoryOnly(projects.xdclPluginDevelopment)
-    distributionRepositoryOnly(libs.xdclGradleApi)
 }
 
 // The manifest auto-derives module names from `gradle-<name>-<version>.jar` file names, which

--- a/platforms/core-configuration/xdcl-common-ecosystem/build.gradle.kts
+++ b/platforms/core-configuration/xdcl-common-ecosystem/build.gradle.kts
@@ -24,9 +24,9 @@ description = "Shared XDCL schema common to the built-in ecosystems: dependency 
 // A schema-only ecosystem foundation: common.xdsl (packed under META-INF/xdcl/ by xdcl-gradle-plugin)
 // and the Java facades generated from it. The built-in ecosystems (plugin-development today; JVM,
 // Native etc. later) `import` this schema and `with` its capability traits, so the shared dependency
-// surface is declared once. Publishable because it carries no internal-Gradle dependency — only the
-// external org.xdcl facade API.
-// No dependencies block: the facade base types (org.gradle.api.xdcl.*) come as `api` from the
+// surface is declared once. Publishable because it carries no internal-Gradle dependency — the facade
+// base types it extends are the distribution's org.xdcl API, a compileOnly dependency.
+// No dependencies block: the facade base types (org.gradle.api.xdcl.*) come as `compileOnly` from the
 // gradlebuild.xdcl-ecosystem-library convention, and this foundational schema imports nothing else.
 
 gradleModule {

--- a/platforms/core-configuration/xdcl-integ-tests/src/integTest/groovy/org/gradle/xdcl/XdclDistributionRepositoryIntegrationTest.groovy
+++ b/platforms/core-configuration/xdcl-integ-tests/src/integTest/groovy/org/gradle/xdcl/XdclDistributionRepositoryIntegrationTest.groovy
@@ -22,11 +22,12 @@ import org.gradle.test.fixtures.plugin.PluginBuilder
 /**
  * The Maven repository EMBEDDED in the distribution image ({@code <gradleHome>/repo}): it serves
  * the published XDCL ecosystem libraries at the running distribution's exact (timestamped) version,
- * with real POM + Gradle Module Metadata, plus the {@code org.xdcl:xdcl-gradle-api} module their
- * published metadata STRICTLY requires — the complete closure, so a consumer build's settings
+ * with real POM + Gradle Module Metadata — the complete closure, so a consumer build's settings
  * classpath can resolve a built-in ecosystem library offline, with no external repository in play.
- * This is the packaging half of resolving built-in ecosystems through ordinary dependency
- * resolution; the provider-side injection is exercised separately.
+ * The org.xdcl API the libraries' facades extend is NOT part of that closure: it is a compileOnly
+ * dependency of theirs, named by no published metadata, and present in the distribution's
+ * {@code lib/}. This is the packaging half of resolving built-in ecosystems through ordinary
+ * dependency resolution; the provider-side injection is exercised separately.
  */
 class XdclDistributionRepositoryIntegrationTest extends AbstractIntegrationSpec {
 
@@ -74,12 +75,42 @@ class XdclDistributionRepositoryIntegrationTest extends AbstractIntegrationSpec 
         executer.withArgument("--offline")
         succeeds("resolveProbe")
 
-        then: 'the requested library, its ecosystem dependency, and the strictly-pinned org.xdcl API all resolve'
+        then: 'the requested library and its ecosystem dependency resolve — and nothing else: the API their facades extend is not a dependency'
         outputContains("xdcl-repo-resolved=gradle-xdcl-plugin-development-")
         outputContains("xdcl-repo-resolved=gradle-xdcl-common-ecosystem-")
-        // Version-agnostic on purpose: WHICH org.xdcl version the closure needs is the published
-        // metadata's strict constraint, served by the same repo — not this test's business.
-        outputContains("xdcl-repo-resolved=xdcl-gradle-api-")
+        outputDoesNotContain("xdcl-repo-resolved=xdcl-gradle-api-")
+    }
+
+    def "the published metadata of an ecosystem library carries no dependency on the org.xdcl API, at any scope"() {
+        given: 'the metadata the embedded repository serves for the common ecosystem library, whose facades extend the API'
+        def version = distribution.version.version
+        def libraryDir = new File(distribution.gradleHomeDir, "repo/org/gradle/gradle-xdcl-common-ecosystem/$version")
+        def moduleFile = new File(libraryDir, "gradle-xdcl-common-ecosystem-${version}.module")
+        def pomFile = new File(libraryDir, "gradle-xdcl-common-ecosystem-${version}.pom")
+
+        expect: 'the metadata files exist alongside the jar'
+        moduleFile.file
+        pomFile.file
+
+        when:
+        def module = new groovy.json.JsonSlurper().parse(moduleFile)
+        def moduleDependencies = module.variants.collectMany { variant ->
+            (variant.dependencies ?: []).collect { "${it.group}:${it.module}".toString() }
+        }
+        def pom = new groovy.xml.XmlSlurper().parse(pomFile)
+        def pomDependencies = pom.dependencies.dependency.collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
+
+        then: 'no variant of the module metadata depends on anything under org.xdcl'
+        moduleDependencies.every { !it.startsWith("org.xdcl:") }
+
+        and: 'nor does the POM, at any scope'
+        pomDependencies.every { !it.startsWith("org.xdcl:") }
+
+        and: 'the embedded repository serves nothing under org.xdcl — there is no API module to resolve'
+        !new File(distribution.gradleHomeDir, "repo/org/xdcl").exists()
+
+        and: 'the API classes are in the distribution itself'
+        new File(distribution.gradleHomeDir, "lib").listFiles().any { it.name.startsWith("xdcl-gradle-api-") && it.name.endsWith(".jar") }
     }
 
     def "the embedded repository pins the running distribution's version against a stale published request"() {


### PR DESCRIPTION
Following the assumption that `xdcl-gradle-api` ends up as part of the Gradle API, we do not
need to "publish" it in the distribution's Maven repo, and we should have no Maven dependencies
on it in the built-in XDCL libs (published to the distribution's repo and as Gradle libs).
