### PR TITLE
Preserve Copy destinationDir output compatibility

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -134,13 +134,13 @@ See <<toolchains.adoc#sec:custom_loc, Custom Toolchain Locations>> in the Gradle
 link:{javadocPath}/org/gradle/api/tasks/Copy.html[`Copy`] and link:{javadocPath}/org/gradle/api/tasks/Sync.html[`Sync`] now expose the destination as an incubating `DirectoryProperty destinationDirectory`, which is the registered output directory of the task.
 The existing `into(...)`, `setDestinationDir(File)` and `getDestinationDir()` methods keep working and read from and write to the same property.
 
-This may affect task types extending `Copy` or `Sync` that override `getDestinationDir()` or `setDestinationDir(File)`:
+For backwards compatibility during Gradle 9.x, the legacy `destinationDir` remains a registered output alongside the new property.
+This allows task types compiled against an earlier Gradle version that override `getDestinationDir()` to continue working when `destinationDirectory` has no value.
 
-* An overridden `getDestinationDir()` is no longer consulted for the task output.
-  If the override was the only way the destination was supplied, the property has no value and the task fails validation with `Type '...' property 'destinationDirectory' doesn't have a configured value`.
-* An overridden `setDestinationDir(File)` is not invoked when the destination is configured through `destinationDirectory`.
+An overridden `setDestinationDir(File)` is not invoked when the destination is configured through `destinationDirectory`.
+Also, an overridden `getDestinationDir()` takes precedence when the task executes, even if `destinationDirectory` is configured separately.
+To avoid the two destinations getting out of sync, task authors should migrate away from overriding either method.
 
-In general, avoid overriding these methods.
 Configure the destination through `into(...)` or `destinationDirectory` instead, and derive anything else you need from `destinationDirectory`.
 For a default that build scripts can still override, set a convention on the property, or call `into(...)` from the constructor if the task type also has to run on Gradle versions before 9.8:
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyDestinationDirectoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyDestinationDirectoryIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.modes.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import spock.lang.Issue
@@ -121,6 +122,25 @@ class CopyDestinationDirectoryIntegrationTest extends AbstractIntegrationSpec {
                 from 'src'
             }
             copy.rootSpec.conventionMapping.map('destinationDir') { file("\$buildDir/mapped") }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('build/mapped/a.txt').text == 'a'
+
+        where:
+        task << ['Copy', 'Sync']
+    }
+
+    @UnsupportedWithConfigurationCache(because = "configuration cache only supports convention mapping for task fields with matching names")
+    def "#task legacy convention mapping on task destinationDir remains supported"() {
+        buildFile """
+            task copy(type: $task) {
+                from 'src'
+            }
+            copy.conventionMapping.map('destinationDir') { file("\$buildDir/mapped") }
         """
 
         when:
@@ -241,6 +261,38 @@ class CopyDestinationDirectoryIntegrationTest extends AbstractIntegrationSpec {
         file('build/sandbox/plugins/a.txt').text == 'a'
         outputContains("destinationDirectory: " + file('build/sandbox/plugins'))
         outputContains("destinationDir: " + file('build/sandbox/plugins'))
+
+        where:
+        task << ['Copy', 'Sync']
+    }
+
+    def "#task subclass can continue to provide its destination by overriding destinationDir"() {
+        buildFile """
+            abstract class CustomCopy extends $task {
+                @Internal abstract DirectoryProperty getDefaultDestinationDirectory()
+
+                @Override
+                File getDestinationDir() {
+                    return defaultDestinationDirectory.get().asFile
+                }
+            }
+            tasks.register("copy", CustomCopy) {
+                from 'src'
+                defaultDestinationDirectory = layout.buildDirectory.dir("sandbox")
+            }
+        """
+
+        when:
+        run 'copy'
+
+        then:
+        file('build/sandbox/a.txt').text == 'a'
+
+        when:
+        run 'copy'
+
+        then:
+        result.assertTaskSkipped(':copy')
 
         where:
         task << ['Copy', 'Sync']

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DestinationRootCopySpec;
 import org.gradle.api.internal.file.copy.FileCopyAction;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
 
@@ -105,6 +104,7 @@ public abstract class Copy extends AbstractCopyTask {
      */
     @Incubating
     @OutputDirectory
+    @Optional
     public DirectoryProperty getDestinationDirectory() {
         return getRootSpec().getDestinationDirectory();
     }
@@ -115,7 +115,7 @@ public abstract class Copy extends AbstractCopyTask {
      * @return The destination dir.
      * @since 0.7
      */
-    @ReplacedBy("destinationDirectory")
+    @OutputDirectory
     @NotToBeReplacedByLazyProperty(because = "Superseded by the lazy getDestinationDirectory() property", willBeDeprecated = true)
     public File getDestinationDir() {
         return getRootSpec().getDestinationDir();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DestinationRootCopySpec;
 import org.gradle.api.internal.file.copy.FileCopyAction;
 import org.gradle.api.internal.file.copy.SyncCopyActionDecorator;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.Deleter;
@@ -111,6 +110,7 @@ public abstract class Sync extends AbstractCopyTask {
      */
     @Incubating
     @OutputDirectory
+    @Optional
     public DirectoryProperty getDestinationDirectory() {
         return getRootSpec().getDestinationDirectory();
     }
@@ -121,7 +121,7 @@ public abstract class Sync extends AbstractCopyTask {
      * @return The destination dir.
      * @since 0.9
      */
-    @ReplacedBy("destinationDirectory")
+    @OutputDirectory
     @NotToBeReplacedByLazyProperty(because = "Superseded by the lazy getDestinationDirectory() property", willBeDeprecated = true)
     public File getDestinationDir() {
         return getRootSpec().getDestinationDir();

--- a/testing/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/CopyDestinationDirectoryBinaryCompatibilityCrossVersionSpec.groovy
+++ b/testing/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/CopyDestinationDirectoryBinaryCompatibilityCrossVersionSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests
+
+import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetVersions
+
+@TargetVersions("9.6.1")
+class CopyDestinationDirectoryBinaryCompatibilityCrossVersionSpec extends CrossVersionIntegrationSpec {
+
+    def "Copy and Sync subclasses compiled with an earlier Gradle can override destinationDir"() {
+        given:
+        file("producer/settings.gradle") << "rootProject.name = 'producer'"
+        file("producer/build.gradle") << """
+            plugins {
+                id 'java-gradle-plugin'
+            }
+        """
+        file("producer/src/main/java/SomePlugin.java") << """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.file.DirectoryProperty;
+            import org.gradle.api.tasks.Copy;
+            import org.gradle.api.tasks.Internal;
+            import org.gradle.api.tasks.Sync;
+
+            import java.io.File;
+
+            public class SomePlugin implements Plugin<Project> {
+                public abstract static class CustomCopy extends Copy {
+                    @Internal
+                    public abstract DirectoryProperty getDefaultDestinationDirectory();
+
+                    @Override
+                    public File getDestinationDir() {
+                        return getDefaultDestinationDirectory().get().getAsFile();
+                    }
+                }
+
+                public abstract static class CustomSync extends Sync {
+                    @Internal
+                    public abstract DirectoryProperty getDefaultDestinationDirectory();
+
+                    @Override
+                    public File getDestinationDir() {
+                        return getDefaultDestinationDirectory().get().getAsFile();
+                    }
+                }
+
+                @Override
+                public void apply(Project project) {
+                    project.getTasks().register("customCopy", CustomCopy.class, task -> {
+                        task.from(project.file("src"));
+                        task.getDefaultDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("copy"));
+                    });
+                    project.getTasks().register("customSync", CustomSync.class, task -> {
+                        task.from(project.file("src"));
+                        task.getDefaultDestinationDirectory().set(project.getLayout().getBuildDirectory().dir("sync"));
+                    });
+                }
+            }
+        """
+        buildFile << """
+            buildscript {
+                dependencies { classpath files('producer/build/libs/producer.jar') }
+            }
+
+            apply plugin: SomePlugin
+        """
+        file("src/a.txt") << "a"
+
+        when:
+        version(previous).withTasks('assemble').inDirectory(file("producer")).run()
+        version(current).withTasks('customCopy', 'customSync').run()
+
+        then:
+        file("build/copy/a.txt").text == "a"
+        file("build/sync/a.txt").text == "a"
+
+        when:
+        def secondRun = version(current).withTasks('customCopy', 'customSync').run()
+
+        then:
+        secondRun.assertTasksSkipped(':customCopy', ':customSync')
+    }
+}


### PR DESCRIPTION
### Context

This PR is stacked on #39128.

The lazy `destinationDirectory` output introduced for `Copy` and `Sync` causes task validation to fail for subclasses compiled against earlier Gradle versions when they override `getDestinationDir()` and leave the new property unset.

During Gradle 9.x, this keeps the legacy `destinationDir` getter registered as an output and makes `destinationDirectory` optional. This preserves binary compatibility while allowing Gradle 10 to complete the switch to the lazy property.

Legacy task-level convention mappings remain attached to `destinationDir`. `Copy` and `Sync` execute through that getter, so these conventions continue to work without adding separate convention-routing machinery. The corresponding test is excluded from configuration-cache mode because configuration cache already supports legacy convention mappings only when they correspond to a matching task field.

Tests cover `Copy` and `Sync` subclasses compiled with Gradle 9.6.1, legacy convention mapping, output tracking, and configuration-cache behavior.

AI disclosure: I used OpenAI Codex extensively to investigate, implement, and test this change. I reviewed and understand the submitted changes and will actively participate in review.

### Verification

- `:core:embeddedIntegTest --tests org.gradle.api.tasks.CopyDestinationDirectoryIntegrationTest`
- `:core:configCacheIntegTest --tests org.gradle.api.tasks.CopyDestinationDirectoryIntegrationTest`
- `:integ-test:gradle9.6.1CrossVersionTest --tests org.gradle.integtests.CopyDestinationDirectoryBinaryCompatibilityCrossVersionSpec`
- `:core:checkstyleMain :core:javadoc`

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits are signed off under the Developer Certificate of Origin.
- [x] All contributed code can be distributed under the Apache License 2.0.
- [x] Allow edits from maintainers.
- [x] Provide integration tests.
- [ ] Provide unit tests.
- [x] Update user-facing documentation.
- [ ] Run `./gradlew sanityCheck`.
- [ ] Run the changed-subproject `quickTest` tasks.